### PR TITLE
fix: UTF-8 encoding + /producto/ 301 redirects

### DIFF
--- a/functions/producto/[[path]].js
+++ b/functions/producto/[[path]].js
@@ -4,13 +4,57 @@
  * Limpieza de URLs viejas del sitio anterior (WooCommerce / CMS legacy).
  * Patrón: /producto/:slug/
  *
- * Devuelve 410 Gone — indica a Google que estas páginas son
- * permanentemente eliminadas y deben ser removidas del índice.
- * Es preferible a un soft 404 (200 con index.html) o a un 301
- * al homepage cuando no existe mapeo directo al nuevo /libro/:id/:slug.
+ * Intenta encontrar el libro equivalente en el catálogo actual (R2) comparando
+ * el slug de la URL con el slug generado a partir del título de cada item.
+ * Si hay coincidencia → 301 a /libro/:id/:slug (canonical).
+ * Sin coincidencia → 410 Gone (página permanentemente eliminada, sin equivalente).
+ *
+ * slugify() es idéntico al de libro/[[path]].js, sitemap.xml.js, catalogo.js y
+ * feed.xml.js — CRÍTICO: debe mantenerse idéntico para que los slugs coincidan.
  */
 
-export async function onRequest() {
+const CATALOG_URL = 'https://pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev/catalog.json';
+const BASE        = 'https://www.amadolibros.com';
+
+function slugify(text) {
+    return (text || '')
+        .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '')
+        .substring(0, 60);
+}
+
+async function fetchCatalog() {
+    try {
+        const resp = await fetch(CATALOG_URL);
+        if (!resp.ok) return null;
+        return await resp.json();
+    } catch {
+        return null;
+    }
+}
+
+export async function onRequest(context) {
+    // Extract the slug from the incoming /producto/:slug URL
+    const pathParts = Array.isArray(context.params.path)
+        ? context.params.path
+        : [context.params.path].filter(Boolean);
+    const incomingSlug = (pathParts[0] || '').toLowerCase().replace(/\/+$/, '');
+
+    if (incomingSlug) {
+        const catalog = await fetchCatalog();
+        if (catalog && Array.isArray(catalog.items)) {
+            const match = catalog.items.find(
+                item => slugify(item.title) === incomingSlug
+            );
+            if (match) {
+                const canonicalSlug = slugify(match.title);
+                return Response.redirect(`${BASE}/libro/${match.id}/${canonicalSlug}`, 301);
+            }
+        }
+    }
+
     const html = `<!DOCTYPE html>
 <html lang="es">
 <head>

--- a/scripts/generate-home-json.js
+++ b/scripts/generate-home-json.js
@@ -40,6 +40,7 @@ function fetchJSON(url) {
                 reject(new Error(`HTTP ${res.statusCode} from ${url}`));
                 return;
             }
+            res.setEncoding('utf8');
             res.on('data', chunk => { raw += chunk; });
             res.on('end', () => {
                 try   { resolve(JSON.parse(raw)); }


### PR DESCRIPTION
## Summary

- **Fix 1 (`scripts/generate-home-json.js`):** Add `res.setEncoding('utf8')` before the data listener. Without it, Node.js HTTP chunks arrive as raw `Buffer` objects; concatenating per-chunk with `+=` calls `chunk.toString('utf8')` independently on each chunk, which can corrupt multi-byte UTF-8 sequences (Spanish accented characters like ó, á, é, ñ) if a byte sequence is split across two TCP chunks. `setEncoding('utf8')` activates Node.js's `StringDecoder` internally, which correctly buffers incomplete sequences across chunk boundaries.

- **Fix 2 (`functions/producto/[[path]].js`):** Replace the unconditional `410 Gone` response with a slug-matching lookup against `catalog.json` (R2). The incoming `/producto/:slug` is compared against `slugify(item.title)` for every catalog item using the **identical** `slugify()` function already used in `libro/[[path]].js`, `catalogo.js`, `sitemap.xml.js`, and `feed.xml.js`. Match found → `301` to `/libro/:id/:slug`. No match → `410 Gone` (unchanged fallback).

## Test plan

- [ ] `curl -sI https://www.amadolibros.com/producto/sarkany-moda-femenina-tendencias-y-creatividad-emprender` returns `301` → `/libro/MLU1285365438/sarkany-moda-femenina-tendencias-y-creatividad-emprender`
- [ ] `/producto/some-unknown-slug` still returns `410 Gone`
- [ ] Next CI deploy runs `generate-home-json.js` without encoding errors on accented titles
- [ ] Check Google Search Console for reduction in `/producto/` coverage errors after next crawl

https://claude.ai/code/session_01UniiprcePPUFZRE6vfxLjY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UniiprcePPUFZRE6vfxLjY)_