### PR TITLE
feat: preparar collector y Turnstile de producción

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Test catalog display
         run: node --test functions/__tests__/*.test.js
 
+      - name: Test Turnstile host matching (carrito.astro)
+        run: node --test astro-front/src/lib/__tests__/*.test.js
+
       - name: Test orders
         run: node --test functions/api/__tests__/orders.test.js
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,12 @@ jobs:
           PUBLIC_INDEXABLE: 'true'
           PUBLIC_GA_ID: G-SDX45VEPP3
           PUBLIC_CHECKOUT_ENABLED: 'false'
+          # Site key pública de Turnstile Production (no es secreto, puede
+          # versionarse) y los hosts exactos donde se acepta — el checkout
+          # sigue apagado (PUBLIC_CHECKOUT_ENABLED=false) hasta que se
+          # habilite explícitamente en un lote aparte.
+          PUBLIC_TURNSTILE_SITE_KEY: '0x4AAAAAAD_Ul8KGae_hdWwj'
+          PUBLIC_TURNSTILE_ALLOWED_HOSTS: 'amadolibros.com,www.amadolibros.com'
         run: npm run build
 
       - name: Deploy via Wrangler

--- a/astro-front/src/lib/__tests__/turnstile-hosts.test.js
+++ b/astro-front/src/lib/__tests__/turnstile-hosts.test.js
@@ -1,0 +1,119 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  hostMatchesEntry,
+  isTurnstileHostAllowed,
+  isTurnstileConfigured,
+} from '../turnstile-hosts.js';
+
+const PRODUCTION_HOSTS = ['amadolibros.com', 'www.amadolibros.com'];
+const PREVIEW_HOSTS = ['amadolibros-web.pages.dev', '.amadolibros-web.pages.dev'];
+
+test('hostMatchesEntry: acepta amadolibros.com como host exacto de Producción', () => {
+  assert.equal(hostMatchesEntry('amadolibros.com', 'amadolibros.com'), true);
+});
+
+test('hostMatchesEntry: acepta www.amadolibros.com como host exacto de Producción', () => {
+  assert.equal(hostMatchesEntry('www.amadolibros.com', 'www.amadolibros.com'), true);
+});
+
+test('hostMatchesEntry: acepta subdominio de deployment de Preview vía entrada con punto inicial', () => {
+  assert.equal(
+    hostMatchesEntry('feature-2-n-g2.amadolibros-web.pages.dev', '.amadolibros-web.pages.dev'),
+    true,
+  );
+});
+
+test('hostMatchesEntry: rechaza evil-amadolibros.com contra amadolibros.com', () => {
+  assert.equal(hostMatchesEntry('evil-amadolibros.com', 'amadolibros.com'), false);
+});
+
+test('hostMatchesEntry: rechaza amadolibros.com.evil.example contra amadolibros.com', () => {
+  assert.equal(hostMatchesEntry('amadolibros.com.evil.example', 'amadolibros.com'), false);
+});
+
+test('hostMatchesEntry: rechaza evilamadolibros-web.pages.dev.evil.example contra .amadolibros-web.pages.dev', () => {
+  assert.equal(
+    hostMatchesEntry('evilamadolibros-web.pages.dev.evil.example', '.amadolibros-web.pages.dev'),
+    false,
+  );
+});
+
+test('hostMatchesEntry: una entrada con punto inicial nunca acepta el host desnudo por sí solo', () => {
+  assert.equal(hostMatchesEntry('amadolibros-web.pages.dev', '.amadolibros-web.pages.dev'), false);
+});
+
+test('hostMatchesEntry: entrada sin punto inicial nunca acepta subdominios', () => {
+  assert.equal(hostMatchesEntry('sub.amadolibros.com', 'amadolibros.com'), false);
+});
+
+test('hostMatchesEntry: entrada vacía o ausente nunca matchea', () => {
+  assert.equal(hostMatchesEntry('amadolibros.com', ''), false);
+});
+
+test('isTurnstileHostAllowed: hosts de Producción aceptados, hosts de Preview rechazados', () => {
+  assert.equal(isTurnstileHostAllowed('amadolibros.com', PRODUCTION_HOSTS), true);
+  assert.equal(isTurnstileHostAllowed('www.amadolibros.com', PRODUCTION_HOSTS), true);
+  assert.equal(
+    isTurnstileHostAllowed('hash123.amadolibros-web.pages.dev', PRODUCTION_HOSTS),
+    false,
+  );
+});
+
+test('isTurnstileHostAllowed: hosts de Preview aceptados, host de Producción rechazado', () => {
+  assert.equal(
+    isTurnstileHostAllowed('hash123.amadolibros-web.pages.dev', PREVIEW_HOSTS),
+    true,
+  );
+  assert.equal(isTurnstileHostAllowed('amadolibros.com', PREVIEW_HOSTS), false);
+});
+
+test('isTurnstileHostAllowed: ataques de spoofing rechazados en ambos ambientes', () => {
+  const attacks = [
+    'evil-amadolibros.com',
+    'amadolibros.com.evil.example',
+    'evilamadolibros-web.pages.dev.evil.example',
+  ];
+  for (const hostname of attacks) {
+    assert.equal(isTurnstileHostAllowed(hostname, PRODUCTION_HOSTS), false, hostname);
+    assert.equal(isTurnstileHostAllowed(hostname, PREVIEW_HOSTS), false, hostname);
+  }
+});
+
+test('isTurnstileConfigured: false si el checkout está apagado, aunque el resto sea válido', () => {
+  assert.equal(
+    isTurnstileConfigured(false, '0xsitekey', 'amadolibros.com', PRODUCTION_HOSTS),
+    false,
+  );
+});
+
+test('isTurnstileConfigured: false si falta la site key', () => {
+  assert.equal(isTurnstileConfigured(true, '', 'amadolibros.com', PRODUCTION_HOSTS), false);
+});
+
+test('isTurnstileConfigured: false si el host actual no está permitido', () => {
+  assert.equal(
+    isTurnstileConfigured(true, '0xsitekey', 'evil-amadolibros.com', PRODUCTION_HOSTS),
+    false,
+  );
+});
+
+test('isTurnstileConfigured: true solo cuando checkout on + site key + host permitido', () => {
+  assert.equal(
+    isTurnstileConfigured(true, '0xsitekey', 'amadolibros.com', PRODUCTION_HOSTS),
+    true,
+  );
+});
+
+test('isTurnstileConfigured: site key de Preview no es válida para host de Producción y viceversa', () => {
+  // La site key en sí no determina el ambiente — lo hace el host permitido
+  // inyectado por build. Este test documenta que isTurnstileConfigured no
+  // valida la site key contra el ambiente, solo su presencia; el aislamiento
+  // real entre site keys de Producción y Preview lo garantiza qué valores
+  // inyecta cada workflow (deploy.yml vs deploy-preview.yml) en build time,
+  // no esta función en tiempo de ejecución.
+  assert.equal(
+    isTurnstileConfigured(true, '0xpreviewkey', 'amadolibros.com', PRODUCTION_HOSTS),
+    true,
+  );
+});

--- a/astro-front/src/lib/turnstile-hosts.js
+++ b/astro-front/src/lib/turnstile-hosts.js
@@ -1,0 +1,44 @@
+// Lógica de coincidencia de hosts para el widget de Turnstile en carrito.astro.
+//
+// Copia probada/canónica de la función inline en astro-front/src/pages/carrito.astro
+// (bloque <script is:inline>, que no puede usar `import` porque corre sin bundler).
+// Si se modifica la lógica acá, replicar el cambio ahí también — ver el
+// comentario recíproco junto a `hostMatchesEntry` en carrito.astro.
+//
+// Convención de cada entrada de `allowedHosts`:
+//   - sin punto inicial ("amadolibros.com"): coincidencia EXACTA solamente,
+//     nunca acepta subdominios.
+//   - con punto inicial (".amadolibros-web.pages.dev"): acepta cualquier
+//     subdominio ESTRICTO de ese dominio, nunca el host desnudo por sí solo.
+// La comparación siempre es por labels completos del hostname (nunca
+// substring/startsWith/endsWith sobre el string crudo).
+export function hostMatchesEntry(hostname, entry) {
+  if (!entry) return false;
+  if (entry.charAt(0) === '.') {
+    const domainLabels = entry.slice(1).split('.').filter(Boolean);
+    const hostLabels = hostname.split('.');
+    if (domainLabels.length === 0 || hostLabels.length <= domainLabels.length) return false;
+    const tail = hostLabels.slice(hostLabels.length - domainLabels.length);
+    for (let i = 0; i < domainLabels.length; i++) {
+      if (tail[i] !== domainLabels[i]) return false;
+    }
+    return true;
+  }
+  return hostname === entry;
+}
+
+export function isTurnstileHostAllowed(hostname, allowedHosts) {
+  for (const entry of allowedHosts) {
+    if (hostMatchesEntry(hostname, entry)) return true;
+  }
+  return false;
+}
+
+// Falla cerrado: si el checkout está habilitado pero falta la site key o el
+// host actual no está permitido, el widget nunca se carga y el intento de
+// pago se bloquea (ver `turnstileBlocked` en carrito.astro).
+export function isTurnstileConfigured(onlineCheckoutEnabled, siteKey, hostname, allowedHosts) {
+  if (!onlineCheckoutEnabled) return false;
+  if (!siteKey) return false;
+  return isTurnstileHostAllowed(hostname, allowedHosts);
+}

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -5,6 +5,16 @@ import Footer from '../components/Footer.astro';
 import WAFloat from '../components/WAFloat.astro';
 
 const checkoutEnabled = import.meta.env.PUBLIC_CHECKOUT_ENABLED === 'true';
+
+// Site key pública de Turnstile y hosts donde puede usarse — inyectadas por
+// ambiente en tiempo de build (nunca hardcodeadas ni derivadas del hostname
+// del navegador). Ver PUBLIC_TURNSTILE_SITE_KEY / PUBLIC_TURNSTILE_ALLOWED_HOSTS
+// en deploy.yml / deploy-preview.yml.
+const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY || '';
+const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS || '')
+  .split(',')
+  .map((h) => h.trim())
+  .filter(Boolean);
 ---
 <BaseLayout
   title="Tu carrito — Amado Libros"
@@ -728,15 +738,61 @@ const checkoutEnabled = import.meta.env.PUBLIC_CHECKOUT_ENABLED === 'true';
   .btn-pay-mp:disabled { background: #9ca3af; cursor: not-allowed; }
 </style>
 
-<script is:inline>
-  // ── Turnstile Preview ────────────────────────────────────────────────────
+<script is:inline define:vars={{ turnstileSiteKey, turnstileAllowedHosts }}>
+  // ── Turnstile ────────────────────────────────────────────────────────────
   var onlineCheckoutEnabled = document.querySelector('.cart-page')?.dataset.onlineCheckout === 'enabled';
-  var TS_PREVIEW_HOST = 'amadolibros-web.pages.dev';
-  var TS_SITE_KEY     = '0x4AAAAAAD6E9kz8K3comwjj';
-  var tsIsPreview     = window.location.hostname === TS_PREVIEW_HOST ||
-                        window.location.hostname.endsWith('.' + TS_PREVIEW_HOST);
-  var tsWidgetId      = null;
-  var tsPending       = null;
+
+  // Hosts aceptados para Turnstile, inyectados por ambiente (nunca
+  // hardcodeados ni derivados de heurísticas sobre el hostname del
+  // navegador). Convención de cada entrada:
+  //   - sin punto inicial ("amadolibros.com"): coincidencia EXACTA solamente,
+  //     nunca acepta subdominios (así se comportan los hosts de Producción).
+  //   - con punto inicial (".amadolibros-web.pages.dev"): acepta cualquier
+  //     subdominio ESTRICTO de ese dominio, nunca el host desnudo por sí solo
+  //     ni coincidencias parciales.
+  // La comparación siempre es por labels completos del hostname (nunca
+  // substring/startsWith/endsWith sobre el string crudo), para que
+  // "evil-amadolibros.com", "amadolibros.com.evil.example" o
+  // "evilamadolibros-web.pages.dev.evil.example" nunca puedan pasar.
+  //
+  // Copia inline de src/lib/turnstile-hosts.js (probada con `node --test` en
+  // astro-front/src/lib/__tests__/turnstile-hosts.test.js). No puede
+  // importarse acá porque este <script is:inline> corre sin bundler; si se
+  // cambia esta lógica, replicar el cambio también en ese módulo.
+  function hostMatchesEntry(hostname, entry) {
+    if (!entry) return false;
+    if (entry.charAt(0) === '.') {
+      var domainLabels = entry.slice(1).split('.').filter(Boolean);
+      var hostLabels   = hostname.split('.');
+      if (domainLabels.length === 0 || hostLabels.length <= domainLabels.length) return false;
+      var tail = hostLabels.slice(hostLabels.length - domainLabels.length);
+      for (var i = 0; i < domainLabels.length; i++) {
+        if (tail[i] !== domainLabels[i]) return false;
+      }
+      return true;
+    }
+    return hostname === entry;
+  }
+  function isTurnstileHostAllowed(hostname) {
+    for (var i = 0; i < turnstileAllowedHosts.length; i++) {
+      if (hostMatchesEntry(hostname, turnstileAllowedHosts[i])) return true;
+    }
+    return false;
+  }
+
+  // turnstileConfigured: todo lo necesario está presente y el host actual
+  // está permitido -> se carga el widget real.
+  // turnstileBlocked: el checkout está habilitado pero Turnstile NO puede
+  // inicializarse (falta site key, o el host no está en la lista) -> falla
+  // cerrado: nunca se carga el script de Cloudflare ni se intenta un pago
+  // sin verificación; el intento de "Preparar pago online" muestra un error
+  // controlado en vez de mandar la request igual.
+  var turnstileHostOk      = isTurnstileHostAllowed(window.location.hostname);
+  var turnstileConfigured  = onlineCheckoutEnabled && !!turnstileSiteKey && turnstileHostOk;
+  var turnstileBlocked     = onlineCheckoutEnabled && !turnstileConfigured;
+
+  var tsWidgetId = null;
+  var tsPending  = null;
 
   function tsOnSuccess(token) { if (tsPending) { var r=tsPending.resolve; tsPending=null; r(token); } }
   function tsOnError()        { if (tsPending) { var r=tsPending.reject;  tsPending=null; r(new Error('ts-error')); } }
@@ -747,7 +803,7 @@ const checkoutEnabled = import.meta.env.PUBLIC_CHECKOUT_ENABLED === 'true';
     var container = document.getElementById('cf-ts-container');
     if (!container || tsWidgetId != null) return;
     tsWidgetId = window.turnstile.render(container, {
-      sitekey:             TS_SITE_KEY,
+      sitekey:             turnstileSiteKey,
       action:              'prepare_order',
       appearance:          'interaction-only',
       execution:           'execute',
@@ -771,13 +827,15 @@ const checkoutEnabled = import.meta.env.PUBLIC_CHECKOUT_ENABLED === 'true';
     });
   }
 
-  if (onlineCheckoutEnabled && tsIsPreview) {
+  if (turnstileConfigured) {
     window.__tsOnLoad = function () { tsRenderWidget(); };
     var _tsScript = document.createElement('script');
     _tsScript.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?onload=__tsOnLoad&render=explicit';
     _tsScript.async = true;
     _tsScript.defer = true;
     document.head.appendChild(_tsScript);
+  } else if (turnstileBlocked) {
+    console.error('[carrito] Turnstile no configurado para este host — pago online deshabilitado.');
   }
   // ─────────────────────────────────────────────────────────────────────────
 
@@ -1205,10 +1263,20 @@ const checkoutEnabled = import.meta.env.PUBLIC_CHECKOUT_ENABLED === 'true';
         }
 
         btnPrepare.disabled = true;
-        btnPrepare.textContent = tsIsPreview ? 'Verificando…' : 'Procesando…';
+
+        // Fail closed: si el checkout está habilitado pero Turnstile no
+        // pudo configurarse (site key ausente, o este host no está
+        // permitido), nunca se manda la request sin verificación.
+        if (turnstileBlocked) {
+          alert('El pago online no está disponible en este momento. Probá más tarde o escribinos por WhatsApp.');
+          btnPrepare.disabled = false;
+          return;
+        }
+
+        btnPrepare.textContent = turnstileConfigured ? 'Verificando…' : 'Procesando…';
 
         var cfTsResponse = null;
-        if (tsIsPreview) {
+        if (turnstileConfigured) {
           if (tsWidgetId == null) {
             alert('La verificación aún no cargó. Esperá un momento y reintentá.');
             btnPrepare.disabled = false;
@@ -1270,7 +1338,7 @@ const checkoutEnabled = import.meta.env.PUBLIC_CHECKOUT_ENABLED === 'true';
           if (resultEl)    resultEl.hidden = false;
           btnPrepare.textContent = 'Pedido preparado';
 
-          if (tsIsPreview) {
+          if (turnstileConfigured) {
             mpPublicCode     = data.order.public_code;
             mpIdempotencyKey = cart.idempotency_key;
             var noteEl = document.getElementById('order-result-note');

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,10 +1,15 @@
-# Ambientes — Preview y Production (2-N-E1)
+# Ambientes — Preview y Production (2-N-E1, actualizado en 2-N-G2)
 
 Este documento describe la configuración centralizada introducida en 2-N-E1
 (`functions/api/_env_config.js`). El código queda preparado para operar en
-Preview y Production. Production ya tiene D1 propia y hosts declarados, pero
-el checkout permanece apagado y oculto: no hay credenciales LIVE ni Turnstile
-de Production configurados.
+Preview y Production. Production ya tiene D1 propia, hosts declarados,
+`MP_COLLECTOR_ID` confirmado y site key pública de Turnstile inyectada por
+`deploy.yml` (2-N-G2) — pero el checkout permanece apagado y oculto:
+`CHECKOUT_ENABLED` y `PUBLIC_CHECKOUT_ENABLED` siguen en `"false"` y
+Mercado Pago no procesa ningún cobro real. `MP_ACCESS_TOKEN` y
+`MP_WEBHOOK_SECRET` de Production están presentes por nombre en el dashboard
+de Cloudflare Pages (confirmado en la auditoría 2-N-G1); sus valores no se
+leen, validan ni modifican desde este repo ni en este lote.
 
 ## Principio general
 
@@ -15,17 +20,19 @@ responde fail-closed (503) sin asumir ningún valor por defecto.
 
 ## Matriz de variables
 
-| Variable | Preview (valor actual) | Production (valor propuesto, no aplicado) | Tipo | Obligatoria | Si falta o es inválida | Quién la configura |
+| Variable | Preview (valor actual) | Production (valor actual — checkout sigue apagado) | Tipo | Obligatoria | Si falta o es inválida | Quién la configura |
 |---|---|---|---|---|---|---|
 | `APP_ENV` | `preview` | `production` | var (`wrangler.toml`) | Sí | 503 en todos los endpoints de pagos/pedidos | Repo — `wrangler.toml` |
-| `MP_COLLECTOR_ID` | `3559407834` (collector de la cuenta TEST) | Collector real de la cuenta LIVE — **a confirmar empíricamente antes de 2-N-E2**, no asumir el `440298103` documentado como owner de la app | var | Sí | 503 fail-closed | Repo — `wrangler.toml` |
+| `MP_COLLECTOR_ID` | `3559407834` (collector de la cuenta TEST) | `440298103` — **confirmado en 2-N-G2**. No confundir con el número de aplicación de Mercado Pago (`6816864196905927`), que es solo informativo y no se usa en runtime | var | Sí | 503 fail-closed | Repo — `wrangler.toml` |
 | `CHECKOUT_ENABLED` | `"true"` | `"false"` | var | No (ausente = deshabilitado) | `POST /api/orders` y `POST /api/preferences` responden `503 checkout_temporarily_unavailable`; webhook, `/api/orders/status` y `/pedido` siguen funcionando | Repo — `wrangler.toml` |
 | `PUBLIC_CHECKOUT_ENABLED` | Según build de Preview | `"false"` | variable de build pública | Sí para mostrar el checkout | Los botones y el flujo de pago online no se renderizan | Workflow de build/deploy |
-| `CANONICAL_ORIGIN` | `https://feature-2-n-e1-production-re.amadolibros-web.pages.dev` (alias truncado por Cloudflare Pages — el nombre completo de la rama no entra en el límite de un label DNS) | `https://www.amadolibros.com` (propuesto) | var | Sí | 503 fail-closed | Repo — `wrangler.toml` |
-| `ALLOWED_HOSTS` | No aplica — Preview usa una validación estructural (ver abajo), no una lista | `amadolibros.com,www.amadolibros.com` (propuesto) | var | Sí en Production | 503 fail-closed en Production | Repo — `wrangler.toml` (bloque `env.production`, a crear en 2-N-E2) |
-| `MP_ACCESS_TOKEN` | Token TEST de la app MP | Token LIVE — **no cargar en este lote** | secret | Sí | `503 MP_NOT_CONFIGURED` (preferencias) / `503` sin cuerpo (webhook) | Dashboard de Cloudflare Pages — nunca en el repo |
-| `MP_WEBHOOK_SECRET` | Secret del webhook configurado para la URL de Preview | Secret del webhook Production — requiere su propia entrada en el panel de MP | secret | Sí | `503` sin cuerpo | Dashboard de Cloudflare Pages |
-| `TURNSTILE_SECRET_KEY` | Secret del widget `amadolibros-orders-preview` | Secret de un widget Production **todavía no creado** | secret | Sí | `503 TS_NOT_CONFIGURED` — bloquea la creación de pedidos, Turnstile nunca se desactiva silenciosamente | Dashboard de Cloudflare Pages |
+| `PUBLIC_TURNSTILE_SITE_KEY` | **Pendiente.** No hay un workflow de GitHub efectivo identificado que construya el Preview con checkout — ver "Pendientes" | `0x4AAAAAAD_Ul8KGae_hdWwj` (inyectada en `deploy.yml`, no es secreta) | variable de build pública | Sí para cargar el widget | El script de `carrito.astro` nunca carga Turnstile ni permite preparar el pago (falla cerrado) | Workflow de build/deploy |
+| `PUBLIC_TURNSTILE_ALLOWED_HOSTS` | **Pendiente**, mismo motivo que la fila anterior | `amadolibros.com,www.amadolibros.com` | variable de build pública | Sí para cargar el widget | Mismo fail-closed que la site key ausente | Workflow de build/deploy |
+| `CANONICAL_ORIGIN` | `https://feature-2-n-e1-production-re.amadolibros-web.pages.dev` (alias truncado por Cloudflare Pages — el nombre completo de la rama no entra en el límite de un label DNS) | `https://www.amadolibros.com` | var | Sí | 503 fail-closed | Repo — `wrangler.toml` |
+| `ALLOWED_HOSTS` | No aplica — Preview usa una validación estructural (ver abajo), no una lista | `amadolibros.com,www.amadolibros.com` | var | Sí en Production | 503 fail-closed en Production | Repo — `wrangler.toml` (bloque `env.production`) |
+| `MP_ACCESS_TOKEN` | Token TEST de la app MP | **Presente por nombre** en Cloudflare Pages Production (confirmado en auditoría 2-N-G1); su valor no fue leído ni validado en 2-N-G2 | secret | Sí | `503 MP_NOT_CONFIGURED` (preferencias) / `503` sin cuerpo (webhook) | Dashboard de Cloudflare Pages — nunca en el repo |
+| `MP_WEBHOOK_SECRET` | Secret del webhook configurado para la URL de Preview | **Presente por nombre** en Cloudflare Pages Production (confirmado en auditoría 2-N-G1); su valor no fue leído ni validado en 2-N-G2 | secret | Sí | `503` sin cuerpo | Dashboard de Cloudflare Pages |
+| `TURNSTILE_SECRET_KEY` | Secret del widget `amadolibros-orders-preview` | Secret del widget Production — **ya cargado manualmente en el dashboard de Cloudflare Pages** (2-N-G2); su valor nunca se lee, imprime ni versiona desde este repo | secret | Sí | `503 TS_NOT_CONFIGURED` — bloquea la creación de pedidos, Turnstile nunca se desactiva silenciosamente | Dashboard de Cloudflare Pages |
 | `ORDERS_DB` (binding D1) | `amadolibros-orders-preview` | `amadolibros-orders-production` | binding D1 | Sí | `503` sin fallback a Preview, memoria u otra base | `wrangler.toml` |
 
 ## Origen canónico vs. hosts aceptados
@@ -60,15 +67,36 @@ Son dos conceptos deliberadamente separados:
 
 ## Turnstile por ambiente
 
-- Preview: widget `amadolibros-orders-preview` (modo `managed`, dominio
-  `amadolibros-web.pages.dev`), secret en `TURNSTILE_SECRET_KEY` de
-  Preview únicamente.
-- Production: **sin crear todavía**. Va a necesitar su propio widget
-  (dominio `amadolibros.com`/`www.amadolibros.com`) y su propio secret.
-  El hostname esperado por `verifyTurnstile()` ya no tiene un valor por
-  defecto hardcodeado — se toma de `resolveConfig()`, así que si falta la
-  configuración, la verificación falla cerrada (bloquea la creación de
-  pedidos) en vez de aceptar cualquier hostname.
+Hay dos mitades independientes, backend y frontend, ambas fail-closed:
+
+- **Backend** (`verifyTurnstile()` en `_turnstile.js`, vía
+  `resolveConfig()`): valida el token contra el hostname esperado del
+  ambiente. Preview usa el widget `amadolibros-orders-preview` (modo
+  `managed`, dominio `amadolibros-web.pages.dev`) con su
+  `TURNSTILE_SECRET_KEY` propio. Production usa su propio widget
+  (dominio `amadolibros.com`/`www.amadolibros.com`); su
+  `TURNSTILE_SECRET_KEY` ya está cargado en el dashboard de Cloudflare
+  Pages (2-N-G2) — su valor no vive ni se lee desde este repo. Si falta
+  la configuración de cualquiera de los dos lados, la verificación falla
+  cerrada (bloquea la creación de pedidos) en vez de aceptar cualquier
+  hostname.
+- **Frontend** (`carrito.astro`, desde 2-N-G2): la site key pública y los
+  hosts permitidos para cargar el widget ya no están hardcodeados ni se
+  infieren del hostname del navegador — se inyectan en build time vía
+  `PUBLIC_TURNSTILE_SITE_KEY`/`PUBLIC_TURNSTILE_ALLOWED_HOSTS` (ver
+  matriz arriba). El matching de hosts es por labels completos, nunca
+  por substring (`evil-amadolibros.com` o `amadolibros.com.evil.example`
+  nunca matchean `amadolibros.com`); está probado en
+  `astro-front/src/lib/__tests__/turnstile-hosts.test.js`. Si el checkout
+  está habilitado pero la site key falta o el host actual no está en la
+  lista, el widget nunca se carga y "Preparar pago online" muestra un
+  error controlado en vez de mandar la request sin verificación.
+  **Solo Production tiene esta configuración conectada a un workflow real
+  (`deploy.yml`).** Para Preview la mecánica está lista en el código
+  (`carrito.astro` acepta las mismas variables) pero **no hay ningún
+  workflow de GitHub identificado como efectivo** para construir un
+  Preview con checkout — ver "Pendientes" más abajo. No se afirma que
+  Preview quede configurado por este lote.
 
 ## Collector por ambiente
 
@@ -134,14 +162,30 @@ y exclusivamente en base al estado que devuelve `POST
    validando ahora mismo; cualquier otra rama de preview que intente usar
    checkout va a generar `notification_url`/`back_urls` apuntando a esta
    rama hasta que se resuelva el alcance (por rama, o con otra estrategia).
-2. **`MP_COLLECTOR_ID` de Production no está confirmado.** El valor
-   documentado como owner de la app (`440298103`) no debe asumirse como el
-   collector real de pagos LIVE sin verificarlo empíricamente, tal como se
-   tuvo que corregir para el collector de TEST en el fix de `live_mode`
-   (commit `6e3e181`).
-3. **Faltan el widget/secret de Turnstile y las credenciales LIVE de
-   Production.** No se crean ni cargan en este lote.
-4. **La activación exige dos llaves explícitas.** El backend requiere
-   `CHECKOUT_ENABLED="true"` y el frontend debe compilarse con
-   `PUBLIC_CHECKOUT_ENABLED="true"`. Mientras cualquiera permanezca apagada,
-   no se ofrece el flujo de cobro.
+2. **`MP_ACCESS_TOKEN` y `MP_WEBHOOK_SECRET` de Production están presentes
+   por nombre** en el dashboard de Cloudflare Pages (confirmado en la
+   auditoría 2-N-G1), y `MP_COLLECTOR_ID` (`440298103`) está confirmado y
+   cargado (2-N-G2). Lo que falta es **validar funcionalmente** esas dos
+   credenciales (que el token sea válido, que el secret del webhook sea
+   el correcto) — ese valor no se lee, no se prueba ni se modifica desde
+   este repo ni en este lote.
+3. **No existe actualmente un workflow de GitHub identificado como
+   efectivo para desplegar un Preview con el checkout de Mercado Pago.**
+   `deploy-preview.yml` sigue exactamente como en `origin/main` (trigger
+   limitado a la rama `astro-migration`, que no tiene código de pagos) —
+   2-N-G2 no lo modificó. La configuración pública de Turnstile para
+   Preview (`PUBLIC_TURNSTILE_SITE_KEY`/`PUBLIC_TURNSTILE_ALLOWED_HOSTS`
+   con los valores `0x4AAAAAAD6E9kz8K3comwjj` /
+   `amadolibros-web.pages.dev,.amadolibros-web.pages.dev`) queda
+   documentada acá como pendiente de conectar el día que se identifique o
+   cree el pipeline efectivo — no se afirma que Preview haya quedado
+   configurado por este lote.
+4. **La activación exige varias llaves explícitas, no solo una.** El
+   backend requiere `CHECKOUT_ENABLED="true"`, el frontend debe
+   compilarse con `PUBLIC_CHECKOUT_ENABLED="true"`, y además necesita
+   `PUBLIC_TURNSTILE_SITE_KEY`/`PUBLIC_TURNSTILE_ALLOWED_HOSTS` válidos
+   para el host que sirve la página — si falta cualquiera de estas
+   últimas dos, el checkout no se oculta pero el pago queda bloqueado
+   igual (fail-closed) hasta que se corrija. Mientras `CHECKOUT_ENABLED`
+   o `PUBLIC_CHECKOUT_ENABLED` permanezcan apagadas, no se ofrece el
+   flujo de cobro en absoluto.

--- a/functions/__tests__/wrangler-config.test.js
+++ b/functions/__tests__/wrangler-config.test.js
@@ -1,0 +1,78 @@
+// Verifica que wrangler.toml, deploy.yml y carrito.astro sigan declarando la
+// configuración de Producción esperada tras 2-N-G2: MP_COLLECTOR_ID
+// confirmado, checkout apagado en ambos niveles (runtime y build), y la site
+// key pública de Turnstile de Producción inyectada por build en vez de
+// hardcodeada en el código.
+//
+// No hay tests sobre deploy-preview.yml acá a propósito: ese workflow no es
+// actualmente el pipeline efectivo para ningún Preview con checkout (su
+// trigger sigue limitado a la rama `astro-migration`, sin código de pagos),
+// y 2-N-G2 no lo modificó — ver docs/environments.md, sección "Pendientes".
+// Afirmar mediante un test que "la site key de Producción no se usa en el
+// build de Preview" no es verificable mientras ese pipeline no exista.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const wranglerToml = readFileSync(path.join(ROOT, 'wrangler.toml'), 'utf8');
+const deployYml = readFileSync(path.join(ROOT, '.github', 'workflows', 'deploy.yml'), 'utf8');
+const carritoAstro = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'pages', 'carrito.astro'),
+  'utf8',
+);
+
+const PRODUCTION_SITE_KEY = '0x4AAAAAAD_Ul8KGae_hdWwj';
+const PREVIEW_SITE_KEY = '0x4AAAAAAD6E9kz8K3comwjj';
+
+function extractTomlSection(toml, header) {
+  const start = toml.indexOf(header);
+  assert.notEqual(start, -1, `sección ${header} no encontrada en wrangler.toml`);
+  const rest = toml.slice(start + header.length);
+  const nextHeaderIdx = rest.search(/\n\s*\[/);
+  return nextHeaderIdx === -1 ? rest : rest.slice(0, nextHeaderIdx);
+}
+
+const productionVars = extractTomlSection(wranglerToml, '[env.production.vars]');
+
+test('wrangler.toml: Producción resuelve MP_COLLECTOR_ID=440298103', () => {
+  assert.match(productionVars, /MP_COLLECTOR_ID\s*=\s*"440298103"/);
+});
+
+test('wrangler.toml: CHECKOUT_ENABLED de Producción permanece en false', () => {
+  assert.match(productionVars, /CHECKOUT_ENABLED\s*=\s*"false"/);
+});
+
+test('wrangler.toml: Producción no declara secrets (MP_ACCESS_TOKEN, MP_WEBHOOK_SECRET, TURNSTILE_SECRET_KEY)', () => {
+  assert.doesNotMatch(productionVars, /MP_ACCESS_TOKEN/);
+  assert.doesNotMatch(productionVars, /MP_WEBHOOK_SECRET/);
+  assert.doesNotMatch(productionVars, /TURNSTILE_SECRET_KEY/);
+});
+
+test('deploy.yml: build de Producción mantiene PUBLIC_CHECKOUT_ENABLED en false', () => {
+  assert.match(deployYml, /PUBLIC_CHECKOUT_ENABLED:\s*'false'/);
+});
+
+test('deploy.yml: contiene solamente la site key pública de Turnstile de Producción', () => {
+  assert.match(deployYml, new RegExp(`PUBLIC_TURNSTILE_SITE_KEY:\\s*'${PRODUCTION_SITE_KEY}'`));
+  assert.doesNotMatch(deployYml, new RegExp(PREVIEW_SITE_KEY));
+});
+
+test('deploy.yml: restringe Turnstile a los hosts de Producción', () => {
+  assert.match(
+    deployYml,
+    /PUBLIC_TURNSTILE_ALLOWED_HOSTS:\s*'amadolibros\.com,www\.amadolibros\.com'/,
+  );
+});
+
+test('carrito.astro: no contiene ninguna site key de Turnstile hardcodeada', () => {
+  assert.doesNotMatch(carritoAstro, new RegExp(PRODUCTION_SITE_KEY));
+  assert.doesNotMatch(carritoAstro, new RegExp(PREVIEW_SITE_KEY));
+});
+
+test('carrito.astro: la site key se lee de PUBLIC_TURNSTILE_SITE_KEY, no de un literal', () => {
+  assert.match(carritoAstro, /import\.meta\.env\.PUBLIC_TURNSTILE_SITE_KEY/);
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -51,13 +51,14 @@ database_name = "amadolibros-orders-production"
 database_id = "6dc8dc3a-2d4f-4045-b428-14323c7b0bcd"
 
 # CHECKOUT_ENABLED en "false": el kill switch queda apagado a propósito.
-# MP_COLLECTOR_ID de Producción todavía no está confirmado (no asumir el
-# ID de owner de la app como collector real de LIVE — ver
-# docs/environments.md) y no se declara acá; sin él, resolveConfig()
-# falla cerrado (503) en cualquier endpoint de pagos, lo cual es
-# intencional mientras no haya credenciales LIVE cargadas.
+# MP_COLLECTOR_ID confirmado en 2-N-G2 (440298103) — NO es el número de
+# aplicación de Mercado Pago (6816864196905927, solo informativo, no se usa
+# en runtime). MP_ACCESS_TOKEN, MP_WEBHOOK_SECRET y TURNSTILE_SECRET_KEY
+# siguen sin declararse acá — son secrets, viven únicamente en el dashboard
+# de Cloudflare Pages.
 [env.production.vars]
 APP_ENV           = "production"
 CHECKOUT_ENABLED  = "false"
 CANONICAL_ORIGIN  = "https://www.amadolibros.com"
 ALLOWED_HOSTS     = "amadolibros.com,www.amadolibros.com"
+MP_COLLECTOR_ID   = "440298103"


### PR DESCRIPTION
## Lote 2-N-G2

Prepara la configuración de Mercado Pago y Turnstile para Producción sin activar cobros.

### Cambios

- agrega MP_COLLECTOR_ID productivo;
- separa la Site key de Turnstile mediante variables públicas de build;
- restringe hosts permitidos y evita suplantación de dominio;
- implementa fallo cerrado cuando Turnstile no está configurado;
- mantiene checkout frontend y backend apagados;
- agrega pruebas de configuración y hosts;
- actualiza documentación de ambientes.

### Validación

- 215 tests aprobados;
- build Production con checkout apagado aprobado;
- build local con checkout habilitado aprobado;
- sin secretos en el repositorio;
- sin llamadas reales a Mercado Pago;
- sin cambios ni escrituras en D1;
- sin deploy.

### Interruptores

CHECKOUT_ENABLED=false
PUBLIC_CHECKOUT_ENABLED=false

No mergear.
No desplegar.