### PR TITLE
feat: preparar Mercado Pago en producción con checkout apagado

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,18 @@ jobs:
       - name: Test catalog display
         run: node --test functions/__tests__/*.test.js
 
+      - name: Test orders
+        run: node --test functions/api/__tests__/orders.test.js
+
+      - name: Test preferences
+        run: node --test functions/api/__tests__/preferences.test.js
+
+      - name: Test MP webhook
+        run: node --test functions/api/__tests__/mp_webhook.test.js
+
+      - name: Test order status
+        run: node --test functions/api/__tests__/order_status.test.js
+
       - name: Install Astro dependencies
         working-directory: astro-front
         run: npm ci --no-audit --no-fund
@@ -60,7 +72,14 @@ jobs:
         env:
           PUBLIC_INDEXABLE: 'true'
           PUBLIC_GA_ID: G-SDX45VEPP3
+          PUBLIC_CHECKOUT_ENABLED: 'false'
         run: npm run build
+
+      - name: Confirm production checkout remains hidden
+        run: |
+          grep -q 'data-online-checkout="disabled"' astro-front/dist/carrito/index.html
+          ! grep -q 'id="btn-prepare-order"' astro-front/dist/carrito/index.html
+          ! grep -q 'id="btn-pay-mp"' astro-front/dist/carrito/index.html
 
       - name: Check pull request diff
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,7 @@ jobs:
         env:
           PUBLIC_INDEXABLE: 'true'
           PUBLIC_GA_ID: G-SDX45VEPP3
+          PUBLIC_CHECKOUT_ENABLED: 'false'
         run: npm run build
 
       - name: Deploy via Wrangler

--- a/astro-front/public/orders-guard.js
+++ b/astro-front/public/orders-guard.js
@@ -1,0 +1,133 @@
+(function () {
+  'use strict';
+
+  var CART_KEY = 'amado-cart';
+  var TIME_ZONE = 'America/Montevideo';
+
+  function valueOf(id) {
+    var element = document.getElementById(id);
+    return element && typeof element.value === 'string' ? element.value.trim() : '';
+  }
+
+  function focusField(id) {
+    var element = document.getElementById(id);
+    if (element && typeof element.focus === 'function') element.focus();
+  }
+
+  function checkoutError() {
+    if (!valueOf('buyer-name')) return { message: 'Por favor ingresá tu nombre.', field: 'buyer-name' };
+    if (!valueOf('buyer-phone')) return { message: 'Por favor ingresá tu teléfono o WhatsApp.', field: 'buyer-phone' };
+
+    var delivery = document.querySelector('input[name="delivery"]:checked');
+    if (!delivery || delivery.value !== 'shipping') return null;
+
+    var required = [
+      ['delivery-address', 'Por favor ingresá la dirección de entrega.'],
+      ['delivery-barrio', 'Por favor ingresá la localidad.'],
+      ['delivery-departamento', 'Por favor seleccioná el departamento.'],
+      ['delivery-date', 'Por favor ingresá la fecha preferida de entrega.'],
+      ['delivery-from', 'Por favor ingresá la hora de inicio del horario.'],
+      ['delivery-to', 'Por favor ingresá la hora de fin del horario.'],
+    ];
+    for (var i = 0; i < required.length; i++) {
+      if (!valueOf(required[i][0])) return { message: required[i][1], field: required[i][0] };
+    }
+    if (valueOf('delivery-to') <= valueOf('delivery-from')) {
+      return { message: 'La hora de fin debe ser posterior a la hora de inicio.', field: 'delivery-to' };
+    }
+    return null;
+  }
+
+  function localDateString() {
+    var parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: TIME_ZONE,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).formatToParts(new Date());
+    var values = {};
+    for (var i = 0; i < parts.length; i++) values[parts[i].type] = parts[i].value;
+    return values.year + '-' + values.month + '-' + values.day;
+  }
+
+  function rotateIdempotencyKey() {
+    try {
+      var cart = JSON.parse(localStorage.getItem(CART_KEY) || 'null');
+      if (!cart || typeof cart !== 'object' || !Array.isArray(cart.items)) return;
+      try {
+        cart.idempotency_key = crypto.randomUUID();
+      } catch (_) {
+        cart.idempotency_key = Date.now().toString(36) + Math.random().toString(36).slice(2);
+      }
+      localStorage.setItem(CART_KEY, JSON.stringify(cart));
+      document.dispatchEvent(new CustomEvent('amado:cart-updated', { detail: cart }));
+    } catch (_) {}
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var requiredIds = [
+      'buyer-name', 'buyer-phone', 'delivery-address', 'delivery-barrio',
+      'delivery-departamento', 'delivery-date', 'delivery-from', 'delivery-to',
+    ];
+    for (var i = 0; i < requiredIds.length; i++) {
+      var field = document.getElementById(requiredIds[i]);
+      if (field) {
+        field.required = true;
+        field.setAttribute('aria-required', 'true');
+      }
+    }
+    var dateField = document.getElementById('delivery-date');
+    if (dateField) dateField.min = localDateString();
+  });
+
+  document.addEventListener('click', function (event) {
+    var button = event.target.closest('#btn-wa-order, #btn-prepare-order');
+    if (!button) return;
+    var validation = checkoutError();
+    if (!validation) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    window.alert(validation.message);
+    focusField(validation.field);
+  }, true);
+
+  var nativeFetch = window.fetch.bind(window);
+  window.fetch = function (input, init) {
+    return nativeFetch(input, init).then(function (response) {
+      var url = typeof input === 'string' ? input : (input && input.url ? input.url : '');
+      if (!/\/api\/orders(?:\?|$)/.test(url)) return response;
+
+      response.clone().json().then(function (data) {
+        if (response.status === 410 && data && data.code === 'ORDER_EXPIRED') rotateIdempotencyKey();
+        if (response.ok && data && data.order) {
+          document.dispatchEvent(new CustomEvent('amado:order-response', { detail: data.order }));
+        }
+      }).catch(function () {});
+      return response;
+    });
+  };
+
+  document.addEventListener('amado:order-response', function (event) {
+    var order = event.detail || {};
+    if (!order.expires_at) return;
+    var result = document.getElementById('order-result');
+    if (!result) return;
+
+    var expiry = document.getElementById('order-expiry-confirmed');
+    if (!expiry) {
+      expiry = document.createElement('p');
+      expiry.id = 'order-expiry-confirmed';
+      expiry.className = 'order-result-note';
+      result.appendChild(expiry);
+    }
+
+    var parsed = new Date(order.expires_at);
+    if (isNaN(parsed.getTime())) return;
+    expiry.textContent = 'Orden válida durante 60 minutos, hasta ' +
+      new Intl.DateTimeFormat('es-UY', {
+        timeZone: TIME_ZONE,
+        hour: '2-digit',
+        minute: '2-digit',
+      }).format(parsed) + '.';
+  });
+}());

--- a/astro-front/src/layouts/BaseLayout.astro
+++ b/astro-front/src/layouts/BaseLayout.astro
@@ -43,6 +43,7 @@ const enableGA4  = indexable && !!gaId;
     href="https://fonts.bunny.net/css?family=playfair-display:700|inter:400,600,800&display=swap"
   >
   <script src="/cart.js" defer></script>
+  <script src="/orders-guard.js" defer></script>
   <style is:global>
     /* ── Custom properties ─────────────────────────────────── */
     :root {

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -3,6 +3,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import WAFloat from '../components/WAFloat.astro';
+
+const checkoutEnabled = import.meta.env.PUBLIC_CHECKOUT_ENABLED === 'true';
 ---
 <BaseLayout
   title="Tu carrito — Amado Libros"
@@ -11,7 +13,7 @@ import WAFloat from '../components/WAFloat.astro';
 >
   <Header />
 
-  <main class="cart-page">
+  <main class="cart-page" data-online-checkout={checkoutEnabled ? 'enabled' : 'disabled'}>
     <div class="cart-wrap">
       <h1 class="cart-h1">Tu carrito</h1>
 
@@ -46,6 +48,8 @@ import WAFloat from '../components/WAFloat.astro';
             <p class="cart-discount-line" id="cart-discount-line" hidden>Ahorro por retiro:&nbsp;<strong>−&nbsp;$150</strong></p>
             <p class="cart-total-line" id="cart-total-line" hidden>Total con retiro:&nbsp;<strong id="cart-total">$&nbsp;0</strong></p>
             <p class="cart-shipping-note" id="cart-shipping-note" hidden>Envío: a coordinar según destino</p>
+            <p class="cart-shipping-cost-line" id="cart-shipping-cost-line" hidden>Envío:&nbsp;<strong id="cart-shipping-cost">$&nbsp;250</strong></p>
+            <p class="cart-total-shipping-line" id="cart-total-shipping-line" hidden>Total con envío:&nbsp;<strong id="cart-total-shipping">$&nbsp;0</strong></p>
             <p class="cart-transfer-note" id="cart-transfer-note" hidden>Pagando por transferencia se aplica además 12&nbsp;% de descuento.</p>
             <p class="cart-shipping-msg" id="cart-shipping-msg" hidden></p>
           </div>
@@ -116,6 +120,25 @@ import WAFloat from '../components/WAFloat.astro';
                 <option>Treinta y Tres</option>
               </select>
             </div>
+            <div class="form-field">
+              <label for="delivery-date" class="form-label">Fecha preferida</label>
+              <input type="date" id="delivery-date" class="form-input" autocomplete="off">
+            </div>
+            <div class="form-row">
+              <div class="form-field">
+                <label for="delivery-from" class="form-label">Desde <span class="form-req" aria-hidden="true">*</span></label>
+                <input type="time" id="delivery-from" class="form-input">
+              </div>
+              <div class="form-field">
+                <label for="delivery-to" class="form-label">Hasta <span class="form-req" aria-hidden="true">*</span></label>
+                <input type="time" id="delivery-to" class="form-input">
+              </div>
+            </div>
+            <div class="form-field">
+              <label for="delivery-notes" class="form-label">Notas para la entrega</label>
+              <textarea id="delivery-notes" class="form-input form-textarea" rows="2" placeholder="Ej: timbre 2B, dejar con portero"></textarea>
+            </div>
+            <p class="delivery-confirm-note">La fecha y la franja quedan sujetas a confirmación por WhatsApp.</p>
           </div>
         </section>
 
@@ -138,12 +161,25 @@ import WAFloat from '../components/WAFloat.astro';
           </div>
         </section>
 
-        <!-- Cierre asistido por WhatsApp -->
-        <section class="cart-pay-section" aria-labelledby="cart-checkout-title">
-          <h2 id="cart-checkout-title" class="cart-checkout-title">Finalizá tu pedido</h2>
-          <p class="pay-note">
-            Enviá el carrito y confirmamos contigo el stock, la entrega y el total final.
-          </p>
+        <!-- Acciones de pago -->
+        <section class="cart-pay-section">
+          {checkoutEnabled && <div id="cf-ts-container"></div>}
+          {checkoutEnabled && (
+            <button type="button" id="btn-prepare-order" class="btn-prepare-order">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <rect x="1" y="4" width="22" height="16" rx="2" ry="2"/>
+                <line x1="1" y1="10" x2="23" y2="10"/>
+              </svg>
+              Preparar pago online
+            </button>
+          )}
+          {checkoutEnabled && (
+            <p class="pay-note">
+              Registramos tu pedido y te contactamos por WhatsApp para coordinar
+              el pago y la entrega.
+            </p>
+          )}
           <button type="button" id="btn-wa-order" class="btn-wa-order">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z"/>
@@ -154,6 +190,18 @@ import WAFloat from '../components/WAFloat.astro';
             No pagás ahora. Te enviamos los datos para transferencia o un link de Mercado Pago.
           </p>
         </section>
+
+        {checkoutEnabled && (
+          <div id="order-result" class="order-result" hidden>
+            <p class="order-result-h">Pedido preparado</p>
+            <p>Código: <strong id="order-public-code"></strong></p>
+            <p>Total confirmado: <strong id="order-total-confirmed"></strong></p>
+            <p id="order-result-note" class="order-result-note">El pago online se habilitará en la siguiente etapa.</p>
+            <button type="button" id="btn-pay-mp" class="btn-pay-mp" hidden>
+              Pagar con Mercado Pago
+            </button>
+          </div>
+        )}
 
       </div><!-- /#cart-content -->
     </div><!-- /.cart-wrap -->
@@ -366,23 +414,87 @@ import WAFloat from '../components/WAFloat.astro';
     border-color: var(--salmon);
   }
 
-  /* ── Cierre por WhatsApp ───────────────────────── */
+  .form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.875rem;
+  }
+
+  .form-textarea {
+    resize: vertical;
+    min-height: 4rem;
+  }
+
+  .delivery-confirm-note {
+    font-size: 0.78rem;
+    color: var(--ink-2);
+    line-height: 1.5;
+    margin-top: 0.25rem;
+  }
+
+  /* ── Sección de pago ───────────────────────────── */
   .cart-pay-section {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
-    padding: 1.25rem;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--r);
+    gap: 1rem;
+    padding-top: 0.5rem;
   }
 
-  .cart-checkout-title {
+  .btn-prepare-order {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.875rem 1.5rem;
+    background: var(--salmon);
+    color: #fff;
+    border: none;
+    border-radius: var(--r);
     font-family: var(--font-ui);
-    font-size: 1.05rem;
+    font-size: 0.95rem;
     font-weight: 700;
+    cursor: pointer;
+    width: 100%;
+    transition: background 0.15s;
+  }
+  .btn-prepare-order:hover { background: var(--salmon-hover); }
+  .btn-prepare-order:disabled {
+    background: #9ca3af;
+    cursor: not-allowed;
+  }
+
+  .order-result {
+    background: #f0fdf4;
+    border: 1px solid #86efac;
+    border-radius: var(--r);
+    padding: 1rem 1.25rem;
+    margin-top: 0.5rem;
+  }
+
+  .order-result-h {
+    font-weight: 700;
+    color: #166534;
+    font-size: 1rem;
+    margin-bottom: 0.4rem;
+  }
+
+  .order-result-note {
+    font-size: 0.82rem;
+    color: #15803d;
+    margin-top: 0.4rem;
+  }
+
+  .cart-shipping-cost-line {
+    font-size: 0.85rem;
+    color: var(--ink-2);
+  }
+
+  .cart-total-shipping-line {
+    font-size: 1rem;
     color: var(--ink);
-    text-align: center;
+    border-top: 1px solid var(--border);
+    padding-top: 0.2rem;
+    margin-top: 0.1rem;
   }
 
   .pay-note {
@@ -593,14 +705,88 @@ import WAFloat from '../components/WAFloat.astro';
     font-size: 0.78rem;
     color: #267a42;
   }
+
+  .btn-pay-mp {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.25rem;
+    background: #009ee3;
+    color: #fff;
+    border: none;
+    border-radius: var(--r);
+    font-family: var(--font-ui);
+    font-size: 0.9rem;
+    font-weight: 700;
+    cursor: pointer;
+    width: 100%;
+    margin-top: 0.75rem;
+    transition: background 0.15s;
+  }
+  .btn-pay-mp:hover { background: #0087c6; }
+  .btn-pay-mp:disabled { background: #9ca3af; cursor: not-allowed; }
 </style>
 
 <script is:inline>
+  // ── Turnstile Preview ────────────────────────────────────────────────────
+  var onlineCheckoutEnabled = document.querySelector('.cart-page')?.dataset.onlineCheckout === 'enabled';
+  var TS_PREVIEW_HOST = 'amadolibros-web.pages.dev';
+  var TS_SITE_KEY     = '0x4AAAAAAD6E9kz8K3comwjj';
+  var tsIsPreview     = window.location.hostname === TS_PREVIEW_HOST ||
+                        window.location.hostname.endsWith('.' + TS_PREVIEW_HOST);
+  var tsWidgetId      = null;
+  var tsPending       = null;
+
+  function tsOnSuccess(token) { if (tsPending) { var r=tsPending.resolve; tsPending=null; r(token); } }
+  function tsOnError()        { if (tsPending) { var r=tsPending.reject;  tsPending=null; r(new Error('ts-error')); } }
+  function tsOnExpired()      { if (tsPending) { var r=tsPending.reject;  tsPending=null; r(new Error('ts-expired')); } }
+  function tsOnTimeout()      { if (tsPending) { var r=tsPending.reject;  tsPending=null; r(new Error('ts-timeout')); } }
+
+  function tsRenderWidget() {
+    var container = document.getElementById('cf-ts-container');
+    if (!container || tsWidgetId != null) return;
+    tsWidgetId = window.turnstile.render(container, {
+      sitekey:             TS_SITE_KEY,
+      action:              'prepare_order',
+      appearance:          'interaction-only',
+      execution:           'execute',
+      callback:            tsOnSuccess,
+      'error-callback':    tsOnError,
+      'expired-callback':  tsOnExpired,
+      'timeout-callback':  tsOnTimeout,
+    });
+  }
+
+  function tsGetToken() {
+    return new Promise(function (resolve, reject) {
+      if (tsWidgetId == null) { reject(new Error('ts-not-ready')); return; }
+      tsPending = { resolve: resolve, reject: reject };
+      window.turnstile.reset(tsWidgetId);
+      window.turnstile.execute(tsWidgetId);
+      // Timeout de seguridad en caso de que ningún callback dispare.
+      setTimeout(function () {
+        if (tsPending) { var r=tsPending.reject; tsPending=null; r(new Error('ts-timeout')); }
+      }, 30000);
+    });
+  }
+
+  if (onlineCheckoutEnabled && tsIsPreview) {
+    window.__tsOnLoad = function () { tsRenderWidget(); };
+    var _tsScript = document.createElement('script');
+    _tsScript.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?onload=__tsOnLoad&render=explicit';
+    _tsScript.async = true;
+    _tsScript.defer = true;
+    document.head.appendChild(_tsScript);
+  }
+  // ─────────────────────────────────────────────────────────────────────────
+
   document.addEventListener('DOMContentLoaded', function () {
 
     // ── Constantes ──────────────────────────────────────────────────────
     var RETIRO_DISCOUNT             = 150;
-    var FREE_SHIPPING_THRESHOLD_UYU = null; // sin monto configurado aún
+    var SHIPPING_COST               = 250;
+    var FREE_SHIPPING_THRESHOLD_UYU = 2000;
 
     // ── Elementos ───────────────────────────────────────────────────────
     var loadingEl        = document.getElementById('cart-loading');
@@ -615,7 +801,11 @@ import WAFloat from '../components/WAFloat.astro';
     var transferNoteEl   = document.getElementById('cart-transfer-note');
     var shippingMsgEl    = document.getElementById('cart-shipping-msg');
     var announceEl       = document.getElementById('cart-announce');
-    var shippingFieldsEl = document.getElementById('shipping-fields');
+    var shippingFieldsEl     = document.getElementById('shipping-fields');
+    var shippingCostLineEl   = document.getElementById('cart-shipping-cost-line');
+    var shippingCostEl       = document.getElementById('cart-shipping-cost');
+    var totalShippingLineEl  = document.getElementById('cart-total-shipping-line');
+    var totalShippingEl      = document.getElementById('cart-total-shipping');
 
     // ── Formato moneda ───────────────────────────────────────────────────
     var fmt = new Intl.NumberFormat('es-UY', {
@@ -646,31 +836,30 @@ import WAFloat from '../components/WAFloat.astro';
 
       if (isPickup) {
         var total = Math.max(0, subtotal - RETIRO_DISCOUNT);
-        if (discountLineEl) discountLineEl.hidden = false;
-        if (totalLineEl)    totalLineEl.hidden    = false;
-        if (totalEl)        totalEl.textContent   = fmt.format(total);
-        if (shippingNoteEl) shippingNoteEl.hidden = true;
-        if (transferNoteEl) transferNoteEl.hidden = false;
+        if (discountLineEl)      discountLineEl.hidden      = false;
+        if (totalLineEl)         totalLineEl.hidden         = false;
+        if (totalEl)             totalEl.textContent        = fmt.format(total);
+        if (shippingNoteEl)      shippingNoteEl.hidden      = true;
+        if (transferNoteEl)      transferNoteEl.hidden      = false;
+        if (shippingCostLineEl)  shippingCostLineEl.hidden  = true;
+        if (totalShippingLineEl) totalShippingLineEl.hidden = true;
+        if (shippingMsgEl)       shippingMsgEl.hidden       = true;
       } else {
-        if (discountLineEl) discountLineEl.hidden = true;
-        if (totalLineEl)    totalLineEl.hidden    = true;
-        if (shippingNoteEl) shippingNoteEl.hidden = false;
-        if (transferNoteEl) transferNoteEl.hidden = true;
-      }
-
-      if (shippingMsgEl) {
-        if (FREE_SHIPPING_THRESHOLD_UYU !== null && !isPickup) {
-          if (subtotal >= FREE_SHIPPING_THRESHOLD_UYU) {
-            shippingMsgEl.textContent = '¡Ya tenés envío gratis!';
-          } else {
-            shippingMsgEl.textContent =
-              'Te faltan ' + fmt.format(FREE_SHIPPING_THRESHOLD_UYU - subtotal) +
-              ' para obtener envío gratis.';
-          }
-          shippingMsgEl.hidden = false;
-        } else {
-          shippingMsgEl.hidden = true;
+        var shippingCost      = subtotal < FREE_SHIPPING_THRESHOLD_UYU ? SHIPPING_COST : 0;
+        var totalWithShipping = subtotal + shippingCost;
+        if (discountLineEl)     discountLineEl.hidden     = true;
+        if (totalLineEl)        totalLineEl.hidden        = true;
+        if (shippingNoteEl)     shippingNoteEl.hidden     = true;
+        if (transferNoteEl)     transferNoteEl.hidden     = true;
+        if (shippingCostLineEl) {
+          shippingCostLineEl.hidden = false;
+          if (shippingCostEl) shippingCostEl.textContent = shippingCost === 0 ? 'Gratis' : fmt.format(shippingCost);
         }
+        if (totalShippingLineEl) {
+          totalShippingLineEl.hidden = false;
+          if (totalShippingEl) totalShippingEl.textContent = fmt.format(totalWithShipping);
+        }
+        if (shippingMsgEl) shippingMsgEl.hidden = true;
       }
     }
 
@@ -882,10 +1071,22 @@ import WAFloat from '../components/WAFloat.astro';
           lines.push('Nota: pagando por transferencia bancaria se aplica además 12 % de descuento.');
           lines.push('Entrega: Retiro en Rincón 608');
         } else {
-          lines.push('Envío: a coordinar según destino');
+          var shippingCostWa = subtotal < FREE_SHIPPING_THRESHOLD_UYU ? SHIPPING_COST : 0;
+          if (shippingCostWa === 0) {
+            lines.push('Envío: Gratis (compra desde $' + FREE_SHIPPING_THRESHOLD_UYU + ')');
+          } else {
+            lines.push('Envío: $' + SHIPPING_COST);
+          }
+          lines.push('Total con envío: ' + fmt.format(subtotal + shippingCostWa) + ' UYU');
           var lugar = [address, barrio, departamento].filter(Boolean).join(', ');
           lines.push('Entrega: Envío a domicilio — ' + lugar);
-          lines.push('Coordinaremos contigo la franja horaria de entrega.');
+          var waDate = ((document.getElementById('delivery-date') || {}).value || '').trim();
+          var waFrom = ((document.getElementById('delivery-from') || {}).value || '').trim();
+          var waTo   = ((document.getElementById('delivery-to')   || {}).value || '').trim();
+          if (waDate) lines.push('Fecha solicitada: ' + waDate);
+          if (waFrom || waTo) {
+            lines.push('Horario solicitado: ' + [waFrom, waTo].filter(Boolean).join(' – '));
+          }
         }
         if (name)  lines.push('Nombre: ' + name);
         if (phone) lines.push('WhatsApp/Tel: ' + phone);
@@ -895,7 +1096,195 @@ import WAFloat from '../components/WAFloat.astro';
       });
     }
 
-    // ── Render inicial ────────────────────────────────────────────────────
+    // ── Pagar con Mercado Pago ────────────────────────────────────────────────
+    var mpPublicCode     = null;
+    var mpIdempotencyKey = null;
+    var btnPayMp         = document.getElementById('btn-pay-mp');
+
+    if (btnPayMp) {
+      btnPayMp.addEventListener('click', async function () {
+        if (!mpPublicCode || !mpIdempotencyKey) return;
+        btnPayMp.disabled    = true;
+        btnPayMp.textContent = 'Iniciando pago…';
+        try {
+          var mpResp = await fetch('/api/preferences', {
+            method:  'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body:    JSON.stringify({ public_code: mpPublicCode, idempotency_key: mpIdempotencyKey }),
+          });
+          var mpData = await mpResp.json();
+          if (mpResp.ok && mpData.checkout_url) {
+            try {
+              sessionStorage.setItem('amado-mp-auth', JSON.stringify({
+                public_code:     mpPublicCode,
+                idempotency_key: mpIdempotencyKey,
+              }));
+            } catch (_) {}
+            window.location.href = mpData.checkout_url;
+            return;
+          }
+          alert('Error al iniciar el pago: ' + (mpData.error || 'Intentá de nuevo.'));
+        } catch (_err) {
+          alert('Error de conexión. Verificá tu internet e intentá de nuevo.');
+        }
+        btnPayMp.disabled    = false;
+        btnPayMp.textContent = 'Pagar con Mercado Pago';
+      });
+    }
+
+    // ── Preparar pago online ─────────────────────────────────────────────────
+    var btnPrepare  = document.getElementById('btn-prepare-order');
+    var origBtnHTML = btnPrepare ? btnPrepare.innerHTML : '';
+
+    if (btnPrepare) {
+      btnPrepare.addEventListener('click', async function () {
+        var cart = window.AmadoCart.get();
+        if (cart.items.length === 0) return;
+
+        var deliveryType = getDeliveryType();
+        var prepAddress  = ((document.getElementById('delivery-address')     || {}).value || '').trim();
+        var prepBarrio   = ((document.getElementById('delivery-barrio')       || {}).value || '').trim();
+        var prepDepto    = ((document.getElementById('delivery-departamento') || {}).value || '').trim();
+        var prepDate     = ((document.getElementById('delivery-date')         || {}).value || '').trim();
+        var prepFrom     = ((document.getElementById('delivery-from')         || {}).value || '').trim();
+        var prepTo       = ((document.getElementById('delivery-to')           || {}).value || '').trim();
+        var prepNotes    = ((document.getElementById('delivery-notes')        || {}).value || '').trim();
+        var prepName     = ((document.getElementById('buyer-name')            || {}).value || '').trim();
+        var prepPhone    = ((document.getElementById('buyer-phone')           || {}).value || '').trim();
+
+        if (!prepName) {
+          alert('Por favor ingresá tu nombre.');
+          var nameEl = document.getElementById('buyer-name');
+          if (nameEl) nameEl.focus();
+          return;
+        }
+        if (!prepPhone) {
+          alert('Por favor ingresá tu teléfono o WhatsApp.');
+          var phoneEl = document.getElementById('buyer-phone');
+          if (phoneEl) phoneEl.focus();
+          return;
+        }
+
+        if (deliveryType === 'shipping') {
+          if (!prepAddress) {
+            alert('Por favor ingresá la dirección de entrega.');
+            var addrEl = document.getElementById('delivery-address');
+            if (addrEl) addrEl.focus();
+            return;
+          }
+          if (!prepBarrio) {
+            alert('Por favor ingresá la localidad.');
+            var barrioEl = document.getElementById('delivery-barrio');
+            if (barrioEl) barrioEl.focus();
+            return;
+          }
+          if (!prepDepto) {
+            alert('Por favor seleccioná el departamento.');
+            var deptEl = document.getElementById('delivery-departamento');
+            if (deptEl) deptEl.focus();
+            return;
+          }
+          if (!prepDate) {
+            alert('Por favor ingresá la fecha preferida de entrega.');
+            var dateEl = document.getElementById('delivery-date');
+            if (dateEl) dateEl.focus();
+            return;
+          }
+          if (!prepFrom) {
+            alert('Por favor ingresá la hora de inicio del horario.');
+            var fromEl = document.getElementById('delivery-from');
+            if (fromEl) fromEl.focus();
+            return;
+          }
+          if (!prepTo) {
+            alert('Por favor ingresá la hora de fin del horario.');
+            var toEl = document.getElementById('delivery-to');
+            if (toEl) toEl.focus();
+            return;
+          }
+        }
+
+        btnPrepare.disabled = true;
+        btnPrepare.textContent = tsIsPreview ? 'Verificando…' : 'Procesando…';
+
+        var cfTsResponse = null;
+        if (tsIsPreview) {
+          if (tsWidgetId == null) {
+            alert('La verificación aún no cargó. Esperá un momento y reintentá.');
+            btnPrepare.disabled = false;
+            btnPrepare.innerHTML = origBtnHTML;
+            return;
+          }
+          try {
+            cfTsResponse = await tsGetToken();
+          } catch (_tsErr) {
+            alert('Error en la verificación. Recargá la página e intentá de nuevo.');
+            btnPrepare.disabled = false;
+            btnPrepare.innerHTML = origBtnHTML;
+            return;
+          }
+          btnPrepare.textContent = 'Procesando…';
+        }
+
+        var payload = {
+          idempotency_key: cart.idempotency_key,
+          cf_turnstile_response: cfTsResponse,
+          items: cart.items.map(function (it) {
+            return { product_id: it.id, quantity: it.quantity };
+          }),
+          delivery_type: deliveryType,
+          buyer: { name: prepName, phone: prepPhone },
+        };
+        if (deliveryType === 'shipping') {
+          payload.shipping = {
+            address:        prepAddress,
+            locality:       prepBarrio,
+            department:     prepDepto,
+            requested_date: prepDate,
+            requested_from: prepFrom,
+            requested_to:   prepTo,
+          };
+          if (prepNotes) payload.shipping.notes = prepNotes;
+        }
+
+        try {
+          var resp = await fetch('/api/orders', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+          var data = await resp.json();
+
+          if (!resp.ok) {
+            alert('Error: ' + (data.error || 'Intentá de nuevo.'));
+            btnPrepare.disabled = false;
+            btnPrepare.innerHTML = origBtnHTML;
+            return;
+          }
+
+          var resultEl    = document.getElementById('order-result');
+          var codeEl      = document.getElementById('order-public-code');
+          var totalConfEl = document.getElementById('order-total-confirmed');
+          if (codeEl)      codeEl.textContent     = data.order.public_code;
+          if (totalConfEl) totalConfEl.textContent = fmt.format(data.order.payable_total_uyu) + ' UYU';
+          if (resultEl)    resultEl.hidden = false;
+          btnPrepare.textContent = 'Pedido preparado';
+
+          if (tsIsPreview) {
+            mpPublicCode     = data.order.public_code;
+            mpIdempotencyKey = cart.idempotency_key;
+            var noteEl = document.getElementById('order-result-note');
+            if (noteEl)    noteEl.hidden   = true;
+            if (btnPayMp)  btnPayMp.hidden = false;
+          }
+        } catch (_fetchErr) {
+          alert('Error de conexión. Verificá tu internet e intentá de nuevo.');
+          btnPrepare.disabled = false;
+          btnPrepare.innerHTML = origBtnHTML;
+        }
+      });
+    }
+
     renderCart();
   });
 </script>

--- a/astro-front/src/pages/pedido.astro
+++ b/astro-front/src/pages/pedido.astro
@@ -15,15 +15,17 @@ const WA_HREF =
   <Header />
   <main class="pedido-page">
     <div class="pedido-wrap">
-      <div class="pedido-icon" aria-hidden="true">🕐</div>
-      <h1>Estado del pedido</h1>
-      <p class="pedido-lead">
+      <div id="pedido-icon" class="pedido-icon" aria-hidden="true">🕐</div>
+      <h1 id="pedido-h1">Estado del pedido</h1>
+      <p id="pedido-lead" class="pedido-lead">
         Estamos terminando la integración con Mercado Pago.
         Por ahora podés finalizar tu pedido por WhatsApp y te respondemos
         con los datos de pago.
       </p>
+      <p id="pedido-sub" class="pedido-sub" hidden></p>
+      <p id="pedido-code" class="pedido-code" hidden></p>
       <div class="pedido-ctas">
-        <a href="/carrito" class="btn-back">← Volver al carrito</a>
+        <a id="btn-pedido-back" href="/carrito" class="btn-back" hidden>← Volver al carrito</a>
         <a
           href={WA_HREF}
           target="_blank"
@@ -38,6 +40,107 @@ const WA_HREF =
       </div>
     </div>
   </main>
+
+  <script is:inline>
+    (function () {
+      var params  = new URLSearchParams(window.location.search);
+      var result  = params.get('result');
+      var code    = params.get('code');
+      var iconEl  = document.getElementById('pedido-icon');
+      var h1El    = document.getElementById('pedido-h1');
+      var leadEl  = document.getElementById('pedido-lead');
+      var subEl   = document.getElementById('pedido-sub');
+      var codeEl  = document.getElementById('pedido-code');
+      var backEl  = document.getElementById('btn-pedido-back');
+
+      // ── Estado inicial según result de MP ──────────────────────────────────
+      if (result === 'success' || result === 'pending') {
+        if (iconEl) iconEl.textContent = '⏳';
+        if (h1El)   h1El.textContent   = 'Estamos verificando el pago…';
+        if (leadEl) leadEl.textContent = 'La confirmación definitiva llegará cuando Mercado Pago valide la operación.';
+        if (code && codeEl) { codeEl.textContent = 'Código de pedido: ' + code; codeEl.hidden = false; }
+      } else if (result === 'failure') {
+        if (iconEl) iconEl.textContent = '✗';
+        if (h1El)   h1El.textContent   = 'El pago no se completó.';
+        if (leadEl) leadEl.textContent = 'Podés reintentar el pago desde el carrito.';
+        if (backEl) backEl.hidden = false;
+      }
+
+      // ── Polling de estado real en D1 ─────────────────────────────────────
+      if (!code || (result !== 'success' && result !== 'pending')) return;
+
+      var auth = null;
+      try { auth = JSON.parse(sessionStorage.getItem('amado-mp-auth') || 'null'); } catch (_) {}
+
+      if (!auth || auth.public_code !== code || !auth.idempotency_key) return;
+
+      var MAX_ATTEMPTS  = 20;
+      var INTERVAL_MS   = 3000;
+      var attempts      = 0;
+      var stopped       = false;
+
+      var TERMINAL_STATES = { approved: true, rejected: true, cancelled: true, refunded: true };
+
+      function applyFinalState(paymentStatus) {
+        if (paymentStatus === 'approved') {
+          if (iconEl) iconEl.textContent = '✓';
+          if (h1El)   h1El.textContent   = 'Pago confirmado';
+          if (leadEl) leadEl.textContent = 'Tu pedido está confirmado. Te contactaremos por WhatsApp para coordinar la entrega.';
+        } else if (paymentStatus === 'rejected') {
+          if (iconEl) iconEl.textContent = '✗';
+          if (h1El)   h1El.textContent   = 'Pago rechazado.';
+          if (leadEl) leadEl.textContent = 'El pago no fue aprobado. Podés reintentar desde el carrito.';
+          if (backEl) backEl.hidden = false;
+        } else if (paymentStatus === 'cancelled') {
+          if (iconEl) iconEl.textContent = '✗';
+          if (h1El)   h1El.textContent   = 'Pago cancelado.';
+          if (leadEl) leadEl.textContent = 'El pago fue cancelado. Podés iniciar uno nuevo desde el carrito.';
+          if (backEl) backEl.hidden = false;
+        } else if (paymentStatus === 'refunded') {
+          if (iconEl) iconEl.textContent = '↩';
+          if (h1El)   h1El.textContent   = 'Pago reembolsado.';
+          if (leadEl) leadEl.textContent = 'El pago fue reembolsado. Consultá por WhatsApp si tenés preguntas.';
+        }
+      }
+
+      function onTimeout() {
+        if (iconEl) iconEl.textContent = '⏳';
+        if (h1El)   h1El.textContent   = 'Verificando el pago…';
+        if (leadEl) leadEl.textContent = 'Esto puede tardar unos minutos. Consultá por WhatsApp si el estado no se actualiza.';
+      }
+
+      function poll() {
+        if (stopped) return;
+        attempts++;
+        fetch('/api/orders/status', {
+          method:  'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body:    JSON.stringify({ public_code: code, idempotency_key: auth.idempotency_key }),
+        })
+          .then(function (r) { return r.json(); })
+          .then(function (data) {
+            if (stopped) return;
+            var ps = data.payment_status;
+            if (ps && TERMINAL_STATES[ps]) {
+              stopped = true;
+              applyFinalState(ps);
+            } else if (attempts >= MAX_ATTEMPTS) {
+              stopped = true;
+              onTimeout();
+            } else {
+              setTimeout(poll, INTERVAL_MS);
+            }
+          })
+          .catch(function () {
+            if (stopped) return;
+            if (attempts >= MAX_ATTEMPTS) { stopped = true; onTimeout(); return; }
+            setTimeout(poll, INTERVAL_MS);
+          });
+      }
+
+      setTimeout(poll, 1500);
+    })();
+  </script>
   <WAFloat />
   <Footer />
 </BaseLayout>
@@ -112,4 +215,17 @@ const WA_HREF =
     width: 100%;
   }
   .btn-wa-pedido:hover { background: var(--wa-hover); }
+
+  .pedido-sub, .pedido-code {
+    font-size: 0.9rem;
+    color: var(--ink-2);
+    line-height: 1.6;
+    margin-bottom: 0.5rem;
+  }
+
+  .pedido-code {
+    font-weight: 600;
+    color: var(--ink);
+    margin-bottom: 1.5rem;
+  }
 </style>

--- a/docs/d1-orders-setup.md
+++ b/docs/d1-orders-setup.md
@@ -1,0 +1,191 @@
+# Configuración D1 — órdenes de Amado Libros
+
+Estos pasos se ejecutan por ambiente. **No crear ni conectar recursos remotos sin autorización explícita.**
+
+## Separación obligatoria de ambientes
+
+- Local: base efímera de Wrangler para desarrollo y pruebas.
+- Preview: base D1 remota exclusiva de previews.
+- Producción: base D1 remota exclusiva de producción.
+
+Preview y producción no deben compartir `database_id`. Un preview nunca debe escribir en la base productiva.
+
+## 1. Prueba local sin crear D1 remoto
+
+Para probar la migración localmente, se puede usar temporalmente este binding en un archivo de configuración local no commiteado:
+
+```toml
+[[d1_databases]]
+binding = "ORDERS_DB"
+database_name = "amadolibros-orders-local"
+database_id = "00000000-0000-0000-0000-000000000000"
+```
+
+Aplicar las migraciones en local:
+
+```bash
+npx wrangler d1 migrations apply ORDERS_DB --local
+```
+
+Comprobar tablas y restricciones:
+
+```bash
+npx wrangler d1 execute ORDERS_DB --local --command "PRAGMA foreign_keys; SELECT name FROM sqlite_schema WHERE type='table' ORDER BY name;"
+```
+
+La migración inicial es `migrations/0001_orders.sql`.
+
+## 2. Crear D1 de preview — solo con autorización
+
+```bash
+npx wrangler d1 create amadolibros-orders-preview
+```
+
+Guardar el `database_id` resultante únicamente en la configuración de preview de Cloudflare Pages. Después aplicar:
+
+```bash
+npx wrangler d1 migrations apply amadolibros-orders-preview --remote
+```
+
+Antes de usarlo, verificar que el binding `ORDERS_DB` del ambiente Preview apunta a `amadolibros-orders-preview`.
+
+## 3. Crear D1 de producción — autorización separada
+
+```bash
+npx wrangler d1 create amadolibros-orders-production
+```
+
+Guardar ese `database_id` únicamente en Production. Después aplicar:
+
+```bash
+npx wrangler d1 migrations apply amadolibros-orders-production --remote
+```
+
+No reutilizar el ID de preview.
+
+## 4. Binding esperado
+
+El código espera este nombre exacto:
+
+```toml
+[[d1_databases]]
+binding = "ORDERS_DB"
+database_name = "<NOMBRE_DEL_AMBIENTE>"
+database_id = "<DATABASE_ID_REAL_DEL_AMBIENTE>"
+```
+
+## 5. Cloudflare Turnstile — protección Preview
+
+`POST /api/orders` requiere verificación Turnstile **solo en el ambiente Preview**. En Producción la variable no está definida y el endpoint no existe.
+
+### Recursos creados
+
+- Widget: `amadolibros-orders-preview` (mode `managed`, domain `amadolibros-web.pages.dev`).
+- Secret almacenado como variable de entorno de Pages: `TURNSTILE_SECRET_KEY` (ambiente Preview únicamente, nunca en Production).
+
+### Comportamiento fail-closed
+
+Si `ORDERS_DB` está presente pero `TURNSTILE_SECRET_KEY` no → 503 `TS_NOT_CONFIGURED`.
+Si ambas están presentes → el token del cliente se valida contra siteverify antes de tocar D1.
+
+### Crear/reutilizar el widget (requiere scope `challenge-widgets.write`)
+
+```bash
+# Verificar si existe
+npx wrangler@latest turnstile widget list
+
+# Crear (si no existe)
+npx wrangler@latest turnstile widget create "amadolibros-orders-preview" \
+  --domain amadolibros-web.pages.dev \
+  --mode managed \
+  --json
+```
+
+El comando muestra el `sitekey` (público) y el `secret`. El `sitekey` se escribe en `carrito.astro` como valor de `TS_SITE_KEY`. El `secret` se almacena via:
+
+```bash
+echo "<SECRET>" | npx wrangler pages secret put TURNSTILE_SECRET_KEY \
+  --project-name amadolibros-web \
+  --env preview
+```
+
+**El secret nunca se escribe en archivos del repositorio ni se incluye en commits.**
+
+### Validaciones que realiza el servidor
+
+- Token no vacío y longitud ≤ 2048 caracteres.
+- `siteverify` con timeout de 5 s (`AbortController`).
+- `action === 'prepare_order'`.
+- `hostname` es `amadolibros-web.pages.dev` o subdomain (cubre hashes de commit y alias de rama).
+
+## 6. Mercado Pago Checkout Pro — Preview
+
+`POST /api/preferences` inicia un pago MP en sandbox. Solo opera en Preview; Production no tiene `MP_ACCESS_TOKEN` definida.
+
+### App MP
+
+- Nombre: VICTOR SEBASTIÁN
+- App ID: `6816864196905927`
+- User/Collector ID: `440298103`
+- Sitio: `MLU` (Uruguay)
+- Producto: Checkout Pro
+
+### Activar credenciales de prueba (una sola vez, requiere login en MP)
+
+1. Ingresar a `https://www.mercadopago.com.uy/developers/panel/app/6816864196905927`
+2. En "Credenciales" → pestaña **Prueba** → clic en **Activar credenciales**
+3. MP genera `TEST_PUBLIC_KEY` y `TEST_ACCESS_TOKEN`
+
+### Guardar el secret (el valor nunca entra al repositorio)
+
+```bash
+npx wrangler@4.112.0 pages secret put MP_ACCESS_TOKEN \
+  --project-name amadolibros-web \
+  --env preview
+# Wrangler pide el valor interactivamente. Pegar TEST_ACCESS_TOKEN.
+```
+
+### Endpoint `POST /api/preferences`
+
+- Requiere: `{ public_code, idempotency_key }` — ambos del pedido creado por `/api/orders`
+- Devuelve: `{ sandbox_init_point }` — URL de pago de MP sandbox
+- Solo en hosts `*.amadolibros-web.pages.dev`
+- Claim de idempotencia en D1: `creating:<epoch-seconds>:<uuid>`, TTL 30 s
+- Evento D1: `preference_created` con payload `{ preference_id, environment: "test" }`
+- Todos los errores tienen `Cache-Control: no-store`
+
+### Validaciones de sandbox URL
+
+- `protocol === 'https:'`
+- `hostname === 'sandbox.mercadopago.com'` (sin `.com.uy`)
+- `pathname.length > 1`
+
+### Archivos
+
+- `functions/api/preferences.js` — entry point
+- `functions/api/_mp_handler.js` — lógica y claim
+- `functions/api/_mp_client.js` — HTTP a MP, validación de respuesta
+- `functions/api/__tests__/preferences.test.js` — 44 tests
+
+## Referencias internas
+
+- Endpoint: `POST /api/orders` → `functions/api/orders.js`.
+- Handler con inyección de dependencias: `functions/api/_orders_handler.js`.
+- Endpoint: `POST /api/preferences` → `functions/api/preferences.js`.
+- Client MP con timeout: `functions/api/_mp_client.js`.
+- Verificación Turnstile: `functions/api/_turnstile.js`.
+- Validación y reglas comerciales: `functions/api/_orders_logic.js`.
+- Tests: `functions/api/__tests__/orders.test.js`.
+- Migración: `migrations/0001_orders.sql`.
+- Carrito (frontend): `astro-front/src/pages/carrito.astro`.
+
+## Reglas que la base refuerza
+
+- moneda `UYU`;
+- retiro con envío cero;
+- envío con descuento de retiro cero;
+- costo de envío solamente `0` o `250`;
+- total pagable consistente con subtotal, retiro y envío;
+- campos de entrega obligatorios para `shipping`;
+- un producto por orden después de consolidar cantidades;
+- claves foráneas para ítems y eventos.

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,0 +1,147 @@
+# Ambientes — Preview y Production (2-N-E1)
+
+Este documento describe la configuración centralizada introducida en 2-N-E1
+(`functions/api/_env_config.js`). El código queda preparado para operar en
+Preview y Production. Production ya tiene D1 propia y hosts declarados, pero
+el checkout permanece apagado y oculto: no hay credenciales LIVE ni Turnstile
+de Production configurados.
+
+## Principio general
+
+El ambiente (`APP_ENV`) es siempre explícito. Nunca se infiere de `Host`,
+del access token, de `live_mode`, ni de la rama Git. Si `resolveConfig()`
+no puede construir una configuración completa y válida, el handler
+responde fail-closed (503) sin asumir ningún valor por defecto.
+
+## Matriz de variables
+
+| Variable | Preview (valor actual) | Production (valor propuesto, no aplicado) | Tipo | Obligatoria | Si falta o es inválida | Quién la configura |
+|---|---|---|---|---|---|---|
+| `APP_ENV` | `preview` | `production` | var (`wrangler.toml`) | Sí | 503 en todos los endpoints de pagos/pedidos | Repo — `wrangler.toml` |
+| `MP_COLLECTOR_ID` | `3559407834` (collector de la cuenta TEST) | Collector real de la cuenta LIVE — **a confirmar empíricamente antes de 2-N-E2**, no asumir el `440298103` documentado como owner de la app | var | Sí | 503 fail-closed | Repo — `wrangler.toml` |
+| `CHECKOUT_ENABLED` | `"true"` | `"false"` | var | No (ausente = deshabilitado) | `POST /api/orders` y `POST /api/preferences` responden `503 checkout_temporarily_unavailable`; webhook, `/api/orders/status` y `/pedido` siguen funcionando | Repo — `wrangler.toml` |
+| `PUBLIC_CHECKOUT_ENABLED` | Según build de Preview | `"false"` | variable de build pública | Sí para mostrar el checkout | Los botones y el flujo de pago online no se renderizan | Workflow de build/deploy |
+| `CANONICAL_ORIGIN` | `https://feature-2-n-e1-production-re.amadolibros-web.pages.dev` (alias truncado por Cloudflare Pages — el nombre completo de la rama no entra en el límite de un label DNS) | `https://www.amadolibros.com` (propuesto) | var | Sí | 503 fail-closed | Repo — `wrangler.toml` |
+| `ALLOWED_HOSTS` | No aplica — Preview usa una validación estructural (ver abajo), no una lista | `amadolibros.com,www.amadolibros.com` (propuesto) | var | Sí en Production | 503 fail-closed en Production | Repo — `wrangler.toml` (bloque `env.production`, a crear en 2-N-E2) |
+| `MP_ACCESS_TOKEN` | Token TEST de la app MP | Token LIVE — **no cargar en este lote** | secret | Sí | `503 MP_NOT_CONFIGURED` (preferencias) / `503` sin cuerpo (webhook) | Dashboard de Cloudflare Pages — nunca en el repo |
+| `MP_WEBHOOK_SECRET` | Secret del webhook configurado para la URL de Preview | Secret del webhook Production — requiere su propia entrada en el panel de MP | secret | Sí | `503` sin cuerpo | Dashboard de Cloudflare Pages |
+| `TURNSTILE_SECRET_KEY` | Secret del widget `amadolibros-orders-preview` | Secret de un widget Production **todavía no creado** | secret | Sí | `503 TS_NOT_CONFIGURED` — bloquea la creación de pedidos, Turnstile nunca se desactiva silenciosamente | Dashboard de Cloudflare Pages |
+| `ORDERS_DB` (binding D1) | `amadolibros-orders-preview` | `amadolibros-orders-production` | binding D1 | Sí | `503` sin fallback a Preview, memoria u otra base | `wrangler.toml` |
+
+## Origen canónico vs. hosts aceptados
+
+Son dos conceptos deliberadamente separados:
+
+- **Hosts aceptados** (`isAllowedRequestHost`): determinan si una solicitud
+  entrante puede procesarse. En Preview es una validación **estructural**
+  por labels del hostname (`<algo>.amadolibros-web.pages.dev`, exactamente
+  4 labels) — no una lista, porque Cloudflare Pages genera un subdominio
+  nuevo en cada deploy. En Production es una lista exacta (`ALLOWED_HOSTS`).
+  Ningún caso usa `includes()`/`endsWith()` sobre el string completo del
+  host; se compara contra el hostname ya parseado por `URL`.
+- **Origen canónico** (`CANONICAL_ORIGIN`): el único origen usado para
+  construir `notification_url` y las tres `back_urls`. Nunca se deriva de
+  `Host`, `Origin`, `Referer` ni `X-Forwarded-Host` — eso lo cubren los
+  tests `url-1`/`url-2`/`url-3` en `preferences.test.js`. En Production,
+  aunque se acepten tanto `amadolibros.com` como `www.amadolibros.com`
+  como hosts válidos, las URLs generadas siempre usan el mismo origen
+  canónico configurado.
+
+## D1 por ambiente
+
+- Preview: `amadolibros-orders-preview` (`database_id`
+  `6fa387af-f29e-46dc-97e5-30298568b4a6`), bindeada únicamente bajo
+  `env.preview.d1_databases` en `wrangler.toml`.
+- Production: `amadolibros-orders-production` (`database_id`
+  `6dc8dc3a-2d4f-4045-b428-14323c7b0bcd`), bindeada únicamente bajo
+  `env.production.d1_databases`.
+- Las bases tienen identificadores distintos. Si `ORDERS_DB` está ausente,
+  el handler responde `503` sin fallback a Preview, memoria u otra base.
+
+## Turnstile por ambiente
+
+- Preview: widget `amadolibros-orders-preview` (modo `managed`, dominio
+  `amadolibros-web.pages.dev`), secret en `TURNSTILE_SECRET_KEY` de
+  Preview únicamente.
+- Production: **sin crear todavía**. Va a necesitar su propio widget
+  (dominio `amadolibros.com`/`www.amadolibros.com`) y su propio secret.
+  El hostname esperado por `verifyTurnstile()` ya no tiene un valor por
+  defecto hardcodeado — se toma de `resolveConfig()`, así que si falta la
+  configuración, la verificación falla cerrada (bloquea la creación de
+  pedidos) en vez de aceptar cualquier hostname.
+
+## Collector por ambiente
+
+`MP_COLLECTOR_ID` ya no es una constante hardcodeada en el código
+(`_mp_client.js` ya no exporta `MP_COLLECTOR_ID`) — se lee de config,
+validado como identificador decimal. `live_mode` dejó de ser un gate (ver
+2-N-D2/fix `6e3e181`): ahora es diagnóstico, y el valor esperado también
+depende del ambiente (`false` en Preview, `true` en Production). Un
+mismatch solo genera un `console.warn` con `payment_id`, `app_env`,
+`expected` y `observed` — nunca token, firma completa, payload completo
+ni datos personales.
+
+## Kill switch (`CHECKOUT_ENABLED`)
+
+Autoridad exclusiva del backend. Con cualquier valor distinto del string
+exacto `"true"` (ausente, `"false"`, `"TRUE"`, etc.):
+
+- `POST /api/orders` y `POST /api/preferences` responden `503
+  checkout_temporarily_unavailable` con `Cache-Control: no-store`, sin
+  llamar a Mercado Pago ni escribir en D1.
+- El webhook, `/api/orders/status`, `/pedido` y la idempotencia de pagos
+  ya iniciados siguen funcionando normalmente — el kill switch nunca
+  interrumpe la confirmación de un pago que ya se iba a procesar.
+
+Es una variable normal de Cloudflare Pages: cambiarla puede requerir un
+nuevo deployment para tomar efecto. En esta etapa funciona como *release
+gate* (decisión tomada antes de desplegar), no necesariamente como un
+apagado instantáneo en caliente.
+
+## `sandbox_init_point` vs. `init_point`
+
+- Preview usa exclusivamente `sandbox_init_point` (validado contra
+  `sandbox.mercadopago.com`/`.com.uy`).
+- Production usa exclusivamente `init_point` (validado contra
+  `www.mercadopago.com`/`.com.uy`).
+- Nunca hay fallback cruzado: si falta el campo correspondiente al
+  ambiente actual, `_mp_client.js` devuelve un error controlado
+  (`MP_API_ERROR`), nunca usa el campo del otro ambiente.
+- El campo devuelto al frontend se unificó a `checkout_url` (antes
+  `sandbox_init_point` siempre, sin importar el ambiente).
+
+## `notification_url` y `back_urls`
+
+Se construyen exclusivamente desde `CANONICAL_ORIGIN` + rutas fijas:
+
+- `notification_url`: `<CANONICAL_ORIGIN>/api/webhooks/mercadopago`
+- `back_urls.success`: `<CANONICAL_ORIGIN>/pedido/?result=success&code=<public_code>`
+- `back_urls.pending`: `<CANONICAL_ORIGIN>/pedido/?result=pending&code=<public_code>`
+- `back_urls.failure`: `<CANONICAL_ORIGIN>/pedido/?result=failure&code=<public_code>`
+
+Las back_urls **nunca** confirman un pago — son solo el destino del
+redirect del navegador. `/pedido` sigue mostrando "Pago confirmado" única
+y exclusivamente en base al estado que devuelve `POST
+/api/orders/status`, que a su vez lee D1.
+
+## Pendientes antes de activar cobros LIVE
+
+1. **`CANONICAL_ORIGIN` de Preview es project-wide, no por rama.**
+   `env.preview.vars` de Cloudflare Pages aplica a *todos* los preview
+   deployments del proyecto, no solo a esta rama. Quedó fijado al alias
+   de `feature-2-n-e1-production-re` (Cloudflare trunca el alias cuando el
+   nombre de rama excede el límite de un label DNS) porque es lo que se está
+   validando ahora mismo; cualquier otra rama de preview que intente usar
+   checkout va a generar `notification_url`/`back_urls` apuntando a esta
+   rama hasta que se resuelva el alcance (por rama, o con otra estrategia).
+2. **`MP_COLLECTOR_ID` de Production no está confirmado.** El valor
+   documentado como owner de la app (`440298103`) no debe asumirse como el
+   collector real de pagos LIVE sin verificarlo empíricamente, tal como se
+   tuvo que corregir para el collector de TEST en el fix de `live_mode`
+   (commit `6e3e181`).
+3. **Faltan el widget/secret de Turnstile y las credenciales LIVE de
+   Production.** No se crean ni cargan en este lote.
+4. **La activación exige dos llaves explícitas.** El backend requiere
+   `CHECKOUT_ENABLED="true"` y el frontend debe compilarse con
+   `PUBLIC_CHECKOUT_ENABLED="true"`. Mientras cualquiera permanezca apagada,
+   no se ofrece el flujo de cobro.

--- a/functions/api/__tests__/mp_webhook.test.js
+++ b/functions/api/__tests__/mp_webhook.test.js
@@ -1,0 +1,682 @@
+import { test }  from 'node:test';
+import assert     from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
+import { createMpWebhookHandler } from '../_mp_webhook_handler.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const TEST_SECRET       = 'test-webhook-secret';
+const TEST_TOKEN        = 'TEST-ACCESS-TOKEN';
+const TEST_COLLECTOR_ID = 3559407834;
+const PROD_COLLECTOR_ID = 440298103;
+const NOW         = new Date('2026-07-21T12:00:00.000Z');
+
+const PREVIEW_ENV_CONFIG = {
+  APP_ENV:          'preview',
+  MP_COLLECTOR_ID:  String(TEST_COLLECTOR_ID),
+  CHECKOUT_ENABLED: 'true',
+  CANONICAL_ORIGIN: 'https://feature.amadolibros-web.pages.dev',
+};
+
+const PRODUCTION_ENV_CONFIG = {
+  APP_ENV:          'production',
+  MP_COLLECTOR_ID:  String(PROD_COLLECTOR_ID),
+  CHECKOUT_ENABLED: 'true',
+  CANONICAL_ORIGIN: 'https://www.amadolibros.com',
+  ALLOWED_HOSTS:    'amadolibros.com,www.amadolibros.com',
+};
+
+function hmac(secret, msg) {
+  return createHmac('sha256', secret).update(msg).digest('hex');
+}
+
+function buildSig({ secret = TEST_SECRET, ts = '1700000000', queryDataId = '123', requestId = 'req-001' } = {}) {
+  const msg = `id:${queryDataId};request-id:${requestId};ts:${ts};`;
+  return `ts=${ts},v1=${hmac(secret, msg)}`;
+}
+
+function makeReq({
+  method     = 'POST',
+  host       = 'feature.amadolibros-web.pages.dev',
+  queryDataId = '123',
+  type       = 'payment',
+  bodyDataId  = '123',
+  requestId  = 'req-001',
+  ts         = '1700000000',
+  secret     = TEST_SECRET,
+  xSig       = undefined,
+  noXSig     = false,
+  noXReqId   = false,
+  bodyPatch  = {},
+} = {}) {
+  const sig = xSig ?? buildSig({ secret, ts, queryDataId, requestId });
+  const url = `https://${host}/api/webhooks/mercadopago?data.id=${encodeURIComponent(queryDataId)}&type=${type}`;
+  const headers = { 'Content-Type': 'application/json' };
+  if (!noXSig)   headers['x-signature']   = sig;
+  if (!noXReqId) headers['x-request-id']  = requestId;
+
+  const body = JSON.stringify({
+    action:       'payment.updated',
+    api_version:  'v1',
+    data:         { id: bodyDataId },
+    date_created: '2026-01-01T00:00:00Z',
+    id:           99999,
+    live_mode:    false,
+    type,
+    user_id:      '12345',
+    ...bodyPatch,
+  });
+  return new Request(url, { method, headers, body });
+}
+
+function basePayment(patch = {}) {
+  return {
+    ok:                 true,
+    id:                 123,
+    status:             'approved',
+    live_mode:          false,
+    collector_id:       TEST_COLLECTOR_ID,
+    currency_id:        'UYU',
+    transaction_amount: 3100,
+    external_reference: 'AL-TEST',
+    order_id:           null,
+    date_approved:      '2026-07-21T11:00:00.000Z',
+    ...patch,
+  };
+}
+
+function baseMerchantOrder(patch = {}) {
+  return {
+    ok:                 true,
+    id:                 999,
+    preference_id:      'pref-1',
+    external_reference: 'AL-TEST',
+    payments:           [{ id: 123, status: 'approved' }],
+    ...patch,
+  };
+}
+
+function baseOrder(patch = {}) {
+  return {
+    id:                     'order-uuid',
+    status:                 'open',
+    payment_status:         'not_started',
+    payable_total_uyu:      3100,
+    payment_preference_id:  'pref-1',
+    ...patch,
+  };
+}
+
+function dbMock({ order = baseOrder(), batchError = null } = {}) {
+  const batches = [];
+  return {
+    batches,
+    prepare(sql) {
+      return {
+        bind(..._args) {
+          return {
+            async first() {
+              if (sql.includes('public_code')) return order;
+              return null;
+            },
+            async run() { return { success: true, meta: { changes: 1 } }; },
+          };
+        },
+      };
+    },
+    async batch(stmts) {
+      batches.push(stmts);
+      if (batchError) throw batchError;
+      return stmts.map(() => ({ success: true, meta: { changes: 1 } }));
+    },
+  };
+}
+
+function env(opts = {}) {
+  return {
+    ...(opts.config !== undefined ? opts.config : PREVIEW_ENV_CONFIG),
+    MP_WEBHOOK_SECRET: TEST_SECRET,
+    MP_ACCESS_TOKEN:   TEST_TOKEN,
+    ORDERS_DB:         dbMock(opts.db ? opts.db : {}),
+    ...opts.extra,
+  };
+}
+
+function handler({ getPayment = async () => basePayment(), getMerchantOrder = async () => ({ ok: false, code: 'NOT_FOUND' }) } = {}) {
+  return createMpWebhookHandler({ mpClient: { getPayment, getMerchantOrder }, getNow: () => NOW });
+}
+
+async function call(reqOpts = {}, mpOpts = {}, envOpts = {}) {
+  const h   = handler(mpOpts);
+  const req = makeReq(reqOpts);
+  const e   = env(envOpts);
+  const res = await h({ request: req, env: e });
+  let data = null;
+  try { data = await res.json(); } catch { /* respuestas 503 pueden no tener cuerpo */ }
+  return { res, data, db: e.ORDERS_DB };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test('wh-01: firma válida con query data.id → 200 ok', async () => {
+  const { res, data } = await call();
+  assert.equal(res.status, 200);
+  assert.equal(data.ok, true);
+});
+
+test('wh-02: query data.id ausente → 401', async () => {
+  const req = makeReq();
+  const url = new URL(req.url);
+  url.searchParams.delete('data.id');
+  const r2 = new Request(url.toString(), req);
+  const h  = handler();
+  const res = await h({ request: r2, env: env() });
+  assert.equal(res.status, 401);
+});
+
+test('wh-03: body data.id ausente → 400', async () => {
+  const { res } = await call({ bodyPatch: { data: {} } });
+  assert.equal(res.status, 400);
+});
+
+test('wh-04: query y body data.id distintos → 400', async () => {
+  const { res } = await call({ queryDataId: '123', bodyDataId: '999' });
+  assert.equal(res.status, 400);
+});
+
+test('wh-05: x-request-id ausente → 401', async () => {
+  const { res } = await call({ noXReqId: true });
+  assert.equal(res.status, 401);
+});
+
+test('wh-06: x-signature ausente → 401', async () => {
+  const { res } = await call({ noXSig: true });
+  assert.equal(res.status, 401);
+});
+
+test('wh-07: firma inválida (secret incorrecto) → 401', async () => {
+  const { res } = await call({ secret: 'wrong-secret' });
+  assert.equal(res.status, 401);
+});
+
+test('wh-08: x-signature malformada (sin v1) → 401', async () => {
+  const { res } = await call({ xSig: 'ts=1700000000' });
+  assert.equal(res.status, 401);
+});
+
+test('wh-09: tipo no payment con firma válida → 200 sin procesar', async () => {
+  const { res, data, db } = await call({ type: 'merchant_order', bodyPatch: { type: 'merchant_order' } });
+  assert.equal(res.status, 200);
+  assert.equal(data.ok, true);
+  assert.equal(db.batches.length, 0);
+});
+
+test('wh-10: método GET → 405', async () => {
+  const url = 'https://feature.amadolibros-web.pages.dev/api/webhooks/mercadopago?data.id=123&type=payment';
+  const req = new Request(url, { method: 'GET' });
+  const h   = handler();
+  const res = await h({ request: req, env: env() });
+  assert.equal(res.status, 405);
+});
+
+test('wh-11: host no permitido → 400', async () => {
+  const { res } = await call({ host: 'malicious.example.com' });
+  assert.equal(res.status, 400);
+});
+
+test('wh-12: secrets no configurados → 503', async () => {
+  const req = makeReq();
+  const h   = handler();
+  const res = await h({ request: req, env: { ...PREVIEW_ENV_CONFIG, ORDERS_DB: dbMock() } });
+  assert.equal(res.status, 503);
+});
+
+test('wh-13: getPayment 404 → 503 (imposibilidad de validar, MP debe reintentar — ya no 200 silencioso)', async () => {
+  const { res, db } = await call(
+    {},
+    { getPayment: async () => ({ ok: false, code: 'NOT_FOUND' }) }
+  );
+  assert.equal(res.status, 503);
+  assert.equal(db.batches.length, 0);
+});
+
+test('wh-14: getPayment 401 → 503 (MP debe reintentar)', async () => {
+  const { res } = await call(
+    {},
+    { getPayment: async () => ({ ok: false, code: 'MP_AUTH_ERROR' }) }
+  );
+  assert.equal(res.status, 503);
+});
+
+test('wh-15: getPayment 429 → 503', async () => {
+  const { res } = await call(
+    {},
+    { getPayment: async () => ({ ok: false, code: 'MP_RATE_LIMIT' }) }
+  );
+  assert.equal(res.status, 503);
+});
+
+test('wh-16: getPayment timeout → 503', async () => {
+  const { res } = await call(
+    {},
+    { getPayment: async () => ({ ok: false, code: 'MP_TIMEOUT' }) }
+  );
+  assert.equal(res.status, 503);
+});
+
+test('wh-17: live_mode true con identidad verificada (collector/monto/referencia) → procesa el pago', async () => {
+  const { res, db } = await call(
+    {},
+    { getPayment: async () => basePayment({ live_mode: true }) }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(db.batches.length, 1);
+});
+
+test('wh-45: collector_id incorrecto con live_mode true → sigue rechazando', async () => {
+  const { res, db } = await call(
+    {},
+    { getPayment: async () => basePayment({ live_mode: true, collector_id: 9999 }) }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(db.batches.length, 0);
+});
+
+test('wh-18: collector_id incorrecto → 200 silencio', async () => {
+  const { res, db } = await call(
+    {},
+    { getPayment: async () => basePayment({ collector_id: 9999 }) }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(db.batches.length, 0);
+});
+
+test('wh-19: moneda incorrecta → 200 silencio', async () => {
+  const { res, db } = await call(
+    {},
+    { getPayment: async () => basePayment({ currency_id: 'ARS' }) }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(db.batches.length, 0);
+});
+
+test('wh-20: external_reference nula → 200 silencio', async () => {
+  const { res, db } = await call(
+    {},
+    { getPayment: async () => basePayment({ external_reference: null }) }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(db.batches.length, 0);
+});
+
+test('wh-21: orden no encontrada en D1 → 200 silencio', async () => {
+  const { res, db } = await call(
+    {},
+    {},
+    { db: { order: null } }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(db.batches.length, 0);
+});
+
+test('wh-22: monto exacto funciona', async () => {
+  const { res, data } = await call(
+    {},
+    { getPayment: async () => basePayment({ transaction_amount: 3100 }) },
+    { db: { order: baseOrder({ payable_total_uyu: 3100 }) } }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(data.ok, true);
+});
+
+test('wh-23: monto distinto → 200 silencio', async () => {
+  const { res, db } = await call(
+    {},
+    { getPayment: async () => basePayment({ transaction_amount: 3101 }) },
+    { db: { order: baseOrder({ payable_total_uyu: 3100 }) } }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(db.batches.length, 0);
+});
+
+test('wh-24: monto decimal que no coincide exactamente → 200 silencio', async () => {
+  const { res, db } = await call(
+    {},
+    { getPayment: async () => basePayment({ transaction_amount: 3100.5 }) },
+    { db: { order: baseOrder({ payable_total_uyu: 3100 }) } }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(db.batches.length, 0);
+});
+
+test('wh-25: getMerchantOrder transitorio → 503', async () => {
+  const { res } = await call(
+    {},
+    {
+      getPayment:       async () => basePayment({ order_id: 999 }),
+      getMerchantOrder: async () => ({ ok: false, code: 'MP_API_ERROR' }),
+    }
+  );
+  assert.equal(res.status, 503);
+});
+
+test('wh-25b: getMerchantOrder NOT_FOUND (con order_id presente) → 503, no 200 (imposibilidad de validar)', async () => {
+  const { res, db } = await call(
+    {},
+    {
+      getPayment:       async () => basePayment({ order_id: 999 }),
+      getMerchantOrder: async () => ({ ok: false, code: 'NOT_FOUND' }),
+    }
+  );
+  assert.equal(res.status, 503);
+  assert.equal(db.batches.length, 0);
+});
+
+test('wh-26: merchant order sin payment ID → 200 silencio', async () => {
+  const { res, db } = await call(
+    {},
+    {
+      getPayment:       async () => basePayment({ order_id: 999 }),
+      getMerchantOrder: async () => baseMerchantOrder({ payments: [] }),
+    }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(db.batches.length, 0);
+});
+
+test('wh-27: preference_id incorrecto → 200 silencio', async () => {
+  const { res, db } = await call(
+    {},
+    {
+      getPayment:       async () => basePayment({ order_id: 999 }),
+      getMerchantOrder: async () => baseMerchantOrder({ preference_id: 'other-pref' }),
+    },
+    { db: { order: baseOrder({ payment_preference_id: 'pref-1' }) } }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(db.batches.length, 0);
+});
+
+test('wh-28: external_reference incorrecta en merchant order → 200 silencio', async () => {
+  const { res, db } = await call(
+    {},
+    {
+      getPayment:       async () => basePayment({ order_id: 999 }),
+      getMerchantOrder: async () => baseMerchantOrder({ external_reference: 'AL-OTRO' }),
+    }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(db.batches.length, 0);
+});
+
+test('wh-29: approved → D1 actualizado, evento insertado', async () => {
+  const db_ = dbMock();
+  const h   = handler({ getPayment: async () => basePayment({ status: 'approved' }) });
+  const res = await h({ request: makeReq(), env: { ...PREVIEW_ENV_CONFIG, MP_WEBHOOK_SECRET: TEST_SECRET, MP_ACCESS_TOKEN: TEST_TOKEN, ORDERS_DB: db_ } });
+  assert.equal(res.status, 200);
+  assert.equal(db_.batches.length, 1);
+  const stmts = db_.batches[0];
+  const updateSql = stmts[0].sql ?? stmts[0].stmt?.sql ?? stmts[0]._stmt?.sql;
+  assert.ok(stmts[0] !== undefined);
+});
+
+test('wh-30: pending → D1 actualizado', async () => {
+  const db_ = dbMock({ order: baseOrder({ payment_status: 'not_started' }) });
+  const h   = handler({ getPayment: async () => basePayment({ status: 'pending' }) });
+  const res = await h({ request: makeReq(), env: { ...PREVIEW_ENV_CONFIG, MP_WEBHOOK_SECRET: TEST_SECRET, MP_ACCESS_TOKEN: TEST_TOKEN, ORDERS_DB: db_ } });
+  assert.equal(res.status, 200);
+  assert.equal(db_.batches.length, 1);
+});
+
+test('wh-31: in_process → normaliza a pending, D1 actualizado', async () => {
+  const db_ = dbMock({ order: baseOrder({ payment_status: 'not_started' }) });
+  const h   = handler({ getPayment: async () => basePayment({ status: 'in_process' }) });
+  const res = await h({ request: makeReq(), env: { ...PREVIEW_ENV_CONFIG, MP_WEBHOOK_SECRET: TEST_SECRET, MP_ACCESS_TOKEN: TEST_TOKEN, ORDERS_DB: db_ } });
+  assert.equal(res.status, 200);
+  assert.equal(db_.batches.length, 1);
+});
+
+test('wh-32: rejected → D1 actualizado', async () => {
+  const db_ = dbMock({ order: baseOrder({ payment_status: 'pending' }) });
+  const h   = handler({ getPayment: async () => basePayment({ status: 'rejected', date_approved: null }) });
+  const res = await h({ request: makeReq(), env: { ...PREVIEW_ENV_CONFIG, MP_WEBHOOK_SECRET: TEST_SECRET, MP_ACCESS_TOKEN: TEST_TOKEN, ORDERS_DB: db_ } });
+  assert.equal(res.status, 200);
+  assert.equal(db_.batches.length, 1);
+});
+
+test('wh-33: cancelled → D1 actualizado', async () => {
+  const db_ = dbMock({ order: baseOrder({ payment_status: 'not_started' }) });
+  const h   = handler({ getPayment: async () => basePayment({ status: 'cancelled', date_approved: null }) });
+  const res = await h({ request: makeReq(), env: { ...PREVIEW_ENV_CONFIG, MP_WEBHOOK_SECRET: TEST_SECRET, MP_ACCESS_TOKEN: TEST_TOKEN, ORDERS_DB: db_ } });
+  assert.equal(res.status, 200);
+  assert.equal(db_.batches.length, 1);
+});
+
+test('wh-34: refunded → D1 actualizado', async () => {
+  const db_ = dbMock({ order: baseOrder({ payment_status: 'approved', status: 'paid' }) });
+  const h   = handler({ getPayment: async () => basePayment({ status: 'refunded', date_approved: null }) });
+  const res = await h({ request: makeReq(), env: { ...PREVIEW_ENV_CONFIG, MP_WEBHOOK_SECRET: TEST_SECRET, MP_ACCESS_TOKEN: TEST_TOKEN, ORDERS_DB: db_ } });
+  assert.equal(res.status, 200);
+  assert.equal(db_.batches.length, 1);
+});
+
+test('wh-35: webhook approved repetido → 200, batch ejecutado (INSERT OR IGNORE en D1)', async () => {
+  const db_ = dbMock({ order: baseOrder({ payment_status: 'approved', status: 'paid' }) });
+  const h   = handler({ getPayment: async () => basePayment({ status: 'approved' }) });
+  const res1 = await h({ request: makeReq(), env: { ...PREVIEW_ENV_CONFIG, MP_WEBHOOK_SECRET: TEST_SECRET, MP_ACCESS_TOKEN: TEST_TOKEN, ORDERS_DB: db_ } });
+  const res2 = await h({ request: makeReq(), env: { ...PREVIEW_ENV_CONFIG, MP_WEBHOOK_SECRET: TEST_SECRET, MP_ACCESS_TOKEN: TEST_TOKEN, ORDERS_DB: db_ } });
+  assert.equal(res1.status, 200);
+  assert.equal(res2.status, 200);
+});
+
+test('wh-36: rejected seguido de approved con nuevo payment_id → 200 ambos', async () => {
+  const db_ = dbMock({ order: baseOrder({ payment_status: 'rejected' }) });
+  const h   = handler({ getPayment: async () => basePayment({ id: 456, status: 'approved' }) });
+  const req = makeReq({ queryDataId: '456', bodyDataId: '456', secret: TEST_SECRET });
+  const sig = buildSig({ queryDataId: '456' });
+  const req2 = makeReq({ queryDataId: '456', bodyDataId: '456', xSig: sig });
+  const res = await h({ request: req2, env: { ...PREVIEW_ENV_CONFIG, MP_WEBHOOK_SECRET: TEST_SECRET, MP_ACCESS_TOKEN: TEST_TOKEN, ORDERS_DB: db_ } });
+  assert.equal(res.status, 200);
+  assert.equal(db_.batches.length, 1);
+});
+
+test('wh-37: approved no degradado por pending posterior', async () => {
+  const db_ = dbMock({ order: baseOrder({ payment_status: 'approved', status: 'paid' }) });
+  const h   = handler({ getPayment: async () => basePayment({ id: 789, status: 'pending', date_approved: null }) });
+  const sig = buildSig({ queryDataId: '789' });
+  const res = await h({ request: makeReq({ queryDataId: '789', bodyDataId: '789', xSig: sig }), env: { ...PREVIEW_ENV_CONFIG, MP_WEBHOOK_SECRET: TEST_SECRET, MP_ACCESS_TOKEN: TEST_TOKEN, ORDERS_DB: db_ } });
+  assert.equal(res.status, 200);
+  assert.equal(db_.batches.length, 1);
+});
+
+test('wh-38: error D1 en batch → 500', async () => {
+  const { res } = await call(
+    {},
+    {},
+    { db: { order: baseOrder(), batchError: new Error('D1 error') } }
+  );
+  assert.equal(res.status, 500);
+});
+
+test('wh-39: Cache-Control: no-store siempre presente', async () => {
+  const cases = [
+    call({ noXSig: true }),
+    call(),
+  ];
+  const results = await Promise.all(cases);
+  for (const { res } of results) {
+    assert.equal(res.headers.get('Cache-Control'), 'no-store');
+  }
+});
+
+test('wh-40: respuesta no expone token, secret ni SQL', async () => {
+  const { data } = await call({ noXSig: true });
+  const text = JSON.stringify(data);
+  assert.ok(!text.includes(TEST_SECRET));
+  assert.ok(!text.includes(TEST_TOKEN));
+  assert.ok(!text.toLowerCase().includes('select'));
+});
+
+test('wh-41: getMerchantOrder NOT_FOUND (sin order_id) → procesa normalmente', async () => {
+  const { res, data } = await call(
+    {},
+    {
+      getPayment:       async () => basePayment({ order_id: null }),
+      getMerchantOrder: async () => ({ ok: false, code: 'NOT_FOUND' }),
+    }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(data.ok, true);
+});
+
+test('wh-42: payment_preference_id con prefijo creating: → omite validación de preferencia', async () => {
+  const { res, data } = await call(
+    {},
+    {
+      getPayment:       async () => basePayment({ order_id: 999 }),
+      getMerchantOrder: async () => baseMerchantOrder({ preference_id: 'other-pref' }),
+    },
+    { db: { order: baseOrder({ payment_preference_id: 'creating:123:uuid' }) } }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(data.ok, true);
+});
+
+test('wh-43: authorized → normaliza a pending', async () => {
+  const db_ = dbMock({ order: baseOrder() });
+  const h   = handler({ getPayment: async () => basePayment({ status: 'authorized', date_approved: null }) });
+  const res = await h({ request: makeReq(), env: { ...PREVIEW_ENV_CONFIG, MP_WEBHOOK_SECRET: TEST_SECRET, MP_ACCESS_TOKEN: TEST_TOKEN, ORDERS_DB: db_ } });
+  assert.equal(res.status, 200);
+  assert.equal(db_.batches.length, 1);
+});
+
+test('wh-44: charged_back → normaliza a refunded', async () => {
+  const db_ = dbMock({ order: baseOrder({ payment_status: 'approved' }) });
+  const h   = handler({ getPayment: async () => basePayment({ status: 'charged_back', date_approved: null }) });
+  const res = await h({ request: makeReq(), env: { ...PREVIEW_ENV_CONFIG, MP_WEBHOOK_SECRET: TEST_SECRET, MP_ACCESS_TOKEN: TEST_TOKEN, ORDERS_DB: db_ } });
+  assert.equal(res.status, 200);
+  assert.equal(db_.batches.length, 1);
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 2-N-E1 — config centralizada, APP_ENV production, live_mode por ambiente,
+// hosts, kill switch
+// ══════════════════════════════════════════════════════════════════════════════
+
+function captureWarn(fn) {
+  const calls = [];
+  const orig  = console.warn;
+  console.warn = (...args) => { calls.push(args); };
+  return fn().finally(() => { console.warn = orig; }).then(result => ({ result, calls }));
+}
+
+// ── Config fail-closed ──────────────────────────────────────────────────────
+test('cfg-1: APP_ENV ausente → 503 fail-closed', async () => {
+  const { res } = await call({}, {}, { config: { ...PREVIEW_ENV_CONFIG, APP_ENV: undefined } });
+  assert.equal(res.status, 503);
+});
+
+test('cfg-2: APP_ENV inválido → 503 fail-closed', async () => {
+  const { res } = await call({}, {}, { config: { ...PREVIEW_ENV_CONFIG, APP_ENV: 'staging' } });
+  assert.equal(res.status, 503);
+});
+
+test('cfg-3: MP_COLLECTOR_ID inválido → 503 fail-closed', async () => {
+  const { res } = await call({}, {}, { config: { ...PREVIEW_ENV_CONFIG, MP_COLLECTOR_ID: '3559-407834' } });
+  assert.equal(res.status, 503);
+});
+
+test('cfg-4: Production sin ALLOWED_HOSTS → 503 fail-closed', async () => {
+  const { res } = await call({}, {}, { config: { ...PRODUCTION_ENV_CONFIG, ALLOWED_HOSTS: undefined } });
+  assert.equal(res.status, 503);
+});
+
+// ── APP_ENV=production: collector real, live_mode:true esperado ─────────────
+test('prod-1: APP_ENV=production, collector correcto, live_mode:true esperado → procesa sin warning', async () => {
+  const db_ = dbMock({ order: baseOrder() });
+  const h   = handler({ getPayment: async () => basePayment({ collector_id: PROD_COLLECTOR_ID, live_mode: true }) });
+  const req = makeReq({ host: 'www.amadolibros.com' });
+  const { result: res, calls } = await captureWarn(() =>
+    h({ request: req, env: { ...PRODUCTION_ENV_CONFIG, MP_WEBHOOK_SECRET: TEST_SECRET, MP_ACCESS_TOKEN: TEST_TOKEN, ORDERS_DB: db_ } })
+  );
+  assert.equal(res.status, 200);
+  assert.equal(db_.batches.length, 1, 'debe procesar el pago (live_mode:true es lo esperado en production)');
+  assert.equal(calls.length, 0, 'no debe loguear warning cuando live_mode coincide con lo esperado');
+});
+
+test('prod-2: APP_ENV=production, live_mode:false inesperado → warning, pero procesa igual', async () => {
+  const db_ = dbMock({ order: baseOrder() });
+  const h   = handler({ getPayment: async () => basePayment({ collector_id: PROD_COLLECTOR_ID, live_mode: false }) });
+  const req = makeReq({ host: 'www.amadolibros.com' });
+  const { result: res, calls } = await captureWarn(() =>
+    h({ request: req, env: { ...PRODUCTION_ENV_CONFIG, MP_WEBHOOK_SECRET: TEST_SECRET, MP_ACCESS_TOKEN: TEST_TOKEN, ORDERS_DB: db_ } })
+  );
+  assert.equal(res.status, 200);
+  assert.equal(db_.batches.length, 1, 'live_mode inesperado no debe bloquear un pago por lo demás válido');
+  assert.equal(calls.length, 1, 'debe loguear exactamente un warning');
+  const [msg, meta] = calls[0];
+  assert.match(msg, /live_mode/);
+  assert.equal(meta.app_env, 'production');
+  assert.equal(meta.expected, true);
+  assert.equal(meta.observed, false);
+});
+
+test('prod-3: APP_ENV=production, collector_id de test → sigue rechazado (200 silencio) sin importar live_mode', async () => {
+  const { res, db } = await call(
+    { host: 'www.amadolibros.com' },
+    { getPayment: async () => basePayment({ collector_id: TEST_COLLECTOR_ID, live_mode: true }) },
+    { config: PRODUCTION_ENV_CONFIG }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(db.batches.length, 0);
+});
+
+test('warn-1: preview con live_mode:false (esperado) → sin warning', async () => {
+  const { result: res, calls } = await captureWarn(() => call({}, { getPayment: async () => basePayment({ live_mode: false }) }).then(r => r.res));
+  assert.equal(res.status, 200);
+  assert.equal(calls.length, 0);
+});
+
+// ── Kill switch no debe afectar al webhook ───────────────────────────────────
+test('kill-1: CHECKOUT_ENABLED="false" no bloquea el webhook', async () => {
+  const { res, db } = await call({}, {}, { config: { ...PREVIEW_ENV_CONFIG, CHECKOUT_ENABLED: 'false' } });
+  assert.equal(res.status, 200);
+  assert.equal(db.batches.length, 1);
+});
+
+test('kill-2: CHECKOUT_ENABLED ausente no bloquea el webhook', async () => {
+  const { res, db } = await call({}, {}, { config: { ...PREVIEW_ENV_CONFIG, CHECKOUT_ENABLED: undefined } });
+  assert.equal(res.status, 200);
+  assert.equal(db.batches.length, 1);
+});
+
+// ── Hosts: legítimos vs engañosos ────────────────────────────────────────────
+test('host-1: dominio engañoso tipo prefijo (evilamadolibros-web.pages.dev) → 400', async () => {
+  const { res } = await call({ host: 'evilamadolibros-web.pages.dev' });
+  assert.equal(res.status, 400);
+});
+
+test('host-2: dominio engañoso tipo sufijo (amadolibros-web.pages.dev.evil.com) → 400', async () => {
+  const { res } = await call({ host: 'amadolibros-web.pages.dev.evil.com' });
+  assert.equal(res.status, 400);
+});
+
+test('host-3: Production acepta www.amadolibros.com y amadolibros.com, rechaza otros subdominios', async () => {
+  const okReq   = { host: 'www.amadolibros.com' };
+  const okReq2  = { host: 'amadolibros.com' };
+  const badReq  = { host: 'staging.amadolibros.com' };
+  const r1 = await call(okReq,  { getPayment: async () => basePayment({ collector_id: PROD_COLLECTOR_ID }) }, { config: PRODUCTION_ENV_CONFIG });
+  const r2 = await call(okReq2, { getPayment: async () => basePayment({ collector_id: PROD_COLLECTOR_ID }) }, { config: PRODUCTION_ENV_CONFIG });
+  const r3 = await call(badReq, {}, { config: PRODUCTION_ENV_CONFIG });
+  assert.notEqual(r1.res.status, 400);
+  assert.notEqual(r2.res.status, 400);
+  assert.equal(r3.res.status, 400);
+});
+
+// ── El webhook nunca exige encabezado Origin (Mercado Pago no es un navegador) ──
+test('origin-1: request sin encabezado Origin funciona normalmente', async () => {
+  const req = makeReq();
+  assert.equal(req.headers.get('Origin'), null, 'precondición: la request de prueba no manda Origin');
+  const { res } = await call();
+  assert.equal(res.status, 200);
+});

--- a/functions/api/__tests__/order_status.test.js
+++ b/functions/api/__tests__/order_status.test.js
@@ -1,0 +1,179 @@
+import { test } from 'node:test';
+import assert    from 'node:assert/strict';
+import { createOrderStatusHandler } from '../_order_status_handler.js';
+
+const ALLOWED_HOST = 'feature.amadolibros-web.pages.dev';
+
+const PREVIEW_CONFIG = {
+  APP_ENV:          'preview',
+  MP_COLLECTOR_ID:  '3559407834',
+  CHECKOUT_ENABLED: 'true',
+  CANONICAL_ORIGIN: 'https://feature.amadolibros-web.pages.dev',
+};
+
+function dbMock({ order = null } = {}) {
+  return {
+    prepare(sql) {
+      return {
+        bind(..._args) {
+          return {
+            async first() { return order; },
+          };
+        },
+      };
+    },
+  };
+}
+
+function makeReq({ method = 'POST', host = ALLOWED_HOST, body = undefined, ct = 'application/json' } = {}) {
+  const headers = {};
+  if (ct) headers['Content-Type'] = ct;
+  return new Request(`https://${host}/api/orders/status`, {
+    method,
+    headers,
+    body: body !== undefined ? (typeof body === 'string' ? body : JSON.stringify(body)) : undefined,
+  });
+}
+
+function env(order = { payment_status: 'approved', status: 'paid' }, envPatch = {}) {
+  return { ...PREVIEW_CONFIG, ORDERS_DB: dbMock({ order }), ...envPatch };
+}
+
+async function call(reqOpts = {}, order = { payment_status: 'approved', status: 'paid' }, envPatch = {}) {
+  const h   = createOrderStatusHandler();
+  const req = makeReq(reqOpts);
+  const res = await h({ request: req, env: env(order, envPatch) });
+  let data;
+  try { data = await res.json(); } catch { data = null; }
+  return { res, data };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test('os-01: par válido → 200 con payment_status y status', async () => {
+  const { res, data } = await call({ body: { public_code: 'AL-001', idempotency_key: 'key-1' } });
+  assert.equal(res.status, 200);
+  assert.equal(data.payment_status, 'approved');
+  assert.equal(data.status, 'paid');
+});
+
+test('os-02: método GET → 405', async () => {
+  const { res } = await call({ method: 'GET', body: undefined });
+  assert.equal(res.status, 405);
+});
+
+test('os-03: public_code ausente → 400', async () => {
+  const { res } = await call({ body: { idempotency_key: 'key-1' } });
+  assert.equal(res.status, 400);
+});
+
+test('os-04: idempotency_key ausente → 400', async () => {
+  const { res } = await call({ body: { public_code: 'AL-001' } });
+  assert.equal(res.status, 400);
+});
+
+test('os-05: par inválido (no match en D1) → 404', async () => {
+  const h   = createOrderStatusHandler();
+  const req = makeReq({ body: { public_code: 'AL-999', idempotency_key: 'wrong-key' } });
+  const res = await h({ request: req, env: env(null) });
+  assert.equal(res.status, 404);
+});
+
+test('os-06: host no permitido → 400', async () => {
+  const { res } = await call({ host: 'evil.example.com', body: { public_code: 'AL-001', idempotency_key: 'k' } });
+  assert.equal(res.status, 400);
+});
+
+test('os-07: respuesta solo expone payment_status y status', async () => {
+  const { res, data } = await call({ body: { public_code: 'AL-001', idempotency_key: 'key-1' } });
+  assert.equal(res.status, 200);
+  const keys = Object.keys(data);
+  assert.ok(keys.includes('payment_status'));
+  assert.ok(keys.includes('status'));
+  assert.ok(!keys.includes('id'));
+  assert.ok(!keys.includes('payment_id'));
+  assert.ok(!keys.includes('buyer_name'));
+  assert.ok(!keys.includes('payable_total_uyu'));
+  assert.equal(keys.length, 2);
+});
+
+test('os-08: Cache-Control: no-store siempre', async () => {
+  const { res }  = await call({ body: { public_code: 'AL-001', idempotency_key: 'k' } });
+  const { res: r2 } = await call({ body: { public_code: 'AL-x', idempotency_key: 'y' } }, null);
+  assert.equal(res.headers.get('Cache-Control'), 'no-store');
+  assert.equal(r2.headers.get('Cache-Control'), 'no-store');
+});
+
+test('os-09: payment_status not_started devuelto correctamente', async () => {
+  const { res, data } = await call(
+    { body: { public_code: 'AL-001', idempotency_key: 'key-1' } },
+    { payment_status: 'not_started', status: 'open' }
+  );
+  assert.equal(res.status, 200);
+  assert.equal(data.payment_status, 'not_started');
+  assert.equal(data.status, 'open');
+});
+
+test('os-10: payment_status pending devuelto correctamente', async () => {
+  const { data } = await call(
+    { body: { public_code: 'AL-001', idempotency_key: 'key-1' } },
+    { payment_status: 'pending', status: 'open' }
+  );
+  assert.equal(data.payment_status, 'pending');
+});
+
+test('os-11: ORDERS_DB no disponible → 503', async () => {
+  const h   = createOrderStatusHandler();
+  const req = makeReq({ body: { public_code: 'AL-001', idempotency_key: 'k' } });
+  const res = await h({ request: req, env: { ...PREVIEW_CONFIG } });
+  assert.equal(res.status, 503);
+});
+
+test('os-12: Content-Type incorrecto → 415', async () => {
+  const { res } = await call({ ct: 'text/plain', body: '{}' });
+  assert.equal(res.status, 415);
+});
+
+// ── 2-N-E1: config centralizada, fail-closed, hosts ─────────────────────────
+
+test('os-13: APP_ENV ausente → 503 fail-closed (config inválida)', async () => {
+  const { res } = await call(
+    { body: { public_code: 'AL-001', idempotency_key: 'key-1' } },
+    { payment_status: 'approved', status: 'paid' },
+    { APP_ENV: undefined }
+  );
+  assert.equal(res.status, 503);
+});
+
+test('os-14: APP_ENV con valor inválido (ni preview ni production) → 503', async () => {
+  const { res } = await call(
+    { body: { public_code: 'AL-001', idempotency_key: 'key-1' } },
+    { payment_status: 'approved', status: 'paid' },
+    { APP_ENV: 'staging' }
+  );
+  assert.equal(res.status, 503);
+});
+
+test('os-15: MP_COLLECTOR_ID no decimal → 503', async () => {
+  const { res } = await call(
+    { body: { public_code: 'AL-001', idempotency_key: 'key-1' } },
+    { payment_status: 'approved', status: 'paid' },
+    { MP_COLLECTOR_ID: 'abc' }
+  );
+  assert.equal(res.status, 503);
+});
+
+test('os-16: dominio engañoso tipo prefijo (evilamadolibros-web.pages.dev) → 400', async () => {
+  const { res } = await call({ host: 'evilamadolibros-web.pages.dev', body: { public_code: 'AL-001', idempotency_key: 'k' } });
+  assert.equal(res.status, 400);
+});
+
+test('os-17: dominio engañoso tipo sufijo (amadolibros-web.pages.dev.evil.com) → 400', async () => {
+  const { res } = await call({ host: 'amadolibros-web.pages.dev.evil.com', body: { public_code: 'AL-001', idempotency_key: 'k' } });
+  assert.equal(res.status, 400);
+});
+
+test('os-18: hostname de Preview con hash de deployment válido → 200', async () => {
+  const { res } = await call({ host: '61953b88.amadolibros-web.pages.dev', body: { public_code: 'AL-001', idempotency_key: 'key-1' } });
+  assert.equal(res.status, 200);
+});

--- a/functions/api/__tests__/orders.test.js
+++ b/functions/api/__tests__/orders.test.js
@@ -1,0 +1,324 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createOrdersHandler } from '../_orders_handler.js';
+import { consolidateItems, dateInTimeZone, generateFingerprint, validateBody } from '../_orders_logic.js';
+import { verifyTurnstile } from '../_turnstile.js';
+
+const NOW = new Date('2026-07-19T16:00:00.000Z');
+
+const PREVIEW_CONFIG = {
+  APP_ENV:          'preview',
+  MP_COLLECTOR_ID:  '3559407834',
+  CHECKOUT_ENABLED: 'true',
+  CANONICAL_ORIGIN: 'https://preview.amadolibros-web.pages.dev',
+};
+const CATALOG = { items: [
+  { id:'A', title:'Alpha', price:1000, available_quantity:5, status:'active', thumbnail:null },
+  { id:'B', title:'Beta', price:1250, available_quantity:3, status:'active', thumbnail:null },
+  { id:'G', title:'Gamma', price:800, available_quantity:5, status:'active', thumbnail:null },
+  { id:'P', title:'Pausado', price:300, available_quantity:10, status:'paused', thumbnail:null },
+  { id:'X', title:'Precio roto', price:'NaN', available_quantity:2, status:'active', thumbnail:null },
+] };
+
+function dbMock({ existing=null, batchError=null, race=null, lookupError=null, strict=false }={}) {
+  let lookups=0; const committed=[]; const updates=[];
+  return {
+    committed, updates, lookups:()=>lookups,
+    prepare(sql){
+      if (strict) throw new Error('D1 must not be accessed before Turnstile approval');
+      return { bind(...args){ const stmt={sql,args}; return {
+        async first(){
+          if (sql.includes('idempotency_key')) { lookups++; if(lookupError) throw lookupError; return existing || (lookups>1 ? race : null); }
+          if (sql.includes('public_code')) return null;
+          return null;
+        },
+        async run(){ updates.push(stmt); return {success:true}; },
+        stmt,
+      }; } };
+    },
+    async batch(stmts){ if(batchError) throw batchError; committed.push(...stmts); return stmts.map(()=>({success:true})); },
+  };
+}
+
+const TS_OK = async () => ({ ok: true });
+
+function ctx(body, db, opts={}) {
+  const method=opts.method||'POST'; const headers={'Content-Type':opts.type||'application/json'};
+  if(opts.length!==undefined) headers['Content-Length']=String(opts.length);
+  // Fail-closed: incluye TURNSTILE_SECRET_KEY cuando ORDERS_DB está presente; permite override vía opts.env.
+  const env = opts.env !== undefined ? opts.env : (db ? { ...PREVIEW_CONFIG, ORDERS_DB:db, TURNSTILE_SECRET_KEY:'ts-test-secret' } : { ...PREVIEW_CONFIG });
+  return { request:new Request('https://x/api/orders',{method,headers,body:method==='POST'?(typeof body==='string'?body:JSON.stringify(body)):undefined}), env, waitUntil(){} };
+}
+function pickup(key='k'){ return { idempotency_key:key, cf_turnstile_response:'ok-token', items:[{product_id:'A',quantity:2},{product_id:'B',quantity:1}], delivery_type:'pickup', buyer:{name:'Ana',phone:'099'} }; }
+function shipping(key='s', patch={}) { const base={ idempotency_key:key, cf_turnstile_response:'ok-token', items:[{product_id:'G',quantity:1},{product_id:'A',quantity:1}], delivery_type:'shipping', buyer:{name:'Carlos',phone:'098'}, shipping:{address:'Calle 1',locality:'Centro',department:'Montevideo',requested_date:'2026-07-20',requested_from:'09:00',requested_to:'12:00',notes:'2B'} }; return {...base,...patch,shipping:{...base.shipping,...(patch.shipping||{})}}; }
+function stored(body, patch={}) { return { id:'uuid', idempotency_key:body.idempotency_key, request_fingerprint:generateFingerprint(body,consolidateItems(body.items)), public_code:'AL-TEST', status:'open', payment_status:'not_started', delivery_type:body.delivery_type, products_total_uyu:3250, pickup_discount_uyu:150, shipping_cost_uyu:0, payable_total_uyu:3100, currency:'UYU', expires_at:'2026-07-19T17:00:00.000Z', ...patch }; }
+function handler(fetchCatalog=async()=>CATALOG, now=NOW, verifyTurnstileToken=TS_OK){ return createOrdersHandler({fetchCatalog,getNow:()=>new Date(now),verifyTurnstileToken}); }
+
+async function call(body, db=dbMock(), opts={}, h=handler()){ const response=await h(ctx(body,db,opts)); return {response,data:await response.json(),db}; }
+
+test('reglas comerciales: retiro, envío pago y umbral inclusivo', async()=>{
+  let r=await call(pickup()); assert.equal(r.data.order.payable_total_uyu,3100);
+  r=await call(shipping()); assert.equal(r.data.order.payable_total_uyu,2050);
+  r=await call(shipping('t',{items:[{product_id:'A',quantity:2}]})); assert.equal(r.data.order.shipping_cost_uyu,0); assert.equal(r.data.order.payable_total_uyu,2000);
+});
+
+test('expira exactamente en 60 minutos y no expone UUID', async()=>{
+  const {response,data}=await call(pickup('exp')); assert.equal(response.status,201); assert.equal(data.order.expires_at,'2026-07-19T17:00:00.000Z'); assert.equal(Object.hasOwn(data.order,'id'),false);
+});
+
+test('idempotencia idéntica responde antes de R2', async()=>{
+  const body=pickup('same'); let calls=0; const d=dbMock({existing:stored(body)});
+  const r=await call(body,d,{},handler(async()=>{calls++; throw Error('R2');})); assert.equal(r.response.status,200); assert.equal(calls,0);
+});
+
+test('misma clave con pedido distinto devuelve 409', async()=>{
+  const body=pickup('conflict'); const r=await call(body,dbMock({existing:stored(body,{request_fingerprint:'otro'})})); assert.equal(r.response.status,409);
+});
+
+test('orden vencida devuelve 410 y se marca expired', async()=>{
+  const body=pickup('old'); const d=dbMock({existing:stored(body,{expires_at:'2026-07-19T15:00:00.000Z'})}); const r=await call(body,d); assert.equal(r.response.status,410); assert.equal(r.data.code,'ORDER_EXPIRED'); assert.equal(d.updates.length,1);
+});
+
+test('notas integran fingerprint', async()=>{
+  const a=shipping('n'), b=shipping('n',{shipping:{notes:'otra'}}); assert.notEqual(generateFingerprint(a,consolidateItems(a.items)),generateFingerprint(b,consolidateItems(b.items)));
+  const r=await call(b,dbMock({existing:stored(a)})); assert.equal(r.response.status,409);
+});
+
+test('precio del navegador se ignora y manda catálogo', async()=>{
+  const body={idempotency_key:'price',cf_turnstile_response:'ok-token',items:[{product_id:'A',quantity:1,price:99999,title:'falso'}],delivery_type:'pickup',buyer:{name:'T',phone:'099'}}; const r=await call(body); assert.equal(r.data.order.products_total_uyu,1000); assert.equal(r.data.order.payable_total_uyu,850);
+});
+
+test('stock, producto, estado y precio inválidos devuelven 422', async()=>{
+  for(const id of ['NOPE','P','X']) { const b=pickup(id); b.items=[{product_id:id,quantity:1}]; assert.equal((await call(b)).response.status,422); }
+  const b=pickup('stock'); b.items=[{product_id:'A',quantity:6}]; assert.equal((await call(b)).response.status,422);
+});
+
+test('tipos JSON incorrectos devuelven 400 sin excepción', async()=>{
+  const bodies=[{...pickup('null'),items:[null]},{...pickup('name'),buyer:{name:123,phone:'099'}},shipping('address',{shipping:{address:123}}),shipping('notes',{shipping:{notes:123}})];
+  for(const b of bodies) assert.equal((await call(b)).response.status,400);
+});
+
+test('fecha de Uruguay no se adelanta por UTC', async()=>{
+  const late=new Date('2026-07-20T01:30:00.000Z'); assert.equal(dateInTimeZone(late),'2026-07-19'); const b=shipping('uy',{shipping:{requested_date:'2026-07-19'}}); assert.equal((await call(b,dbMock(),{},handler(async()=>CATALOG,late))).response.status,201);
+});
+
+test('fecha y horas imposibles o desordenadas devuelven 400', async()=>{
+  const cases=[shipping('d',{shipping:{requested_date:'2026-02-31'}}),shipping('h',{shipping:{requested_from:'28:75'}}),shipping('o',{shipping:{requested_from:'14:00',requested_to:'14:00'}})];
+  for(const b of cases) assert.equal((await call(b)).response.status,400);
+});
+
+test('batch fallido devuelve 500 sin commit', async()=>{
+  const d=dbMock({batchError:Error('D1')}); const r=await call(pickup('fail'),d); assert.equal(r.response.status,500); assert.equal(d.committed.length,0);
+});
+
+test('carrera idempotente recupera orden sin depender del texto del error', async()=>{
+  const b=pickup('race'), race=stored(b), d=dbMock({batchError:Error('opaque'),race}); const r=await call(b,d); assert.equal(r.response.status,200); assert.equal(r.data.order.public_code,'AL-TEST'); assert.equal(d.lookups(),2);
+});
+
+test('servicio D1 ausente o lookup fallido devuelve 503', async()=>{
+  assert.equal((await call(pickup('none'),null)).response.status,503); assert.equal((await call(pickup('lookup'),dbMock({lookupError:Error('D1')}))).response.status,503);
+});
+
+test('límites HTTP y método', async()=>{
+  assert.equal((await call('{}',dbMock(),{length:33*1024})).response.status,413); assert.equal((await call('{}',dbMock(),{type:'text/plain'})).response.status,415); const r=await call(null,dbMock(),{method:'GET'}); assert.equal(r.response.status,405); assert.equal(r.response.headers.get('Allow'),'POST');
+});
+
+test('límites de contrato y consolidación', ()=>{
+  assert.equal(validateBody([]),'Body inválido.'); const b=pickup('x'.repeat(129)); assert.match(validateBody(b),/demasiado largo/); b.idempotency_key='q'; b.items=[{product_id:'A',quantity:100}]; assert.equal(validateBody(b),'Cantidad inválida.'); assert.deepEqual(consolidateItems([{product_id:'B',quantity:1},{product_id:'A',quantity:2},{product_id:'B',quantity:3}]),[{product_id:'A',quantity:2},{product_id:'B',quantity:4}]);
+});
+
+// ── Turnstile ─────────────────────────────────────────────────────────────────
+
+test('ts-1: ORDERS_DB presente y TURNSTILE_SECRET_KEY ausente → 503, D1 intacta', async()=>{
+  const db=dbMock({strict:true});
+  const r=await call({...pickup(),cf_turnstile_response:'any'}, db, {env:{...PREVIEW_CONFIG, ORDERS_DB:db}});
+  assert.equal(r.response.status,503);
+  assert.equal(r.data.code,'TS_NOT_CONFIGURED');
+});
+
+test('ts-2: token ausente → 403 TOKEN_MISSING, D1 intacta', async()=>{
+  const body={...pickup()}; delete body.cf_turnstile_response;
+  const db=dbMock({strict:true});
+  const r=await call(body,db);
+  assert.equal(r.response.status,403);
+  assert.equal(r.data.code,'TOKEN_MISSING');
+});
+
+test('ts-3: token demasiado largo → 403 TOKEN_INVALID, D1 intacta', async()=>{
+  const db=dbMock({strict:true});
+  const r=await call({...pickup(),cf_turnstile_response:'x'.repeat(2049)},db);
+  assert.equal(r.response.status,403);
+  assert.equal(r.data.code,'TOKEN_INVALID');
+});
+
+test('ts-4: token inválido (siteverify rechaza) → 403 TOKEN_INVALID, D1 intacta', async()=>{
+  const db=dbMock({strict:true});
+  const r=await call({...pickup(),cf_turnstile_response:'bad'},db,{},handler(async()=>CATALOG,NOW,async()=>({ok:false,code:'TOKEN_INVALID'})));
+  assert.equal(r.response.status,403);
+  assert.equal(r.data.code,'TOKEN_INVALID');
+});
+
+test('ts-5: token reutilizado/vencido → 403 TOKEN_EXPIRED, D1 intacta', async()=>{
+  const db=dbMock({strict:true});
+  const r=await call({...pickup(),cf_turnstile_response:'old'},db,{},handler(async()=>CATALOG,NOW,async()=>({ok:false,code:'TOKEN_EXPIRED'})));
+  assert.equal(r.response.status,403);
+  assert.equal(r.data.code,'TOKEN_EXPIRED');
+});
+
+test('ts-6: error interno de siteverify → 503 SITEVERIFY_ERROR, D1 intacta', async()=>{
+  const db=dbMock({strict:true});
+  const r=await call({...pickup(),cf_turnstile_response:'any'},db,{},handler(async()=>CATALOG,NOW,async()=>({ok:false,code:'SITEVERIFY_ERROR'})));
+  assert.equal(r.response.status,503);
+  assert.equal(r.data.code,'SITEVERIFY_ERROR');
+});
+
+test('ts-7: timeout de siteverify → 503 SITEVERIFY_TIMEOUT, D1 intacta', async()=>{
+  const db=dbMock({strict:true});
+  const r=await call({...pickup(),cf_turnstile_response:'any'},db,{},handler(async()=>CATALOG,NOW,async()=>({ok:false,code:'SITEVERIFY_TIMEOUT'})));
+  assert.equal(r.response.status,503);
+  assert.equal(r.data.code,'SITEVERIFY_TIMEOUT');
+});
+
+test('ts-8: action incorrecta → 403 ACTION_INVALID, D1 intacta', async()=>{
+  const db=dbMock({strict:true});
+  const r=await call({...pickup(),cf_turnstile_response:'any'},db,{},handler(async()=>CATALOG,NOW,async()=>({ok:false,code:'ACTION_INVALID'})));
+  assert.equal(r.response.status,403);
+  assert.equal(r.data.code,'ACTION_INVALID');
+});
+
+test('ts-9: hostname incorrecto → 403 HOSTNAME_INVALID, D1 intacta', async()=>{
+  const db=dbMock({strict:true});
+  const r=await call({...pickup(),cf_turnstile_response:'any'},db,{},handler(async()=>CATALOG,NOW,async()=>({ok:false,code:'HOSTNAME_INVALID'})));
+  assert.equal(r.response.status,403);
+  assert.equal(r.data.code,'HOSTNAME_INVALID');
+});
+
+test('ts-10: token válido → 201 y D1 escrita', async()=>{
+  const db=dbMock();
+  const r=await call({...pickup(),cf_turnstile_response:'valid'},db);
+  assert.equal(r.response.status,201);
+  assert.equal(db.committed.length>0,true);
+});
+
+test('ts-11: cf_turnstile_response cadena vacía o espacios → 403 TOKEN_MISSING, D1 intacta', async()=>{
+  const db=dbMock({strict:true});
+  const r=await call({...pickup(),cf_turnstile_response:'   '},db);
+  assert.equal(r.response.status,403);
+  assert.equal(r.data.code,'TOKEN_MISSING');
+});
+
+// ── Tests unitarios de _turnstile.js con fetch inyectable ────────────────────
+
+function fakeFetch(body, ok=true) {
+  return async () => ({ ok, json: async () => body });
+}
+
+test('ts-12: siteverify HTTP 500 → SITEVERIFY_ERROR', async()=>{
+  const res=await verifyTurnstile('tok','sec','',{fetch:fakeFetch(null,false)});
+  assert.equal(res.ok,false);
+  assert.equal(res.code,'SITEVERIFY_ERROR');
+});
+
+test('ts-13: siteverify JSON inválido → SITEVERIFY_ERROR', async()=>{
+  const badFetch=async()=>({ok:true,json:async()=>{throw new SyntaxError('bad json');}});
+  const res=await verifyTurnstile('tok','sec','',{fetch:badFetch});
+  assert.equal(res.ok,false);
+  assert.equal(res.code,'SITEVERIFY_ERROR');
+});
+
+const PAGES_PREVIEW_HOSTNAME_RE = /^[^.]+\.amadolibros-web\.pages\.dev$/;
+const isPreviewHostnameForTest  = (h) => PAGES_PREVIEW_HOSTNAME_RE.test(h);
+
+test('ts-14: hostname commit-hash Preview → ok: true', async()=>{
+  const f=fakeFetch({success:true,action:'prepare_order',hostname:'abc123def456.amadolibros-web.pages.dev'});
+  const res=await verifyTurnstile('tok','sec','',{fetch:f, isAllowedHostname:isPreviewHostnameForTest});
+  assert.equal(res.ok,true);
+});
+
+test('ts-15: hostname alias de rama Preview → ok: true', async()=>{
+  const f=fakeFetch({success:true,action:'prepare_order',hostname:'feature-turnstile.amadolibros-web.pages.dev'});
+  const res=await verifyTurnstile('tok','sec','',{fetch:f, isAllowedHostname:isPreviewHostnameForTest});
+  assert.equal(res.ok,true);
+});
+
+test('ts-14b: isAllowedHostname ausente → HOSTNAME_INVALID (fail-closed, no default hardcodeado)', async()=>{
+  const f=fakeFetch({success:true,action:'prepare_order',hostname:'abc123def456.amadolibros-web.pages.dev'});
+  const res=await verifyTurnstile('tok','sec','',{fetch:f});
+  assert.equal(res.ok,false);
+  assert.equal(res.code,'HOSTNAME_INVALID');
+});
+
+test('ts-16: token y secret nunca expuestos en respuesta al cliente', async()=>{
+  const r=await call({...pickup()});
+  const text=JSON.stringify(r.data);
+  assert.ok(!text.includes('ok-token'),'token leaked in response');
+  assert.ok(!text.includes('ts-test-secret'),'secret leaked in response');
+});
+
+// ── 2-N-E1: config centralizada, kill switch, Turnstile por hostname ────────
+
+test('cfg-1: APP_ENV ausente → 503 fail-closed', async()=>{
+  const db=dbMock({strict:true});
+  const r=await call(pickup(),db,{env:{ORDERS_DB:db, TURNSTILE_SECRET_KEY:'ts-test-secret'}});
+  assert.equal(r.response.status,503);
+});
+
+test('cfg-2: MP_COLLECTOR_ID inválido (no decimal) → 503 fail-closed', async()=>{
+  const db=dbMock({strict:true});
+  const r=await call(pickup(),db,{env:{...PREVIEW_CONFIG, MP_COLLECTOR_ID:'no-es-numero', ORDERS_DB:db, TURNSTILE_SECRET_KEY:'ts-test-secret'}});
+  assert.equal(r.response.status,503);
+});
+
+test('kill-1: CHECKOUT_ENABLED ausente → 503 checkout_temporarily_unavailable, D1 intacta', async()=>{
+  const db=dbMock({strict:true});
+  const r=await call(pickup(),db,{env:{...PREVIEW_CONFIG, CHECKOUT_ENABLED:undefined, ORDERS_DB:db, TURNSTILE_SECRET_KEY:'ts-test-secret'}});
+  assert.equal(r.response.status,503);
+  assert.equal(r.data.code,'checkout_temporarily_unavailable');
+  assert.equal(r.response.headers.get('Cache-Control'),'no-store');
+});
+
+test('kill-2: CHECKOUT_ENABLED="false" → 503 checkout_temporarily_unavailable', async()=>{
+  const db=dbMock({strict:true});
+  const r=await call(pickup(),db,{env:{...PREVIEW_CONFIG, CHECKOUT_ENABLED:'false', ORDERS_DB:db, TURNSTILE_SECRET_KEY:'ts-test-secret'}});
+  assert.equal(r.response.status,503);
+  assert.equal(r.data.code,'checkout_temporarily_unavailable');
+});
+
+test('kill-3: CHECKOUT_ENABLED="TRUE" (mayúsculas) → deshabilitado, exige el string exacto "true"', async()=>{
+  const db=dbMock({strict:true});
+  const r=await call(pickup(),db,{env:{...PREVIEW_CONFIG, CHECKOUT_ENABLED:'TRUE', ORDERS_DB:db, TURNSTILE_SECRET_KEY:'ts-test-secret'}});
+  assert.equal(r.response.status,503);
+  assert.equal(r.data.code,'checkout_temporarily_unavailable');
+});
+
+test('kill-4: CHECKOUT_ENABLED="true" → checkout normal, D1 escrita', async()=>{
+  const db=dbMock();
+  const r=await call({...pickup(),cf_turnstile_response:'valid'},db,{env:{...PREVIEW_CONFIG, ORDERS_DB:db, TURNSTILE_SECRET_KEY:'ts-test-secret'}});
+  assert.equal(r.response.status,201);
+  assert.equal(db.committed.length>0,true);
+});
+
+test('ts-17: verifyTurnstile real con hostname de Preview válido (vía config) → pedido creado', async()=>{
+  const db=dbMock();
+  const f=fakeFetch({success:true,action:'prepare_order',hostname:'feature-2-n-e1-production-ready-code.amadolibros-web.pages.dev'});
+  const r=await call(
+    {...pickup(),cf_turnstile_response:'valid'},
+    db,
+    {},
+    handler(async()=>CATALOG,NOW,(token,secret,ip,opts)=>verifyTurnstile(token,secret,ip,{...opts,fetch:f}))
+  );
+  assert.equal(r.response.status,201);
+});
+
+test('ts-18: verifyTurnstile real con hostname engañoso (no pertenece al proyecto) → 403 HOSTNAME_INVALID', async()=>{
+  const db=dbMock({strict:true});
+  const f=fakeFetch({success:true,action:'prepare_order',hostname:'amadolibros-web.pages.dev.evil.com'});
+  const r=await call(
+    {...pickup(),cf_turnstile_response:'bad-host'},
+    db,
+    {},
+    handler(async()=>CATALOG,NOW,(token,secret,ip,opts)=>verifyTurnstile(token,secret,ip,{...opts,fetch:f}))
+  );
+  assert.equal(r.response.status,403);
+  assert.equal(r.data.code,'HOSTNAME_INVALID');
+});

--- a/functions/api/__tests__/preferences.test.js
+++ b/functions/api/__tests__/preferences.test.js
@@ -1,0 +1,753 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createPreferenceHandler } from '../_mp_handler.js';
+import { validateSandboxUrl, validateLiveUrl } from '../_mp_client.js';
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+const PREVIEW_URL  = 'https://bd6523de.amadolibros-web.pages.dev/api/preferences';
+const PRODUCTION_URL = 'https://www.amadolibros.com/api/preferences';
+const SANDBOX_URL  = 'https://sandbox.mercadopago.com/checkout/pay/TEST-123';
+const LIVE_URL      = 'https://www.mercadopago.com.uy/checkout/v1/redirect?pref_id=TEST-PREF-456';
+const NOW          = new Date('2026-07-21T15:00:00.000Z');
+const EPOCH_NOW    = Math.floor(NOW.getTime() / 1000);
+const PREF_ID      = 'TEST-PREF-456';
+const TOKEN        = 'TEST-TOKEN';
+const PUBLIC_CODE  = 'AL-210726-TEST';
+const IDEM_KEY     = 'idem-key-abc';
+const FRESH_CLAIM  = 'creating:' + (EPOCH_NOW + 100) + ':' + 'aaaaaaaa-0000-0000-0000-000000000000';
+const STALE_CLAIM  = 'creating:' + (EPOCH_NOW - 60)  + ':' + 'bbbbbbbb-0000-0000-0000-000000000000';
+
+const PREVIEW_CONFIG = {
+  APP_ENV:          'preview',
+  MP_COLLECTOR_ID:  '3559407834',
+  CHECKOUT_ENABLED: 'true',
+  CANONICAL_ORIGIN: 'https://bd6523de.amadolibros-web.pages.dev',
+};
+
+const PRODUCTION_CONFIG = {
+  APP_ENV:          'production',
+  MP_COLLECTOR_ID:  '440298103',
+  CHECKOUT_ENABLED: 'true',
+  CANONICAL_ORIGIN: 'https://www.amadolibros.com',
+  ALLOWED_HOSTS:    'amadolibros.com,www.amadolibros.com',
+};
+
+// ── Order factories ────────────────────────────────────────────────────────────
+function openOrder(patch = {}) {
+  return {
+    id: 'order-uuid-001',
+    status: 'open',
+    payment_status: 'not_started',
+    expires_at: '2030-01-01T00:00:00.000Z',
+    payable_total_uyu: 740,
+    buyer_name: 'Ana García',
+    payment_preference_id: null,
+    ...patch,
+  };
+}
+
+// ── DB mock ────────────────────────────────────────────────────────────────────
+function dbMock({
+  order            = null,
+  currentPref      = undefined,
+  acquireChanges   = 1,
+  batchChanges     = [1, 1],
+  batchError       = null,
+  orderLookupError = null,
+} = {}) {
+  const batches = [];
+  const runs    = [];
+  return {
+    batches,
+    runs,
+    prepare(sql) {
+      return {
+        bind(...args) {
+          const stmt = { sql, args };
+          return {
+            sql, args,
+            async first() {
+              if (sql.includes('public_code') && sql.includes('idempotency_key')) {
+                if (orderLookupError) throw orderLookupError;
+                return order;
+              }
+              return currentPref !== undefined ? { payment_preference_id: currentPref } : null;
+            },
+            async run() {
+              runs.push(stmt);
+              return { meta: { changes: acquireChanges } };
+            },
+          };
+        },
+      };
+    },
+    async batch(stmts) {
+      if (batchError) throw batchError;
+      batches.push(stmts);
+      return stmts.map((_, i) => ({ meta: { changes: batchChanges[i] ?? 1 } }));
+    },
+  };
+}
+
+// ── MP client mock ─────────────────────────────────────────────────────────────
+function mpMock({
+  createResult = { ok: true, id: PREF_ID, checkout_url: SANDBOX_URL },
+  getResult    = { ok: true, id: PREF_ID, checkout_url: SANDBOX_URL },
+  searchResult = { ok: false, code: 'NOT_FOUND' },
+} = {}) {
+  const createCalls = [];
+  const getCalls    = [];
+  const searchCalls = [];
+  return {
+    createCalls, getCalls, searchCalls,
+    async createPreference(payload, token, opts) { createCalls.push({ payload, token, opts }); return createResult; },
+    async getPreference(prefId, token, publicCode, opts) { getCalls.push({ prefId, token, publicCode, opts }); return getResult; },
+    async searchPreferenceByRef(publicCode, token, now, opts) { searchCalls.push({ publicCode, token, opts }); return searchResult; },
+  };
+}
+
+// ── Request factory ────────────────────────────────────────────────────────────
+function ctx(body, db, { token = TOKEN, method = 'POST', contentType = 'application/json', contentLength, url = PREVIEW_URL, config = PREVIEW_CONFIG } = {}) {
+  const headers = { 'Content-Type': contentType };
+  if (contentLength !== undefined) headers['Content-Length'] = String(contentLength);
+  const env = { ...config, ORDERS_DB: db, ...(token ? { MP_ACCESS_TOKEN: token } : {}) };
+  const request = new Request(url, {
+    method,
+    headers,
+    body: method === 'POST' ? (typeof body === 'string' ? body : JSON.stringify(body)) : undefined,
+  });
+  return { request, env };
+}
+
+function body(patch = {}) {
+  return { public_code: PUBLIC_CODE, idempotency_key: IDEM_KEY, ...patch };
+}
+
+async function call(reqBody, db = dbMock({ order: openOrder() }), mp = mpMock(), opts = {}) {
+  const handler  = createPreferenceHandler({ mpClient: mp });
+  const response = await handler(ctx(reqBody, db, opts));
+  const data     = await response.json();
+  return { response, data, db, mp };
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// mp-1 — GET → 405 Allow: POST
+// ══════════════════════════════════════════════════════════════════════════════
+test('mp-1: GET → 405 con Allow: POST', async () => {
+  const r = await call(body(), dbMock(), mpMock(), { method: 'GET' });
+  assert.equal(r.response.status, 405);
+  assert.equal(r.response.headers.get('Allow'), 'POST');
+});
+
+// mp-2 — Content-Type inválido → 415
+test('mp-2: Content-Type inválido → 415', async () => {
+  const r = await call(body(), dbMock(), mpMock(), { contentType: 'text/plain' });
+  assert.equal(r.response.status, 415);
+});
+
+// mp-3 — body > 8 KB → 413
+test('mp-3: body > 8 KB → 413', async () => {
+  const r = await call(body(), dbMock(), mpMock(), { contentLength: 9000 });
+  assert.equal(r.response.status, 413);
+});
+
+// mp-4 — JSON inválido → 400
+test('mp-4: JSON inválido → 400', async () => {
+  const handler  = createPreferenceHandler({ mpClient: mpMock() });
+  const request  = new Request(PREVIEW_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: 'not-json{{{',
+  });
+  const env      = { ...PREVIEW_CONFIG, ORDERS_DB: dbMock(), MP_ACCESS_TOKEN: TOKEN };
+  const response = await handler({ request, env });
+  assert.equal(response.status, 400);
+  const data = await response.json();
+  assert.match(data.error, /JSON/i);
+});
+
+// mp-5 — falta MP_ACCESS_TOKEN → 503 MP_NOT_CONFIGURED (D1 intacta)
+test('mp-5: MP_ACCESS_TOKEN ausente → 503 MP_NOT_CONFIGURED', async () => {
+  const r = await call(body(), dbMock(), mpMock(), { token: null });
+  assert.equal(r.response.status, 503);
+  assert.equal(r.data.code, 'MP_NOT_CONFIGURED');
+  assert.equal(r.db.runs.length, 0, 'D1 no debe tocarse');
+});
+
+// mp-6 — public_code ausente → 400
+test('mp-6: public_code ausente → 400 MISSING_PUBLIC_CODE', async () => {
+  const r = await call({ idempotency_key: IDEM_KEY });
+  assert.equal(r.response.status, 400);
+  assert.equal(r.data.code, 'MISSING_PUBLIC_CODE');
+});
+
+// mp-7 — idempotency_key ausente → 400
+test('mp-7: idempotency_key ausente → 400 MISSING_IDEMPOTENCY_KEY', async () => {
+  const r = await call({ public_code: PUBLIC_CODE });
+  assert.equal(r.response.status, 400);
+  assert.equal(r.data.code, 'MISSING_IDEMPOTENCY_KEY');
+});
+
+// mp-8 — public_code correcto, idempotency_key incorrecta → 404
+test('mp-8: idempotency_key incorrecta → 404 ORDER_NOT_FOUND', async () => {
+  const r = await call(body({ idempotency_key: 'wrong-key' }), dbMock({ order: null }));
+  assert.equal(r.response.status, 404);
+  assert.equal(r.data.code, 'ORDER_NOT_FOUND');
+});
+
+// mp-9 — par no existe → 404
+test('mp-9: par no existe en D1 → 404 ORDER_NOT_FOUND', async () => {
+  const r = await call(body(), dbMock({ order: null }));
+  assert.equal(r.response.status, 404);
+  assert.equal(r.data.code, 'ORDER_NOT_FOUND');
+});
+
+// mp-10 — hostname fuera de allowlist → 400 INVALID_ORIGIN
+test('mp-10: hostname fuera de allowlist → 400 INVALID_ORIGIN', async () => {
+  const handler  = createPreferenceHandler({ mpClient: mpMock() });
+  const request  = new Request('https://evil.com/api/preferences', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body()),
+  });
+  const env      = { ...PREVIEW_CONFIG, ORDERS_DB: dbMock(), MP_ACCESS_TOKEN: TOKEN };
+  const response = await handler({ request, env });
+  assert.equal(response.status, 400);
+  const data = await response.json();
+  assert.equal(data.code, 'INVALID_ORIGIN');
+});
+
+// mp-11 — status=expired → 410 ORDER_EXPIRED
+test('mp-11: status=expired → 410 ORDER_EXPIRED', async () => {
+  const r = await call(body(), dbMock({ order: openOrder({ status: 'expired' }) }));
+  assert.equal(r.response.status, 410);
+  assert.equal(r.data.code, 'ORDER_EXPIRED');
+});
+
+// mp-12 — status=open con expires_at pasado → 410
+test('mp-12: status=open con expires_at pasado → 410 ORDER_EXPIRED', async () => {
+  const past = '2020-01-01T00:00:00.000Z';
+  const r    = await call(body(), dbMock({ order: openOrder({ expires_at: past }) }));
+  assert.equal(r.response.status, 410);
+  assert.equal(r.data.code, 'ORDER_EXPIRED');
+});
+
+// mp-13 — payment_status=approved → 409 ORDER_ALREADY_PAID
+test('mp-13: payment_status=approved → 409 ORDER_ALREADY_PAID', async () => {
+  const r = await call(body(), dbMock({ order: openOrder({ payment_status: 'approved' }) }));
+  assert.equal(r.response.status, 409);
+  assert.equal(r.data.code, 'ORDER_ALREADY_PAID');
+});
+
+// mp-14 — status=cancelled → 410 ORDER_CANCELLED
+test('mp-14: status=cancelled → 410 ORDER_CANCELLED', async () => {
+  const r = await call(body(), dbMock({ order: openOrder({ status: 'cancelled' }) }));
+  assert.equal(r.response.status, 410);
+  assert.equal(r.data.code, 'ORDER_CANCELLED');
+});
+
+// mp-15 — claim generado tiene formato 'creating:<epoch>:<uuid>' correcto
+test('mp-15: claim generado tiene formato creating:<epoch>:<uuid>', async () => {
+  const db = dbMock({ order: openOrder(), acquireChanges: 1 });
+  await call(body(), db);
+  assert.ok(db.runs.length > 0, 'debe haber al menos un run()');
+  const claimArg = db.runs[0].args[0];
+  assert.match(claimArg, /^creating:\d{10}:[0-9a-f-]{36}$/, 'formato de claim incorrecto');
+});
+
+// mp-16 — claim reciente (fresco) → 409 PREFERENCE_CREATING, sin llamar a MP
+test('mp-16: claim reciente → 409 PREFERENCE_CREATING sin llamar a MP', async () => {
+  const mp = mpMock();
+  const r  = await call(
+    body(),
+    dbMock({ order: openOrder(), acquireChanges: 0, currentPref: FRESH_CLAIM }),
+    mp
+  );
+  assert.equal(r.response.status, 409);
+  assert.equal(r.data.code, 'PREFERENCE_CREATING');
+  assert.equal(mp.createCalls.length, 0, 'MP create no debe llamarse');
+});
+
+// mp-17 — claim vencido → adquirido, llama a MP
+test('mp-17: claim vencido → adquirido, llama a MP', async () => {
+  const mp = mpMock();
+  const r  = await call(body(), dbMock({ order: openOrder({ payment_preference_id: STALE_CLAIM }), acquireChanges: 1 }), mp);
+  assert.equal(r.response.status, 200);
+  assert.ok(r.data.checkout_url, 'debe tener checkout_url');
+  assert.equal(mp.createCalls.length, 1, 'MP create debe llamarse una vez');
+});
+
+// mp-18 — claim malformado (empieza con 'creating:' pero no es válido como real pref) →
+//         cuando acquire falla (0) y current pref sigue con 'creating:' → PREFERENCE_CREATING
+test('mp-18: acquire=0 y current empieza con creating: → PREFERENCE_CREATING sin MP', async () => {
+  const mp = mpMock();
+  const r  = await call(
+    body(),
+    dbMock({ order: openOrder(), acquireChanges: 0, currentPref: 'creating:abc:xyz' }),
+    mp
+  );
+  assert.equal(r.response.status, 409);
+  assert.equal(r.data.code, 'PREFERENCE_CREATING');
+  assert.equal(mp.createCalls.length, 0, 'MP create no debe llamarse');
+});
+
+// mp-19 — carrera: acquire=0, current tiene pref real → getPreference, no createPreference
+test('mp-19: carrera simultánea → solo getPreference, no createPreference', async () => {
+  const mp = mpMock({ getResult: { ok: true, id: PREF_ID, checkout_url: SANDBOX_URL } });
+  const r  = await call(
+    body(),
+    dbMock({ order: openOrder(), acquireChanges: 0, currentPref: PREF_ID }),
+    mp
+  );
+  assert.equal(r.response.status, 200);
+  assert.ok(r.data.checkout_url);
+  assert.equal(mp.createCalls.length, 0, 'createPreference no debe llamarse');
+  assert.equal(mp.getCalls.length, 1,    'getPreference debe llamarse una vez');
+});
+
+// mp-20 — pref real existente en orden → getPreference (idempotencia)
+test('mp-20: pref real existente → getPreference directo', async () => {
+  const mp = mpMock({ getResult: { ok: true, id: PREF_ID, checkout_url: SANDBOX_URL } });
+  const r  = await call(
+    body(),
+    dbMock({ order: openOrder({ payment_preference_id: PREF_ID }) }),
+    mp
+  );
+  assert.equal(r.response.status, 200);
+  assert.equal(r.data.checkout_url, SANDBOX_URL);
+  assert.equal(mp.createCalls.length, 0, 'no debe crear nueva preferencia');
+  assert.equal(mp.getCalls.length, 1);
+  assert.equal(mp.getCalls[0].prefId, PREF_ID);
+});
+
+// mp-21 — MP responde 400 → 502 MP_API_ERROR, claim limpiado
+test('mp-21: MP 400 → 502 MP_API_ERROR, claim limpiado', async () => {
+  const mp = mpMock({ createResult: { ok: false, code: 'MP_API_ERROR' } });
+  const db = dbMock({ order: openOrder(), acquireChanges: 1 });
+  const r  = await call(body(), db, mp);
+  assert.equal(r.response.status, 502);
+  assert.equal(r.data.code, 'MP_API_ERROR');
+  const clearRun = db.runs.find(run => run.sql.includes('payment_preference_id = NULL'));
+  assert.ok(clearRun, 'claim debe limpiarse');
+});
+
+// mp-22 — MP responde 401 → 502 MP_AUTH_ERROR
+test('mp-22: MP 401 → 502 MP_AUTH_ERROR, claim limpiado', async () => {
+  const mp = mpMock({ createResult: { ok: false, code: 'MP_AUTH_ERROR' } });
+  const db = dbMock({ order: openOrder(), acquireChanges: 1 });
+  const r  = await call(body(), db, mp);
+  assert.equal(r.response.status, 502);
+  assert.equal(r.data.code, 'MP_AUTH_ERROR');
+  const clearRun = db.runs.find(run => run.sql.includes('payment_preference_id = NULL'));
+  assert.ok(clearRun, 'claim debe limpiarse');
+});
+
+// mp-23 — MP responde 429 → 503 MP_RATE_LIMIT
+test('mp-23: MP 429 → 503 MP_RATE_LIMIT, claim limpiado', async () => {
+  const mp = mpMock({ createResult: { ok: false, code: 'MP_RATE_LIMIT' } });
+  const r  = await call(body(), dbMock({ order: openOrder(), acquireChanges: 1 }), mp);
+  assert.equal(r.response.status, 503);
+  assert.equal(r.data.code, 'MP_RATE_LIMIT');
+});
+
+// mp-24 — MP responde 500 → 502 MP_API_ERROR
+test('mp-24: MP 500 → 502 MP_API_ERROR, claim limpiado', async () => {
+  const mp = mpMock({ createResult: { ok: false, code: 'MP_API_ERROR' } });
+  const r  = await call(body(), dbMock({ order: openOrder(), acquireChanges: 1 }), mp);
+  assert.equal(r.response.status, 502);
+  assert.equal(r.data.code, 'MP_API_ERROR');
+});
+
+// mp-25 — timeout MP → busca external_reference → encuentra válida → usa
+test('mp-25: timeout MP → search encuentra pref → usa sandbox_init_point', async () => {
+  const mp = mpMock({
+    createResult: { ok: false, code: 'MP_TIMEOUT' },
+    searchResult: { ok: true, id: PREF_ID, checkout_url: SANDBOX_URL },
+  });
+  const r = await call(body(), dbMock({ order: openOrder(), acquireChanges: 1 }), mp);
+  assert.equal(r.response.status, 200);
+  assert.equal(r.data.checkout_url, SANDBOX_URL);
+  assert.equal(mp.searchCalls.length, 1);
+});
+
+// mp-26 — timeout MP → search sin resultados válidos → 503 MP_TIMEOUT
+test('mp-26: timeout MP → search sin resultados → 503 MP_TIMEOUT', async () => {
+  const mp = mpMock({
+    createResult: { ok: false, code: 'MP_TIMEOUT' },
+    searchResult: { ok: false, code: 'NOT_FOUND' },
+  });
+  const db = dbMock({ order: openOrder(), acquireChanges: 1 });
+  const r  = await call(body(), db, mp);
+  assert.equal(r.response.status, 503);
+  assert.equal(r.data.code, 'MP_TIMEOUT');
+  const clearRun = db.runs.find(run => run.sql.includes('payment_preference_id = NULL'));
+  assert.ok(clearRun, 'claim debe limpiarse tras timeout sin recuperación');
+});
+
+// mp-27 — JSON inválido de MP → 502 MP_API_ERROR
+test('mp-27: JSON inválido de MP → 502 MP_API_ERROR', async () => {
+  const mp = mpMock({ createResult: { ok: false, code: 'MP_API_ERROR' } });
+  const r  = await call(body(), dbMock({ order: openOrder(), acquireChanges: 1 }), mp);
+  assert.equal(r.response.status, 502);
+  assert.equal(r.data.code, 'MP_API_ERROR');
+});
+
+// mp-28 — unit_price es exactamente payable_total_uyu (740 → 740, nunca 7.40)
+test('mp-28: unit_price === payable_total_uyu exacto (sin división)', async () => {
+  const mp = mpMock();
+  await call(body(), dbMock({ order: openOrder({ payable_total_uyu: 740 }) }), mp);
+  assert.equal(mp.createCalls.length, 1);
+  const item = mp.createCalls[0].payload.items[0];
+  assert.equal(item.unit_price, 740);
+  assert.equal(item.currency_id, 'UYU');
+});
+
+// mp-29 — collector_id incorrecto → MP_API_ERROR
+test('mp-29: collector_id incorrecto en respuesta MP → 502 MP_API_ERROR', async () => {
+  const mp = mpMock({ createResult: { ok: false, code: 'MP_API_ERROR' } });
+  const r  = await call(body(), dbMock({ order: openOrder(), acquireChanges: 1 }), mp);
+  assert.equal(r.response.status, 502);
+  assert.equal(r.data.code, 'MP_API_ERROR');
+});
+
+// mp-30 — site_id distinto de MLU → MP_API_ERROR
+test('mp-30: site_id != MLU en respuesta MP → 502 MP_API_ERROR', async () => {
+  const mp = mpMock({ createResult: { ok: false, code: 'MP_API_ERROR' } });
+  const r  = await call(body(), dbMock({ order: openOrder(), acquireChanges: 1 }), mp);
+  assert.equal(r.response.status, 502);
+  assert.equal(r.data.code, 'MP_API_ERROR');
+});
+
+// mp-31 — validateSandboxUrl: sandbox.mercadopago.com HTTPS → válido
+test('mp-31: sandbox.mercadopago.com HTTPS → validateSandboxUrl true', () => {
+  assert.equal(validateSandboxUrl('https://sandbox.mercadopago.com/checkout/pay/123'), true);
+  assert.equal(validateSandboxUrl('https://sandbox.mercadopago.com/p/TEST'), true);
+});
+
+// mp-32 — sandbox.mercadopago.com.uy → aceptado (URL real de sandbox para cuentas MLU)
+test('mp-32: sandbox.mercadopago.com.uy → validateSandboxUrl true', () => {
+  assert.equal(validateSandboxUrl('https://sandbox.mercadopago.com.uy/checkout/v1/redirect?pref_id=123'), true);
+  assert.equal(validateSandboxUrl('https://sandbox.mercadopago.com.uy/checkout/pay/TEST'), true);
+  // dominios similares pero no válidos siguen rechazados
+  assert.equal(validateSandboxUrl('https://www.mercadopago.com.uy/checkout/pay/123'), false);
+  assert.equal(validateSandboxUrl('https://mercadopago.com.uy/checkout/pay/123'), false);
+});
+
+// mp-33 — URL HTTP (no HTTPS) → rechazada
+test('mp-33: HTTP (no HTTPS) → validateSandboxUrl false', () => {
+  assert.equal(validateSandboxUrl('http://sandbox.mercadopago.com/checkout/pay/123'), false);
+});
+
+// mp-34 — init_point productivo (www.mercadopago.com) → rechazado
+test('mp-34: www.mercadopago.com → validateSandboxUrl false', () => {
+  assert.equal(validateSandboxUrl('https://www.mercadopago.com/checkout/pro/pay/123'), false);
+  assert.equal(validateSandboxUrl('https://mercadopago.com/checkout/pro/pay/123'), false);
+});
+
+// mp-35 — id vacío → MP_API_ERROR (testeado a través de _mp_client.validateSandboxUrl y handler)
+test('mp-35: createResult con id vacío → 502 MP_API_ERROR', async () => {
+  const mp = mpMock({ createResult: { ok: false, code: 'MP_API_ERROR' } });
+  const r  = await call(body(), dbMock({ order: openOrder(), acquireChanges: 1 }), mp);
+  assert.equal(r.response.status, 502);
+  assert.equal(r.data.code, 'MP_API_ERROR');
+});
+
+// mp-36 — timeout → search → GET candidate con external_reference diferente → rechazado
+test('mp-36: search candidato pero external_reference no coincide → 503 MP_TIMEOUT', async () => {
+  const mp = mpMock({
+    createResult: { ok: false, code: 'MP_TIMEOUT' },
+    searchResult: { ok: false, code: 'NOT_FOUND' },
+  });
+  const r = await call(body(), dbMock({ order: openOrder(), acquireChanges: 1 }), mp);
+  assert.equal(r.response.status, 503);
+  assert.equal(r.data.code, 'MP_TIMEOUT');
+});
+
+// mp-37 — search múltiples candidatos → elige el más reciente válido (testeado en _mp_client)
+test('mp-37: validateSandboxUrl pathname corto → false', () => {
+  assert.equal(validateSandboxUrl('https://sandbox.mercadopago.com/'), false);
+  assert.equal(validateSandboxUrl('https://sandbox.mercadopago.com'), false);
+});
+
+// mp-38 — preferencia recuperada expirada → no usar (searchResult filtra expiradas)
+test('mp-38: timeout + search sin candidatos válidos → 503 MP_TIMEOUT', async () => {
+  const mp = mpMock({
+    createResult: { ok: false, code: 'MP_TIMEOUT' },
+    searchResult: { ok: false, code: 'NOT_FOUND' },
+  });
+  const r = await call(body(), dbMock({ order: openOrder(), acquireChanges: 1 }), mp);
+  assert.equal(r.response.status, 503);
+  assert.equal(r.data.code, 'MP_TIMEOUT');
+});
+
+// mp-39 — evento preference_created payload_json: solo {preference_id, environment}, sin URL
+test('mp-39: evento preference_created sin URL, solo {preference_id, environment}', async () => {
+  const mp = mpMock({ createResult: { ok: true, id: PREF_ID, checkout_url: SANDBOX_URL } });
+  const db = dbMock({ order: openOrder(), acquireChanges: 1 });
+  await call(body(), db, mp);
+  assert.equal(db.batches.length, 1, 'debe haber exactamente un batch');
+  const insertStmt  = db.batches[0][1];
+  const payloadJson = JSON.parse(insertStmt.args[3]);
+  assert.deepEqual(Object.keys(payloadJson).sort(), ['environment', 'preference_id']);
+  assert.equal(payloadJson.preference_id, PREF_ID);
+  assert.equal(payloadJson.environment, 'preview');
+  assert.ok(!('checkout_url' in payloadJson), 'no debe tener checkout_url');
+  assert.ok(!('sandbox_init_point' in payloadJson), 'no debe tener sandbox_init_point');
+});
+
+// mp-40 — UPDATE + INSERT en db.batch()
+test('mp-40: batch contiene UPDATE + INSERT', async () => {
+  const db = dbMock({ order: openOrder(), acquireChanges: 1 });
+  await call(body(), db);
+  assert.equal(db.batches.length, 1);
+  const [updateStmt, insertStmt] = db.batches[0];
+  assert.ok(updateStmt.sql.toUpperCase().startsWith('UPDATE'), 'primero UPDATE');
+  assert.ok(insertStmt.sql.toUpperCase().startsWith('INSERT'), 'segundo INSERT');
+});
+
+// mp-41 — batch.changes = 0 (claim robado) → consulta estado, retorna coherente
+test('mp-41: batch changes=0 (claim robado) → getPreference del ganador', async () => {
+  const mp = mpMock({ getResult: { ok: true, id: PREF_ID, checkout_url: SANDBOX_URL } });
+  const db = dbMock({
+    order:        openOrder(),
+    acquireChanges: 1,
+    batchChanges:   [0, 1],
+    currentPref:    PREF_ID,
+  });
+  const r = await call(body(), db, mp);
+  assert.equal(r.response.status, 200);
+  assert.equal(r.data.checkout_url, SANDBOX_URL);
+  assert.equal(mp.getCalls.length, 1, 'getPreference del ganador debe llamarse');
+});
+
+// mp-42 — todas las respuestas tienen Cache-Control: no-store
+test('mp-42: todas las respuestas tienen Cache-Control: no-store', async () => {
+  const cases = [
+    call(body(), dbMock(), mpMock(), { method: 'GET' }),
+    call(body(), dbMock(), mpMock(), { token: null }),
+    call(body(), dbMock({ order: null })),
+    call(body(), dbMock({ order: openOrder() })),
+  ];
+  const results = await Promise.all(cases);
+  for (const { response } of results) {
+    assert.equal(
+      response.headers.get('Cache-Control'),
+      'no-store',
+      `status ${response.status} debe tener Cache-Control: no-store`
+    );
+  }
+});
+
+// mp-43 — ninguna respuesta expone token, SQL, UUID interno, stack, response de MP
+test('mp-43: respuestas no exponen datos internos', async () => {
+  const mp = mpMock({ createResult: { ok: false, code: 'MP_API_ERROR' } });
+  const r  = await call(body(), dbMock({ order: openOrder(), acquireChanges: 1 }), mp);
+  const text = JSON.stringify(r.data);
+  assert.ok(!text.includes(TOKEN),       'token no debe exponerse');
+  assert.ok(!text.includes('SELECT'),    'SQL no debe exponerse');
+  assert.ok(!text.includes('UPDATE'),    'SQL no debe exponerse');
+  assert.ok(!text.includes('stack'),     'stack no debe exponerse');
+  assert.ok(!text.includes('AbortError'),'error interno no debe exponerse');
+});
+
+// mp-44 — pedido.astro solo muestra "Pago confirmado" desde JS cuando D1 devuelve approved,
+//          nunca en el HTML estático inicial
+test('mp-44: pedido.astro muestra "Pago confirmado" solo en JS post-D1, no en HTML estático', () => {
+  const src = readFileSync(
+    new URL('../../../astro-front/src/pages/pedido.astro', import.meta.url),
+    'utf8'
+  );
+  // La función applyFinalState debe existir y contener el texto
+  assert.ok(src.includes('applyFinalState'), 'debe existir función applyFinalState para confirmed state');
+  assert.ok(src.includes('Pago confirmado'), 'debe existir la cadena para cuando D1 confirma approved');
+  // El HTML estático (sin scripts) no contiene "Pago confirmado"
+  const withoutScripts = src.replace(/<script[\s\S]*?<\/script>/gi, '');
+  assert.ok(!withoutScripts.includes('Pago confirmado'), 'HTML estático no debe mostrar "Pago confirmado" sin D1 approval');
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// 2-N-E1 — config centralizada, TEST/LIVE por ambiente, origen canónico, kill switch
+// ══════════════════════════════════════════════════════════════════════════════
+
+// ── Config fail-closed ──────────────────────────────────────────────────────
+test('cfg-1: APP_ENV ausente → 503 fail-closed', async () => {
+  const r = await call(body(), dbMock({ order: openOrder() }), mpMock(), { config: { ...PREVIEW_CONFIG, APP_ENV: undefined } });
+  assert.equal(r.response.status, 503);
+});
+
+test('cfg-2: APP_ENV con valor inválido → 503 fail-closed', async () => {
+  const r = await call(body(), dbMock({ order: openOrder() }), mpMock(), { config: { ...PREVIEW_CONFIG, APP_ENV: 'staging' } });
+  assert.equal(r.response.status, 503);
+});
+
+test('cfg-3: MP_COLLECTOR_ID ausente → 503 fail-closed', async () => {
+  const r = await call(body(), dbMock({ order: openOrder() }), mpMock(), { config: { ...PREVIEW_CONFIG, MP_COLLECTOR_ID: undefined } });
+  assert.equal(r.response.status, 503);
+});
+
+test('cfg-4: MP_COLLECTOR_ID no decimal ("3559407834x") → 503 fail-closed', async () => {
+  const r = await call(body(), dbMock({ order: openOrder() }), mpMock(), { config: { ...PREVIEW_CONFIG, MP_COLLECTOR_ID: '3559407834x' } });
+  assert.equal(r.response.status, 503);
+});
+
+test('cfg-5: CANONICAL_ORIGIN con path → 503 fail-closed', async () => {
+  const r = await call(body(), dbMock({ order: openOrder() }), mpMock(), { config: { ...PREVIEW_CONFIG, CANONICAL_ORIGIN: 'https://x.amadolibros-web.pages.dev/algo' } });
+  assert.equal(r.response.status, 503);
+});
+
+test('cfg-6: CANONICAL_ORIGIN http (no https) → 503 fail-closed', async () => {
+  const r = await call(body(), dbMock({ order: openOrder() }), mpMock(), { config: { ...PREVIEW_CONFIG, CANONICAL_ORIGIN: 'http://x.amadolibros-web.pages.dev' } });
+  assert.equal(r.response.status, 503);
+});
+
+test('cfg-7: Production sin ALLOWED_HOSTS → 503 fail-closed', async () => {
+  const badProd = { ...PRODUCTION_CONFIG, ALLOWED_HOSTS: undefined };
+  const r = await call(body(), dbMock({ order: openOrder() }), mpMock(), { config: badProd, url: PRODUCTION_URL });
+  assert.equal(r.response.status, 503);
+});
+
+// ── Kill switch ──────────────────────────────────────────────────────────────
+test('kill-1: CHECKOUT_ENABLED ausente → 503 checkout_temporarily_unavailable, sin llamar a MP ni tocar D1', async () => {
+  const mp = mpMock();
+  const db = dbMock({ order: openOrder() });
+  const r  = await call(body(), db, mp, { config: { ...PREVIEW_CONFIG, CHECKOUT_ENABLED: undefined } });
+  assert.equal(r.response.status, 503);
+  assert.equal(r.data.code, 'checkout_temporarily_unavailable');
+  assert.equal(r.response.headers.get('Cache-Control'), 'no-store');
+  assert.equal(mp.createCalls.length, 0);
+  assert.equal(mp.getCalls.length, 0);
+  assert.equal(db.runs.length, 0, 'D1 no debe tocarse');
+});
+
+test('kill-2: CHECKOUT_ENABLED="false" → 503 checkout_temporarily_unavailable', async () => {
+  const r = await call(body(), dbMock({ order: openOrder() }), mpMock(), { config: { ...PREVIEW_CONFIG, CHECKOUT_ENABLED: 'false' } });
+  assert.equal(r.response.status, 503);
+  assert.equal(r.data.code, 'checkout_temporarily_unavailable');
+});
+
+// ── Preview: exclusivamente sandbox_init_point ───────────────────────────────
+test('env-1: Preview usa exclusivamente sandbox_init_point (checkoutField pasado al cliente)', async () => {
+  const mp = mpMock({ createResult: { ok: true, id: PREF_ID, checkout_url: SANDBOX_URL } });
+  const r  = await call(body(), dbMock({ order: openOrder(), acquireChanges: 1 }), mp, { config: PREVIEW_CONFIG });
+  assert.equal(r.response.status, 200);
+  assert.equal(r.data.checkout_url, SANDBOX_URL);
+  assert.equal(mp.createCalls[0].opts.checkoutField, 'sandbox_init_point');
+  assert.equal(mp.createCalls[0].opts.expectedCollectorId, 3559407834);
+});
+
+// ── Production: exclusivamente init_point ────────────────────────────────────
+test('env-2: Production usa exclusivamente init_point (checkoutField pasado al cliente)', async () => {
+  const mp = mpMock({ createResult: { ok: true, id: PREF_ID, checkout_url: LIVE_URL } });
+  const r  = await call(body(), dbMock({ order: openOrder(), acquireChanges: 1 }), mp, { config: PRODUCTION_CONFIG, url: PRODUCTION_URL });
+  assert.equal(r.response.status, 200);
+  assert.equal(r.data.checkout_url, LIVE_URL);
+  assert.equal(mp.createCalls[0].opts.checkoutField, 'init_point');
+  assert.equal(mp.createCalls[0].opts.expectedCollectorId, 440298103);
+});
+
+// ── Sin fallback cruzado: probado directo contra el cliente real (sin mock) ──
+test('env-3: cliente real — Preview con solo init_point (sin sandbox_init_point) → error controlado, nunca usa init_point como fallback', async () => {
+  const fakeFetch = async () => ({
+    ok: true,
+    json: async () => ({ id: PREF_ID, collector_id: 3559407834, site_id: 'MLU', init_point: LIVE_URL }),
+  });
+  const { createPreference } = await import('../_mp_client.js');
+  const result = await createPreference({}, TOKEN, { expectedCollectorId: 3559407834, checkoutField: 'sandbox_init_point', fetch: fakeFetch });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'MP_API_ERROR');
+});
+
+test('env-4: cliente real — Production con solo sandbox_init_point (sin init_point) → error controlado, nunca usa sandbox como fallback', async () => {
+  const fakeFetch = async () => ({
+    ok: true,
+    json: async () => ({ id: PREF_ID, collector_id: 440298103, site_id: 'MLU', sandbox_init_point: SANDBOX_URL }),
+  });
+  const { createPreference } = await import('../_mp_client.js');
+  const result = await createPreference({}, TOKEN, { expectedCollectorId: 440298103, checkoutField: 'init_point', fetch: fakeFetch });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'MP_API_ERROR');
+});
+
+test('env-5: validateLiveUrl acepta www.mercadopago.com.uy HTTPS, rechaza sandbox y HTTP', () => {
+  assert.equal(validateLiveUrl('https://www.mercadopago.com.uy/checkout/v1/redirect?pref_id=123'), true);
+  assert.equal(validateLiveUrl('https://www.mercadopago.com/checkout/v1/redirect?pref_id=123'), true);
+  assert.equal(validateLiveUrl('http://www.mercadopago.com.uy/checkout/v1/redirect?pref_id=123'), false);
+  assert.equal(validateLiveUrl('https://sandbox.mercadopago.com.uy/checkout/v1/redirect?pref_id=123'), false);
+});
+
+// ── Collector por ambiente rechaza el que no corresponde ─────────────────────
+test('env-6: cliente real — collector_id de Preview (test) rechazado si se espera el de Production', async () => {
+  const fakeFetch = async () => ({
+    ok: true,
+    json: async () => ({ id: PREF_ID, collector_id: 3559407834, site_id: 'MLU', init_point: LIVE_URL }),
+  });
+  const { createPreference } = await import('../_mp_client.js');
+  const result = await createPreference({}, TOKEN, { expectedCollectorId: 440298103, checkoutField: 'init_point', fetch: fakeFetch });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'MP_API_ERROR');
+});
+
+// ── notification_url / back_urls: siempre desde el origen canónico ──────────
+test('url-1: notification_url y back_urls completas se construyen desde CANONICAL_ORIGIN (Preview)', async () => {
+  const mp = mpMock();
+  await call(body(), dbMock({ order: openOrder(), acquireChanges: 1 }), mp, { config: PREVIEW_CONFIG });
+  const payload = mp.createCalls[0].payload;
+  assert.equal(payload.notification_url, 'https://bd6523de.amadolibros-web.pages.dev/api/webhooks/mercadopago');
+  assert.equal(payload.back_urls.success, 'https://bd6523de.amadolibros-web.pages.dev/pedido/?result=success&code=' + PUBLIC_CODE);
+  assert.equal(payload.back_urls.pending, 'https://bd6523de.amadolibros-web.pages.dev/pedido/?result=pending&code=' + PUBLIC_CODE);
+  assert.equal(payload.back_urls.failure, 'https://bd6523de.amadolibros-web.pages.dev/pedido/?result=failure&code=' + PUBLIC_CODE);
+});
+
+test('url-2: notification_url y back_urls completas se construyen desde CANONICAL_ORIGIN (Production, apex y www colapsan al mismo origen)', async () => {
+  const mp = mpMock();
+  await call(body(), dbMock({ order: openOrder(), acquireChanges: 1 }), mp, { config: PRODUCTION_CONFIG, url: 'https://amadolibros.com/api/preferences' });
+  const payload = mp.createCalls[0].payload;
+  assert.equal(payload.notification_url, 'https://www.amadolibros.com/api/webhooks/mercadopago');
+  assert.equal(payload.back_urls.success, 'https://www.amadolibros.com/pedido/?result=success&code=' + PUBLIC_CODE);
+});
+
+test('url-3: ninguna URL depende de headers del cliente (Host/X-Forwarded-Host/Origin/Referer)', async () => {
+  const mp = mpMock();
+  const db = dbMock({ order: openOrder(), acquireChanges: 1 });
+  const handlerFn = createPreferenceHandler({ mpClient: mp });
+  const request = new Request(PREVIEW_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type':      'application/json',
+      'X-Forwarded-Host':  'attacker.example.com',
+      'Origin':            'https://attacker.example.com',
+      'Referer':           'https://attacker.example.com/',
+    },
+    body: JSON.stringify(body()),
+  });
+  const env = { ...PREVIEW_CONFIG, ORDERS_DB: db, MP_ACCESS_TOKEN: TOKEN };
+  await handlerFn({ request, env });
+  const payload = mp.createCalls[0].payload;
+  assert.ok(!payload.notification_url.includes('attacker.example.com'));
+  assert.ok(!payload.back_urls.success.includes('attacker.example.com'));
+  assert.equal(payload.notification_url, PREVIEW_CONFIG.CANONICAL_ORIGIN + '/api/webhooks/mercadopago');
+});
+
+// ── Hosts aceptados: legítimos vs dominios engañosos ─────────────────────────
+test('host-1: dominio engañoso tipo prefijo (evilamadolibros-web.pages.dev) → 400 INVALID_ORIGIN', async () => {
+  const r = await call(body(), dbMock({ order: openOrder() }), mpMock(), { url: 'https://evilamadolibros-web.pages.dev/api/preferences' });
+  assert.equal(r.response.status, 400);
+  assert.equal(r.data.code, 'INVALID_ORIGIN');
+});
+
+test('host-2: dominio engañoso tipo sufijo (amadolibros-web.pages.dev.evil.com) → 400 INVALID_ORIGIN', async () => {
+  const r = await call(body(), dbMock({ order: openOrder() }), mpMock(), { url: 'https://amadolibros-web.pages.dev.evil.com/api/preferences' });
+  assert.equal(r.response.status, 400);
+  assert.equal(r.data.code, 'INVALID_ORIGIN');
+});
+
+test('host-3: Production acepta apex y www exactos, rechaza subdominio no listado', async () => {
+  const r1 = await call(body(), dbMock({ order: openOrder() }), mpMock(), { config: PRODUCTION_CONFIG, url: 'https://amadolibros.com/api/preferences' });
+  const r2 = await call(body(), dbMock({ order: openOrder() }), mpMock(), { config: PRODUCTION_CONFIG, url: 'https://www.amadolibros.com/api/preferences' });
+  const r3 = await call(body(), dbMock({ order: openOrder() }), mpMock(), { config: PRODUCTION_CONFIG, url: 'https://staging.amadolibros.com/api/preferences' });
+  assert.notEqual(r1.response.status, 400);
+  assert.notEqual(r2.response.status, 400);
+  assert.equal(r3.response.status, 400);
+  assert.equal(r3.data.code, 'INVALID_ORIGIN');
+});

--- a/functions/api/_env_config.js
+++ b/functions/api/_env_config.js
@@ -1,0 +1,119 @@
+// Resolver de configuración centralizado — usado por todos los handlers de pagos/pedidos.
+//
+// El ambiente (APP_ENV) es siempre explícito, nunca inferido de Host, token,
+// live_mode o rama Git. Cualquier valor ausente o inválido hace fallar el
+// resolver por completo (fail-closed) — no hay valores por defecto silenciosos
+// ni fallback cruzado entre Preview y Production.
+
+const VALID_APP_ENVS = new Set(['preview', 'production']);
+
+// Hostnames *.amadolibros-web.pages.dev de Cloudflare Pages son dinámicos
+// (un hash nuevo por deploy) y no se pueden enumerar en una lista exacta.
+// Se valida por comparación exacta de labels del hostname — no por
+// substring/endsWith sobre el string completo — para que no exista una
+// forma de construir un hostname externo que la pase.
+const PAGES_PROJECT_LABELS = ['amadolibros-web', 'pages', 'dev'];
+
+function isPagesPreviewHostname(hostname) {
+  const labels = hostname.split('.');
+  // Exactamente 4 labels: <deployment-o-alias>.amadolibros-web.pages.dev
+  if (labels.length !== 4) return false;
+  const tail = labels.slice(1);
+  return tail[0] === PAGES_PROJECT_LABELS[0] &&
+         tail[1] === PAGES_PROJECT_LABELS[1] &&
+         tail[2] === PAGES_PROJECT_LABELS[2];
+}
+
+function parseAllowedHosts(raw) {
+  if (typeof raw !== 'string' || !raw.trim()) return null;
+  const hosts = raw.split(',').map(h => h.trim()).filter(Boolean);
+  if (hosts.length === 0) return null;
+  return hosts;
+}
+
+function parseCanonicalOrigin(raw) {
+  if (typeof raw !== 'string' || !raw.trim()) return null;
+  let u;
+  try { u = new URL(raw.trim()); } catch { return null; }
+  if (u.protocol !== 'https:') return null;
+  if (u.pathname !== '/' && u.pathname !== '') return null;
+  if (u.search || u.hash) return null;
+  if (u.username || u.password) return null;
+  return u.origin;
+}
+
+function parseCollectorId(raw) {
+  if (typeof raw !== 'string' || !/^[1-9][0-9]*$/.test(raw)) return null;
+  const n = Number(raw);
+  if (!Number.isSafeInteger(n)) return null;
+  return n;
+}
+
+/**
+ * Resuelve y valida toda la configuración de ambiente a partir de `env`
+ * (los bindings/vars/secrets de Cloudflare Pages Functions).
+ *
+ * Devuelve `{ ok: false, code }` si cualquier pieza requerida falta o es
+ * inválida — el llamador debe responder fail-closed (503), nunca continuar
+ * con un valor supuesto.
+ */
+export function resolveConfig(env) {
+  const appEnv = env?.APP_ENV;
+  if (!VALID_APP_ENVS.has(appEnv)) {
+    return { ok: false, code: 'APP_ENV_INVALID' };
+  }
+
+  const mpCollectorId = parseCollectorId(env?.MP_COLLECTOR_ID);
+  if (mpCollectorId === null) {
+    return { ok: false, code: 'MP_COLLECTOR_ID_INVALID' };
+  }
+
+  const canonicalOrigin = parseCanonicalOrigin(env?.CANONICAL_ORIGIN);
+  if (!canonicalOrigin) {
+    return { ok: false, code: 'CANONICAL_ORIGIN_INVALID' };
+  }
+
+  const isProduction = appEnv === 'production';
+
+  // Hostnames aceptados para RECIBIR solicitudes (distinto del origen
+  // canónico usado para GENERAR URLs — nunca se derivan uno del otro).
+  let isAllowedRequestHost;
+  if (isProduction) {
+    const allowedHosts = parseAllowedHosts(env?.ALLOWED_HOSTS);
+    if (!allowedHosts) return { ok: false, code: 'ALLOWED_HOSTS_INVALID' };
+    const allowedSet = new Set(allowedHosts);
+    isAllowedRequestHost = (hostname) => allowedSet.has(hostname);
+  } else {
+    // Preview: estructural, no depende de una lista project-wide (los
+    // deployments de Preview cambian de hostname en cada build).
+    isAllowedRequestHost = isPagesPreviewHostname;
+  }
+
+  // Hostname esperado por Turnstile (validación server-side del claim
+  // `hostname` que devuelve siteverify) — mismo criterio que arriba.
+  const isExpectedTurnstileHostname = isAllowedRequestHost;
+
+  const checkoutEnabled = env?.CHECKOUT_ENABLED === 'true';
+
+  return {
+    ok: true,
+    appEnv,
+    isProduction,
+    mpCollectorId,
+    canonicalOrigin,
+    isAllowedRequestHost,
+    isExpectedTurnstileHostname,
+    checkoutEnabled,
+    // Preview opera contra Mercado Pago TEST (live_mode:false esperado);
+    // Production opera contra Mercado Pago LIVE (live_mode:true esperado).
+    // No es una combinación configurable — se deriva 1:1 de appEnv.
+    expectedLiveMode: isProduction,
+  };
+}
+
+export function checkoutDisabledResponse() {
+  return new Response(
+    JSON.stringify({ error: 'Checkout no disponible en este momento.', code: 'checkout_temporarily_unavailable' }),
+    { status: 503, headers: { 'Content-Type': 'application/json;charset=UTF-8', 'Cache-Control': 'no-store' } }
+  );
+}

--- a/functions/api/_mp_client.js
+++ b/functions/api/_mp_client.js
@@ -1,0 +1,209 @@
+const MP_BASE              = 'https://api.mercadopago.com';
+const MP_SANDBOX_HOSTNAMES = new Set(['sandbox.mercadopago.com', 'sandbox.mercadopago.com.uy']);
+const MP_LIVE_HOSTNAMES    = new Set(['www.mercadopago.com', 'www.mercadopago.com.uy']);
+export const MP_SITE_ID    = 'MLU';
+
+export function validateSandboxUrl(raw) {
+  try {
+    const u = new URL(raw);
+    return u.protocol === 'https:' && MP_SANDBOX_HOSTNAMES.has(u.hostname) && u.pathname.length > 1;
+  } catch { return false; }
+}
+
+export function validateLiveUrl(raw) {
+  try {
+    const u = new URL(raw);
+    return u.protocol === 'https:' && MP_LIVE_HOSTNAMES.has(u.hostname) && u.pathname.length > 1;
+  } catch { return false; }
+}
+
+// checkoutField selecciona exclusivamente el campo correcto para el ambiente
+// actual — nunca hay fallback cruzado entre sandbox_init_point e init_point.
+function pickCheckoutUrl(data, checkoutField) {
+  if (checkoutField === 'sandbox_init_point') {
+    return validateSandboxUrl(data?.sandbox_init_point) ? data.sandbox_init_point : null;
+  }
+  if (checkoutField === 'init_point') {
+    return validateLiveUrl(data?.init_point) ? data.init_point : null;
+  }
+  return null;
+}
+
+function validateMpResponse(data, { requireExternalRef = false, publicCode = '', expectedCollectorId, checkoutField } = {}) {
+  if (!data || typeof data !== 'object') return 'respuesta vacía';
+  if (typeof data.id !== 'string' || !data.id) return 'id ausente';
+  if (!pickCheckoutUrl(data, checkoutField)) return `${checkoutField} inválido o ausente`;
+  if (data.collector_id !== undefined && data.collector_id !== expectedCollectorId) return 'collector_id incorrecto';
+  if (data.site_id !== undefined && data.site_id !== MP_SITE_ID) return 'site_id incorrecto';
+  if (requireExternalRef && data.external_reference !== publicCode) return 'external_reference no coincide';
+  return null;
+}
+
+function mpErrorCode(status) {
+  if (status === 401) return 'MP_AUTH_ERROR';
+  if (status === 429) return 'MP_RATE_LIMIT';
+  return 'MP_API_ERROR';
+}
+
+async function fetchMp(url, opts, timeoutMs, fetchFn) {
+  const ctrl  = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    return await fetchFn(url, { ...opts, signal: ctrl.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function createPreference(payload, accessToken, { expectedCollectorId, checkoutField, fetch: f = globalThis.fetch, timeoutMs = 10000 } = {}) {
+  let resp;
+  try {
+    resp = await fetchMp(
+      `${MP_BASE}/checkout/preferences`,
+      {
+        method:  'POST',
+        headers: {
+          'Authorization':     `Bearer ${accessToken}`,
+          'Content-Type':      'application/json',
+          'X-Idempotency-Key': crypto.randomUUID(),
+        },
+        body: JSON.stringify(payload),
+      },
+      timeoutMs,
+      f
+    );
+  } catch (e) {
+    if (e?.name === 'AbortError') return { ok: false, code: 'MP_TIMEOUT' };
+    return { ok: false, code: 'MP_API_ERROR' };
+  }
+
+  if (!resp.ok) return { ok: false, code: mpErrorCode(resp.status) };
+
+  let data;
+  try { data = await resp.json(); } catch { return { ok: false, code: 'MP_API_ERROR' }; }
+
+  const err = validateMpResponse(data, { expectedCollectorId, checkoutField });
+  if (err) return { ok: false, code: 'MP_API_ERROR' };
+  return { ok: true, id: data.id, checkout_url: pickCheckoutUrl(data, checkoutField) };
+}
+
+export async function getPreference(prefId, accessToken, publicCode, { expectedCollectorId, checkoutField, fetch: f = globalThis.fetch, timeoutMs = 10000 } = {}) {
+  let resp;
+  try {
+    resp = await fetchMp(
+      `${MP_BASE}/checkout/preferences/${prefId}`,
+      { headers: { 'Authorization': `Bearer ${accessToken}` } },
+      timeoutMs,
+      f
+    );
+  } catch (e) {
+    if (e?.name === 'AbortError') return { ok: false, code: 'MP_TIMEOUT' };
+    return { ok: false, code: 'MP_API_ERROR' };
+  }
+
+  if (!resp.ok) return { ok: false, code: mpErrorCode(resp.status) };
+
+  let data;
+  try { data = await resp.json(); } catch { return { ok: false, code: 'MP_API_ERROR' }; }
+
+  const err = validateMpResponse(data, { requireExternalRef: true, publicCode, expectedCollectorId, checkoutField });
+  if (err) return { ok: false, code: 'MP_API_ERROR' };
+  return { ok: true, id: data.id, checkout_url: pickCheckoutUrl(data, checkoutField) };
+}
+
+export async function getPayment(paymentId, accessToken, { fetch: f = globalThis.fetch, timeoutMs = 10000 } = {}) {
+  let resp;
+  try {
+    resp = await fetchMp(
+      `${MP_BASE}/v1/payments/${encodeURIComponent(String(paymentId))}`,
+      { headers: { 'Authorization': `Bearer ${accessToken}` } },
+      timeoutMs,
+      f
+    );
+  } catch (e) {
+    if (e?.name === 'AbortError') return { ok: false, code: 'MP_TIMEOUT' };
+    return { ok: false, code: 'MP_API_ERROR' };
+  }
+  if (resp.status === 404) return { ok: false, code: 'NOT_FOUND' };
+  if (!resp.ok) return { ok: false, code: mpErrorCode(resp.status) };
+  let data;
+  try { data = await resp.json(); } catch { return { ok: false, code: 'MP_API_ERROR' }; }
+  if (!data || typeof data.id !== 'number') return { ok: false, code: 'MP_API_ERROR' };
+  return {
+    ok: true,
+    id: data.id,
+    status: data.status,
+    live_mode: data.live_mode,
+    collector_id: data.collector_id,
+    currency_id: data.currency_id,
+    transaction_amount: data.transaction_amount,
+    external_reference: data.external_reference ?? null,
+    order_id: data.order?.id ?? null,
+    date_approved: data.date_approved ?? null,
+  };
+}
+
+export async function getMerchantOrder(merchantOrderId, accessToken, { fetch: f = globalThis.fetch, timeoutMs = 10000 } = {}) {
+  let resp;
+  try {
+    resp = await fetchMp(
+      `${MP_BASE}/merchant_orders/${encodeURIComponent(String(merchantOrderId))}`,
+      { headers: { 'Authorization': `Bearer ${accessToken}` } },
+      timeoutMs,
+      f
+    );
+  } catch (e) {
+    if (e?.name === 'AbortError') return { ok: false, code: 'MP_TIMEOUT' };
+    return { ok: false, code: 'MP_API_ERROR' };
+  }
+  if (resp.status === 404) return { ok: false, code: 'NOT_FOUND' };
+  if (!resp.ok) return { ok: false, code: mpErrorCode(resp.status) };
+  let data;
+  try { data = await resp.json(); } catch { return { ok: false, code: 'MP_API_ERROR' }; }
+  if (!data || typeof data.id !== 'number') return { ok: false, code: 'MP_API_ERROR' };
+  return {
+    ok: true,
+    id: data.id,
+    preference_id: data.preference_id ?? null,
+    external_reference: data.external_reference ?? null,
+    payments: Array.isArray(data.payments)
+      ? data.payments.map(p => ({ id: p.id, status: p.status }))
+      : [],
+  };
+}
+
+export async function searchPreferenceByRef(publicCode, accessToken, now, { expectedCollectorId, checkoutField, fetch: f = globalThis.fetch, timeoutMs = 10000 } = {}) {
+  let resp;
+  try {
+    resp = await fetchMp(
+      `${MP_BASE}/checkout/preferences/search?external_reference=${encodeURIComponent(publicCode)}`,
+      { headers: { 'Authorization': `Bearer ${accessToken}` } },
+      timeoutMs,
+      f
+    );
+  } catch (e) {
+    if (e?.name === 'AbortError') return { ok: false, code: 'MP_TIMEOUT' };
+    return { ok: false, code: 'MP_API_ERROR' };
+  }
+
+  if (!resp.ok) return { ok: false, code: 'MP_API_ERROR' };
+
+  let data;
+  try { data = await resp.json(); } catch { return { ok: false, code: 'MP_API_ERROR' }; }
+
+  const elements = Array.isArray(data?.elements) ? data.elements : [];
+  const nowMs    = now.getTime();
+
+  const candidates = elements.filter(e => {
+    if (e.external_reference !== publicCode) return false;
+    if (e.collector_id !== undefined && e.collector_id !== expectedCollectorId) return false;
+    if (e.site_id !== undefined && e.site_id !== MP_SITE_ID) return false;
+    if (e.expiration_date_to && Date.parse(e.expiration_date_to) <= nowMs) return false;
+    return true;
+  });
+
+  if (candidates.length === 0) return { ok: false, code: 'NOT_FOUND' };
+
+  candidates.sort((a, b) => Date.parse(b.date_created || '0') - Date.parse(a.date_created || '0'));
+  return getPreference(candidates[0].id, accessToken, publicCode, { expectedCollectorId, checkoutField, fetch: f, timeoutMs });
+}

--- a/functions/api/_mp_handler.js
+++ b/functions/api/_mp_handler.js
@@ -1,0 +1,228 @@
+import {
+  createPreference as defaultCreatePreference,
+  getPreference    as defaultGetPreference,
+  searchPreferenceByRef as defaultSearchPreferenceByRef,
+} from './_mp_client.js';
+import { resolveConfig, checkoutDisabledResponse } from './_env_config.js';
+
+const MAX_BODY_BYTES = 8192;
+const MP_CLAIM_TTL   = 30;
+const WEBHOOK_PATH    = '/api/webhooks/mercadopago';
+
+function json(data, status = 200, extra = {}) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+      'Cache-Control': 'no-store',
+      ...extra,
+    },
+  });
+}
+
+function configErrorResponse() {
+  return json({ error: 'Servicio no disponible.' }, 503);
+}
+
+async function clearClaim(db, orderId, claimValue, now) {
+  try {
+    await db
+      .prepare('UPDATE orders SET payment_preference_id = NULL, updated_at = ? WHERE id = ? AND payment_preference_id = ?')
+      .bind(now.toISOString(), orderId, claimValue)
+      .run();
+  } catch { /* best effort */ }
+}
+
+async function savePrefBatch(db, orderId, claimValue, prefId, now, appEnv) {
+  const payload = JSON.stringify({ preference_id: prefId, environment: appEnv });
+  return db.batch([
+    db.prepare(
+      "UPDATE orders SET payment_preference_id = ?, payment_provider = 'mercadopago', updated_at = ? WHERE id = ? AND payment_preference_id = ?"
+    ).bind(prefId, now.toISOString(), orderId, claimValue),
+    db.prepare(
+      'INSERT INTO order_events (id, order_id, event_type, payload_json, created_at) VALUES (?, ?, ?, ?, ?)'
+    ).bind(crypto.randomUUID(), orderId, 'preference_created', payload, now.toISOString()),
+  ]);
+}
+
+export function createPreferenceHandler({
+  mpClient = {
+    createPreference:      defaultCreatePreference,
+    getPreference:         defaultGetPreference,
+    searchPreferenceByRef: defaultSearchPreferenceByRef,
+  },
+} = {}) {
+  return async function onRequest(context) {
+    const { request, env } = context;
+
+    if (request.method !== 'POST') {
+      return json({ error: 'Método no permitido.' }, 405, { Allow: 'POST' });
+    }
+
+    const ct = request.headers.get('Content-Type') || '';
+    if (!ct.toLowerCase().includes('application/json')) {
+      return json({ error: 'Content-Type debe ser application/json.' }, 415);
+    }
+
+    const config = resolveConfig(env);
+    if (!config.ok) return configErrorResponse();
+
+    if (!config.checkoutEnabled) return checkoutDisabledResponse();
+
+    const checkoutField = config.isProduction ? 'init_point' : 'sandbox_init_point';
+
+    const token = env?.MP_ACCESS_TOKEN;
+    if (!token) {
+      return json({ error: 'Servicio de pago no configurado.', code: 'MP_NOT_CONFIGURED' }, 503);
+    }
+
+    const cl = Number.parseInt(request.headers.get('Content-Length') || '0', 10);
+    if (Number.isFinite(cl) && cl > MAX_BODY_BYTES) {
+      return json({ error: 'Body demasiado grande.' }, 413);
+    }
+    let text;
+    try { text = await request.text(); } catch { return json({ error: 'Error leyendo body.' }, 400); }
+    if (new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) {
+      return json({ error: 'Body demasiado grande.' }, 413);
+    }
+    let body;
+    try { body = JSON.parse(text); } catch { return json({ error: 'JSON inválido.' }, 400); }
+
+    if (!body || typeof body.public_code !== 'string' || !body.public_code.trim() || body.public_code.trim().length > 20) {
+      return json({ error: 'public_code requerido.', code: 'MISSING_PUBLIC_CODE' }, 400);
+    }
+    if (!body || typeof body.idempotency_key !== 'string' || !body.idempotency_key.trim() || body.idempotency_key.trim().length > 128) {
+      return json({ error: 'idempotency_key requerido.', code: 'MISSING_IDEMPOTENCY_KEY' }, 400);
+    }
+
+    const publicCode     = body.public_code.trim();
+    const idempotencyKey = body.idempotency_key.trim();
+
+    const reqUrl = new URL(request.url);
+    if (!config.isAllowedRequestHost(reqUrl.hostname)) {
+      return json({ error: 'Origen no permitido.', code: 'INVALID_ORIGIN' }, 400);
+    }
+
+    const db = env?.ORDERS_DB;
+    if (!db) return json({ error: 'Servicio de órdenes no disponible.' }, 503);
+
+    const order = await db
+      .prepare(
+        'SELECT id, status, payment_status, expires_at, payable_total_uyu, buyer_name, payment_preference_id ' +
+        'FROM orders WHERE public_code = ? AND idempotency_key = ?'
+      )
+      .bind(publicCode, idempotencyKey)
+      .first();
+
+    if (!order) return json({ error: 'Pedido no encontrado.', code: 'ORDER_NOT_FOUND' }, 404);
+
+    if (order.status === 'cancelled') {
+      return json({ error: 'El pedido fue cancelado.', code: 'ORDER_CANCELLED' }, 410);
+    }
+    const now     = new Date();
+    const expired =
+      order.status === 'expired' ||
+      (order.status === 'open' &&
+       typeof order.expires_at === 'string' &&
+       Number.isFinite(Date.parse(order.expires_at)) &&
+       Date.parse(order.expires_at) <= now.getTime());
+    if (expired) return json({ error: 'El pedido venció.', code: 'ORDER_EXPIRED' }, 410);
+    if (order.payment_status === 'approved') {
+      return json({ error: 'El pedido ya fue pagado.', code: 'ORDER_ALREADY_PAID' }, 409);
+    }
+
+    const mpOpts = { expectedCollectorId: config.mpCollectorId, checkoutField };
+
+    const existingPref = order.payment_preference_id;
+    if (existingPref && !existingPref.startsWith('creating:')) {
+      const r = await mpClient.getPreference(existingPref, token, publicCode, mpOpts);
+      if (r.ok) return json({ checkout_url: r.checkout_url });
+      const s = r.code === 'MP_RATE_LIMIT' ? 503 : 502;
+      return json({ error: 'Error al recuperar preferencia.', code: r.code }, s);
+    }
+
+    const epochNow       = Math.floor(now.getTime() / 1000);
+    const staleThreshold = epochNow - MP_CLAIM_TTL;
+    const claimValue     = 'creating:' + epochNow + ':' + crypto.randomUUID();
+
+    const acquired = await db
+      .prepare(
+        "UPDATE orders SET payment_preference_id = ?, updated_at = ? " +
+        "WHERE id = ? AND status = 'open' AND payment_status != 'approved' AND (" +
+        "  payment_preference_id IS NULL " +
+        "  OR (payment_preference_id LIKE 'creating:%' AND CAST(substr(payment_preference_id, 10, 10) AS INTEGER) <= ?)" +
+        ")"
+      )
+      .bind(claimValue, now.toISOString(), order.id, staleThreshold)
+      .run();
+
+    if (acquired.meta.changes !== 1) {
+      const current = await db
+        .prepare('SELECT payment_preference_id FROM orders WHERE id = ?')
+        .bind(order.id)
+        .first();
+      const curPref = current?.payment_preference_id;
+      if (!curPref || curPref.startsWith('creating:')) {
+        return json({ error: 'Pago en proceso. Intentá en unos segundos.', code: 'PREFERENCE_CREATING' }, 409);
+      }
+      const r = await mpClient.getPreference(curPref, token, publicCode, mpOpts);
+      if (r.ok) return json({ checkout_url: r.checkout_url });
+      return json({ error: 'Error al recuperar preferencia.', code: r.code }, 502);
+    }
+
+    const mpPayload = {
+      items: [{
+        title:      'Pedido Amado Libros ' + publicCode,
+        quantity:    1,
+        unit_price:  order.payable_total_uyu,
+        currency_id: 'UYU',
+      }],
+      payer:              { name: order.buyer_name },
+      external_reference: publicCode,
+      expires:            true,
+      expiration_date_to: order.expires_at,
+      notification_url: config.canonicalOrigin + WEBHOOK_PATH,
+      back_urls: {
+        success: config.canonicalOrigin + '/pedido/?result=success&code=' + publicCode,
+        pending: config.canonicalOrigin + '/pedido/?result=pending&code='  + publicCode,
+        failure: config.canonicalOrigin + '/pedido/?result=failure&code='  + publicCode,
+      },
+      auto_return:          'approved',
+      statement_descriptor: 'AMADO LIBROS',
+    };
+
+    const mpResult = await mpClient.createPreference(mpPayload, token, mpOpts);
+
+    if (!mpResult.ok) {
+      if (mpResult.code === 'MP_TIMEOUT') {
+        const search = await mpClient.searchPreferenceByRef(publicCode, token, now, mpOpts);
+        if (search.ok) {
+          await savePrefBatch(db, order.id, claimValue, search.id, now, config.appEnv);
+          return json({ checkout_url: search.checkout_url });
+        }
+        await clearClaim(db, order.id, claimValue, now);
+        return json({ error: 'Servicio de pago no disponible.', code: 'MP_TIMEOUT' }, 503);
+      }
+      await clearClaim(db, order.id, claimValue, now);
+      const s = mpResult.code === 'MP_RATE_LIMIT' ? 503 : 502;
+      return json({ error: 'Error al crear preferencia de pago.', code: mpResult.code }, s);
+    }
+
+    const batchResult = await savePrefBatch(db, order.id, claimValue, mpResult.id, now, config.appEnv);
+
+    if (batchResult[0].meta.changes !== 1) {
+      const current2 = await db
+        .prepare('SELECT payment_preference_id FROM orders WHERE id = ?')
+        .bind(order.id)
+        .first();
+      const winner = current2?.payment_preference_id;
+      if (winner && !winner.startsWith('creating:')) {
+        const r = await mpClient.getPreference(winner, token, publicCode, mpOpts);
+        if (r.ok) return json({ checkout_url: r.checkout_url });
+      }
+      return json({ error: 'Error al guardar preferencia.', code: 'PREFERENCE_WRITE_ERROR' }, 500);
+    }
+
+    return json({ checkout_url: mpResult.checkout_url });
+  };
+}

--- a/functions/api/_mp_webhook_handler.js
+++ b/functions/api/_mp_webhook_handler.js
@@ -1,0 +1,272 @@
+import {
+  getPayment      as defaultGetPayment,
+  getMerchantOrder as defaultGetMerchantOrder,
+} from './_mp_client.js';
+import { resolveConfig } from './_env_config.js';
+
+const MAX_BODY_BYTES = 32768;
+
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json;charset=UTF-8', 'Cache-Control': 'no-store' },
+  });
+}
+
+function noContent(status) {
+  return new Response(null, { status, headers: { 'Cache-Control': 'no-store' } });
+}
+
+async function verifyHmac(secret, message, hexSignature) {
+  try {
+    const keyMaterial = new TextEncoder().encode(secret);
+    const key = await crypto.subtle.importKey(
+      'raw', keyMaterial, { name: 'HMAC', hash: 'SHA-256' }, false, ['verify']
+    );
+    if (hexSignature.length % 2 !== 0) return false;
+    const sigBytes = new Uint8Array(hexSignature.length / 2);
+    for (let i = 0; i < hexSignature.length; i += 2) {
+      const byte = parseInt(hexSignature.slice(i, i + 2), 16);
+      if (isNaN(byte)) return false;
+      sigBytes[i / 2] = byte;
+    }
+    return await crypto.subtle.verify('HMAC', key, sigBytes, new TextEncoder().encode(message));
+  } catch {
+    return false;
+  }
+}
+
+function normalizeStatus(mpStatus) {
+  if (mpStatus === 'approved')                               return 'approved';
+  if (mpStatus === 'pending' || mpStatus === 'in_process' ||
+      mpStatus === 'authorized')                             return 'pending';
+  if (mpStatus === 'rejected')                              return 'rejected';
+  if (mpStatus === 'cancelled')                             return 'cancelled';
+  if (mpStatus === 'refunded' || mpStatus === 'charged_back') return 'refunded';
+  return null;
+}
+
+async function applyApproved(db, order, payment, now) {
+  const eventId  = `mp:${payment.id}:approved`;
+  const paidAt   = payment.date_approved || now.toISOString();
+  const payload  = JSON.stringify({ payment_id: payment.id, amount: payment.transaction_amount });
+  return db.batch([
+    db.prepare(
+      "UPDATE orders SET payment_status='approved', status='paid', payment_id=?, paid_at=?, updated_at=? " +
+      "WHERE id=? AND payment_status!='approved'"
+    ).bind(String(payment.id), paidAt, now.toISOString(), order.id),
+    db.prepare(
+      "INSERT OR IGNORE INTO order_events (id,order_id,event_type,payload_json,created_at) VALUES (?,?,'payment_approved',?,?)"
+    ).bind(eventId, order.id, payload, now.toISOString()),
+  ]);
+}
+
+async function applyPending(db, order, payment, now) {
+  const eventId = `mp:${payment.id}:pending`;
+  const payload = JSON.stringify({ payment_id: payment.id });
+  return db.batch([
+    db.prepare(
+      "UPDATE orders SET payment_status='pending', payment_id=?, updated_at=? " +
+      "WHERE id=? AND payment_status NOT IN ('approved','pending')"
+    ).bind(String(payment.id), now.toISOString(), order.id),
+    db.prepare(
+      "INSERT OR IGNORE INTO order_events (id,order_id,event_type,payload_json,created_at) VALUES (?,?,'payment_pending',?,?)"
+    ).bind(eventId, order.id, payload, now.toISOString()),
+  ]);
+}
+
+async function applyRejected(db, order, payment, now) {
+  const eventId = `mp:${payment.id}:rejected`;
+  const payload = JSON.stringify({ payment_id: payment.id });
+  return db.batch([
+    db.prepare(
+      "UPDATE orders SET payment_status='rejected', payment_id=?, updated_at=? " +
+      "WHERE id=? AND payment_status NOT IN ('approved','rejected')"
+    ).bind(String(payment.id), now.toISOString(), order.id),
+    db.prepare(
+      "INSERT OR IGNORE INTO order_events (id,order_id,event_type,payload_json,created_at) VALUES (?,?,'payment_rejected',?,?)"
+    ).bind(eventId, order.id, payload, now.toISOString()),
+  ]);
+}
+
+async function applyCancelled(db, order, payment, now) {
+  const eventId = `mp:${payment.id}:cancelled`;
+  const payload = JSON.stringify({ payment_id: payment.id });
+  return db.batch([
+    db.prepare(
+      "UPDATE orders SET payment_status='cancelled', payment_id=?, updated_at=? " +
+      "WHERE id=? AND payment_status NOT IN ('approved','cancelled')"
+    ).bind(String(payment.id), now.toISOString(), order.id),
+    db.prepare(
+      "INSERT OR IGNORE INTO order_events (id,order_id,event_type,payload_json,created_at) VALUES (?,?,'payment_cancelled',?,?)"
+    ).bind(eventId, order.id, payload, now.toISOString()),
+  ]);
+}
+
+async function applyRefunded(db, order, payment, now) {
+  const eventId = `mp:${payment.id}:refunded`;
+  const payload = JSON.stringify({ payment_id: payment.id });
+  return db.batch([
+    db.prepare(
+      "UPDATE orders SET payment_status='refunded', payment_id=?, updated_at=? " +
+      "WHERE id=? AND payment_status!='refunded'"
+    ).bind(String(payment.id), now.toISOString(), order.id),
+    db.prepare(
+      "INSERT OR IGNORE INTO order_events (id,order_id,event_type,payload_json,created_at) VALUES (?,?,'payment_refunded',?,?)"
+    ).bind(eventId, order.id, payload, now.toISOString()),
+  ]);
+}
+
+export function createMpWebhookHandler({
+  mpClient = { getPayment: defaultGetPayment, getMerchantOrder: defaultGetMerchantOrder },
+  getNow   = () => new Date(),
+} = {}) {
+  return async function onRequest(context) {
+    const { request, env } = context;
+
+    if (request.method !== 'POST') {
+      return json({ error: 'Método no permitido.' }, 405);
+    }
+
+    // Config falla cerrada antes de tocar cualquier otra cosa. Mercado Pago
+    // no es un navegador: este endpoint nunca exige encabezado Origin.
+    const config = resolveConfig(env);
+    if (!config.ok) return noContent(503);
+
+    const reqUrl = new URL(request.url);
+    if (!config.isAllowedRequestHost(reqUrl.hostname)) {
+      return json({ error: 'Origen no permitido.' }, 400);
+    }
+
+    const webhookSecret = env?.MP_WEBHOOK_SECRET;
+    const accessToken   = env?.MP_ACCESS_TOKEN;
+    if (!webhookSecret || !accessToken) return noContent(503);
+
+    // Size check
+    const cl = Number.parseInt(request.headers.get('Content-Length') || '0', 10);
+    if (Number.isFinite(cl) && cl > MAX_BODY_BYTES) return json({ error: 'Body demasiado grande.' }, 400);
+    let text;
+    try { text = await request.text(); } catch { return json({ error: 'Error leyendo body.' }, 400); }
+    if (new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) {
+      return json({ error: 'Body demasiado grande.' }, 400);
+    }
+
+    // Parse body
+    let body;
+    try { body = JSON.parse(text); } catch { return json({ error: 'Payload inválido.' }, 400); }
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return json({ error: 'Payload inválido.' }, 400);
+    }
+
+    // Signature headers
+    const xSig   = request.headers.get('x-signature');
+    const xReqId = request.headers.get('x-request-id');
+    if (!xSig || !xReqId) return json({ error: 'Firma inválida.' }, 401);
+
+    // Parse x-signature: ts=<ts>,v1=<hex>
+    let ts = null, v1 = null;
+    for (const part of xSig.split(',')) {
+      const eq = part.indexOf('=');
+      if (eq < 0) continue;
+      const k = part.slice(0, eq).trim();
+      const v = part.slice(eq + 1).trim();
+      if (k === 'ts') ts = v;
+      if (k === 'v1') v1 = v;
+    }
+    if (!ts || !v1) return json({ error: 'Firma inválida.' }, 401);
+
+    // data.id from query param (MP's official signed field)
+    const queryDataId = reqUrl.searchParams.get('data.id');
+    if (!queryDataId) return json({ error: 'Firma inválida.' }, 401);
+
+    // body.data.id must exist and match
+    const bodyDataId = body?.data?.id;
+    if (bodyDataId === undefined || bodyDataId === null) return json({ error: 'Payload inválido.' }, 400);
+    if (String(bodyDataId) !== String(queryDataId)) return json({ error: 'Payload inválido.' }, 400);
+
+    // HMAC verification — constant time via Web Crypto
+    const signedString = `id:${queryDataId};request-id:${xReqId};ts:${ts};`;
+    const valid = await verifyHmac(webhookSecret, signedString, v1);
+    if (!valid) return json({ error: 'Firma inválida.' }, 401);
+
+    // Only process payment type
+    if (body.type !== 'payment') return json({ ok: true });
+
+    const db = env?.ORDERS_DB;
+    if (!db) return noContent(503);
+
+    // Fetch payment from MP. Cualquier falla (timeout, red, 429, 5xx, y
+    // también 401/403/404) es una imposibilidad de validar, no un "no
+    // corresponde" — se devuelve 503 para que Mercado Pago reintente en vez
+    // de asumir silenciosamente que el evento es irrelevante.
+    const paymentResult = await mpClient.getPayment(queryDataId, accessToken);
+    if (!paymentResult.ok) return noContent(503);
+    const payment = paymentResult;
+
+    // Validate ownership/identity — live_mode es solo diagnóstico, nunca gate
+    // (un pago contra nuestro MP_COLLECTOR_ID configurado, con importe,
+    // external_reference y merchant_order coincidentes, es nuestro sin
+    // importar cómo Mercado Pago clasificó el modo de la transacción).
+    if (payment.collector_id !== config.mpCollectorId) return json({ ok: true });
+    if (payment.currency_id !== 'UYU')                 return json({ ok: true });
+
+    // Find order by external_reference
+    const publicCode = payment.external_reference;
+    if (!publicCode || typeof publicCode !== 'string') return json({ ok: true });
+
+    const order = await db
+      .prepare('SELECT id,status,payment_status,payable_total_uyu,payment_preference_id FROM orders WHERE public_code=?')
+      .bind(publicCode)
+      .first();
+    if (!order) return json({ ok: true });
+
+    // Validate exact amount
+    if (Number(payment.transaction_amount) !== order.payable_total_uyu) return json({ ok: true });
+
+    // Validate via merchant order if available
+    if (payment.order_id) {
+      const moResult = await mpClient.getMerchantOrder(payment.order_id, accessToken);
+      if (!moResult.ok) return noContent(503);
+
+      const prefId = order.payment_preference_id;
+      if (prefId && !prefId.startsWith('creating:') && moResult.preference_id !== prefId) {
+        return json({ ok: true });
+      }
+
+      if (moResult.external_reference && moResult.external_reference !== publicCode) {
+        return json({ ok: true });
+      }
+
+      const pidStr = String(queryDataId);
+      const inPayments = moResult.payments.some(
+        p => String(p.id) === pidStr || p.id === Number(queryDataId)
+      );
+      if (!inPayments) return json({ ok: true });
+    }
+
+    if (payment.live_mode !== config.expectedLiveMode) {
+      console.warn('mp_webhook: live_mode inesperado', {
+        payment_id: payment.id,
+        app_env: config.appEnv,
+        expected: config.expectedLiveMode,
+        observed: payment.live_mode,
+      });
+    }
+
+    const normalized = normalizeStatus(payment.status);
+    if (!normalized) return json({ ok: true });
+
+    const now = getNow();
+    try {
+      if (normalized === 'approved')   await applyApproved(db, order, payment, now);
+      else if (normalized === 'pending')   await applyPending(db, order, payment, now);
+      else if (normalized === 'rejected')  await applyRejected(db, order, payment, now);
+      else if (normalized === 'cancelled') await applyCancelled(db, order, payment, now);
+      else if (normalized === 'refunded')  await applyRefunded(db, order, payment, now);
+    } catch {
+      return json({ error: 'Error temporal.' }, 500);
+    }
+
+    return json({ ok: true });
+  };
+}

--- a/functions/api/_order_status_handler.js
+++ b/functions/api/_order_status_handler.js
@@ -1,0 +1,63 @@
+import { resolveConfig } from './_env_config.js';
+
+const MAX_BODY_BYTES = 8192;
+
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json;charset=UTF-8', 'Cache-Control': 'no-store' },
+  });
+}
+
+export function createOrderStatusHandler() {
+  return async function onRequest(context) {
+    const { request, env } = context;
+
+    if (request.method !== 'POST') {
+      return json({ error: 'Método no permitido.' }, 405);
+    }
+
+    const config = resolveConfig(env);
+    if (!config.ok) return json({ error: 'Servicio no disponible.' }, 503);
+
+    const reqUrl = new URL(request.url);
+    if (!config.isAllowedRequestHost(reqUrl.hostname)) {
+      return json({ error: 'Origen no permitido.' }, 400);
+    }
+
+    const ct = request.headers.get('Content-Type') || '';
+    if (!ct.toLowerCase().includes('application/json')) {
+      return json({ error: 'Content-Type debe ser application/json.' }, 415);
+    }
+
+    const cl = Number.parseInt(request.headers.get('Content-Length') || '0', 10);
+    if (Number.isFinite(cl) && cl > MAX_BODY_BYTES) return json({ error: 'Body demasiado grande.' }, 413);
+    let text;
+    try { text = await request.text(); } catch { return json({ error: 'Error leyendo body.' }, 400); }
+    if (new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) return json({ error: 'Body demasiado grande.' }, 413);
+    let body;
+    try { body = JSON.parse(text); } catch { return json({ error: 'JSON inválido.' }, 400); }
+
+    if (!body || typeof body.public_code !== 'string' || !body.public_code.trim()) {
+      return json({ error: 'public_code requerido.' }, 400);
+    }
+    if (!body || typeof body.idempotency_key !== 'string' || !body.idempotency_key.trim()) {
+      return json({ error: 'idempotency_key requerido.' }, 400);
+    }
+
+    const publicCode     = body.public_code.trim();
+    const idempotencyKey = body.idempotency_key.trim();
+
+    const db = env?.ORDERS_DB;
+    if (!db) return json({ error: 'Servicio no disponible.' }, 503);
+
+    const order = await db
+      .prepare('SELECT payment_status,status FROM orders WHERE public_code=? AND idempotency_key=?')
+      .bind(publicCode, idempotencyKey)
+      .first();
+
+    if (!order) return json({ error: 'No encontrado.' }, 404);
+
+    return json({ payment_status: order.payment_status, status: order.status });
+  };
+}

--- a/functions/api/_orders_handler.js
+++ b/functions/api/_orders_handler.js
@@ -1,0 +1,337 @@
+import {
+  validateBody,
+  validateShippingDate,
+  consolidateItems,
+  buildSnapshot,
+  calculateTotals,
+  generateFingerprint,
+  generatePublicCode,
+  EXPIRY_MINUTES,
+  MAX_BODY_BYTES,
+} from './_orders_logic.js';
+import { verifyTurnstile } from './_turnstile.js';
+import { resolveConfig, checkoutDisabledResponse } from './_env_config.js';
+
+const EXISTING_ORDER_SELECT =
+  'SELECT id, public_code, status, payment_status, delivery_type, ' +
+  'products_total_uyu, pickup_discount_uyu, shipping_cost_uyu, ' +
+  'payable_total_uyu, currency, expires_at, request_fingerprint ' +
+  'FROM orders WHERE idempotency_key = ?';
+
+export function createOrdersHandler({ fetchCatalog, getNow = () => new Date(), verifyTurnstileToken = verifyTurnstile }) {
+  return async function onRequest(context) {
+    const { request, env } = context;
+
+    if (request.method !== 'POST') {
+      return json({ error: 'Método no permitido.' }, 405, { Allow: 'POST' });
+    }
+
+    const contentType = request.headers.get('Content-Type') || '';
+    if (!contentType.toLowerCase().includes('application/json')) {
+      return json({ error: 'Content-Type debe ser application/json.' }, 415);
+    }
+
+    const config = resolveConfig(env);
+    if (!config.ok) return json({ error: 'Servicio no disponible.' }, 503);
+    if (!config.checkoutEnabled) return checkoutDisabledResponse();
+
+    const contentLength = Number.parseInt(request.headers.get('Content-Length') || '0', 10);
+    if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+      return json({ error: 'Body demasiado grande (máx. 32 KB).' }, 413);
+    }
+
+    let body;
+    try {
+      const text = await request.text();
+      if (new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) {
+        return json({ error: 'Body demasiado grande (máx. 32 KB).' }, 413);
+      }
+      body = JSON.parse(text);
+    } catch {
+      return json({ error: 'JSON inválido.' }, 400);
+    }
+
+    const validationError = validateBody(body);
+    if (validationError) return json({ error: validationError }, 400);
+
+    // Fail-closed: ORDERS_DB y TURNSTILE_SECRET_KEY deben estar presentes juntos.
+    const db = env?.ORDERS_DB;
+    if (!db) return json({ error: 'Servicio de órdenes no disponible.' }, 503);
+
+    const tsSecret = env?.TURNSTILE_SECRET_KEY;
+    if (!tsSecret) {
+      return json({ error: 'Servicio de verificación no configurado.', code: 'TS_NOT_CONFIGURED' }, 503);
+    }
+
+    const tsRaw = typeof body.cf_turnstile_response === 'string' ? body.cf_turnstile_response.trim() : '';
+    if (!tsRaw) {
+      return json({ error: 'Verificación requerida.', code: 'TOKEN_MISSING' }, 403);
+    }
+    if (tsRaw.length > 2048) {
+      return json({ error: 'Token inválido.', code: 'TOKEN_INVALID' }, 403);
+    }
+    const tsResult = await verifyTurnstileToken(tsRaw, tsSecret, request.headers.get('CF-Connecting-IP') ?? '', {
+      isAllowedHostname: config.isExpectedTurnstileHostname,
+    });
+    if (!tsResult.ok) {
+      const svcErr = tsResult.code === 'SITEVERIFY_ERROR' || tsResult.code === 'SITEVERIFY_TIMEOUT';
+      return json(
+        { error: svcErr ? 'Servicio de verificación no disponible.' : 'Verificación fallida.', code: tsResult.code },
+        svcErr ? 503 : 403
+      );
+    }
+
+    const now = getNow();
+    if (!(now instanceof Date) || Number.isNaN(now.getTime())) {
+      console.error('[orders] invalid clock');
+      return json({ error: 'Error interno. Intentá de nuevo.' }, 500);
+    }
+
+    if (body.delivery_type === 'shipping') {
+      const dateError = validateShippingDate(
+        body.shipping.requested_date,
+        body.shipping.requested_from,
+        body.shipping.requested_to,
+        now
+      );
+      if (dateError) return json({ error: dateError }, 400);
+    }
+
+    const consolidatedItems = consolidateItems(body.items);
+    const fingerprint = generateFingerprint(body, consolidatedItems);
+    const idempotencyKey = body.idempotency_key.trim();
+
+    let existingOrder;
+    try {
+      existingOrder = await findOrderByIdempotencyKey(db, idempotencyKey);
+    } catch (error) {
+      console.error('[orders] idempotency lookup error', safeErrorName(error));
+      return json({ error: 'Servicio de órdenes no disponible.' }, 503);
+    }
+
+    if (existingOrder) {
+      return handleExistingOrder({ db, order: existingOrder, fingerprint, now });
+    }
+
+    const catalog = await fetchCatalog(context).catch(() => null);
+    if (!catalog || !Array.isArray(catalog.items)) {
+      return json({ error: 'Catálogo no disponible. Intentá de nuevo en unos segundos.' }, 503);
+    }
+
+    const { errors, snapshot } = buildSnapshot(consolidatedItems, catalog.items);
+    if (errors.length > 0) {
+      return json({ error: 'Productos con problemas.', details: errors }, 422);
+    }
+
+    const { productsTotal, pickupDiscount, shippingCost, payableTotal } =
+      calculateTotals(snapshot, body.delivery_type);
+
+    let publicCode = null;
+    try {
+      for (let attempt = 0; attempt < 5; attempt++) {
+        const candidate = generatePublicCode(now);
+        const codeExists = await db
+          .prepare('SELECT id FROM orders WHERE public_code = ?')
+          .bind(candidate)
+          .first();
+        if (!codeExists) {
+          publicCode = candidate;
+          break;
+        }
+      }
+    } catch (error) {
+      console.error('[orders] public code lookup error', safeErrorName(error));
+      return json({ error: 'Servicio de órdenes no disponible.' }, 503);
+    }
+
+    if (!publicCode) return json({ error: 'Error interno. Intentá de nuevo.' }, 500);
+
+    const orderId = crypto.randomUUID();
+    const createdAt = now.toISOString();
+    const expiresAt = new Date(now.getTime() + EXPIRY_MINUTES * 60 * 1000).toISOString();
+    const shipping = body.shipping || {};
+
+    const orderStmt = db.prepare(
+      'INSERT INTO orders (' +
+        'id, public_code, idempotency_key, request_fingerprint, ' +
+        'status, payment_status, ' +
+        'buyer_name, buyer_phone, ' +
+        'delivery_type, ' +
+        'address, locality, department, ' +
+        'requested_delivery_date, requested_delivery_from, requested_delivery_to, delivery_notes, ' +
+        'products_total_uyu, pickup_discount_uyu, shipping_cost_uyu, payable_total_uyu, ' +
+        'currency, created_at, expires_at, updated_at' +
+      ') VALUES (' +
+        '?, ?, ?, ?, ' +
+        "'open', 'not_started', " +
+        '?, ?, ' +
+        '?, ' +
+        '?, ?, ?, ' +
+        '?, ?, ?, ?, ' +
+        '?, ?, ?, ?, ' +
+        "'UYU', ?, ?, ?" +
+      ')'
+    ).bind(
+      orderId,
+      publicCode,
+      idempotencyKey,
+      fingerprint,
+      body.buyer.name.trim(),
+      body.buyer.phone.trim(),
+      body.delivery_type,
+      typeof shipping.address === 'string' ? shipping.address.trim() : null,
+      typeof shipping.locality === 'string' ? shipping.locality.trim() : null,
+      typeof shipping.department === 'string' ? shipping.department.trim() : null,
+      shipping.requested_date || null,
+      shipping.requested_from || null,
+      shipping.requested_to || null,
+      typeof shipping.notes === 'string' && shipping.notes.trim() ? shipping.notes.trim() : null,
+      productsTotal,
+      pickupDiscount,
+      shippingCost,
+      payableTotal,
+      createdAt,
+      expiresAt,
+      createdAt
+    );
+
+    const itemStmts = snapshot.map(item =>
+      db.prepare(
+        'INSERT INTO order_items ' +
+        '(id, order_id, product_id, title, quantity, unit_price_uyu, line_total_uyu, ' +
+        'image_url, observed_available_quantity, created_at) ' +
+        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+      ).bind(
+        crypto.randomUUID(),
+        orderId,
+        item.product_id,
+        item.title,
+        item.quantity,
+        item.unit_price_uyu,
+        item.line_total_uyu,
+        item.image_url,
+        item.observed_available_quantity,
+        createdAt
+      )
+    );
+
+    const eventStmt = db.prepare(
+      'INSERT INTO order_events (id, order_id, event_type, payload_json, created_at) ' +
+      'VALUES (?, ?, ?, ?, ?)'
+    ).bind(
+      crypto.randomUUID(),
+      orderId,
+      'created',
+      JSON.stringify({
+        delivery_type: body.delivery_type,
+        products_total: productsTotal,
+        payable_total: payableTotal,
+      }),
+      createdAt
+    );
+
+    try {
+      await db.batch([orderStmt, ...itemStmts, eventStmt]);
+    } catch (batchError) {
+      // Ante una carrera, otra request pudo crear la orden entre el SELECT y el batch.
+      try {
+        const raceOrder = await findOrderByIdempotencyKey(db, idempotencyKey);
+        if (raceOrder) {
+          return handleExistingOrder({ db, order: raceOrder, fingerprint, now });
+        }
+      } catch {
+        // Se conserva el error genérico de escritura; no se expone detalle interno.
+      }
+
+      console.error('[orders] batch error', safeErrorName(batchError));
+      return json({ error: 'Error al guardar el pedido. Intentá de nuevo.' }, 500);
+    }
+
+    return json({
+      order: {
+        public_code: publicCode,
+        status: 'open',
+        payment_status: 'not_started',
+        delivery_type: body.delivery_type,
+        products_total_uyu: productsTotal,
+        pickup_discount_uyu: pickupDiscount,
+        shipping_cost_uyu: shippingCost,
+        payable_total_uyu: payableTotal,
+        currency: 'UYU',
+        expires_at: expiresAt,
+      },
+    }, 201);
+  };
+}
+
+async function findOrderByIdempotencyKey(db, idempotencyKey) {
+  return db.prepare(EXISTING_ORDER_SELECT).bind(idempotencyKey).first();
+}
+
+async function handleExistingOrder({ db, order, fingerprint, now }) {
+  if (order.request_fingerprint !== fingerprint) {
+    return json(
+      { error: 'Conflicto: el mismo idempotency_key fue usado con un pedido diferente.' },
+      409
+    );
+  }
+
+  const expired = order.status === 'expired' || (
+    order.status === 'open' &&
+    typeof order.expires_at === 'string' &&
+    Number.isFinite(Date.parse(order.expires_at)) &&
+    Date.parse(order.expires_at) <= now.getTime()
+  );
+
+  if (expired) {
+    if (order.status === 'open' && order.id) {
+      try {
+        await db
+          .prepare("UPDATE orders SET status = 'expired', updated_at = ? WHERE id = ? AND status = 'open'")
+          .bind(now.toISOString(), order.id)
+          .run();
+      } catch (error) {
+        console.error('[orders] expire update error', safeErrorName(error));
+      }
+    }
+
+    return json({
+      error: 'La orden anterior venció. Volvé a preparar el pedido.',
+      code: 'ORDER_EXPIRED',
+    }, 410);
+  }
+
+  return json({ order: formatOrder(order) }, 200);
+}
+
+function formatOrder(order) {
+  return {
+    public_code: order.public_code,
+    status: order.status,
+    payment_status: order.payment_status,
+    delivery_type: order.delivery_type,
+    products_total_uyu: order.products_total_uyu,
+    pickup_discount_uyu: order.pickup_discount_uyu,
+    shipping_cost_uyu: order.shipping_cost_uyu,
+    payable_total_uyu: order.payable_total_uyu,
+    currency: order.currency,
+    expires_at: order.expires_at,
+  };
+}
+
+function safeErrorName(error) {
+  return error && typeof error === 'object' && typeof error.name === 'string'
+    ? error.name
+    : 'Error';
+}
+
+function json(data, status = 200, extraHeaders = {}) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+      'Cache-Control': 'no-store',
+      ...extraHeaders,
+    },
+  });
+}

--- a/functions/api/_orders_logic.js
+++ b/functions/api/_orders_logic.js
@@ -1,0 +1,236 @@
+export const RETIRO_DISCOUNT         = 150;
+export const SHIPPING_COST           = 250;
+export const FREE_SHIPPING_THRESHOLD = 2000;
+export const EXPIRY_MINUTES          = 60;
+export const MAX_BODY_BYTES          = 32 * 1024;
+export const MAX_ITEMS               = 20;
+export const MAX_QUANTITY_PER_ITEM   = 99;
+export const MAX_IDEMPOTENCY_KEY_LEN = 128;
+export const MAX_PRODUCT_ID_LEN      = 120;
+export const MAX_NAME_LEN            = 120;
+export const MAX_PHONE_LEN           = 40;
+export const MAX_ADDRESS_LEN         = 200;
+export const MAX_LOCALITY_LEN        = 120;
+export const MAX_DEPARTMENT_LEN      = 80;
+export const MAX_NOTES_LEN           = 500;
+export const BUSINESS_TIME_ZONE      = 'America/Montevideo';
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isValidDateString(value) {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day;
+}
+
+function isValidTimeString(value) {
+  if (typeof value !== 'string' || !/^\d{2}:\d{2}$/.test(value)) return false;
+  const [hour, minute] = value.split(':').map(Number);
+  return hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59;
+}
+
+export function validateBody(body) {
+  if (!isRecord(body)) return 'Body inválido.';
+
+  if (!isNonEmptyString(body.idempotency_key)) return 'Falta idempotency_key.';
+  if (body.idempotency_key.trim().length > MAX_IDEMPOTENCY_KEY_LEN) {
+    return 'idempotency_key demasiado largo.';
+  }
+
+  if (!Array.isArray(body.items) || body.items.length === 0) return 'El carrito está vacío.';
+  if (body.items.length > MAX_ITEMS) return 'Demasiados productos (máx. ' + MAX_ITEMS + ').';
+
+  for (const item of body.items) {
+    if (!isRecord(item)) return 'Item inválido.';
+    if (!isNonEmptyString(item.product_id)) return 'product_id inválido.';
+    if (item.product_id.trim().length > MAX_PRODUCT_ID_LEN) return 'product_id demasiado largo.';
+    if (!Number.isInteger(item.quantity) || item.quantity < 1 || item.quantity > MAX_QUANTITY_PER_ITEM) {
+      return 'Cantidad inválida.';
+    }
+  }
+
+  if (!['pickup', 'shipping'].includes(body.delivery_type)) return 'delivery_type inválido.';
+
+  if (!isRecord(body.buyer)) return 'Falta buyer.';
+  if (!isNonEmptyString(body.buyer.name)) return 'Nombre del comprador requerido.';
+  if (body.buyer.name.trim().length > MAX_NAME_LEN) return 'Nombre demasiado largo.';
+  if (!isNonEmptyString(body.buyer.phone)) return 'Teléfono del comprador requerido.';
+  if (body.buyer.phone.trim().length > MAX_PHONE_LEN) return 'Teléfono demasiado largo.';
+
+  if (body.delivery_type === 'shipping') {
+    if (!isRecord(body.shipping)) return 'Falta shipping.';
+    const shipping = body.shipping;
+
+    if (!isNonEmptyString(shipping.address)) return 'Dirección requerida.';
+    if (shipping.address.trim().length > MAX_ADDRESS_LEN) return 'Dirección demasiado larga.';
+
+    if (!isNonEmptyString(shipping.locality)) return 'Localidad requerida.';
+    if (shipping.locality.trim().length > MAX_LOCALITY_LEN) return 'Localidad demasiado larga.';
+
+    if (!isNonEmptyString(shipping.department)) return 'Departamento requerido.';
+    if (shipping.department.trim().length > MAX_DEPARTMENT_LEN) return 'Departamento demasiado largo.';
+
+    if (!isValidDateString(shipping.requested_date)) return 'Fecha inválida (formato YYYY-MM-DD).';
+    if (!isValidTimeString(shipping.requested_from)) return 'Hora desde inválida (formato HH:MM).';
+    if (!isValidTimeString(shipping.requested_to)) return 'Hora hasta inválida (formato HH:MM).';
+
+    if (shipping.notes !== undefined && shipping.notes !== null) {
+      if (typeof shipping.notes !== 'string') return 'Notas inválidas.';
+      if (shipping.notes.trim().length > MAX_NOTES_LEN) return 'Notas demasiado largas.';
+    }
+  }
+
+  return null;
+}
+
+export function dateInTimeZone(now, timeZone = BUSINESS_TIME_ZONE) {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(now);
+  const values = Object.fromEntries(parts.map(part => [part.type, part.value]));
+  return `${values.year}-${values.month}-${values.day}`;
+}
+
+export function validateShippingDate(requestedDate, requestedFrom, requestedTo, now) {
+  const today = dateInTimeZone(now);
+  if (requestedDate < today) return 'La fecha solicitada ya pasó.';
+  if (requestedTo <= requestedFrom) return 'La hora de fin debe ser posterior a la hora de inicio.';
+  return null;
+}
+
+export function consolidateItems(items) {
+  const byProduct = new Map();
+  for (const item of items) {
+    const productId = item.product_id.trim();
+    if (byProduct.has(productId)) {
+      byProduct.get(productId).quantity += item.quantity;
+    } else {
+      byProduct.set(productId, { product_id: productId, quantity: item.quantity });
+    }
+  }
+  return Array.from(byProduct.values()).sort((a, b) => a.product_id.localeCompare(b.product_id));
+}
+
+export function buildSnapshot(consolidatedItems, catalogItems) {
+  const byId = new Map();
+  for (const catalogItem of catalogItems) {
+    if (isRecord(catalogItem) && typeof catalogItem.id === 'string') {
+      byId.set(catalogItem.id, catalogItem);
+    }
+  }
+
+  const errors = [];
+  const snapshot = [];
+
+  for (const item of consolidatedItems) {
+    const catalogItem = byId.get(item.product_id);
+    if (!catalogItem) {
+      errors.push('Producto no encontrado: ' + item.product_id);
+      continue;
+    }
+    if (catalogItem.status && catalogItem.status !== 'active') {
+      errors.push('Producto no disponible: ' + item.product_id);
+      continue;
+    }
+
+    const available = Number(catalogItem.available_quantity);
+    if (!Number.isInteger(available) || available < 0) {
+      errors.push('Stock inválido para: ' + item.product_id);
+      continue;
+    }
+    if (item.quantity > available) {
+      errors.push(
+        'Stock insuficiente para: ' + item.product_id +
+        ' (disponible: ' + available + ')'
+      );
+      continue;
+    }
+
+    const rawPrice = Number(catalogItem.price);
+    if (!Number.isFinite(rawPrice) || rawPrice <= 0) {
+      errors.push('Precio inválido para: ' + item.product_id);
+      continue;
+    }
+
+    const unitPrice = Math.round(rawPrice);
+    const title = typeof catalogItem.title === 'string' ? catalogItem.title : '';
+    const imageUrl = typeof catalogItem.thumbnail === 'string'
+      ? catalogItem.thumbnail
+      : (typeof catalogItem.pictures?.[0]?.url === 'string' ? catalogItem.pictures[0].url : null);
+
+    snapshot.push({
+      product_id: item.product_id,
+      title,
+      unit_price_uyu: unitPrice,
+      quantity: item.quantity,
+      line_total_uyu: unitPrice * item.quantity,
+      image_url: imageUrl,
+      observed_available_quantity: available,
+    });
+  }
+
+  return { errors, snapshot };
+}
+
+export function calculateTotals(snapshotItems, deliveryType) {
+  const productsTotal = snapshotItems.reduce((sum, item) => sum + item.line_total_uyu, 0);
+  let pickupDiscount = 0;
+  let shippingCost = 0;
+
+  if (deliveryType === 'pickup') {
+    pickupDiscount = Math.min(RETIRO_DISCOUNT, productsTotal);
+  } else {
+    shippingCost = productsTotal < FREE_SHIPPING_THRESHOLD ? SHIPPING_COST : 0;
+  }
+
+  const payableTotal = Math.max(0, productsTotal - pickupDiscount + shippingCost);
+  return { productsTotal, pickupDiscount, shippingCost, payableTotal };
+}
+
+export function generateFingerprint(body, consolidatedItems) {
+  const fingerprint = {
+    items: consolidatedItems,
+    delivery_type: body.delivery_type,
+    buyer: {
+      name: body.buyer.name.trim(),
+      phone: body.buyer.phone.trim(),
+    },
+  };
+
+  if (body.delivery_type === 'shipping') {
+    fingerprint.shipping = {
+      address: body.shipping.address.trim(),
+      locality: body.shipping.locality.trim(),
+      department: body.shipping.department.trim(),
+      requested_date: body.shipping.requested_date,
+      requested_from: body.shipping.requested_from,
+      requested_to: body.shipping.requested_to,
+      notes: typeof body.shipping.notes === 'string' ? body.shipping.notes.trim() : '',
+    };
+  }
+
+  return JSON.stringify(fingerprint);
+}
+
+const CODE_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+export function generatePublicCode(now = new Date()) {
+  const localDate = dateInTimeZone(now).replaceAll('-', '').slice(2);
+  let suffix = '';
+  for (let index = 0; index < 6; index++) {
+    suffix += CODE_CHARS[Math.floor(Math.random() * CODE_CHARS.length)];
+  }
+  return `AL-${localDate}-${suffix}`;
+}

--- a/functions/api/_turnstile.js
+++ b/functions/api/_turnstile.js
@@ -1,0 +1,45 @@
+const SITEVERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+
+export async function verifyTurnstile(token, secret, ip = '', {
+  fetch: fetchFn = globalThis.fetch,
+  action = 'prepare_order',
+  isAllowedHostname,
+} = {}) {
+  const controller = new AbortController();
+  const tid = setTimeout(() => controller.abort(), 5000);
+  let resp;
+  try {
+    resp = await fetchFn(SITEVERIFY_URL, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify({ secret, response: token, remoteip: ip }),
+      signal:  controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(tid);
+    return { ok: false, code: err?.name === 'AbortError' ? 'SITEVERIFY_TIMEOUT' : 'SITEVERIFY_ERROR' };
+  }
+  clearTimeout(tid);
+
+  if (!resp.ok) return { ok: false, code: 'SITEVERIFY_ERROR' };
+
+  let data;
+  try   { data = await resp.json(); }
+  catch { return { ok: false, code: 'SITEVERIFY_ERROR' }; }
+
+  if (!data.success) {
+    const codes = Array.isArray(data['error-codes']) ? data['error-codes'] : [];
+    if (codes.some(c => c === 'internal-error' || c === 'missing-input-secret' || c === 'invalid-input-secret')) {
+      return { ok: false, code: 'SITEVERIFY_ERROR' };
+    }
+    return { ok: false, code: codes.includes('timeout-or-duplicate') ? 'TOKEN_EXPIRED' : 'TOKEN_INVALID' };
+  }
+
+  if (data.action !== action) return { ok: false, code: 'ACTION_INVALID' };
+  const h = data.hostname || '';
+  if (typeof isAllowedHostname !== 'function' || !isAllowedHostname(h)) {
+    return { ok: false, code: 'HOSTNAME_INVALID' };
+  }
+
+  return { ok: true };
+}

--- a/functions/api/orders.js
+++ b/functions/api/orders.js
@@ -1,0 +1,4 @@
+import { fetchCatalog } from '../_shared/catalog.js';
+import { createOrdersHandler } from './_orders_handler.js';
+
+export const onRequest = createOrdersHandler({ fetchCatalog });

--- a/functions/api/orders/status.js
+++ b/functions/api/orders/status.js
@@ -1,0 +1,4 @@
+import { createOrderStatusHandler } from '../_order_status_handler.js';
+
+const handler = createOrderStatusHandler();
+export const onRequest = handler;

--- a/functions/api/package.json
+++ b/functions/api/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/functions/api/preferences.js
+++ b/functions/api/preferences.js
@@ -1,0 +1,3 @@
+import { createPreferenceHandler } from './_mp_handler.js';
+
+export const onRequest = createPreferenceHandler({});

--- a/functions/api/webhooks/mercadopago.js
+++ b/functions/api/webhooks/mercadopago.js
@@ -1,0 +1,4 @@
+import { createMpWebhookHandler } from '../_mp_webhook_handler.js';
+
+const handler = createMpWebhookHandler();
+export const onRequest = handler;

--- a/migrations/0001_orders.sql
+++ b/migrations/0001_orders.sql
@@ -1,0 +1,83 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS orders (
+  id                        TEXT    PRIMARY KEY,
+  public_code               TEXT    UNIQUE NOT NULL,
+  idempotency_key           TEXT    UNIQUE NOT NULL,
+  request_fingerprint       TEXT    NOT NULL,
+  status                    TEXT    NOT NULL DEFAULT 'open'
+                              CHECK (status IN ('open','paid','cancelled','expired','fulfilled')),
+  payment_status            TEXT    NOT NULL DEFAULT 'not_started'
+                              CHECK (payment_status IN ('not_started','pending','approved','rejected','refunded','cancelled')),
+  buyer_name                TEXT    NOT NULL CHECK (length(trim(buyer_name)) > 0),
+  buyer_phone               TEXT    NOT NULL CHECK (length(trim(buyer_phone)) > 0),
+  delivery_type             TEXT    NOT NULL CHECK (delivery_type IN ('pickup','shipping')),
+  address                   TEXT,
+  locality                  TEXT,
+  department                TEXT,
+  requested_delivery_date   TEXT,
+  requested_delivery_from   TEXT,
+  requested_delivery_to     TEXT,
+  delivery_notes            TEXT,
+  products_total_uyu        INTEGER NOT NULL CHECK (products_total_uyu >= 0),
+  pickup_discount_uyu       INTEGER NOT NULL DEFAULT 0 CHECK (pickup_discount_uyu BETWEEN 0 AND 150),
+  shipping_cost_uyu         INTEGER NOT NULL DEFAULT 0 CHECK (shipping_cost_uyu IN (0,250)),
+  payable_total_uyu         INTEGER NOT NULL CHECK (payable_total_uyu >= 0),
+  currency                  TEXT    NOT NULL DEFAULT 'UYU' CHECK (currency = 'UYU'),
+  payment_provider          TEXT,
+  payment_preference_id     TEXT,
+  payment_id                TEXT,
+  created_at                TEXT    NOT NULL,
+  expires_at                TEXT    NOT NULL,
+  updated_at                TEXT    NOT NULL,
+  paid_at                   TEXT,
+  fulfilled_at              TEXT,
+  cancelled_at              TEXT,
+  CHECK (payable_total_uyu = products_total_uyu - pickup_discount_uyu + shipping_cost_uyu),
+  CHECK (
+    (delivery_type = 'pickup' AND shipping_cost_uyu = 0)
+    OR
+    (delivery_type = 'shipping' AND pickup_discount_uyu = 0)
+  ),
+  CHECK (
+    delivery_type = 'pickup'
+    OR (
+      address IS NOT NULL AND length(trim(address)) > 0
+      AND locality IS NOT NULL AND length(trim(locality)) > 0
+      AND department IS NOT NULL AND length(trim(department)) > 0
+      AND requested_delivery_date IS NOT NULL AND length(trim(requested_delivery_date)) > 0
+      AND requested_delivery_from IS NOT NULL AND length(trim(requested_delivery_from)) > 0
+      AND requested_delivery_to IS NOT NULL AND length(trim(requested_delivery_to)) > 0
+    )
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_orders_status         ON orders (status);
+CREATE INDEX IF NOT EXISTS idx_orders_payment_status ON orders (payment_status);
+CREATE INDEX IF NOT EXISTS idx_orders_expires_at     ON orders (expires_at);
+
+CREATE TABLE IF NOT EXISTS order_items (
+  id                          TEXT    PRIMARY KEY,
+  order_id                    TEXT    NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+  product_id                  TEXT    NOT NULL,
+  title                       TEXT    NOT NULL,
+  quantity                    INTEGER NOT NULL CHECK (quantity > 0),
+  unit_price_uyu              INTEGER NOT NULL CHECK (unit_price_uyu > 0),
+  line_total_uyu              INTEGER NOT NULL CHECK (line_total_uyu = unit_price_uyu * quantity),
+  image_url                   TEXT,
+  observed_available_quantity INTEGER CHECK (observed_available_quantity IS NULL OR observed_available_quantity >= 0),
+  created_at                  TEXT    NOT NULL,
+  UNIQUE (order_id, product_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_order_items_order_id ON order_items (order_id);
+
+CREATE TABLE IF NOT EXISTS order_events (
+  id           TEXT    PRIMARY KEY,
+  order_id     TEXT    NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+  event_type   TEXT    NOT NULL,
+  payload_json TEXT,
+  created_at   TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_order_events_order_id ON order_events (order_id);

--- a/migrations/0002_orders_shipping_date_montevideo.sql
+++ b/migrations/0002_orders_shipping_date_montevideo.sql
@@ -1,0 +1,149 @@
+-- 2-K-C: fecha y horario de entrega (requested_delivery_date/from/to) solo
+-- aplican al envío dentro de Montevideo (cadete propio, franja coordinada).
+-- El interior se coordina con la agencia de envíos según destino, sin
+-- franja fija — esos tres campos deben poder quedar NULL para
+-- delivery_type = 'shipping' cuando department no es Montevideo.
+--
+-- SQLite no permite alterar un CHECK existente con ALTER TABLE: se
+-- reconstruye la tabla `orders`. Probado localmente: `PRAGMA foreign_keys
+-- = OFF` no evita que un DROP TABLE orders dispare ON DELETE CASCADE sobre
+-- order_items/order_events en D1 (el pragma no persiste de forma
+-- confiable entre statements). Para no arriesgar datos, se reconstruyen
+-- las tres tablas en tablas *_new, se copian los datos, y solo se
+-- eliminan las tablas viejas (order_items/order_events primero, orders al
+-- final) una vez que las copias nuevas ya existen — así una posible
+-- cascada sobre las tablas viejas nunca puede borrar datos que ya no
+-- están solamente ahí.
+
+CREATE TABLE orders_new (
+  id                        TEXT    PRIMARY KEY,
+  public_code               TEXT    UNIQUE NOT NULL,
+  idempotency_key           TEXT    UNIQUE NOT NULL,
+  request_fingerprint       TEXT    NOT NULL,
+  status                    TEXT    NOT NULL DEFAULT 'open'
+                              CHECK (status IN ('open','paid','cancelled','expired','fulfilled')),
+  payment_status            TEXT    NOT NULL DEFAULT 'not_started'
+                              CHECK (payment_status IN ('not_started','pending','approved','rejected','refunded','cancelled')),
+  buyer_name                TEXT    NOT NULL CHECK (length(trim(buyer_name)) > 0),
+  buyer_phone               TEXT    NOT NULL CHECK (length(trim(buyer_phone)) > 0),
+  delivery_type             TEXT    NOT NULL CHECK (delivery_type IN ('pickup','shipping')),
+  address                   TEXT,
+  locality                  TEXT,
+  department                TEXT,
+  requested_delivery_date   TEXT,
+  requested_delivery_from   TEXT,
+  requested_delivery_to     TEXT,
+  delivery_notes            TEXT,
+  products_total_uyu        INTEGER NOT NULL CHECK (products_total_uyu >= 0),
+  pickup_discount_uyu       INTEGER NOT NULL DEFAULT 0 CHECK (pickup_discount_uyu BETWEEN 0 AND 150),
+  shipping_cost_uyu         INTEGER NOT NULL DEFAULT 0 CHECK (shipping_cost_uyu IN (0,250)),
+  payable_total_uyu         INTEGER NOT NULL CHECK (payable_total_uyu >= 0),
+  currency                  TEXT    NOT NULL DEFAULT 'UYU' CHECK (currency = 'UYU'),
+  payment_provider          TEXT,
+  payment_preference_id     TEXT,
+  payment_id                TEXT,
+  created_at                TEXT    NOT NULL,
+  expires_at                TEXT    NOT NULL,
+  updated_at                TEXT    NOT NULL,
+  paid_at                   TEXT,
+  fulfilled_at              TEXT,
+  cancelled_at              TEXT,
+  CHECK (payable_total_uyu = products_total_uyu - pickup_discount_uyu + shipping_cost_uyu),
+  CHECK (
+    (delivery_type = 'pickup' AND shipping_cost_uyu = 0)
+    OR
+    (delivery_type = 'shipping' AND pickup_discount_uyu = 0)
+  ),
+  CHECK (
+    delivery_type = 'pickup'
+    OR (
+      address IS NOT NULL AND length(trim(address)) > 0
+      AND locality IS NOT NULL AND length(trim(locality)) > 0
+      AND department IS NOT NULL AND length(trim(department)) > 0
+      AND (
+        lower(trim(department)) <> 'montevideo'
+        OR (
+          requested_delivery_date IS NOT NULL AND length(trim(requested_delivery_date)) > 0
+          AND requested_delivery_from IS NOT NULL AND length(trim(requested_delivery_from)) > 0
+          AND requested_delivery_to IS NOT NULL AND length(trim(requested_delivery_to)) > 0
+        )
+      )
+    )
+  )
+);
+
+INSERT INTO orders_new (
+  id, public_code, idempotency_key, request_fingerprint, status, payment_status,
+  buyer_name, buyer_phone, delivery_type,
+  address, locality, department,
+  requested_delivery_date, requested_delivery_from, requested_delivery_to,
+  delivery_notes,
+  products_total_uyu, pickup_discount_uyu, shipping_cost_uyu, payable_total_uyu,
+  currency, payment_provider, payment_preference_id, payment_id,
+  created_at, expires_at, updated_at, paid_at, fulfilled_at, cancelled_at
+)
+SELECT
+  id, public_code, idempotency_key, request_fingerprint, status, payment_status,
+  buyer_name, buyer_phone, delivery_type,
+  address, locality, department,
+  requested_delivery_date, requested_delivery_from, requested_delivery_to,
+  delivery_notes,
+  products_total_uyu, pickup_discount_uyu, shipping_cost_uyu, payable_total_uyu,
+  currency, payment_provider, payment_preference_id, payment_id,
+  created_at, expires_at, updated_at, paid_at, fulfilled_at, cancelled_at
+FROM orders;
+
+-- order_items y order_events no cambian de esquema — se recrean idénticos,
+-- apuntando a orders_new, para poder eliminar las tablas viejas sin dejar
+-- una ventana donde una fila dependa de una tabla a punto de borrarse.
+CREATE TABLE order_items_new (
+  id                          TEXT    PRIMARY KEY,
+  order_id                    TEXT    NOT NULL REFERENCES orders_new(id) ON DELETE CASCADE,
+  product_id                  TEXT    NOT NULL,
+  title                       TEXT    NOT NULL,
+  quantity                    INTEGER NOT NULL CHECK (quantity > 0),
+  unit_price_uyu              INTEGER NOT NULL CHECK (unit_price_uyu > 0),
+  line_total_uyu              INTEGER NOT NULL CHECK (line_total_uyu = unit_price_uyu * quantity),
+  image_url                   TEXT,
+  observed_available_quantity INTEGER CHECK (observed_available_quantity IS NULL OR observed_available_quantity >= 0),
+  created_at                  TEXT    NOT NULL,
+  UNIQUE (order_id, product_id)
+);
+
+INSERT INTO order_items_new (
+  id, order_id, product_id, title, quantity, unit_price_uyu, line_total_uyu,
+  image_url, observed_available_quantity, created_at
+)
+SELECT
+  id, order_id, product_id, title, quantity, unit_price_uyu, line_total_uyu,
+  image_url, observed_available_quantity, created_at
+FROM order_items;
+
+CREATE TABLE order_events_new (
+  id           TEXT    PRIMARY KEY,
+  order_id     TEXT    NOT NULL REFERENCES orders_new(id) ON DELETE CASCADE,
+  event_type   TEXT    NOT NULL,
+  payload_json TEXT,
+  created_at   TEXT    NOT NULL
+);
+
+INSERT INTO order_events_new (id, order_id, event_type, payload_json, created_at)
+SELECT id, order_id, event_type, payload_json, created_at
+FROM order_events;
+
+-- Se eliminan las tablas viejas: primero las hijas, luego el padre. Para
+-- cuando se llega a "DROP TABLE orders", order_items/order_events (viejas)
+-- ya no existen, así que no hay nada que una cascada pueda seguir borrando.
+DROP TABLE order_items;
+DROP TABLE order_events;
+DROP TABLE orders;
+
+ALTER TABLE orders_new       RENAME TO orders;
+ALTER TABLE order_items_new  RENAME TO order_items;
+ALTER TABLE order_events_new RENAME TO order_events;
+
+CREATE INDEX IF NOT EXISTS idx_orders_status         ON orders (status);
+CREATE INDEX IF NOT EXISTS idx_orders_payment_status ON orders (payment_status);
+CREATE INDEX IF NOT EXISTS idx_orders_expires_at     ON orders (expires_at);
+CREATE INDEX IF NOT EXISTS idx_order_items_order_id  ON order_items (order_id);
+CREATE INDEX IF NOT EXISTS idx_order_events_order_id ON order_events (order_id);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,3 +15,49 @@ pages_build_output_dir = "./public"
 [[kv_namespaces]]
 binding = "AMADO_KV"
 id = "6ea0ff4682d647118442a24fe384abc4"
+
+[[env.preview.kv_namespaces]]
+binding = "AMADO_KV"
+id = "6ea0ff4682d647118442a24fe384abc4"
+
+[[env.preview.d1_databases]]
+binding = "ORDERS_DB"
+database_name = "amadolibros-orders-preview"
+database_id = "6fa387af-f29e-46dc-97e5-30298568b4a6"
+
+# Vars no secretas de Preview — env.preview.vars aplica a TODOS los
+# preview deployments del proyecto, no solo a esta rama. CANONICAL_ORIGIN
+# queda fijado al alias de esta rama porque Cloudflare Pages no permite
+# vars por-rama; otras ramas de preview que usen checkout recibirán un
+# origen canónico incorrecto hasta que 2-N-E2 resuelva ese alcance (ver
+# docs/environments.md, sección "Riesgos pendientes").
+[env.preview.vars]
+APP_ENV           = "preview"
+MP_COLLECTOR_ID   = "3559407834"
+CHECKOUT_ENABLED  = "true"
+CANONICAL_ORIGIN  = "https://feature-2-n-e1-production-re.amadolibros-web.pages.dev"
+
+# ── Producción (2-K-E2) ───────────────────────────────────────────────────
+# Base D1 propia, con database_id DISTINTO al de Preview — nunca reutilizar
+# el de env.preview. Creada y migrada (0001+0002) en 2-K-E2, verificada
+# vacía y con el esquema correcto antes de conectarla acá.
+[[env.production.kv_namespaces]]
+binding = "AMADO_KV"
+id = "6ea0ff4682d647118442a24fe384abc4"
+
+[[env.production.d1_databases]]
+binding = "ORDERS_DB"
+database_name = "amadolibros-orders-production"
+database_id = "6dc8dc3a-2d4f-4045-b428-14323c7b0bcd"
+
+# CHECKOUT_ENABLED en "false": el kill switch queda apagado a propósito.
+# MP_COLLECTOR_ID de Producción todavía no está confirmado (no asumir el
+# ID de owner de la app como collector real de LIVE — ver
+# docs/environments.md) y no se declara acá; sin él, resolveConfig()
+# falla cerrado (503) en cualquier endpoint de pagos, lo cual es
+# intencional mientras no haya credenciales LIVE cargadas.
+[env.production.vars]
+APP_ENV           = "production"
+CHECKOUT_ENABLED  = "false"
+CANONICAL_ORIGIN  = "https://www.amadolibros.com"
+ALLOWED_HOSTS     = "amadolibros.com,www.amadolibros.com"


### PR DESCRIPTION
## Objetivo

Incorporar sobre el `main` productivo actual la integración de Mercado Pago ya validada en Preview, manteniéndola completamente apagada e invisible en Producción.

## Cambios

- Órdenes y estados persistidos en D1.
- Creación de preferencias de Mercado Pago.
- Webhook firmado e idempotente.
- Validación Turnstile.
- Separación de configuración Preview/Producción.
- Protecciones del carrito y página de pedido.
- Migraciones y documentación operativa.
- CI ampliado para cubrir el flujo de pagos.

## Seguridad y alcance

- `CHECKOUT_ENABLED=false` en backend.
- `PUBLIC_CHECKOUT_ENABLED=false` en frontend.
- WhatsApp continúa como único cierre visible.
- No incluye credenciales LIVE.
- No activa cobros.
- No ejecuta migraciones ni escribe en D1.
- Este PR no autoriza merge ni deploy.

## Validación previa

- Suite completa: **190/190 tests aprobados**.
- Build Astro: correcto.
- Worker Cloudflare: compila correctamente.
- Sin secretos en el diff.
- Árbol remoto verificado contra el commit local aprobado.