### PR TITLE
fix(seo): publicar robots.txt y canonical correctos

### DIFF
--- a/astro-front/public/robots.txt
+++ b/astro-front/public/robots.txt
@@ -1,0 +1,15 @@
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /admin/
+
+Sitemap: https://www.amadolibros.com/sitemap.xml

--- a/astro-front/src/layouts/BaseLayout.astro
+++ b/astro-front/src/layouts/BaseLayout.astro
@@ -3,11 +3,13 @@ interface Props {
   title?: string;
   description?: string;
   indexable?: boolean;
+  canonical?: string;
 }
 const {
   title = 'Amado Libros — Librería uruguaya',
   description = 'Libros importados y por encargo en Uruguay. Entrega hoy en Montevideo, envíos a todo el país.',
   indexable: indexableProp,
+  canonical,
 } = Astro.props;
 
 const indexable  = indexableProp !== undefined ? indexableProp : import.meta.env.PUBLIC_INDEXABLE === 'true';
@@ -22,6 +24,7 @@ const enableGA4  = indexable && !!gaId;
   <meta name="robots" content={indexable ? 'index, follow' : 'noindex, nofollow'}>
   <title>{title}</title>
   <meta name="description" content={description}>
+  {canonical && <link rel="canonical" href={canonical}>}
   {enableGA4 && (
     <>
       <script async src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}></script>

--- a/astro-front/src/pages/index.astro
+++ b/astro-front/src/pages/index.astro
@@ -13,7 +13,7 @@ import HowToBuy           from '../components/HowToBuy.astro';
 import ShippingPayments    from '../components/ShippingPayments.astro';
 import NotFoundCTA         from '../components/NotFoundCTA.astro';
 ---
-<BaseLayout>
+<BaseLayout canonical="https://www.amadolibros.com/">
   <Header showSearch={false} showMobileDeliveryBanner={true} />
   <main>
     <Hero />

--- a/functions/sitemap.xml.js
+++ b/functions/sitemap.xml.js
@@ -28,7 +28,6 @@ export async function onRequest(ctx) {
     // Páginas estáticas: lastmod = hoy (se actualizan con cada deploy).
     const staticPages = [
         { loc: `${BASE}/`,                                    changefreq: 'daily',   priority: '1.0', lastmod: today },
-        { loc: `${BASE}/politicas`,                         changefreq: 'monthly', priority: '0.3', lastmod: today },
         { loc: `${BASE}/catalogo`,                          changefreq: 'daily',   priority: '0.5', lastmod: today },
         { loc: `${BASE}/libros-maria-montessori-uruguay`,   changefreq: 'weekly',  priority: '0.8', lastmod: today },
     ];

--- a/scripts/smoke-production.js
+++ b/scripts/smoke-production.js
@@ -29,8 +29,11 @@ const INTERNAL_FIELDS = [
 ];
 
 const ROUTES = [
-  { path: '/' },
-  { path: '/catalogo' },
+  { path: '/', kind: 'html', canonical: `${BASE_URL}/`, robots: 'index, follow' },
+  { path: '/catalogo', kind: 'html', canonical: `${BASE_URL}/catalogo`, robots: 'index, follow' },
+  { path: '/catalogo?q=zzzinexistente999', kind: 'html', canonical: `${BASE_URL}/catalogo`, robots: 'noindex' },
+  { path: '/robots.txt', kind: 'robots' },
+  { path: '/sitemap.xml', kind: 'sitemap' },
   { path: '/api/health' },
   { path: '/api/status' },
 ];
@@ -67,6 +70,17 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function hasHtmlMeta(body, name, expected) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const tag = body.match(new RegExp(`<meta\\s+name=["']${escaped}["'][^>]*>`, 'i'));
+  return !!tag && tag[0].toLowerCase().includes(`content="${expected.toLowerCase()}"`);
+}
+
+function hasCanonical(body, expected) {
+  const tags = body.match(/<link\s+[^>]*rel=["']canonical["'][^>]*>/gi) || [];
+  return tags.some(tag => tag.includes(`href="${expected}"`));
+}
+
 function writeGitHubOutputs(attemptsUsed, result) {
   const outputFile = process.env.GITHUB_OUTPUT;
   if (!outputFile) return;
@@ -91,8 +105,9 @@ async function checkRoute(path) {
 
   const { status } = resp;
 
-  // ── / and /catalogo ──────────────────────────────────────────────────────
-  if (path === '/' || path === '/catalogo') {
+  // ── HTML indexable/noindex routes ────────────────────────────────────────
+  const route = ROUTES.find(r => r.path === path);
+  if (route && route.kind === 'html') {
     if (status !== 200) {
       return { ok: false, path, reason: `HTTP ${status} (expected 200)` };
     }
@@ -102,6 +117,44 @@ async function checkRoute(path) {
     const body = await resp.text();
     if (!body || body.trim().length === 0) {
       return { ok: false, path, reason: 'empty body' };
+    }
+    if (!hasCanonical(body, route.canonical)) {
+      return { ok: false, path, reason: `missing canonical "${route.canonical}"` };
+    }
+    if (!hasHtmlMeta(body, 'robots', route.robots)) {
+      return { ok: false, path, reason: `missing robots meta "${route.robots}"` };
+    }
+    return { ok: true, path };
+  }
+
+  // ── /robots.txt ──────────────────────────────────────────────────────────
+  if (path === '/robots.txt') {
+    if (status !== 200) return { ok: false, path, reason: `HTTP ${status} (expected 200)` };
+    if (!hasContentType(resp.headers, 'text/plain')) {
+      return { ok: false, path, reason: `Content-Type not text/plain (got: ${resp.headers.get('content-type') || 'none'})` };
+    }
+    const body = await resp.text();
+    if (!/^User-agent:/m.test(body) || !body.includes(`Sitemap: ${BASE_URL}/sitemap.xml`)) {
+      return { ok: false, path, reason: 'invalid robots.txt body or missing sitemap directive' };
+    }
+    if (/<html|<!doctype/i.test(body)) {
+      return { ok: false, path, reason: 'robots.txt returned HTML' };
+    }
+    return { ok: true, path };
+  }
+
+  // ── /sitemap.xml ─────────────────────────────────────────────────────────
+  if (path === '/sitemap.xml') {
+    if (status !== 200) return { ok: false, path, reason: `HTTP ${status} (expected 200)` };
+    if (!hasContentType(resp.headers, 'application/xml')) {
+      return { ok: false, path, reason: `Content-Type not XML (got: ${resp.headers.get('content-type') || 'none'})` };
+    }
+    const body = await resp.text();
+    if (!body.startsWith('<?xml') || !body.includes('<urlset ') || !body.includes(`<loc>${BASE_URL}/</loc>`)) {
+      return { ok: false, path, reason: 'invalid sitemap XML body' };
+    }
+    if (body.includes(`<loc>${BASE_URL}/politicas</loc>`)) {
+      return { ok: false, path, reason: 'sitemap includes unavailable /politicas page' };
     }
     return { ok: true, path };
   }


### PR DESCRIPTION
## Qué corrige

- Publica `robots.txt` desde el directorio que Astro despliega.
- Agrega canonical absoluto a la portada.
- Quita temporalmente `/politicas` del sitemap porque hoy resuelve a la portada y el contenido fuente está desactualizado.
- Amplía el smoke test productivo para validar canonical, robots, búsquedas noindex y sitemap XML.

## Causa

El build productivo despliega `astro-front/dist`, pero `robots.txt` estaba solo en `public/` de la raíz. Cloudflare respondía la portada HTML para `/robots.txt`. La portada tampoco declaraba canonical y el sitemap incluía una URL no disponible.

## Validación

- 6/6 tests de catálogo y encargos.
- Sintaxis JS completa.
- Build Astro productivo correcto.
- HTML generado con canonical y `robots.txt` de texto.
- Smoke nuevo reproduce los tres defectos actuales antes del deploy.

No modifica catálogo, sincronizador, Mercado Pago ni D1.