### PR TITLE
2-J-A3 worker sync observable y trigger await

### DIFF
--- a/.github/workflows/deploy-worker-sync.yml
+++ b/.github/workflows/deploy-worker-sync.yml
@@ -32,6 +32,44 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      - name: Wait for Worker propagation
+        if: ${{ inputs.run_trigger == true }}
+        run: |
+          if [ -z "$WORKER_SYNC_TRIGGER_URL" ]; then
+            echo "ERROR: WORKER_SYNC_TRIGGER_URL no está configurada."
+            exit 1
+          fi
+
+          BASE_URL="${WORKER_SYNC_TRIGGER_URL%/trigger}"
+          STATUS_URL="${BASE_URL}/status"
+
+          echo "Esperando propagación del Worker nuevo..."
+          sleep 20
+
+          for i in 1 2 3 4 5 6; do
+            RESPONSE=$(curl -sS --max-time 30 -w "\nHTTP_STATUS:%{http_code}" \
+              -X GET "$STATUS_URL" \
+              -H "Authorization: Bearer $SYNC_SECRET")
+
+            HTTP_STATUS=$(echo "$RESPONSE" | grep -o "HTTP_STATUS:[0-9]*" | cut -d: -f2)
+            BODY=$(echo "$RESPONSE" | sed '/HTTP_STATUS:/d')
+
+            echo "Status probe $i HTTP: $HTTP_STATUS"
+            echo "Status probe $i body: $BODY"
+
+            if [ "$HTTP_STATUS" = "200" ]; then
+              exit 0
+            fi
+
+            sleep 10
+          done
+
+          echo "ERROR: /status no respondió 200 después de esperar propagación."
+          exit 1
+        env:
+          SYNC_SECRET: ${{ secrets.SYNC_SECRET }}
+          WORKER_SYNC_TRIGGER_URL: ${{ vars.WORKER_SYNC_TRIGGER_URL }}
+
       - name: Trigger catalog sync
         if: ${{ inputs.run_trigger == true }}
         run: |
@@ -58,6 +96,16 @@ jobs:
 
           if [ "$HTTP_STATUS" != "200" ]; then
             echo "ERROR: trigger respondió $HTTP_STATUS"
+            exit 1
+          fi
+
+          if ! echo "$BODY" | grep -q '"source":"manual-await"'; then
+            echo "ERROR: trigger no devolvió source=manual-await. Probablemente respondió una versión vieja del Worker."
+            exit 1
+          fi
+
+          if ! echo "$BODY" | grep -q '"status":"ok"'; then
+            echo "ERROR: trigger no devolvió status=ok."
             exit 1
           fi
         env:

--- a/.github/workflows/deploy-worker-sync.yml
+++ b/.github/workflows/deploy-worker-sync.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       run_trigger:
-        description: 'Ejecutar sync trigger después del deploy (POST /trigger)'
+        description: 'Ejecutar sync trigger después del deploy (POST /trigger?mode=await)'
         type: boolean
         required: true
         default: false
@@ -40,8 +40,14 @@ jobs:
             exit 1
           fi
 
-          RESPONSE=$(curl -sS --max-time 30 -w "\nHTTP_STATUS:%{http_code}" \
-            -X POST "$WORKER_SYNC_TRIGGER_URL" \
+          if [[ "$WORKER_SYNC_TRIGGER_URL" == *\?* ]]; then
+            TRIGGER_URL="${WORKER_SYNC_TRIGGER_URL}&mode=await"
+          else
+            TRIGGER_URL="${WORKER_SYNC_TRIGGER_URL}?mode=await"
+          fi
+
+          RESPONSE=$(curl -sS --max-time 900 -w "\nHTTP_STATUS:%{http_code}" \
+            -X POST "$TRIGGER_URL" \
             -H "Authorization: Bearer $SYNC_SECRET")
 
           HTTP_STATUS=$(echo "$RESPONSE" | grep -o "HTTP_STATUS:[0-9]*" | cut -d: -f2)
@@ -50,8 +56,37 @@ jobs:
           echo "HTTP status: $HTTP_STATUS"
           echo "Response body: $BODY"
 
-          if [ "$HTTP_STATUS" != "200" ] && [ "$HTTP_STATUS" != "202" ]; then
+          if [ "$HTTP_STATUS" != "200" ]; then
             echo "ERROR: trigger respondió $HTTP_STATUS"
+            exit 1
+          fi
+        env:
+          SYNC_SECRET: ${{ secrets.SYNC_SECRET }}
+          WORKER_SYNC_TRIGGER_URL: ${{ vars.WORKER_SYNC_TRIGGER_URL }}
+
+      - name: Read sync status
+        if: ${{ inputs.run_trigger == true }}
+        run: |
+          if [ -z "$WORKER_SYNC_TRIGGER_URL" ]; then
+            echo "ERROR: WORKER_SYNC_TRIGGER_URL no está configurada."
+            exit 1
+          fi
+
+          BASE_URL="${WORKER_SYNC_TRIGGER_URL%/trigger}"
+          STATUS_URL="${BASE_URL}/status"
+
+          RESPONSE=$(curl -sS --max-time 30 -w "\nHTTP_STATUS:%{http_code}" \
+            -X GET "$STATUS_URL" \
+            -H "Authorization: Bearer $SYNC_SECRET")
+
+          HTTP_STATUS=$(echo "$RESPONSE" | grep -o "HTTP_STATUS:[0-9]*" | cut -d: -f2)
+          BODY=$(echo "$RESPONSE" | sed '/HTTP_STATUS:/d')
+
+          echo "HTTP status: $HTTP_STATUS"
+          echo "Response body: $BODY"
+
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "ERROR: status respondió $HTTP_STATUS"
             exit 1
           fi
         env:

--- a/worker-sync/index.js
+++ b/worker-sync/index.js
@@ -6,7 +6,8 @@
  * Triggers:
  *   scheduled(event) — cron "15 7 * * *" (07:15 UTC = 04:15 Montevideo)
  *   fetch(request)   — POST /trigger con header Authorization: Bearer <SYNC_SECRET>
- *                      para disparar sync manualmente sin esperar al cron
+ *                      para disparar sync manualmente.
+ *                    — GET /status con el mismo header para auditar KV + R2.
  *
  * Flujo de runSync():
  *   1. Obtener ML access token (meli-auth.js — KV lock + retry)
@@ -17,18 +18,17 @@
  * KV keys escritas por este Worker:
  *   auth:refresh_token       — compartido con Pages (se actualiza en meli-auth.js)
  *   auth:refresh_token_lock  — mutex para el intercambio de token
+ *   sync:last_started        — ISO timestamp del último sync iniciado
  *   sync:last_ok             — ISO timestamp del último sync exitoso
  *   sync:last_error          — string corto del último error (ausente si el último sync fue ok)
  *
  * KV keys que este Worker NO escribe:
  *   catalog:full, catalog_index, catalog_index:*, item:MLU*  — esquemas obsoletos
  *
- * Nota de tiempo de ejecución:
+ * Nota operativa:
  *   Con ~16.000 items, el sync tarda ~5-8 minutos (principalmente I/O hacia ML API).
- *   El tiempo de CPU real es < 1 segundo (parsing JSON, array ops).
- *   Cron triggers en CF Workers tienen 15 minutos de wall-clock time — suficiente.
- *   Para el fetch trigger el sync corre en ctx.waitUntil() — la respuesta HTTP
- *   vuelve inmediatamente, el sync continúa en background.
+ *   El cron trigger es el camino principal. Para ejecución manual verificable, usar:
+ *   POST /trigger?mode=await
  */
 
 import { getAccessToken } from './meli-auth.js';
@@ -39,10 +39,10 @@ export default {
   // ── Cron trigger ────────────────────────────────────────────────────────────
   async scheduled(event, env, ctx) {
     console.log(`[Worker] Cron trigger: ${new Date().toISOString()}`);
-    ctx.waitUntil(runSync(env));
+    ctx.waitUntil(runSync(env, { source: 'cron' }));
   },
 
-  // ── Manual trigger ───────────────────────────────────────────────────────────
+  // ── Manual trigger / status ─────────────────────────────────────────────────
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
 
@@ -56,26 +56,40 @@ export default {
       return json({ error: 'Unauthorized.' }, 401);
     }
 
-    // Solo acepta POST /trigger
-    if (request.method !== 'POST' || url.pathname !== '/trigger') {
-      return json({ error: 'Not found. Use POST /trigger.' }, 404);
+    if (request.method === 'GET' && url.pathname === '/status') {
+      return json(await readStatus(env));
     }
 
-    console.log(`[Worker] Trigger manual: ${new Date().toISOString()}`);
-    ctx.waitUntil(runSync(env));
+    if (request.method !== 'POST' || url.pathname !== '/trigger') {
+      return json({ error: 'Not found. Use POST /trigger or GET /status.' }, 404);
+    }
+
+    const mode = url.searchParams.get('mode') || 'async';
+    console.log(`[Worker] Trigger manual: ${new Date().toISOString()} | mode=${mode}`);
+
+    if (mode === 'await') {
+      const result = await runSync(env, { source: 'manual-await' });
+      return json(result, result.status === 'ok' ? 200 : 500);
+    }
+
+    ctx.waitUntil(runSync(env, { source: 'manual-async' }));
 
     return json({
       status:  'SYNC_TRIGGERED',
-      message: 'Sync iniciado en background. Consultá KV sync:last_ok / sync:last_error para el resultado.',
-    });
+      mode:    'async',
+      message: 'Sync iniciado en background. Usá GET /status para auditar sync:last_ok, sync:last_error y R2/meta.json.',
+      status_url: '/status',
+    }, 202);
   },
 };
 
 // ── Sync principal ────────────────────────────────────────────────────────────
 
-async function runSync(env) {
+async function runSync(env, options = {}) {
   const startedAt = new Date().toISOString();
-  console.log(`[Sync] Iniciando sync completo — ${startedAt}`);
+  const source = options.source || 'unknown';
+  console.log(`[Sync] Iniciando sync completo — ${startedAt} | source=${source}`);
+  await kvPut(env, 'sync:last_started', startedAt);
 
   try {
     // 1. Auth
@@ -94,24 +108,112 @@ async function runSync(env) {
       last_full_sync: finishedAt,
       duration_ms:    durationMs,
       status:         'ok',
+      source,
     };
     await publishToR2(env, catalog, syncMeta);
 
     // 4. Estado: éxito
     await kvPut(env, 'sync:last_ok', finishedAt);
+    await kvDelete(env, 'sync:last_error');
 
     console.log(`[Sync] Completado: ${catalog.total} items en ${Math.round(durationMs / 1000)}s`);
+    return {
+      status:         'ok',
+      source,
+      total:          catalog.total,
+      updated_at:     catalog.updated_at,
+      started_at:     startedAt,
+      finished_at:    finishedAt,
+      duration_ms:    durationMs,
+    };
 
   } catch (err) {
     console.error(`[Sync] Error crítico: ${err.message}`);
 
     // Estado: error (string corto)
-    const summary = `${new Date().toISOString()} — ${err.message}`.slice(0, 400);
+    const finishedAt = new Date().toISOString();
+    const durationMs = Date.now() - new Date(startedAt).getTime();
+    const summary = `${finishedAt} — ${err.message}`.slice(0, 400);
     await kvPut(env, 'sync:last_error', summary);
+
+    return {
+      status:      'error',
+      source,
+      started_at:  startedAt,
+      finished_at: finishedAt,
+      duration_ms: durationMs,
+      error:       err.message,
+    };
+  }
+}
+
+// ── Status ───────────────────────────────────────────────────────────────────
+
+async function readStatus(env) {
+  const [lastStarted, lastOk, lastError, meta, catalogHead] = await Promise.all([
+    kvGet(env, 'sync:last_started'),
+    kvGet(env, 'sync:last_ok'),
+    kvGet(env, 'sync:last_error'),
+    readR2Json(env, 'meta.json'),
+    readR2Head(env, 'catalog.json'),
+  ]);
+
+  return {
+    status: 'ok',
+    checked_at: new Date().toISOString(),
+    kv: {
+      last_started: lastStarted,
+      last_ok:      lastOk,
+      last_error:   lastError,
+    },
+    r2: {
+      meta,
+      catalog: catalogHead,
+    },
+  };
+}
+
+async function readR2Json(env, key) {
+  try {
+    const obj = await env.CATALOG_R2.get(key);
+    if (!obj) return { exists: false };
+    return {
+      exists: true,
+      size: obj.size ?? null,
+      uploaded: dateToIso(obj.uploaded),
+      etag: obj.etag || obj.httpEtag || null,
+      body: JSON.parse(await obj.text()),
+    };
+  } catch (e) {
+    return { exists: false, error: e.message };
+  }
+}
+
+async function readR2Head(env, key) {
+  try {
+    const obj = await env.CATALOG_R2.head(key);
+    if (!obj) return { exists: false };
+    return {
+      exists: true,
+      size: obj.size ?? null,
+      uploaded: dateToIso(obj.uploaded),
+      etag: obj.etag || obj.httpEtag || null,
+    };
+  } catch (e) {
+    return { exists: false, error: e.message };
   }
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function kvGet(env, key) {
+  try {
+    return await env.AMADO_KV.get(key);
+  } catch (e) {
+    console.error(`[Sync] Error leyendo KV ${key}:`, e.message);
+    return null;
+  }
+}
 
 async function kvPut(env, key, value) {
   try {
@@ -121,9 +223,26 @@ async function kvPut(env, key, value) {
   }
 }
 
+async function kvDelete(env, key) {
+  try {
+    await env.AMADO_KV.delete(key);
+  } catch (e) {
+    console.error(`[Sync] Error borrando KV ${key}:`, e.message);
+  }
+}
+
+function dateToIso(value) {
+  if (!value) return null;
+  if (value instanceof Date) return value.toISOString();
+  return String(value);
+}
+
 function json(body, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type':  'application/json',
+      'Cache-Control': 'no-store',
+    },
   });
 }


### PR DESCRIPTION
## Estado

Lote técnico para hacer verificable el sync manual del Worker.

No toca Astro producción, no toca fichas y no toca Mercado Pago.

## Diagnóstico

El workflow anterior ejecutaba `curl --max-time 30` sobre `POST /trigger`, mientras el sync real tarda varios minutos. Además el endpoint respondía `SYNC_TRIGGERED` antes de saber si R2 había sido actualizado.

## Cambios

### Worker

- Agrega `GET /status`, protegido por `SYNC_SECRET`.
- `GET /status` devuelve:
  - `sync:last_started`
  - `sync:last_ok`
  - `sync:last_error`
  - `meta.json` leído desde R2
  - metadata de `catalog.json` leído desde R2
- Agrega `POST /trigger?mode=await` para esperar el resultado real del sync y devolver `status: ok` o `status: error`.
- Mantiene `POST /trigger` sin query como modo async compatible.
- `runSync()` ahora devuelve resultado estructurado y escribe `source` en `meta.json`.
- En éxito borra `sync:last_error`.

### GitHub Actions

- `Deploy Worker Sync` ahora usa `POST /trigger?mode=await` cuando `run_trigger=true`.
- Sube `curl --max-time` de 30 a 900 segundos.
- Después del trigger lee `GET /status` y muestra KV + R2 en el log.

## Riesgo

Medio-bajo. Cambia solo el Worker de sync y su workflow manual. El cron diario sigue usando el mismo `runSync()`. El modo async viejo sigue disponible.

## Validación pendiente

- Deploy manual del Worker desde esta rama.
- Ejecutar workflow con `run_trigger=true`.
- Confirmar que el log termina con HTTP 200 real y que `/status` muestra `meta.json` nuevo.

## No incluido

- No se toca web Astro.
- No se toca ficha de producto.
- No se toca Mercado Pago.
- No se agrega descripción ML.