### PR TITLE
2-M-D harden production deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,32 +5,65 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: production-pages
+  cancel-in-progress: false
+
 jobs:
   deploy:
-    runs-on: ubuntu-latest
     name: Deploy
-    steps:
-      - uses: actions/checkout@v4
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: production
+      url: https://www.amadolibros.com
 
-      - uses: actions/setup-node@v4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: astro-front/package-lock.json
 
       - name: Generate home.json
-        # Genera public/home.json desde el catálogo público de R2.
-        # No requiere credenciales. Si falla (R2 down), el deploy continúa
+        id: home_json
+        # Lee catálogo público de R2. Si falla (R2 down), el deploy continúa
         # usando el último home.json commiteado como fallback.
         run: node scripts/generate-home-json.js
         continue-on-error: true
 
+      - name: Install Astro dependencies
+        working-directory: astro-front
+        run: npm ci --no-audit --no-fund
+
       - name: Build Astro
-        run: |
-          cd astro-front
-          npm ci
-          PUBLIC_INDEXABLE=true PUBLIC_GA_ID=G-SDX45VEPP3 npm run build
+        working-directory: astro-front
+        env:
+          PUBLIC_INDEXABLE: 'true'
+          PUBLIC_GA_ID: G-SDX45VEPP3
+        run: npm run build
 
       - name: Deploy via Wrangler
-        run: npx wrangler@3 pages deploy ./astro-front/dist --project-name amadolibros-web --branch main
+        run: npx wrangler@3.114.17 pages deploy ./astro-front/dist --project-name amadolibros-web --branch main
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deployment summary
+        if: always()
+        run: |
+          echo "## Deploy" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| | |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **SHA** | \`${{ github.sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Trigger** | \`${{ github.event_name }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **home.json** | ${{ steps.home_json.outcome == 'success' && '✅ fresh' || '⚠️ fallback (committed copy)' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **URL** | https://www.amadolibros.com |" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Alcance

Endurece el workflow de producción de Cloudflare Pages para evitar carreras, reducir tiempos y mejorar trazabilidad.

## Archivo

- `.github/workflows/deploy.yml`

## Cambios

- Agrega permisos mínimos `contents: read`.
- Agrega `concurrency` global para producción con `cancel-in-progress: false`.
- Agrega `timeout-minutes: 15`.
- Declara `environment: production` con URL de producción.
- Agrega caché npm basada en `astro-front/package-lock.json`.
- Separa instalación y build con `working-directory`.
- Usa `npm ci --no-audit --no-fund`.
- Fija Wrangler en `3.114.17`.
- Hace visible si `home.json` se generó o si se usó fallback.
- Agrega resumen final con SHA, trigger, estado de `home.json` y URL.

## Lo que NO cambia

- No cambia el proyecto de Cloudflare.
- No cambia secretos.
- No modifica código de aplicación.
- No agrega smoke tests.
- No modifica preview ni worker-sync.

## Validación local

- Diff revisado.
- Solo se modifica un archivo.
- Cambios reportados: +43 / -10.

## Riesgo

Bajo. Cambio limitado al workflow de despliegue de producción.

No hacer merge sin aprobación explícita de Seba.