### PR TITLE
feat(cart): cierre por WhatsApp sin fricción

### DIFF
--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -138,32 +138,21 @@ import WAFloat from '../components/WAFloat.astro';
           </div>
         </section>
 
-        <!-- Acciones de pago -->
-        <section class="cart-pay-section">
-          <button
-            type="button"
-            class="btn-pay-soon"
-            disabled
-            aria-disabled="true"
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
-              stroke="currentColor" stroke-width="2" aria-hidden="true">
-              <rect x="1" y="4" width="22" height="16" rx="2" ry="2"/>
-              <line x1="1" y1="10" x2="23" y2="10"/>
-            </svg>
-            Pagar con Mercado Pago
-            <span class="soon-chip">próximamente</span>
-          </button>
+        <!-- Cierre asistido por WhatsApp -->
+        <section class="cart-pay-section" aria-labelledby="cart-checkout-title">
+          <h2 id="cart-checkout-title" class="cart-checkout-title">Finalizá tu pedido</h2>
           <p class="pay-note">
-            Estamos integrando el pago online. Mientras tanto podés enviarnos el
-            pedido por WhatsApp y te respondemos con los datos de pago.
+            Enviá el carrito y confirmamos contigo el stock, la entrega y el total final.
           </p>
           <button type="button" id="btn-wa-order" class="btn-wa-order">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z"/>
             </svg>
-            Finalizar pedido por WhatsApp
+            Enviar pedido por WhatsApp
           </button>
+          <p class="checkout-reassurance">
+            No pagás ahora. Te enviamos los datos para transferencia o un link de Mercado Pago.
+          </p>
         </section>
 
       </div><!-- /#cart-content -->
@@ -377,46 +366,29 @@ import WAFloat from '../components/WAFloat.astro';
     border-color: var(--salmon);
   }
 
-  /* ── Sección de pago ───────────────────────────── */
+  /* ── Cierre por WhatsApp ───────────────────────── */
   .cart-pay-section {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
-    padding-top: 0.5rem;
-  }
-
-  .btn-pay-soon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    padding: 0.875rem 1.5rem;
-    background: #d1d5db;
-    color: #6b7280;
-    border: none;
+    gap: 0.75rem;
+    padding: 1.25rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
     border-radius: var(--r);
-    font-family: var(--font-ui);
-    font-size: 0.95rem;
-    font-weight: 600;
-    cursor: not-allowed;
-    width: 100%;
   }
 
-  .soon-chip {
-    font-size: 0.7rem;
+  .cart-checkout-title {
+    font-family: var(--font-ui);
+    font-size: 1.05rem;
     font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    background: #9ca3af;
-    color: #fff;
-    padding: 0.2rem 0.5rem;
-    border-radius: 999px;
+    color: var(--ink);
+    text-align: center;
   }
 
   .pay-note {
-    font-size: 0.82rem;
+    font-size: 0.875rem;
     color: var(--ink-2);
-    line-height: 1.6;
+    line-height: 1.5;
     text-align: center;
   }
 
@@ -435,9 +407,22 @@ import WAFloat from '../components/WAFloat.astro';
     font-weight: 700;
     cursor: pointer;
     width: 100%;
-    transition: background 0.15s;
+    min-height: 48px;
+    transition: background 0.15s, transform 0.15s;
   }
   .btn-wa-order:hover { background: var(--wa-hover); }
+  .btn-wa-order:active { transform: translateY(1px); }
+  .btn-wa-order:focus-visible {
+    outline: 3px solid var(--ink);
+    outline-offset: 3px;
+  }
+
+  .checkout-reassurance {
+    font-size: 0.78rem;
+    color: var(--ink-2);
+    line-height: 1.5;
+    text-align: center;
+  }
 
   /* ── Items creados por JS ──────────────────────── */
   :global(.cart-item) {
@@ -882,7 +867,7 @@ import WAFloat from '../components/WAFloat.astro';
 
         var subtotal = window.AmadoCart.subtotal();
 
-        var lines = ['Hola Amado Libros! Quiero hacer este pedido:'];
+        var lines = ['PEDIDO WEB', '', 'Hola Amado Libros! Quiero hacer este pedido:'];
         lines.push('');
         for (var i = 0; i < cart.items.length; i++) {
           var it = cart.items[i];


### PR DESCRIPTION
## Alcance

Este PR modifica únicamente `astro-front/src/pages/carrito.astro`.

## Qué cambia

- elimina el botón deshabilitado de Mercado Pago;
- convierte WhatsApp en la única acción principal del cierre;
- explica que Amado Libros confirma stock, entrega y total final;
- aclara que el cliente no paga al enviar el carrito;
- agrega `PEDIDO WEB` al comienzo del mensaje para identificar el origen;
- mejora jerarquía visual, foco accesible y tamaño táctil mobile.

## Qué no cambia

- precios, descuentos ni totales;
- validaciones de dirección y departamento;
- número de WhatsApp;
- catálogo, fichas, pagos, webhook o D1;
- Producción.

## Validación

- `git diff --check`: OK;
- build con `PUBLIC_INDEXABLE=true`: OK;
- prueba de ausencia del CTA inoperante: OK;
- prueba del CTA único de WhatsApp y prefijo `PEDIDO WEB`: OK;
- diff limitado a un archivo: OK.

## Rollback

Revertir el único commit de este PR.