### PR TITLE
2-M-C add CI validation for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+
+jobs:
+  validate:
+    name: Syntax & Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: astro-front/package-lock.json
+
+      - name: Check JavaScript syntax
+        shell: bash
+        run: |
+          set -euo pipefail
+          find functions scripts worker-sync \
+            -type f \
+            -name '*.js' \
+            -print0 |
+            xargs -0 -r -n1 node --check
+
+      - name: Install Astro dependencies
+        working-directory: astro-front
+        run: npm ci --no-audit --no-fund
+
+      - name: Build production configuration
+        working-directory: astro-front
+        env:
+          PUBLIC_INDEXABLE: 'true'
+          PUBLIC_GA_ID: G-SDX45VEPP3
+        run: npm run build
+
+      - name: Check pull request diff
+        if: github.event_name == 'pull_request'
+        run: |
+          git diff --check \
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
+
+      - name: Confirm tracked files remain unchanged
+        run: git diff --exit-code


### PR DESCRIPTION
## Alcance

Agrega CI automático para cada Pull Request hacia `main`.

## Archivo

- `.github/workflows/ci.yml`

## Cambios

- Verifica sintaxis JavaScript en `functions/`, `scripts/` y `worker-sync/`.
- Usa Node `22.12.0`.
- Reutiliza caché npm basada en `astro-front/package-lock.json`.
- Ejecuta `npm ci --no-audit --no-fund`.
- Compila Astro con la misma configuración de producción.
- Revisa whitespace sobre el rango real del PR.
- Verifica que el build no modifique archivos versionados.
- Cancela ejecuciones anteriores del mismo PR.
- Usa permisos mínimos de solo lectura.

## Lo que NO cambia

- No usa secretos.
- No usa Wrangler.
- No despliega Cloudflare.
- No modifica código de aplicación.
- No toca producción.

## Validación local

- `node --check`: OK en Functions, scripts y Worker.
- `npm ci`: OK.
- `npm run build`: OK.
- `git diff --check`: OK.
- Un solo archivo nuevo.

## Riesgo

Muy bajo. Workflow aislado, sin credenciales ni capacidad de despliegue.

No hacer merge sin aprobación explícita de Seba.