### PR TITLE
feat(2-K-E2b): conectar D1 Producción a wrangler.toml con checkout ap…

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -25,12 +25,6 @@ binding = "ORDERS_DB"
 database_name = "amadolibros-orders-preview"
 database_id = "6fa387af-f29e-46dc-97e5-30298568b4a6"
 
-# Auditoría 2-N-E1: no existe (ni debe crearse en este lote) un bloque
-# [[env.production.d1_databases]] ni un [[d1_databases]] de nivel superior.
-# ORDERS_DB solo vive bajo env.preview. Si algún día se agrega Production,
-# Cloudflare exige declarar su propio binding ORDERS_DB con un database_id
-# DISTINTO al de Preview — nunca reutilizar este database_id.
-#
 # Vars no secretas de Preview — env.preview.vars aplica a TODOS los
 # preview deployments del proyecto, no solo a esta rama. CANONICAL_ORIGIN
 # queda fijado al alias de esta rama porque Cloudflare Pages no permite
@@ -42,3 +36,28 @@ APP_ENV           = "preview"
 MP_COLLECTOR_ID   = "3559407834"
 CHECKOUT_ENABLED  = "true"
 CANONICAL_ORIGIN  = "https://feature-2-n-e1-production-re.amadolibros-web.pages.dev"
+
+# ── Producción (2-K-E2) ───────────────────────────────────────────────────
+# Base D1 propia, con database_id DISTINTO al de Preview — nunca reutilizar
+# el de env.preview. Creada y migrada (0001+0002) en 2-K-E2, verificada
+# vacía y con el esquema correcto antes de conectarla acá.
+[[env.production.kv_namespaces]]
+binding = "AMADO_KV"
+id = "6ea0ff4682d647118442a24fe384abc4"
+
+[[env.production.d1_databases]]
+binding = "ORDERS_DB"
+database_name = "amadolibros-orders-production"
+database_id = "6dc8dc3a-2d4f-4045-b428-14323c7b0bcd"
+
+# CHECKOUT_ENABLED en "false": el kill switch queda apagado a propósito.
+# MP_COLLECTOR_ID de Producción todavía no está confirmado (no asumir el
+# ID de owner de la app como collector real de LIVE — ver
+# docs/environments.md) y no se declara acá; sin él, resolveConfig()
+# falla cerrado (503) en cualquier endpoint de pagos, lo cual es
+# intencional mientras no haya credenciales LIVE cargadas.
+[env.production.vars]
+APP_ENV           = "production"
+CHECKOUT_ENABLED  = "false"
+CANONICAL_ORIGIN  = "https://www.amadolibros.com"
+ALLOWED_HOSTS     = "amadolibros.com,www.amadolibros.com"


### PR DESCRIPTION
…agado

Agrega el bloque env.production que faltaba para que el código de pagos (ya existente en esta rama) pueda resolver ORDERS_DB y APP_ENV en Producción:

- env.production.d1_databases: ORDERS_DB -> amadolibros-orders-production (database_id 6dc8dc3a-2d4f-4045-b428-14323c7b0bcd, DISTINTO al de Preview). Base creada y migrada (0001+0002) en el lote 2-K-E2, verificada vacía y con el esquema correcto antes de conectarla acá.
- env.production.kv_namespaces: AMADO_KV, mismo KV que Preview/top-level.
- env.production.vars: APP_ENV=production, CHECKOUT_ENABLED=false (kill switch apagado a propósito), CANONICAL_ORIGIN= https://www.amadolibros.com, ALLOWED_HOSTS=amadolibros.com, www.amadolibros.com.

MP_COLLECTOR_ID de Producción no se declara: todavía no está confirmado (no asumir el ID de owner de la app como collector real de LIVE). Sin él, resolveConfig() falla cerrado (503) en cualquier endpoint de pagos — intencional mientras no haya credenciales LIVE.

Validado con wrangler d1 migrations list -e production --remote (solo lectura): resuelve correctamente a la base productiva ya migrada, "No migrations to apply".

Tests: 192/192. Build de Astro: OK.

No se tocó main, D1 Preview, D1 Producción (solo lectura), secrets, Mercado Pago ni ningún deploy.