### PR TITLE
fix(seo): quitar bloqueo global de indexación y caché

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -34,7 +34,12 @@ jobs:
           grep -q "Astro build OK" astro-front/dist/index.html
           grep -q "noindex, nofollow" astro-front/dist/index.html
           test -f astro-front/dist/_headers
-          grep -q "X-Robots-Tag: noindex, nofollow" astro-front/dist/_headers
+          # _headers ya no debe llevar la regla global de noindex/no-store:
+          # esa regla se aplicaba por igual en Preview y Producción. La
+          # protección de Preview la impone functions/_middleware.js
+          # (condicionado por hostname *.pages.dev), no _headers.
+          ! grep -q "X-Robots-Tag: noindex, nofollow" astro-front/dist/_headers
+          ! grep -q "Cache-Control: no-store" astro-front/dist/_headers
 
       - name: Deploy preview to CF Pages
         run: npx wrangler@3 pages deploy ./astro-front/dist --project-name amadolibros-web --branch astro-migration

--- a/astro-front/public/_headers
+++ b/astro-front/public/_headers
@@ -1,4 +1,12 @@
-# Preview de migración — no indexar, no cachear
-/*
-  X-Robots-Tag: noindex, nofollow
-  Cache-Control: no-store
+# Este archivo aplica por igual a Preview y a Producción (Cloudflare Pages
+# no permite condicionar _headers por hostname). La protección real de
+# Preview (noindex + no-store) la aplica functions/_middleware.js, que sí
+# distingue el ambiente (hostname *.pages.dev) y la inyecta en cada
+# response — incluidas las de assets estáticos, que pasan por el mismo
+# middleware antes de servirse.
+#
+# Una regla global acá (aunque diga "solo Preview" en el comentario)
+# también se aplica en Producción, sin excepción — eso hacía que la
+# portada, /carrito y /pedido quedaran noindex + no-store en
+# www.amadolibros.com. No agregar reglas de robots/caché en este archivo
+# sin verificar antes que no se filtren a Producción.


### PR DESCRIPTION
## Alcance

Este PR incluye exclusivamente el fix SEO-Headers:

- elimina de `astro-front/public/_headers` la regla global que aplicaba `X-Robots-Tag: noindex, nofollow` y `Cache-Control: no-store`;
- actualiza la validación obsoleta de `.github/workflows/deploy-preview.yml`.

## Motivo

La regla global bloqueaba la indexación de las páginas estáticas de Producción y desactivaba la caché de los assets.

## Protección de Preview

Preview continúa protegido mediante `functions/_middleware.js`, según el hostname.

El workflow automático fue ejecutado correctamente y las rutas verificadas conservaron:

- `X-Robots-Tag: noindex, nofollow`
- `Cache-Control: no-store`

## Validación

- Workflow `Deploy Astro Preview`: exitoso.
- Build de Producción con `PUBLIC_INDEXABLE=true`: exitoso.
- `dist/_headers`: sin bloqueo global.
- Portada: `index, follow`.
- Carrito: `noindex, nofollow`.
- Pedido: `noindex, nofollow`.

## Fuera de alcance

Este PR no incluye:

- Lote Comercial 2-A;
- cambios de catálogo;
- carrito;
- checkout;
- pagos;
- ningún otro cambio funcional.

## Producción

Producción continúa sin modificar en `dae6599`.

## Rollback

Revertir los dos commits incorporados por este PR y permitir que el workflow de Producción redespliegue el estado anterior.