### PR TITLE
2-N-B.1 claridad comercial y control del carrito

### DIFF
--- a/astro-front/public/cart.js
+++ b/astro-front/public/cart.js
@@ -23,12 +23,15 @@
     if (!isFinite(price) || price <= 0) return null;
     var qty = Math.floor(Number(it.quantity));
     if (!isFinite(qty) || qty < 1) return null;
+    var maxQty = Math.floor(Number(it.max_qty));
+    if (!isFinite(maxQty) || maxQty < 0) maxQty = 0;
     return {
       id: id,
       title: String(it.title || '').slice(0, 200),
       price: price,
       quantity: qty,
       thumbnail: String(it.thumbnail || '').slice(0, 500),
+      max_qty: maxQty,
     };
   }
 
@@ -40,12 +43,22 @@
       if (!c || typeof c !== 'object' || c.version !== VERSION || !Array.isArray(c.items)) {
         return emptyCart();
       }
-      var valid = [];
+      var valid   = [];
+      var changed = false;
       for (var i = 0; i < c.items.length; i++) {
         var n = normalizeItem(c.items[i]);
-        if (n) valid.push(n);
+        if (n) {
+          if (n.max_qty > 0 && n.quantity > n.max_qty) {
+            n.quantity = n.max_qty;
+            changed = true;
+          }
+          valid.push(n);
+        }
       }
       c.items = valid;
+      if (changed) {
+        try { localStorage.setItem(STORAGE_KEY, JSON.stringify(c)); } catch (_) {}
+      }
       return c;
     } catch (_) { return emptyCart(); }
   }
@@ -62,13 +75,20 @@
       if (!item || typeof item.id !== 'string' || !item.id.trim()) return false;
       var price = Number(item.price);
       if (!isFinite(price) || price <= 0) return false;
+      var incomingMax = Math.floor(Number(item.max_qty));
+      if (!isFinite(incomingMax) || incomingMax < 0) incomingMax = 0;
       var cart = load();
       var found = null;
       for (var i = 0; i < cart.items.length; i++) {
         if (cart.items[i].id === item.id) { found = cart.items[i]; break; }
       }
       if (found) {
-        found.quantity = (found.quantity || 1) + 1;
+        // Refresh max_qty from catalog if provided
+        if (incomingMax > 0) found.max_qty = incomingMax;
+        var effectiveMax = found.max_qty || 0;
+        var newQty = (found.quantity || 1) + 1;
+        if (effectiveMax > 0 && newQty > effectiveMax) return false;
+        found.quantity = newQty;
       } else {
         cart.items.push({
           id: String(item.id),
@@ -76,6 +96,7 @@
           price: price,
           quantity: 1,
           thumbnail: String(item.thumbnail || '').slice(0, 500),
+          max_qty: incomingMax,
         });
       }
       cart.idempotency_key = uuid();
@@ -96,6 +117,8 @@
       var cart = load();
       for (var i = 0; i < cart.items.length; i++) {
         if (cart.items[i].id === id) {
+          var maxQty = cart.items[i].max_qty || 0;
+          if (maxQty > 0 && qty > maxQty) qty = maxQty;
           cart.items[i].quantity = qty;
           cart.idempotency_key = uuid();
           save(cart);
@@ -128,12 +151,21 @@
   document.addEventListener('click', function (e) {
     var btn = e.target.closest('[data-action="add-to-cart"]');
     if (!btn) return;
-    var rawPrice = parseFloat(btn.dataset.price);
+
+    // En estado post-agregar: segundo clic navega al carrito
+    if (btn.dataset.goCart) {
+      window.location.href = '/carrito';
+      return;
+    }
+
+    var rawPrice  = parseFloat(btn.dataset.price);
+    var rawMaxQty = parseInt(btn.dataset.maxQty || '0', 10);
     var item = {
       id: btn.dataset.id || '',
       title: btn.dataset.title || '',
       price: isFinite(rawPrice) ? rawPrice : -1,
       thumbnail: btn.dataset.thumbnail || '',
+      max_qty: (isFinite(rawMaxQty) && rawMaxQty >= 0) ? rawMaxQty : 0,
     };
     var added = AmadoCart.add(item);
     if (!added) return;
@@ -141,12 +173,21 @@
     if (!label) return;
     var orig = label.dataset.origText || label.textContent;
     label.dataset.origText = orig;
-    label.textContent = 'Agregado ✓';
-    btn.disabled = true;
+    label.textContent = 'Agregado — Ver carrito';
+    btn.dataset.goCart = '1';
+    var prevAriaLabel = btn.getAttribute('aria-label');
+    if (prevAriaLabel !== null) {
+      btn.dataset.origAriaLabel = prevAriaLabel;
+      btn.setAttribute('aria-label', 'Ir al carrito');
+    }
     setTimeout(function () {
       label.textContent = orig;
-      btn.disabled = false;
+      delete btn.dataset.goCart;
       delete label.dataset.origText;
+      if (btn.dataset.origAriaLabel !== undefined) {
+        btn.setAttribute('aria-label', btn.dataset.origAriaLabel);
+        delete btn.dataset.origAriaLabel;
+      }
     }, 1500);
   });
 }());

--- a/astro-front/public/cart.js
+++ b/astro-front/public/cart.js
@@ -3,7 +3,7 @@
   if (window.AmadoCart) return;
 
   var STORAGE_KEY = 'amado-cart';
-  var VERSION = 1;
+  var VERSION = 2; // v2: incorpora max_qty; carritos v1 sin max_qty se descartan
 
   function uuid() {
     try { return crypto.randomUUID(); } catch (_) {
@@ -87,7 +87,7 @@
         if (incomingMax > 0) found.max_qty = incomingMax;
         var effectiveMax = found.max_qty || 0;
         var newQty = (found.quantity || 1) + 1;
-        if (effectiveMax > 0 && newQty > effectiveMax) return false;
+        if (effectiveMax > 0 && newQty > effectiveMax) return 'at_max';
         found.quantity = newQty;
       } else {
         cart.items.push({
@@ -168,12 +168,15 @@
       max_qty: (isFinite(rawMaxQty) && rawMaxQty >= 0) ? rawMaxQty : 0,
     };
     var added = AmadoCart.add(item);
-    if (!added) return;
+    if (added === false) return; // item inválido, sin feedback
+
     var label = btn.querySelector('[data-cart-label]');
     if (!label) return;
     var orig = label.dataset.origText || label.textContent;
     label.dataset.origText = orig;
-    label.textContent = 'Agregado — Ver carrito';
+    label.textContent = added === 'at_max'
+      ? 'Máximo disponible en el carrito — Ver carrito'
+      : 'Agregado — Ver carrito';
     btn.dataset.goCart = '1';
     var prevAriaLabel = btn.getAttribute('aria-label');
     if (prevAriaLabel !== null) {

--- a/astro-front/src/components/BookCard.astro
+++ b/astro-front/src/components/BookCard.astro
@@ -76,6 +76,7 @@ const installment   = fmt.format(Math.ceil(book.price / 12));
         data-title={book.title}
         data-price={book.price}
         data-thumbnail={img}
+        data-max-qty={book.available_quantity}
         aria-label={`Agregar "${book.title}" al carrito`}
       >
         <svg width="13" height="13" viewBox="0 0 24 24" fill="none"

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -82,17 +82,18 @@ import WAFloat from '../components/WAFloat.astro';
               <label for="delivery-address" class="form-label">Dirección <span class="form-req" aria-hidden="true">*</span></label>
               <input type="text" id="delivery-address" class="form-input"
                 placeholder="Ej: Av. Italia 2000, Apto 3"
-                autocomplete="street-address">
+                autocomplete="shipping street-address">
             </div>
             <div class="form-field">
               <label for="delivery-barrio" class="form-label">Barrio / Localidad</label>
               <input type="text" id="delivery-barrio" class="form-input"
                 placeholder="Ej: Pocitos, Centro, Malvín"
-                autocomplete="address-level3">
+                autocomplete="shipping address-level3">
             </div>
             <div class="form-field">
               <label for="delivery-departamento" class="form-label">Departamento <span class="form-req" aria-hidden="true">*</span></label>
-              <select id="delivery-departamento" class="form-input">
+              <select id="delivery-departamento" class="form-input"
+                autocomplete="shipping address-level1">
                 <option value="">Seleccioná tu departamento</option>
                 <option>Artigas</option>
                 <option>Canelones</option>
@@ -115,31 +116,24 @@ import WAFloat from '../components/WAFloat.astro';
                 <option>Treinta y Tres</option>
               </select>
             </div>
-            <div class="form-field">
-              <label for="delivery-phone" class="form-label">Teléfono / WhatsApp para coordinar</label>
-              <input type="tel" id="delivery-phone" class="form-input"
-                placeholder="Ej: 099 123 456"
-                autocomplete="tel">
-            </div>
           </div>
         </section>
 
         <!-- Datos del comprador -->
         <section class="cart-section">
-          <h2 class="cart-section-h2">Tus datos</h2>
-          <p class="buyer-note">Solo para coordinar el pedido. No se guardan en el navegador.</p>
+          <h2 class="cart-section-h2">Datos para coordinar</h2>
+          <p class="buyer-note">Podés usar los datos guardados en tu navegador. Amado Libros no guarda esta información en este dispositivo.</p>
           <div class="form-grid">
             <div class="form-field">
               <label for="buyer-name" class="form-label">Nombre</label>
               <input type="text" id="buyer-name" class="form-input" autocomplete="name">
             </div>
             <div class="form-field">
-              <label for="buyer-email" class="form-label">Email</label>
-              <input type="email" id="buyer-email" class="form-input" autocomplete="email">
-            </div>
-            <div class="form-field">
-              <label for="buyer-phone" class="form-label">Teléfono</label>
-              <input type="tel" id="buyer-phone" class="form-input" autocomplete="tel">
+              <label for="buyer-phone" class="form-label">WhatsApp / Teléfono</label>
+              <input type="tel" id="buyer-phone" class="form-input"
+                placeholder="Ej: 099 123 456"
+                autocomplete="tel"
+                inputmode="tel">
             </div>
           </div>
         </section>
@@ -864,14 +858,12 @@ import WAFloat from '../components/WAFloat.astro';
         var cart = window.AmadoCart.get();
         if (cart.items.length === 0) return;
 
-        var deliveryType  = getDeliveryType();
-        var address       = ((document.getElementById('delivery-address')     || {}).value || '').trim();
-        var barrio        = ((document.getElementById('delivery-barrio')       || {}).value || '').trim();
-        var departamento  = ((document.getElementById('delivery-departamento') || {}).value || '').trim();
-        var deliveryPhone = ((document.getElementById('delivery-phone')        || {}).value || '').trim();
-        var name          = ((document.getElementById('buyer-name')            || {}).value || '').trim();
-        var email         = ((document.getElementById('buyer-email')           || {}).value || '').trim();
-        var phone         = ((document.getElementById('buyer-phone')           || {}).value || '').trim();
+        var deliveryType = getDeliveryType();
+        var address      = ((document.getElementById('delivery-address')     || {}).value || '').trim();
+        var barrio       = ((document.getElementById('delivery-barrio')       || {}).value || '').trim();
+        var departamento = ((document.getElementById('delivery-departamento') || {}).value || '').trim();
+        var name         = ((document.getElementById('buyer-name')            || {}).value || '').trim();
+        var phone        = ((document.getElementById('buyer-phone')           || {}).value || '').trim();
 
         if (deliveryType === 'shipping') {
           if (!address) {
@@ -909,11 +901,9 @@ import WAFloat from '../components/WAFloat.astro';
           var lugar = [address, barrio, departamento].filter(Boolean).join(', ');
           lines.push('Entrega: Envío a domicilio — ' + lugar);
           lines.push('Coordinaremos contigo la franja horaria de entrega.');
-          if (deliveryPhone) lines.push('Tel/WA para coordinar: ' + deliveryPhone);
         }
         if (name)  lines.push('Nombre: ' + name);
-        if (email) lines.push('Email: ' + email);
-        if (phone) lines.push('Teléfono: ' + phone);
+        if (phone) lines.push('WhatsApp/Tel: ' + phone);
 
         var msg = encodeURIComponent(lines.join('\n'));
         window.open('https://wa.me/59899841325?text=' + msg, '_blank', 'noopener,noreferrer');

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -41,15 +41,18 @@ import WAFloat from '../components/WAFloat.astro';
           <button type="button" id="btn-clear" class="btn-clear">
             Vaciar carrito
           </button>
-          <p class="cart-subtotal-line">
-            Subtotal estimado:&nbsp;<strong id="cart-subtotal">$&nbsp;0</strong>
-          </p>
+          <div class="cart-totals">
+            <p class="cart-subtotal-line">Total de productos:&nbsp;<strong id="cart-subtotal">$&nbsp;0</strong></p>
+            <p class="cart-discount-line" id="cart-discount-line" hidden>Descuento retiro en local:&nbsp;<strong>− $150</strong></p>
+            <p class="cart-total-line" id="cart-total-line">Total:&nbsp;<strong id="cart-total">$&nbsp;0</strong></p>
+            <p class="cart-shipping-msg" id="cart-shipping-msg" hidden></p>
+          </div>
         </div>
 
         <p class="cart-price-note">
-          Precios orientativos. El total definitivo y el costo de envío se
-          confirman al coordinar el pago. Para pago por transferencia bancaria
-          aplicá el descuento del&nbsp;12&nbsp;%.
+          Los precios corresponden al catálogo vigente. El total se actualiza
+          según la forma de entrega y los descuentos aplicables.
+          Pagando por transferencia bancaria obtenés&nbsp;12&nbsp;% de descuento.
         </p>
 
         <!-- Entrega -->
@@ -58,22 +61,64 @@ import WAFloat from '../components/WAFloat.astro';
           <div class="delivery-opts">
             <label class="delivery-opt">
               <input type="radio" name="delivery" value="pickup" checked>
-              <span>Retiro en local (Montevideo)</span>
+              <span class="delivery-opt-content">
+                <strong class="delivery-opt-name">Retiro en Rincón 608</strong>
+                <span class="delivery-opt-meta">A pasos de Plaza Matriz · Lun–Vie 7:30–17:00</span>
+                <span class="delivery-opt-badge">Ahorrás $150 retirando aquí</span>
+              </span>
             </label>
             <label class="delivery-opt">
               <input type="radio" name="delivery" value="shipping">
-              <span>Envío a domicilio</span>
+              <span class="delivery-opt-content">
+                <strong class="delivery-opt-name">Envío a domicilio</strong>
+                <span class="delivery-opt-meta">Coordinamos contigo y el cadete entrega en una franja horaria de tu conveniencia.</span>
+              </span>
             </label>
           </div>
-          <div id="address-field" class="form-field" hidden>
-            <label for="delivery-address" class="form-label">Dirección de entrega</label>
-            <input
-              type="text"
-              id="delivery-address"
-              class="form-input"
-              placeholder="Ej: Av. Italia 2000, Apto 3, Montevideo"
-              autocomplete="street-address"
-            >
+          <div id="shipping-fields" class="shipping-fields" hidden>
+            <div class="form-field">
+              <label for="delivery-address" class="form-label">Dirección <span class="form-req" aria-hidden="true">*</span></label>
+              <input type="text" id="delivery-address" class="form-input"
+                placeholder="Ej: Av. Italia 2000, Apto 3"
+                autocomplete="street-address">
+            </div>
+            <div class="form-field">
+              <label for="delivery-barrio" class="form-label">Barrio / Localidad</label>
+              <input type="text" id="delivery-barrio" class="form-input"
+                placeholder="Ej: Pocitos, Centro, Malvín"
+                autocomplete="address-level3">
+            </div>
+            <div class="form-field">
+              <label for="delivery-departamento" class="form-label">Departamento <span class="form-req" aria-hidden="true">*</span></label>
+              <select id="delivery-departamento" class="form-input">
+                <option value="">Seleccioná tu departamento</option>
+                <option>Artigas</option>
+                <option>Canelones</option>
+                <option>Cerro Largo</option>
+                <option>Colonia</option>
+                <option>Durazno</option>
+                <option>Flores</option>
+                <option>Florida</option>
+                <option>Lavalleja</option>
+                <option>Maldonado</option>
+                <option>Montevideo</option>
+                <option>Paysandú</option>
+                <option>Río Negro</option>
+                <option>Rivera</option>
+                <option>Rocha</option>
+                <option>Salto</option>
+                <option>San José</option>
+                <option>Soriano</option>
+                <option>Tacuarembó</option>
+                <option>Treinta y Tres</option>
+              </select>
+            </div>
+            <div class="form-field">
+              <label for="delivery-phone" class="form-label">Teléfono / WhatsApp para coordinar</label>
+              <input type="tel" id="delivery-phone" class="form-input"
+                placeholder="Ej: 099 123 456"
+                autocomplete="tel">
+            </div>
           </div>
         </section>
 
@@ -205,11 +250,6 @@ import WAFloat from '../components/WAFloat.astro';
   }
   .btn-clear:hover { background: var(--border); color: var(--ink); }
 
-  .cart-subtotal-line {
-    font-size: 1rem;
-    color: var(--ink);
-  }
-
   /* ── Nota de precios ───────────────────────────── */
   .cart-price-note {
     font-size: 0.8rem;
@@ -248,11 +288,57 @@ import WAFloat from '../components/WAFloat.astro';
 
   .delivery-opt {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 0.6rem;
     font-size: 0.9rem;
     color: var(--ink);
     cursor: pointer;
+  }
+
+  .delivery-opt input[type="radio"] {
+    margin-top: 0.2rem;
+    flex-shrink: 0;
+  }
+
+  .delivery-opt-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .delivery-opt-name {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--ink);
+  }
+
+  .delivery-opt-meta {
+    font-size: 0.78rem;
+    color: var(--ink-2);
+    line-height: 1.4;
+  }
+
+  .delivery-opt-badge {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #267a42;
+    background: rgba(37, 160, 80, 0.1);
+    border-radius: 999px;
+    padding: 0.1rem 0.5rem;
+    align-self: flex-start;
+  }
+
+  .shipping-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 0.875rem;
+    margin-top: 0.875rem;
+    padding-top: 0.875rem;
+    border-top: 1px solid var(--border);
+  }
+
+  .form-req {
+    color: var(--salmon);
   }
 
   .buyer-note {
@@ -471,40 +557,123 @@ import WAFloat from '../components/WAFloat.astro';
     transition: color 0.1s;
   }
   :global(.cart-item-remove:hover) { color: var(--salmon-hover); }
+
+  /* ── Stock label ───────────────────────────────────── */
+  :global(.cart-item-stock-msg) {
+    grid-column: 2;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #b45309;
+    background: rgba(251, 191, 36, 0.15);
+    border-radius: 999px;
+    padding: 0.1rem 0.5rem;
+    align-self: flex-start;
+    margin-top: 0.1rem;
+  }
+
+  /* ── Totales ───────────────────────────────────────── */
+  .cart-totals {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    text-align: right;
+  }
+
+  .cart-subtotal-line {
+    font-size: 0.9rem;
+    color: var(--ink-2);
+  }
+
+  .cart-discount-line {
+    font-size: 0.875rem;
+    color: #267a42;
+  }
+
+  .cart-total-line {
+    font-size: 1rem;
+    color: var(--ink);
+    border-top: 1px solid var(--border);
+    padding-top: 0.2rem;
+    margin-top: 0.1rem;
+  }
+
+  .cart-shipping-msg {
+    font-size: 0.78rem;
+    color: #267a42;
+  }
 </style>
 
 <script is:inline>
   document.addEventListener('DOMContentLoaded', function () {
-    var loadingEl  = document.getElementById('cart-loading');
-    var emptyEl    = document.getElementById('cart-empty');
-    var contentEl  = document.getElementById('cart-content');
-    var itemsList  = document.getElementById('cart-items');
-    var subtotalEl = document.getElementById('cart-subtotal');
-    var announceEl = document.getElementById('cart-announce');
 
-    function announce(msg) {
-      if (!announceEl) return;
-      announceEl.textContent = '';
-      // pequeño delay para que el lector de pantalla detecte el cambio
-      setTimeout(function () { announceEl.textContent = msg; }, 50);
-    }
+    // ── Constantes ──────────────────────────────────────────────────────
+    var RETIRO_DISCOUNT             = 150;
+    var FREE_SHIPPING_THRESHOLD_UYU = null; // sin monto configurado aún
 
+    // ── Elementos ───────────────────────────────────────────────────────
+    var loadingEl        = document.getElementById('cart-loading');
+    var emptyEl          = document.getElementById('cart-empty');
+    var contentEl        = document.getElementById('cart-content');
+    var itemsList        = document.getElementById('cart-items');
+    var subtotalEl       = document.getElementById('cart-subtotal');
+    var discountLineEl   = document.getElementById('cart-discount-line');
+    var totalEl          = document.getElementById('cart-total');
+    var shippingMsgEl    = document.getElementById('cart-shipping-msg');
+    var announceEl       = document.getElementById('cart-announce');
+    var shippingFieldsEl = document.getElementById('shipping-fields');
+
+    // ── Formato moneda ───────────────────────────────────────────────────
     var fmt = new Intl.NumberFormat('es-UY', {
       style: 'currency', currency: 'UYU', maximumFractionDigits: 0,
     });
 
-    if (!window.AmadoCart) {
-      if (loadingEl) loadingEl.textContent = 'Error al cargar el módulo del carrito.';
-      return;
+    // ── Accesibilidad: anuncios ──────────────────────────────────────────
+    function announce(msg) {
+      if (!announceEl) return;
+      announceEl.textContent = '';
+      setTimeout(function () { announceEl.textContent = msg; }, 50);
     }
 
-    // ── Renderizado de un item ──────────────────────────────────────────
+    // ── Tipo de entrega ──────────────────────────────────────────────────
+    function getDeliveryType() {
+      var checked = document.querySelector('input[name="delivery"]:checked');
+      return checked ? checked.value : 'pickup';
+    }
+
+    // ── Calcular y mostrar totales ───────────────────────────────────────
+    function updateTotals() {
+      if (!window.AmadoCart) return;
+      var subtotal     = window.AmadoCart.subtotal();
+      var deliveryType = getDeliveryType();
+      var discount     = deliveryType === 'pickup' ? RETIRO_DISCOUNT : 0;
+      var total        = Math.max(0, subtotal - discount);
+
+      if (subtotalEl)    subtotalEl.textContent   = fmt.format(subtotal);
+      if (discountLineEl) discountLineEl.hidden    = (discount === 0);
+      if (totalEl)        totalEl.textContent      = fmt.format(total);
+
+      if (shippingMsgEl) {
+        if (FREE_SHIPPING_THRESHOLD_UYU !== null && deliveryType === 'shipping') {
+          if (subtotal >= FREE_SHIPPING_THRESHOLD_UYU) {
+            shippingMsgEl.textContent = '¡Ya tenés envío gratis!';
+          } else {
+            shippingMsgEl.textContent =
+              'Te faltan ' + fmt.format(FREE_SHIPPING_THRESHOLD_UYU - subtotal) +
+              ' para obtener envío gratis.';
+          }
+          shippingMsgEl.hidden = false;
+        } else {
+          shippingMsgEl.hidden = true;
+        }
+      }
+    }
+
+    // ── Construir fila de item ───────────────────────────────────────────
     function buildItemRow(item) {
       var art = document.createElement('article');
       art.className = 'cart-item';
       art.setAttribute('role', 'listitem');
 
-      // Imagen o placeholder
       if (item.thumbnail) {
         var img = document.createElement('img');
         img.src = item.thumbnail;
@@ -520,27 +689,27 @@ import WAFloat from '../components/WAFloat.astro';
         art.appendChild(ph);
       }
 
-      // Título
-      var title = document.createElement('p');
-      title.className = 'cart-item-title';
-      title.textContent = item.title;
-      art.appendChild(title);
+      var titleEl = document.createElement('p');
+      titleEl.className = 'cart-item-title';
+      titleEl.textContent = item.title;
+      art.appendChild(titleEl);
 
-      // Precio unitario
-      var unit = document.createElement('p');
-      unit.className = 'cart-item-unit-price';
-      unit.textContent = fmt.format(item.price) + ' c/u';
-      art.appendChild(unit);
+      var unitEl = document.createElement('p');
+      unitEl.className = 'cart-item-unit-price';
+      unitEl.textContent = fmt.format(item.price) + ' c/u';
+      art.appendChild(unitEl);
 
-      // Controles de cantidad
       var controls = document.createElement('div');
       controls.className = 'cart-item-controls';
+
+      var maxQty = item.max_qty || 0;
+      var atMax  = maxQty > 0 && item.quantity >= maxQty;
 
       var btnMinus = document.createElement('button');
       btnMinus.type = 'button';
       btnMinus.className = 'cart-qty-btn';
       btnMinus.textContent = '−';
-      btnMinus.setAttribute('aria-label', 'Disminuir cantidad');
+      btnMinus.setAttribute('aria-label', 'Disminuir cantidad de ' + item.title);
       btnMinus.addEventListener('click', function () {
         if (item.quantity <= 1) {
           announce('Se eliminó "' + item.title + '" del carrito.');
@@ -560,31 +729,44 @@ import WAFloat from '../components/WAFloat.astro';
       btnPlus.type = 'button';
       btnPlus.className = 'cart-qty-btn';
       btnPlus.textContent = '+';
-      btnPlus.setAttribute('aria-label', 'Aumentar cantidad');
-      btnPlus.addEventListener('click', function () {
-        announce('Cantidad de "' + item.title + '": ' + (item.quantity + 1) + '.');
-        window.AmadoCart.setQty(item.id, item.quantity + 1);
-      });
+      if (atMax) {
+        btnPlus.disabled = true;
+        btnPlus.setAttribute('aria-label', 'Sin stock adicional para ' + item.title);
+        btnPlus.title = 'Sin stock adicional disponible';
+      } else {
+        btnPlus.setAttribute('aria-label', 'Aumentar cantidad de ' + item.title);
+        btnPlus.addEventListener('click', function () {
+          if (maxQty > 0 && item.quantity >= maxQty) return;
+          announce('Cantidad de "' + item.title + '": ' + (item.quantity + 1) + '.');
+          window.AmadoCart.setQty(item.id, item.quantity + 1);
+        });
+      }
 
       controls.appendChild(btnMinus);
       controls.appendChild(qtyVal);
       controls.appendChild(btnPlus);
       art.appendChild(controls);
 
-      // Total de línea + quitar
+      if (maxQty === 1) {
+        var stockMsg = document.createElement('span');
+        stockMsg.className = 'cart-item-stock-msg';
+        stockMsg.textContent = 'Última unidad disponible';
+        art.appendChild(stockMsg);
+      }
+
       var lineTotal = document.createElement('div');
       lineTotal.className = 'cart-item-line-total';
 
-      var totalPrice = document.createElement('span');
-      totalPrice.className = 'cart-item-total-price';
-      totalPrice.textContent = fmt.format(item.price * item.quantity);
-      lineTotal.appendChild(totalPrice);
+      var lineTotalPrice = document.createElement('span');
+      lineTotalPrice.className = 'cart-item-total-price';
+      lineTotalPrice.textContent = fmt.format(item.price * item.quantity);
+      lineTotal.appendChild(lineTotalPrice);
 
       var btnRemove = document.createElement('button');
       btnRemove.type = 'button';
       btnRemove.className = 'cart-item-remove';
       btnRemove.textContent = 'Quitar';
-      btnRemove.setAttribute('aria-label', 'Quitar del carrito');
+      btnRemove.setAttribute('aria-label', 'Quitar "' + item.title + '" del carrito');
       btnRemove.addEventListener('click', function () {
         announce('Se eliminó "' + item.title + '" del carrito.');
         window.AmadoCart.remove(item.id);
@@ -595,44 +777,50 @@ import WAFloat from '../components/WAFloat.astro';
       return art;
     }
 
-    // ── Render completo ─────────────────────────────────────────────────
+    // ── Render completo ──────────────────────────────────────────────────
     function renderCart() {
+      if (!window.AmadoCart) return;
+      // load() ya aplica normalización silenciosa de max_qty
       var cart = window.AmadoCart.get();
 
       if (loadingEl) loadingEl.hidden = true;
 
       if (cart.items.length === 0) {
-        emptyEl.hidden   = false;
-        contentEl.hidden = true;
+        if (emptyEl)   emptyEl.hidden   = false;
+        if (contentEl) contentEl.hidden = true;
         return;
       }
 
-      emptyEl.hidden   = true;
-      contentEl.hidden = false;
+      if (emptyEl)   emptyEl.hidden   = true;
+      if (contentEl) contentEl.hidden = false;
 
-      // Reconstruir lista
       while (itemsList.firstChild) itemsList.removeChild(itemsList.firstChild);
       for (var i = 0; i < cart.items.length; i++) {
         itemsList.appendChild(buildItemRow(cart.items[i]));
       }
 
-      // Subtotal
-      subtotalEl.textContent = fmt.format(window.AmadoCart.subtotal());
+      updateTotals();
     }
 
-    // ── Escuchar cambios ────────────────────────────────────────────────
+    // ── Guardia ──────────────────────────────────────────────────────────
+    if (!window.AmadoCart) {
+      if (loadingEl) loadingEl.textContent = 'Error al cargar el módulo del carrito.';
+      return;
+    }
+
+    // ── Eventos ──────────────────────────────────────────────────────────
     document.addEventListener('amado:cart-updated', renderCart);
 
-    // ── Delivery toggle ─────────────────────────────────────────────────
+    // ── Toggle entrega ───────────────────────────────────────────────────
     var deliveryRadios = document.querySelectorAll('input[name="delivery"]');
-    var addressField   = document.getElementById('address-field');
     deliveryRadios.forEach(function (radio) {
       radio.addEventListener('change', function () {
-        if (addressField) addressField.hidden = (radio.value !== 'shipping');
+        if (shippingFieldsEl) shippingFieldsEl.hidden = (radio.value !== 'shipping');
+        updateTotals();
       });
     });
 
-    // ── Vaciar carrito ──────────────────────────────────────────────────
+    // ── Vaciar carrito ────────────────────────────────────────────────────
     var btnClear = document.getElementById('btn-clear');
     if (btnClear) {
       btnClear.addEventListener('click', function () {
@@ -642,32 +830,60 @@ import WAFloat from '../components/WAFloat.astro';
       });
     }
 
-    // ── WhatsApp: construir y enviar mensaje ────────────────────────────
+    // ── WhatsApp ──────────────────────────────────────────────────────────
     var btnWa = document.getElementById('btn-wa-order');
     if (btnWa) {
       btnWa.addEventListener('click', function () {
         var cart = window.AmadoCart.get();
         if (cart.items.length === 0) return;
 
-        var deliveryEl = document.querySelector('input[name="delivery"]:checked');
-        var deliveryType = deliveryEl ? deliveryEl.value : 'pickup';
-        var address = '';
-        var addrInput = document.getElementById('delivery-address');
-        if (addrInput) address = addrInput.value.trim();
+        var deliveryType  = getDeliveryType();
+        var address       = ((document.getElementById('delivery-address')     || {}).value || '').trim();
+        var barrio        = ((document.getElementById('delivery-barrio')       || {}).value || '').trim();
+        var departamento  = ((document.getElementById('delivery-departamento') || {}).value || '').trim();
+        var deliveryPhone = ((document.getElementById('delivery-phone')        || {}).value || '').trim();
+        var name          = ((document.getElementById('buyer-name')            || {}).value || '').trim();
+        var email         = ((document.getElementById('buyer-email')           || {}).value || '').trim();
+        var phone         = ((document.getElementById('buyer-phone')           || {}).value || '').trim();
 
-        var name  = (document.getElementById('buyer-name')  || {}).value || '';
-        var email = (document.getElementById('buyer-email') || {}).value || '';
-        var phone = (document.getElementById('buyer-phone') || {}).value || '';
+        if (deliveryType === 'shipping') {
+          if (!address) {
+            alert('Por favor ingresá la dirección de entrega.');
+            var addrEl = document.getElementById('delivery-address');
+            if (addrEl) addrEl.focus();
+            return;
+          }
+          if (!departamento) {
+            alert('Por favor seleccioná el departamento.');
+            var deptEl = document.getElementById('delivery-departamento');
+            if (deptEl) deptEl.focus();
+            return;
+          }
+        }
+
+        var subtotal = window.AmadoCart.subtotal();
+        var discount = deliveryType === 'pickup' ? RETIRO_DISCOUNT : 0;
+        var total    = Math.max(0, subtotal - discount);
 
         var lines = ['Hola Amado Libros! Quiero hacer este pedido:'];
+        lines.push('');
         for (var i = 0; i < cart.items.length; i++) {
           var it = cart.items[i];
           lines.push('• ' + it.title + ' (x' + it.quantity + ') — ' + fmt.format(it.price) + ' c/u');
         }
-        lines.push('Subtotal estimado: ' + fmt.format(window.AmadoCart.subtotal()) + ' UYU');
-        lines.push('Entrega: ' + (deliveryType === 'shipping'
-          ? ('Envío a domicilio' + (address ? ': ' + address : ''))
-          : 'Retiro en local'));
+        lines.push('');
+        lines.push('Total de productos: ' + fmt.format(subtotal) + ' UYU');
+        if (deliveryType === 'pickup') {
+          lines.push('Descuento retiro en local: − $' + RETIRO_DISCOUNT);
+          lines.push('Total final: ' + fmt.format(total) + ' UYU');
+          lines.push('Entrega: Retiro en Rincón 608');
+        } else {
+          lines.push('Total final: ' + fmt.format(total) + ' UYU');
+          var lugar = [address, barrio, departamento].filter(Boolean).join(', ');
+          lines.push('Entrega: Envío a domicilio — ' + lugar);
+          lines.push('Coordinaremos contigo la franja horaria de entrega.');
+          if (deliveryPhone) lines.push('Tel/WA para coordinar: ' + deliveryPhone);
+        }
         if (name)  lines.push('Nombre: ' + name);
         if (email) lines.push('Email: ' + email);
         if (phone) lines.push('Teléfono: ' + phone);
@@ -677,7 +893,7 @@ import WAFloat from '../components/WAFloat.astro';
       });
     }
 
-    // ── Render inicial ──────────────────────────────────────────────────
+    // ── Render inicial ────────────────────────────────────────────────────
     renderCart();
   });
 </script>

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -43,8 +43,10 @@ import WAFloat from '../components/WAFloat.astro';
           </button>
           <div class="cart-totals">
             <p class="cart-subtotal-line">Total de productos:&nbsp;<strong id="cart-subtotal">$&nbsp;0</strong></p>
-            <p class="cart-discount-line" id="cart-discount-line" hidden>Descuento retiro en local:&nbsp;<strong>− $150</strong></p>
-            <p class="cart-total-line" id="cart-total-line">Total:&nbsp;<strong id="cart-total">$&nbsp;0</strong></p>
+            <p class="cart-discount-line" id="cart-discount-line" hidden>Ahorro por retiro:&nbsp;<strong>−&nbsp;$150</strong></p>
+            <p class="cart-total-line" id="cart-total-line" hidden>Total con retiro:&nbsp;<strong id="cart-total">$&nbsp;0</strong></p>
+            <p class="cart-shipping-note" id="cart-shipping-note" hidden>Envío: a coordinar según destino</p>
+            <p class="cart-transfer-note" id="cart-transfer-note" hidden>Pagando por transferencia se aplica además 12&nbsp;% de descuento.</p>
             <p class="cart-shipping-msg" id="cart-shipping-msg" hidden></p>
           </div>
         </div>
@@ -597,6 +599,17 @@ import WAFloat from '../components/WAFloat.astro';
     margin-top: 0.1rem;
   }
 
+  .cart-shipping-note {
+    font-size: 0.85rem;
+    color: var(--ink-2);
+  }
+
+  .cart-transfer-note {
+    font-size: 0.78rem;
+    color: var(--ink-2);
+    font-style: italic;
+  }
+
   .cart-shipping-msg {
     font-size: 0.78rem;
     color: #267a42;
@@ -617,7 +630,10 @@ import WAFloat from '../components/WAFloat.astro';
     var itemsList        = document.getElementById('cart-items');
     var subtotalEl       = document.getElementById('cart-subtotal');
     var discountLineEl   = document.getElementById('cart-discount-line');
+    var totalLineEl      = document.getElementById('cart-total-line');
     var totalEl          = document.getElementById('cart-total');
+    var shippingNoteEl   = document.getElementById('cart-shipping-note');
+    var transferNoteEl   = document.getElementById('cart-transfer-note');
     var shippingMsgEl    = document.getElementById('cart-shipping-msg');
     var announceEl       = document.getElementById('cart-announce');
     var shippingFieldsEl = document.getElementById('shipping-fields');
@@ -645,15 +661,26 @@ import WAFloat from '../components/WAFloat.astro';
       if (!window.AmadoCart) return;
       var subtotal     = window.AmadoCart.subtotal();
       var deliveryType = getDeliveryType();
-      var discount     = deliveryType === 'pickup' ? RETIRO_DISCOUNT : 0;
-      var total        = Math.max(0, subtotal - discount);
+      var isPickup     = deliveryType === 'pickup';
 
-      if (subtotalEl)    subtotalEl.textContent   = fmt.format(subtotal);
-      if (discountLineEl) discountLineEl.hidden    = (discount === 0);
-      if (totalEl)        totalEl.textContent      = fmt.format(total);
+      if (subtotalEl) subtotalEl.textContent = fmt.format(subtotal);
+
+      if (isPickup) {
+        var total = Math.max(0, subtotal - RETIRO_DISCOUNT);
+        if (discountLineEl) discountLineEl.hidden = false;
+        if (totalLineEl)    totalLineEl.hidden    = false;
+        if (totalEl)        totalEl.textContent   = fmt.format(total);
+        if (shippingNoteEl) shippingNoteEl.hidden = true;
+        if (transferNoteEl) transferNoteEl.hidden = false;
+      } else {
+        if (discountLineEl) discountLineEl.hidden = true;
+        if (totalLineEl)    totalLineEl.hidden    = true;
+        if (shippingNoteEl) shippingNoteEl.hidden = false;
+        if (transferNoteEl) transferNoteEl.hidden = true;
+      }
 
       if (shippingMsgEl) {
-        if (FREE_SHIPPING_THRESHOLD_UYU !== null && deliveryType === 'shipping') {
+        if (FREE_SHIPPING_THRESHOLD_UYU !== null && !isPickup) {
           if (subtotal >= FREE_SHIPPING_THRESHOLD_UYU) {
             shippingMsgEl.textContent = '¡Ya tenés envío gratis!';
           } else {
@@ -862,8 +889,6 @@ import WAFloat from '../components/WAFloat.astro';
         }
 
         var subtotal = window.AmadoCart.subtotal();
-        var discount = deliveryType === 'pickup' ? RETIRO_DISCOUNT : 0;
-        var total    = Math.max(0, subtotal - discount);
 
         var lines = ['Hola Amado Libros! Quiero hacer este pedido:'];
         lines.push('');
@@ -874,11 +899,13 @@ import WAFloat from '../components/WAFloat.astro';
         lines.push('');
         lines.push('Total de productos: ' + fmt.format(subtotal) + ' UYU');
         if (deliveryType === 'pickup') {
-          lines.push('Descuento retiro en local: − $' + RETIRO_DISCOUNT);
-          lines.push('Total final: ' + fmt.format(total) + ' UYU');
+          var total = Math.max(0, subtotal - RETIRO_DISCOUNT);
+          lines.push('Ahorro por retiro: −$' + RETIRO_DISCOUNT);
+          lines.push('Total con retiro: ' + fmt.format(total) + ' UYU');
+          lines.push('Nota: pagando por transferencia bancaria se aplica además 12 % de descuento.');
           lines.push('Entrega: Retiro en Rincón 608');
         } else {
-          lines.push('Total final: ' + fmt.format(total) + ' UYU');
+          lines.push('Envío: a coordinar según destino');
           var lugar = [address, barrio, departamento].filter(Boolean).join(', ');
           lines.push('Entrega: Envío a domicilio — ' + lugar);
           lines.push('Coordinaremos contigo la franja horaria de entrega.');

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -331,7 +331,18 @@ function renderPage(item, slug, isPreview) {
     header{background:#1e293b;color:white;padding:.75rem 1.25rem;
            display:flex;align-items:center;gap:.75rem}
     header a{color:white;text-decoration:none;font-weight:700;font-size:1.05rem}
-    header span{color:#94a3b8;font-size:.8rem}
+    header span{color:#94a3b8;font-size:.8rem;flex:1}
+    .ssr-cart-link{position:relative;display:inline-flex;align-items:center;justify-content:center;
+                   min-width:44px;min-height:44px;padding:.4rem .6rem;
+                   color:rgba(255,255,255,.75);border:1px solid rgba(255,255,255,.18);
+                   border-radius:999px;background:rgba(255,255,255,.08);
+                   text-decoration:none;flex-shrink:0;
+                   transition:background .15s,border-color .15s,color .15s}
+    .ssr-cart-link:hover{background:rgba(255,255,255,.14);border-color:rgba(255,255,255,.28);color:#fff}
+    .ssr-cart-badge{position:absolute;top:-5px;right:-5px;min-width:17px;height:17px;
+                    padding:0 4px;border-radius:999px;background:#e49982;color:#fff;
+                    font-size:.625rem;font-weight:700;line-height:17px;
+                    text-align:center;pointer-events:none}
     nav{background:white;padding:.5rem 1.25rem;font-size:.85rem;
         border-bottom:1px solid #e2e8f0;color:#64748b}
     nav a{color:#3b82f6;text-decoration:none}
@@ -402,6 +413,14 @@ function renderPage(item, slug, isPreview) {
 <header>
   <a href="/">📚 Amado Libros</a>
   <span>Tu librería para libros difíciles de ubicar</span>
+  <a href="/carrito" id="ssr-cart-link" class="ssr-cart-link" aria-label="Ver carrito">
+    <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/>
+      <path d="M1 1h4l2.68 13.39a2 2 0 001.98 1.61h9.72a2 2 0 001.98-1.61L23 6H6"/>
+    </svg>
+    <span id="ssr-cart-badge" class="ssr-cart-badge" hidden aria-hidden="true">0</span>
+  </a>
 </header>
 
 <nav>
@@ -431,6 +450,7 @@ function renderPage(item, slug, isPreview) {
         data-title="${escapeHtml(item.title)}"
         data-price="${price}"
         data-thumbnail="${escapeHtml(images[0] || '')}"
+        data-max-qty="${stockQty}"
       >
         <span data-cart-label>🛒 Agregar al carrito</span>
       </button>
@@ -450,6 +470,29 @@ function renderPage(item, slug, isPreview) {
   <a href="/">Catálogo</a> ·
   <a href="/politicas">Políticas</a>
 </footer>
+
+<script>(function(){
+  function updateBadge(n){
+    var badge=document.getElementById('ssr-cart-badge');
+    var link=document.getElementById('ssr-cart-link');
+    if(!badge||!link)return;
+    if(n>0){
+      badge.textContent=n>99?'99+':String(n);
+      badge.hidden=false;
+      link.setAttribute('aria-label','Ver carrito ('+(n===1?'1 artículo':n+' artículos')+')');
+    }else{
+      badge.hidden=true;
+      link.setAttribute('aria-label','Ver carrito');
+    }
+  }
+  document.addEventListener('DOMContentLoaded',function(){
+    if(window.AmadoCart)updateBadge(window.AmadoCart.count());
+    document.addEventListener('amado:cart-updated',function(e){
+      var items=e.detail&&Array.isArray(e.detail.items)?e.detail.items:[];
+      updateBadge(items.reduce(function(s,i){return s+(i.quantity||0);},0));
+    });
+  });
+}());<\/script>
 
 </body>
 </html>`;


### PR DESCRIPTION
## Qué incluye

- Elimina “precios orientativos” y “subtotal estimado”.
- Retiro en Rincón 608 con ahorro real de $150.
- Formulario de envío con dirección, localidad y departamento.
- Control de cantidades usando `available_quantity`.
- Carrito visible también en fichas SSR.
- Feedback “Agregado — Ver carrito”.
- WhatsApp con totales, descuentos y entrega completos.
- Umbral de envío gratis preparado, pero desactivado hasta definir monto.

## Qué no incluye

- No Mercado Pago.
- No D1.
- No cambios de workflows, secretos ni producción directa.

## Validación local

- `node --check` OK.
- `git diff --check` OK.
- `npm ci` OK.
- `npm run build` OK.

No mergear sin aprobación explícita de Seba.