### PR TITLE
2-L-A SEO commercial metadata and active sitemap

### DIFF
--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -98,8 +98,8 @@ export async function onRequest(ctx) {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Catálogo completo de libros — Amado Libros</title>
-  <meta name="description" content="Índice completo de ${activeItems.length} libros disponibles en Amado Libros. Importados y por encargo en Uruguay.">
+  <title>Comprar libros online en Uruguay | Amado Libros</title>
+  <meta name="description" content="${activeItems.length} libros para comprar online en Uruguay. 12% de descuento por transferencia y envío gratis desde $1.500. Envíos a todo el país.">
   <link rel="canonical" href="${BASE}/catalogo">
   <meta name="robots" content="index, follow">
   <script type="application/ld+json">${JSON.stringify({

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -330,8 +330,7 @@ function renderPage(item, slug, isPreview) {
         💬 Consultar por WhatsApp
       </a>
     </div>
-    <p class="shipping">📚 El libro que buscás, esté donde esté en el mundo, lo acercamos a tus manos.</p>
-    <p class="shipping">🚚 Envíos a todo Uruguay en 24 a 48 hs hábiles · Envío gratis desde $1.500. <a href="/politicas#envios">Ver política de envíos</a>.</p>
+    <p class="shipping">🚚 Entrega en 2 horas en Montevideo · Envíos a todo Uruguay · Envío gratis desde $1.500. <a href="/politicas#envios">Ver política de envíos</a>.</p>
   </div>
 </main>
 

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -330,11 +330,8 @@ function renderPage(item, slug, isPreview) {
         💬 Consultar por WhatsApp
       </a>
     </div>
-    <p class="shipping">
-      🚚 Envíos a todo Uruguay en 24 a 48hs hábiles.
-      Envío gratis desde $1.500.
-      <a href="/politicas#envios">Ver política de envíos</a>.
-    </p>
+    <p class="shipping">📚 El libro que buscás, esté donde esté en el mundo, lo acercamos a tus manos.</p>
+    <p class="shipping">🚚 Envíos a todo Uruguay en 24 a 48 hs hábiles · Envío gratis desde $1.500. <a href="/politicas#envios">Ver política de envíos</a>.</p>
   </div>
 </main>
 

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -168,8 +168,8 @@ function renderPage(item, slug, isPreview) {
     ].filter(Boolean).join('\n');
 
     const metaDesc = safeAuthor
-        ? `Comprá &quot;${safeTitle}&quot; de ${safeAuthor} en Amado Libros. Precio: $${priceUY} UYU. Envíos a todo Uruguay en 24 a 48hs.`
-        : `Comprá &quot;${safeTitle}&quot; en Amado Libros. Precio: $${priceUY} UYU. Envíos a todo Uruguay en 24 a 48hs.`;
+        ? `Comprá &quot;${safeTitle}&quot; de ${safeAuthor} en Amado Libros. Transferencia: $${transferPrice} UYU, 12% de descuento. Envíos a todo Uruguay.`
+        : `Comprá &quot;${safeTitle}&quot; en Amado Libros. Transferencia: $${transferPrice} UYU, 12% de descuento. Envíos a todo Uruguay.`;
 
     // JSON-LD — generado con JSON.stringify, nunca concatenación
     const schemaProduct = {
@@ -234,6 +234,7 @@ function renderPage(item, slug, isPreview) {
   <meta property="og:description" content="${metaDesc}">
   <meta property="og:image"       content="${escapeHtml(img)}">
   <meta property="og:locale"      content="es_UY">
+  <meta property="og:site_name"   content="Amado Libros">
 
   <meta name="twitter:card"        content="summary_large_image">
   <meta name="twitter:title"       content="${safeTitle} | Amado Libros">
@@ -331,7 +332,7 @@ function renderPage(item, slug, isPreview) {
     </div>
     <p class="shipping">
       🚚 Envíos a todo Uruguay en 24 a 48hs hábiles.
-      Más de 16.000 títulos disponibles en Amado Libros.
+      Envío gratis desde $1.500.
       <a href="/politicas#envios">Ver política de envíos</a>.
     </p>
   </div>

--- a/functions/sitemap.xml.js
+++ b/functions/sitemap.xml.js
@@ -36,7 +36,9 @@ export async function onRequest(ctx) {
     let bookUrls = [];
     const catalog = await fetchCatalog(ctx);
     if (catalog && Array.isArray(catalog.items)) {
-        bookUrls = catalog.items.map(item => ({
+        bookUrls = catalog.items
+            .filter(item => item.status === 'active')
+            .map(item => ({
             loc:        `${BASE}/libro/${item.id}/${slugify(item.title)}`,
             changefreq: 'weekly',
             priority:   '0.7',


### PR DESCRIPTION
## Cambios

- Mejora el title y la meta description de `/catalogo` con enfoque comercial.
- Limita el sitemap a productos con estado `active`.
- Agrega el precio de transferencia y el 12% de descuento en las meta descriptions de fichas.
- Reemplaza el texto de “Más de 16.000 títulos” por un mensaje comercial minimalista:
  - `Entrega en 2 horas en Montevideo`
  - `Envíos a todo Uruguay`
  - `Envío gratis desde $1.500`
- Conserva el enlace a `/politicas#envios`.
- Agrega `og:site_name` en fichas.

## Lo que NO cambia

- Title de fichas.
- JSON-LD.
- Canonical.
- CSS general.
- `public/index.html`.
- Cálculo de precios.
- Galería.
- Checkout.
- Carrito.

## Validación

- `node --check`: OK en los 3 archivos.
- `npm run build`: OK.

No hacer merge sin aprobación explícita de Seba.