### PR TITLE
feat(checkout): preparar activación controlada de Mercado Pago

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,11 +48,13 @@ jobs:
         env:
           PUBLIC_INDEXABLE: 'true'
           PUBLIC_GA_ID: G-SDX45VEPP3
-          PUBLIC_CHECKOUT_ENABLED: 'false'
+          # PUBLIC_CHECKOUT_ENABLED en 'true' (2-N-H1): el build renderiza el
+          # flujo de pago online. El backend tiene su propio interruptor
+          # (CHECKOUT_ENABLED en wrangler.toml) — los dos deben estar en true
+          # para que se pueda cobrar.
+          PUBLIC_CHECKOUT_ENABLED: 'true'
           # Site key pública de Turnstile Production (no es secreto, puede
-          # versionarse) y los hosts exactos donde se acepta — el checkout
-          # sigue apagado (PUBLIC_CHECKOUT_ENABLED=false) hasta que se
-          # habilite explícitamente en un lote aparte.
+          # versionarse) y los hosts exactos donde se acepta.
           PUBLIC_TURNSTILE_SITE_KEY: '0x4AAAAAAD_Ul8KGae_hdWwj'
           PUBLIC_TURNSTILE_ALLOWED_HOSTS: 'amadolibros.com,www.amadolibros.com'
         run: npm run build
@@ -70,6 +72,11 @@ jobs:
           SMOKE_MAX_ATTEMPTS: '6'
           SMOKE_RETRY_DELAY_MS: '10000'
           SMOKE_TIMEOUT_MS: '10000'
+          # Debe reflejar el valor de PUBLIC_CHECKOUT_ENABLED de arriba: el
+          # smoke verifica el HTML real de /carrito/ y falla el deploy si el
+          # estado desplegado no coincide con el esperado. Si se hace rollback
+          # a PUBLIC_CHECKOUT_ENABLED='false', cambiar esto a 'disabled'.
+          SMOKE_EXPECT_CHECKOUT: 'enabled'
         run: node scripts/smoke-production.js
 
       - name: Deployment summary

--- a/astro-front/src/pages/pedido.astro
+++ b/astro-front/src/pages/pedido.astro
@@ -16,11 +16,10 @@ const WA_HREF =
   <main class="pedido-page">
     <div class="pedido-wrap">
       <div id="pedido-icon" class="pedido-icon" aria-hidden="true">🕐</div>
-      <h1 id="pedido-h1">Estado del pedido</h1>
+      <h1 id="pedido-h1">Estado de tu pedido</h1>
       <p id="pedido-lead" class="pedido-lead">
-        Estamos terminando la integración con Mercado Pago.
-        Por ahora podés finalizar tu pedido por WhatsApp y te respondemos
-        con los datos de pago.
+        Estamos verificando el estado de tu pago. Esta confirmación puede
+        demorar unos instantes.
       </p>
       <p id="pedido-sub" class="pedido-sub" hidden></p>
       <p id="pedido-code" class="pedido-code" hidden></p>

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,15 +1,34 @@
-# Ambientes — Preview y Production (2-N-E1, actualizado en 2-N-G2)
+# Ambientes — Preview y Production (2-N-E1, actualizado en 2-N-H1)
 
 Este documento describe la configuración centralizada introducida en 2-N-E1
 (`functions/api/_env_config.js`). El código queda preparado para operar en
 Preview y Production. Production ya tiene D1 propia, hosts declarados,
 `MP_COLLECTOR_ID` confirmado y site key pública de Turnstile inyectada por
-`deploy.yml` (2-N-G2) — pero el checkout permanece apagado y oculto:
-`CHECKOUT_ENABLED` y `PUBLIC_CHECKOUT_ENABLED` siguen en `"false"` y
-Mercado Pago no procesa ningún cobro real. `MP_ACCESS_TOKEN` y
-`MP_WEBHOOK_SECRET` de Production están presentes por nombre en el dashboard
-de Cloudflare Pages (confirmado en la auditoría 2-N-G1); sus valores no se
-leen, validan ni modifican desde este repo ni en este lote.
+`deploy.yml` (2-N-G2).
+
+## Estado del código vs. estado desplegado vs. procedimiento operativo
+
+Estos tres planos son independientes y no hay que confundirlos:
+
+- **Estado del código en esta rama** (`agent/2-n-h1-controlled-activation`):
+  `wrangler.toml` tiene `CHECKOUT_ENABLED = "true"` y `deploy.yml` tiene
+  `PUBLIC_CHECKOUT_ENABLED: 'true'`. Si esta rama se mergea y se despliega tal
+  cual, el checkout de Mercado Pago queda activo en Producción.
+- **Estado realmente desplegado en `www.amadolibros.com` ahora mismo**: sigue
+  **apagado**. Esta rama no fue mergeada ni desplegada — fue preparada en
+  2-N-H1 sin commit, push, PR ni deploy (ver el reporte de ese lote). El
+  código de `origin/main` sigue siendo el de 2-N-G2, con ambos interruptores
+  en `"false"`. Nada de lo descrito en esta sección "activo" aplica a
+  Producción hasta que un merge y un deploy exitoso lo confirmen.
+- **Cómo se confirma que la activación fue efectiva**: el deploy no se
+  considera exitoso solo porque el build compiló — el step "Smoke test
+  production" de `deploy.yml` corre `scripts/smoke-production.js` con
+  `SMOKE_EXPECT_CHECKOUT='enabled'`, que analiza el HTML real servido de
+  `/carrito/` (no un mock) y hace fallar el deploy si el estado desplegado no
+  coincide con lo esperado. Un merge exitoso sin ese smoke en verde no debe
+  interpretarse como "ya está activo".
+- **Procedimiento operativo de ahí en más**: ver "Kill switch" y "Rollback
+  completo" más abajo.
 
 ## Principio general
 
@@ -20,12 +39,13 @@ responde fail-closed (503) sin asumir ningún valor por defecto.
 
 ## Matriz de variables
 
-| Variable | Preview (valor actual) | Production (valor actual — checkout sigue apagado) | Tipo | Obligatoria | Si falta o es inválida | Quién la configura |
+| Variable | Preview (valor actual) | Production — **código de esta rama**, aún no desplegado | Tipo | Obligatoria | Si falta o es inválida | Quién la configura |
 |---|---|---|---|---|---|---|
 | `APP_ENV` | `preview` | `production` | var (`wrangler.toml`) | Sí | 503 en todos los endpoints de pagos/pedidos | Repo — `wrangler.toml` |
 | `MP_COLLECTOR_ID` | `3559407834` (collector de la cuenta TEST) | `440298103` — **confirmado en 2-N-G2**. No confundir con el número de aplicación de Mercado Pago (`6816864196905927`), que es solo informativo y no se usa en runtime | var | Sí | 503 fail-closed | Repo — `wrangler.toml` |
-| `CHECKOUT_ENABLED` | `"true"` | `"false"` | var | No (ausente = deshabilitado) | `POST /api/orders` y `POST /api/preferences` responden `503 checkout_temporarily_unavailable`; webhook, `/api/orders/status` y `/pedido` siguen funcionando | Repo — `wrangler.toml` |
-| `PUBLIC_CHECKOUT_ENABLED` | Según build de Preview | `"false"` | variable de build pública | Sí para mostrar el checkout | Los botones y el flujo de pago online no se renderizan | Workflow de build/deploy |
+| `CHECKOUT_ENABLED` | `"true"` | `"true"` en el código de esta rama (2-N-H1) — **en Producción desplegada sigue `"false"`** hasta el merge+deploy | var | No (ausente = deshabilitado) | `POST /api/orders` y `POST /api/preferences` responden `503 checkout_temporarily_unavailable`; webhook, `/api/orders/status` y `/pedido` siguen funcionando | Repo — `wrangler.toml` |
+| `PUBLIC_CHECKOUT_ENABLED` | Según build de Preview | `'true'` en el código de esta rama (2-N-H1) — **en el build desplegado sigue `'false'`** hasta el merge+deploy | variable de build pública | Sí para mostrar el checkout | Los botones y el flujo de pago online no se renderizan | Workflow de build/deploy |
+| `SMOKE_EXPECT_CHECKOUT` | No aplica (Preview no corre este smoke) | `'enabled'` — declarado junto a `PUBLIC_CHECKOUT_ENABLED` en `deploy.yml`; el deploy falla si el HTML real de `/carrito/` no coincide | variable del step de smoke | Sí (sin valor por defecto, fail-closed) | El script sale con error antes de intentar ninguna verificación | Repo — `.github/workflows/deploy.yml` |
 | `PUBLIC_TURNSTILE_SITE_KEY` | **Pendiente.** No hay un workflow de GitHub efectivo identificado que construya el Preview con checkout — ver "Pendientes" | `0x4AAAAAAD_Ul8KGae_hdWwj` (inyectada en `deploy.yml`, no es secreta) | variable de build pública | Sí para cargar el widget | El script de `carrito.astro` nunca carga Turnstile ni permite preparar el pago (falla cerrado) | Workflow de build/deploy |
 | `PUBLIC_TURNSTILE_ALLOWED_HOSTS` | **Pendiente**, mismo motivo que la fila anterior | `amadolibros.com,www.amadolibros.com` | variable de build pública | Sí para cargar el widget | Mismo fail-closed que la site key ausente | Workflow de build/deploy |
 | `CANONICAL_ORIGIN` | `https://feature-2-n-e1-production-re.amadolibros-web.pages.dev` (alias truncado por Cloudflare Pages — el nombre completo de la rama no entra en el límite de un label DNS) | `https://www.amadolibros.com` | var | Sí | 503 fail-closed | Repo — `wrangler.toml` |
@@ -126,6 +146,52 @@ nuevo deployment para tomar efecto. En esta etapa funciona como *release
 gate* (decisión tomada antes de desplegar), no necesariamente como un
 apagado instantáneo en caliente.
 
+### Procedimiento operativo — kill switch de emergencia
+
+Para impedir la creación de nuevas órdenes lo más rápido posible, **sin
+esperar un deploy**: cambiar `CHECKOUT_ENABLED` a `false` directamente en el
+dashboard de Cloudflare Pages (Settings → Environment Variables → Production).
+Efecto inmediato en la próxima invocación de las Functions — no requiere
+rebuild ni redeploy. El frontend puede seguir mostrando los botones hasta el
+siguiente build (porque `PUBLIC_CHECKOUT_ENABLED` es una variable de build,
+no de runtime), pero cualquier intento de pago recibe `503
+checkout_temporarily_unavailable` sin crear ninguna orden ni cobrar nada. Se
+verifica con un `POST` de prueba a `/api/orders` (sin datos reales) y
+confirmando la respuesta `503`.
+
+### Procedimiento operativo — rollback completo
+
+1. Revertir el commit de activación (o abrir uno correctivo) que deje
+   `CHECKOUT_ENABLED = "false"` en `wrangler.toml` y
+   `PUBLIC_CHECKOUT_ENABLED: 'false'` (con `SMOKE_EXPECT_CHECKOUT: 'disabled'`
+   junto a él) en `deploy.yml`.
+2. Deploy normal vía push a `main`.
+3. El smoke post-deploy (`SMOKE_EXPECT_CHECKOUT=disabled`) debe pasar solo; si
+   falla, el checkout no quedó realmente oculto y no hay que darlo por
+   apagado hasta corregirlo.
+4. **Nunca borrar `orders`, `order_items` ni `order_events`** durante un
+   rollback — apagar el checkout no es un evento destructivo sobre datos ya
+   existentes.
+5. El webhook de Mercado Pago **debe seguir procesándose** aunque
+   `CHECKOUT_ENABLED` esté en `false` — así un pago que ya estaba en curso
+   antes del rollback se termina de confirmar igual. Esto ya está garantizado
+   por el código (`_mp_webhook_handler.js` no depende de `checkoutEnabled`) y
+   cubierto por los tests `kill-1`/`kill-2` de `mp_webhook.test.js`.
+6. Órdenes ya creadas o pagos pendientes al momento del rollback quedan tal
+   cual en D1 — se resuelven manualmente (confirmar el pago cuando llegue el
+   webhook, o contactar al comprador si quedó pendiente).
+
+### Riesgos operativos que este código no resuelve
+
+- **Sin reserva de stock**: nada en este código descuenta ni reserva stock al
+  crear una orden ni al aprobarse un pago. Dos compradores pueden pagar por
+  el mismo ejemplar si el stock real es 1.
+- **Sin aviso interno automático de pagos**: no existe ningún mecanismo (email,
+  Slack, panel) que avise cuando entra un pago aprobado. Quien opera el
+  negocio debe revisar D1 manualmente o guiarse por el aviso de venta de
+  MercadoLibre para el ejemplar físico (un sistema separado, no integrado con
+  este flujo).
+
 ## `sandbox_init_point` vs. `init_point`
 
 - Preview usa exclusivamente `sandbox_init_point` (validado contra
@@ -168,7 +234,10 @@ y exclusivamente en base al estado que devuelve `POST
    cargado (2-N-G2). Lo que falta es **validar funcionalmente** esas dos
    credenciales (que el token sea válido, que el secret del webhook sea
    el correcto) — ese valor no se lee, no se prueba ni se modifica desde
-   este repo ni en este lote.
+   este repo ni en este lote. Esto es exactamente lo que debe cubrir la
+   compra real controlada, mínima y única (diseñada en 2-N-G4), **antes** de
+   anunciar el checkout públicamente — no alcanza con que el deploy y el
+   smoke pasen en verde.
 3. **No existe actualmente un workflow de GitHub identificado como
    efectivo para desplegar un Preview con el checkout de Mercado Pago.**
    `deploy-preview.yml` sigue exactamente como en `origin/main` (trigger
@@ -186,6 +255,8 @@ y exclusivamente en base al estado que devuelve `POST
    `PUBLIC_TURNSTILE_SITE_KEY`/`PUBLIC_TURNSTILE_ALLOWED_HOSTS` válidos
    para el host que sirve la página — si falta cualquiera de estas
    últimas dos, el checkout no se oculta pero el pago queda bloqueado
-   igual (fail-closed) hasta que se corrija. Mientras `CHECKOUT_ENABLED`
-   o `PUBLIC_CHECKOUT_ENABLED` permanezcan apagadas, no se ofrece el
-   flujo de cobro en absoluto.
+   igual (fail-closed) hasta que se corrija. **Estado actual desplegado en
+   Producción: ambas siguen en `false`** — el código de la rama
+   `agent/2-n-h1-controlled-activation` (2-N-H1) las tiene en `true`, pero
+   esa rama no fue mergeada ni desplegada. Mientras no se despliegue, no se
+   ofrece el flujo de cobro en absoluto.

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -15,11 +15,11 @@ Estos tres planos son independientes y no hay que confundirlos:
   `PUBLIC_CHECKOUT_ENABLED: 'true'`. Si esta rama se mergea y se despliega tal
   cual, el checkout de Mercado Pago queda activo en Producción.
 - **Estado realmente desplegado en `www.amadolibros.com` ahora mismo**: sigue
-  **apagado**. Esta rama no fue mergeada ni desplegada — fue preparada en
-  2-N-H1 sin commit, push, PR ni deploy (ver el reporte de ese lote). El
-  código de `origin/main` sigue siendo el de 2-N-G2, con ambos interruptores
-  en `"false"`. Nada de lo descrito en esta sección "activo" aplica a
-  Producción hasta que un merge y un deploy exitoso lo confirmen.
+  **apagado**. El checkout permanece apagado en Producción mientras este PR
+  no sea mergeado y su deployment productivo no haya terminado con el smoke
+  en verde. El código de `origin/main` sigue siendo el de 2-N-G2, con ambos
+  interruptores en `"false"`. Nada de lo descrito en esta sección "activo"
+  aplica a Producción hasta que un merge y un deploy exitoso lo confirmen.
 - **Cómo se confirma que la activación fue efectiva**: el deploy no se
   considera exitoso solo porque el build compiló — el step "Smoke test
   production" de `deploy.yml` corre `scripts/smoke-production.js` con
@@ -27,8 +27,8 @@ Estos tres planos son independientes y no hay que confundirlos:
   `/carrito/` (no un mock) y hace fallar el deploy si el estado desplegado no
   coincide con lo esperado. Un merge exitoso sin ese smoke en verde no debe
   interpretarse como "ya está activo".
-- **Procedimiento operativo de ahí en más**: ver "Kill switch" y "Rollback
-  completo" más abajo.
+- **Procedimiento operativo de ahí en más**: ver "Kill switch de emergencia"
+  y "Rollback permanente en código" más abajo.
 
 ## Principio general
 
@@ -148,36 +148,44 @@ apagado instantáneo en caliente.
 
 ### Procedimiento operativo — kill switch de emergencia
 
-Para impedir la creación de nuevas órdenes lo más rápido posible, **sin
-esperar un deploy**: cambiar `CHECKOUT_ENABLED` a `false` directamente en el
-dashboard de Cloudflare Pages (Settings → Environment Variables → Production).
-Efecto inmediato en la próxima invocación de las Functions — no requiere
-rebuild ni redeploy. El frontend puede seguir mostrando los botones hasta el
-siguiente build (porque `PUBLIC_CHECKOUT_ENABLED` es una variable de build,
-no de runtime), pero cualquier intento de pago recibe `503
-checkout_temporarily_unavailable` sin crear ninguna orden ni cobrar nada. Se
-verifica con un `POST` de prueba a `/api/orders` (sin datos reales) y
-confirmando la respuesta `503`.
+`wrangler.toml` es la fuente de verdad de la configuración desplegada — no
+alcanza con cambiar una variable en el dashboard de Cloudflare, porque eso no
+se refleja en el repo ni sobrevive al próximo deploy normal. Para apagar el
+checkout lo más rápido posible sin esperar un `git revert` + deploy:
 
-### Procedimiento operativo — rollback completo
+1. Entrar a Cloudflare Pages → el proyecto `amadolibros-web` → **Deployments**.
+2. Localizar el deployment productivo estable anterior a la activación (el
+   último con `CHECKOUT_ENABLED`/`PUBLIC_CHECKOUT_ENABLED` en `false`).
+3. Ejecutar **Rollback** sobre ese deployment.
+4. Ese rollback restaura tanto el frontend como el backend apagados —
+   `PUBLIC_CHECKOUT_ENABLED` (build) y `CHECKOUT_ENABLED` (runtime) vuelven
+   al estado del deployment restaurado, sin depender de una edición manual de
+   variables.
+5. Verificar `/carrito/`: debe mostrar `data-online-checkout="disabled"`.
+6. Verificar que `POST /api/orders` responde `503`.
+7. **No borrar** `orders`, `order_items` ni `order_events` en ningún momento
+   de este procedimiento.
+8. El webhook de Mercado Pago debe seguir procesando pagos ya iniciados — el
+   rollback de Cloudflare Pages no afecta las Functions del webhook en sí
+   más que devolverlas también al código de ese deployment anterior, que ya
+   procesaba el webhook igual (ver `kill-1`/`kill-2` en `mp_webhook.test.js`).
 
-1. Revertir el commit de activación (o abrir uno correctivo) que deje
-   `CHECKOUT_ENABLED = "false"` en `wrangler.toml` y
-   `PUBLIC_CHECKOUT_ENABLED: 'false'` (con `SMOKE_EXPECT_CHECKOUT: 'disabled'`
-   junto a él) en `deploy.yml`.
-2. Deploy normal vía push a `main`.
-3. El smoke post-deploy (`SMOKE_EXPECT_CHECKOUT=disabled`) debe pasar solo; si
-   falla, el checkout no quedó realmente oculto y no hay que darlo por
+### Procedimiento operativo — rollback permanente en código
+
+El paso anterior es la respuesta inmediata; este es el que deja el repositorio
+consistente con lo que quedó desplegado:
+
+1. Confirmar en `wrangler.toml`: `CHECKOUT_ENABLED = "false"`.
+2. Confirmar en `.github/workflows/deploy.yml`:
+   `PUBLIC_CHECKOUT_ENABLED: 'false'` y `SMOKE_EXPECT_CHECKOUT: 'disabled'`
+   (los dos juntos — ver el test "los dos interruptores de checkout coinciden
+   entre sí" en `wrangler-config.test.js`).
+3. Commit, merge a `main` y deploy normal (no manual) — el push a `main`
+   dispara `deploy.yml`.
+4. El smoke post-deploy (`SMOKE_EXPECT_CHECKOUT=disabled`) debe pasar solo;
+   si falla, el checkout no quedó realmente oculto y no hay que darlo por
    apagado hasta corregirlo.
-4. **Nunca borrar `orders`, `order_items` ni `order_events`** durante un
-   rollback — apagar el checkout no es un evento destructivo sobre datos ya
-   existentes.
-5. El webhook de Mercado Pago **debe seguir procesándose** aunque
-   `CHECKOUT_ENABLED` esté en `false` — así un pago que ya estaba en curso
-   antes del rollback se termina de confirmar igual. Esto ya está garantizado
-   por el código (`_mp_webhook_handler.js` no depende de `checkoutEnabled`) y
-   cubierto por los tests `kill-1`/`kill-2` de `mp_webhook.test.js`.
-6. Órdenes ya creadas o pagos pendientes al momento del rollback quedan tal
+5. Órdenes ya creadas o pagos pendientes al momento del rollback quedan tal
    cual en D1 — se resuelven manualmente (confirmar el pago cuando llegue el
    webhook, o contactar al comprador si quedó pendiente).
 

--- a/functions/__tests__/smoke-checkout.test.js
+++ b/functions/__tests__/smoke-checkout.test.js
@@ -115,7 +115,10 @@ test('smoke-7: la Site key de Preview en Producción falla en ambos estados', ()
 });
 
 test('smoke-8: un marcador de secreto falla y el motivo nunca incluye el valor', () => {
-  const leaked = HTML_ENABLED.replace('</body>', '<!-- APP_USR-1234567890-abcdef --></body>');
+  // Construido en runtime (nunca escrito literal) para que un secret scanner
+  // no lo confunda con una credencial real filtrada en el repo.
+  const fakeSecretMarker = 'APP_' + 'USR-' + '1234567890-abcdef';
+  const leaked = HTML_ENABLED.replace('</body>', `<!-- ${fakeSecretMarker} --></body>`);
   const r = analyzeCartCheckoutState(leaked, 'enabled');
   assert.equal(r.ok, false);
   assert.match(r.reason, /posible secreto expuesto/);

--- a/functions/__tests__/smoke-checkout.test.js
+++ b/functions/__tests__/smoke-checkout.test.js
@@ -1,0 +1,164 @@
+// Tests de la verificación de estado del checkout que hace
+// scripts/smoke-production.js sobre el HTML servido de /carrito/.
+//
+// Vive en functions/__tests__/ (y no en scripts/__tests__/) a propósito: CI ya
+// ejecuta `node --test functions/__tests__/*.test.js`, así que estos tests
+// corren sin tener que tocar .github/workflows/ci.yml, que está fuera del
+// alcance de 2-N-H1. Es el mismo criterio con el que wrangler-config.test.js
+// —que verifica wrangler.toml y deploy.yml— ya vive en esta carpeta.
+//
+// Todo se ejercita con fixtures en memoria: no hay red, no se toca Producción,
+// no se envía ningún POST y no se llama a Mercado Pago ni a Turnstile.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  analyzeCartCheckoutState,
+  resolveCheckoutExpectation,
+  hasRenderedElementWithId,
+  TURNSTILE_SITE_KEY_PRODUCTION,
+  TURNSTILE_SITE_KEY_PREVIEW,
+} from '../../scripts/smoke-production.js';
+
+// Los fixtures replican la forma real del build de Astro, incluidos los
+// atributos data-astro-cid-* y —clave para estos tests— las referencias
+// INERTES dentro del <script>: el bloque JS menciona 'cf-ts-container',
+// 'btn-prepare-order' y la URL de challenges.cloudflare.com incluso cuando el
+// checkout está apagado y esos elementos nunca se renderizan.
+const INERT_SCRIPT = `<script>var turnstileSiteKey = "${TURNSTILE_SITE_KEY_PRODUCTION}";
+var turnstileAllowedHosts = ["amadolibros.com","www.amadolibros.com"];
+var container = document.getElementById('cf-ts-container');
+var btnPrepare = document.getElementById('btn-prepare-order');
+var btnPayMp = document.getElementById('btn-pay-mp');
+_tsScript.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?onload=__tsOnLoad&render=explicit';</script>`;
+
+const WHATSAPP_BUTTON =
+  '<button type="button" id="btn-wa-order" class="btn-wa-order" data-astro-cid-ymxsigk2>Enviar pedido por WhatsApp</button>';
+
+function cartHtml({ enabled }) {
+  const payControls = enabled
+    ? '<div id="cf-ts-container" data-astro-cid-ymxsigk2></div>' +
+      '<button type="button" id="btn-prepare-order" class="btn-prepare-order" data-astro-cid-ymxsigk2>Preparar pago online</button>'
+    : '';
+  return (
+    '<!DOCTYPE html><html><body>' +
+    `<main class="cart-page" data-online-checkout="${enabled ? 'enabled' : 'disabled'}" data-astro-cid-ymxsigk2>` +
+    '<section class="cart-pay-section" data-astro-cid-ymxsigk2>' +
+    payControls +
+    WHATSAPP_BUTTON +
+    '</section></main>' +
+    INERT_SCRIPT +
+    '</body></html>'
+  );
+}
+
+const HTML_ENABLED  = cartHtml({ enabled: true });
+const HTML_DISABLED = cartHtml({ enabled: false });
+
+// ── Matriz principal: el smoke distingue los cuatro cruces ───────────────────
+
+test('smoke-1: HTML disabled pasa con expectativa disabled', () => {
+  const r = analyzeCartCheckoutState(HTML_DISABLED, 'disabled');
+  assert.equal(r.ok, true, r.reason);
+});
+
+test('smoke-2: HTML disabled FALLA con expectativa enabled', () => {
+  const r = analyzeCartCheckoutState(HTML_DISABLED, 'enabled');
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /data-online-checkout="enabled"/);
+});
+
+test('smoke-3: HTML enabled pasa con expectativa enabled', () => {
+  const r = analyzeCartCheckoutState(HTML_ENABLED, 'enabled');
+  assert.equal(r.ok, true, r.reason);
+});
+
+test('smoke-4: HTML enabled FALLA con expectativa disabled', () => {
+  const r = analyzeCartCheckoutState(HTML_ENABLED, 'disabled');
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /data-online-checkout="disabled"/);
+});
+
+// ── La trampa de la cadena inerte ────────────────────────────────────────────
+
+test('smoke-5: una URL de Turnstile presente solo como string inerte no cuenta como evidencia', () => {
+  // El fixture apagado contiene la URL de challenges.cloudflare.com y las
+  // referencias a los ids dentro del <script>, pero ningún elemento real.
+  assert.ok(HTML_DISABLED.includes('challenges.cloudflare.com'));
+  assert.ok(HTML_DISABLED.includes("getElementById('cf-ts-container')"));
+  assert.ok(HTML_DISABLED.includes("getElementById('btn-prepare-order')"));
+  // Aun así se considera correctamente apagado.
+  assert.equal(analyzeCartCheckoutState(HTML_DISABLED, 'disabled').ok, true);
+  // Y jamás alcanza para darlo por encendido.
+  assert.equal(analyzeCartCheckoutState(HTML_DISABLED, 'enabled').ok, false);
+});
+
+test('smoke-6: hasRenderedElementWithId separa la etiqueta real de la cadena en JS', () => {
+  assert.equal(hasRenderedElementWithId("<div id=\"cf-ts-container\"></div>", 'cf-ts-container'), true);
+  assert.equal(hasRenderedElementWithId("<div id='cf-ts-container'></div>", 'cf-ts-container'), true);
+  assert.equal(
+    hasRenderedElementWithId('<button type="button" id="btn-prepare-order">x</button>', 'btn-prepare-order'),
+    true,
+  );
+  assert.equal(hasRenderedElementWithId("getElementById('cf-ts-container')", 'cf-ts-container'), false);
+  assert.equal(hasRenderedElementWithId('<script>var x = "cf-ts-container";</script>', 'cf-ts-container'), false);
+});
+
+// ── Controles válidos en ambos estados ───────────────────────────────────────
+
+test('smoke-7: la Site key de Preview en Producción falla en ambos estados', () => {
+  for (const [html, expectation] of [[HTML_ENABLED, 'enabled'], [HTML_DISABLED, 'disabled']]) {
+    const contaminated = html.replace(TURNSTILE_SITE_KEY_PRODUCTION, TURNSTILE_SITE_KEY_PREVIEW);
+    const r = analyzeCartCheckoutState(contaminated, expectation);
+    assert.equal(r.ok, false, `esperaba fallo con la key de Preview (${expectation})`);
+    assert.match(r.reason, /Preview/);
+  }
+});
+
+test('smoke-8: un marcador de secreto falla y el motivo nunca incluye el valor', () => {
+  const leaked = HTML_ENABLED.replace('</body>', '<!-- APP_USR-1234567890-abcdef --></body>');
+  const r = analyzeCartCheckoutState(leaked, 'enabled');
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /posible secreto expuesto/);
+  assert.equal(r.reason.includes('1234567890'), false);
+  assert.equal(r.reason.includes('abcdef'), false);
+});
+
+test('smoke-9: si desaparece el cierre por WhatsApp falla en ambos estados', () => {
+  for (const [html, expectation] of [[HTML_ENABLED, 'enabled'], [HTML_DISABLED, 'disabled']]) {
+    const r = analyzeCartCheckoutState(html.replace(WHATSAPP_BUTTON, ''), expectation);
+    assert.equal(r.ok, false);
+    assert.match(r.reason, /WhatsApp/);
+  }
+});
+
+test('smoke-10: falta la Site key Production con el checkout encendido → falla', () => {
+  const r = analyzeCartCheckoutState(HTML_ENABLED.replace(TURNSTILE_SITE_KEY_PRODUCTION, ''), 'enabled');
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /Site key de Turnstile Production/);
+});
+
+test('smoke-11: body vacío falla', () => {
+  assert.equal(analyzeCartCheckoutState('', 'enabled').ok, false);
+  assert.equal(analyzeCartCheckoutState('   ', 'disabled').ok, false);
+});
+
+// ── Validación de SMOKE_EXPECT_CHECKOUT ──────────────────────────────────────
+
+test('smoke-12: SMOKE_EXPECT_CHECKOUT solo acepta "enabled" o "disabled"', () => {
+  assert.deepEqual(resolveCheckoutExpectation('enabled'), { ok: true, value: 'enabled' });
+  assert.deepEqual(resolveCheckoutExpectation('disabled'), { ok: true, value: 'disabled' });
+  assert.deepEqual(resolveCheckoutExpectation('  enabled  '), { ok: true, value: 'enabled' });
+
+  for (const invalid of [undefined, '', 'true', 'false', 'ENABLED', 'on', 'sí', null, 1]) {
+    const r = resolveCheckoutExpectation(invalid);
+    assert.equal(r.ok, false, `esperaba rechazo para ${JSON.stringify(invalid)}`);
+    assert.match(r.reason, /SMOKE_EXPECT_CHECKOUT/);
+  }
+});
+
+test('smoke-13: una expectativa inválida nunca aprueba un HTML', () => {
+  for (const invalid of ['', 'true', 'ENABLED']) {
+    assert.equal(analyzeCartCheckoutState(HTML_ENABLED, invalid).ok, false);
+    assert.equal(analyzeCartCheckoutState(HTML_DISABLED, invalid).ok, false);
+  }
+});

--- a/functions/__tests__/wrangler-config.test.js
+++ b/functions/__tests__/wrangler-config.test.js
@@ -1,8 +1,12 @@
 // Verifica que wrangler.toml, deploy.yml y carrito.astro sigan declarando la
-// configuración de Producción esperada tras 2-N-G2: MP_COLLECTOR_ID
-// confirmado, checkout apagado en ambos niveles (runtime y build), y la site
+// configuración de Producción esperada tras 2-N-H1: MP_COLLECTOR_ID
+// confirmado, checkout ENCENDIDO en ambos niveles (runtime y build), la site
 // key pública de Turnstile de Producción inyectada por build en vez de
-// hardcodeada en el código.
+// hardcodeada en el código, y el smoke post-deploy declarando explícitamente
+// qué estado de checkout espera encontrar.
+//
+// Los dos interruptores deben moverse juntos: si un rollback baja uno solo,
+// estos tests fallan y avisan de la inconsistencia.
 //
 // No hay tests sobre deploy-preview.yml acá a propósito: ese workflow no es
 // actualmente el pipeline efectivo para ningún Preview con checkout (su
@@ -42,8 +46,14 @@ test('wrangler.toml: Producción resuelve MP_COLLECTOR_ID=440298103', () => {
   assert.match(productionVars, /MP_COLLECTOR_ID\s*=\s*"440298103"/);
 });
 
-test('wrangler.toml: CHECKOUT_ENABLED de Producción permanece en false', () => {
-  assert.match(productionVars, /CHECKOUT_ENABLED\s*=\s*"false"/);
+test('wrangler.toml: CHECKOUT_ENABLED de Producción está en true (2-N-H1)', () => {
+  assert.match(productionVars, /CHECKOUT_ENABLED\s*=\s*"true"/);
+});
+
+test('wrangler.toml: Producción conserva APP_ENV, CANONICAL_ORIGIN y ALLOWED_HOSTS intactos', () => {
+  assert.match(productionVars, /APP_ENV\s*=\s*"production"/);
+  assert.match(productionVars, /CANONICAL_ORIGIN\s*=\s*"https:\/\/www\.amadolibros\.com"/);
+  assert.match(productionVars, /ALLOWED_HOSTS\s*=\s*"amadolibros\.com,www\.amadolibros\.com"/);
 });
 
 test('wrangler.toml: Producción no declara secrets (MP_ACCESS_TOKEN, MP_WEBHOOK_SECRET, TURNSTILE_SECRET_KEY)', () => {
@@ -52,8 +62,25 @@ test('wrangler.toml: Producción no declara secrets (MP_ACCESS_TOKEN, MP_WEBHOOK
   assert.doesNotMatch(productionVars, /TURNSTILE_SECRET_KEY/);
 });
 
-test('deploy.yml: build de Producción mantiene PUBLIC_CHECKOUT_ENABLED en false', () => {
-  assert.match(deployYml, /PUBLIC_CHECKOUT_ENABLED:\s*'false'/);
+test('deploy.yml: build de Producción tiene PUBLIC_CHECKOUT_ENABLED en true (2-N-H1)', () => {
+  assert.match(deployYml, /PUBLIC_CHECKOUT_ENABLED:\s*'true'/);
+  assert.doesNotMatch(deployYml, /PUBLIC_CHECKOUT_ENABLED:\s*'false'/);
+});
+
+test('deploy.yml: el smoke post-deploy declara SMOKE_EXPECT_CHECKOUT=enabled', () => {
+  assert.match(deployYml, /SMOKE_EXPECT_CHECKOUT:\s*'enabled'/);
+});
+
+test('deploy.yml: los dos interruptores de checkout coinciden entre sí', () => {
+  // Un rollback a medias (frontend apagado pero smoke esperando "enabled", o
+  // viceversa) haría que el deploy pase el smoke mostrando el estado
+  // equivocado. Los dos valores tienen que moverse juntos.
+  const publicFlag = deployYml.match(/PUBLIC_CHECKOUT_ENABLED:\s*'(true|false)'/);
+  const smokeFlag  = deployYml.match(/SMOKE_EXPECT_CHECKOUT:\s*'(enabled|disabled)'/);
+  assert.ok(publicFlag, 'PUBLIC_CHECKOUT_ENABLED no encontrado en deploy.yml');
+  assert.ok(smokeFlag, 'SMOKE_EXPECT_CHECKOUT no encontrado en deploy.yml');
+  const expectedSmoke = publicFlag[1] === 'true' ? 'enabled' : 'disabled';
+  assert.equal(smokeFlag[1], expectedSmoke);
 });
 
 test('deploy.yml: contiene solamente la site key pública de Turnstile de Producción', () => {

--- a/scripts/smoke-production.js
+++ b/scripts/smoke-production.js
@@ -6,10 +6,21 @@
  * Uses only Node.js 22 native APIs — no external dependencies.
  *
  * Configuration via environment variables:
- *   SMOKE_BASE_URL        default: https://www.amadolibros.com
- *   SMOKE_MAX_ATTEMPTS    default: 6
- *   SMOKE_RETRY_DELAY_MS  default: 10000
- *   SMOKE_TIMEOUT_MS      default: 10000
+ *   SMOKE_BASE_URL          default: https://www.amadolibros.com
+ *   SMOKE_MAX_ATTEMPTS      default: 6
+ *   SMOKE_RETRY_DELAY_MS    default: 10000
+ *   SMOKE_TIMEOUT_MS        default: 10000
+ *   SMOKE_EXPECT_CHECKOUT   required: "enabled" | "disabled"
+ *
+ * SMOKE_EXPECT_CHECKOUT declara en qué estado debe estar el checkout de
+ * Mercado Pago en Producción. El smoke analiza el HTML servido de /carrito/ y
+ * falla si el estado desplegado no coincide. No tiene valor por defecto a
+ * propósito (fail-closed): quien despliega debe declarar explícitamente qué
+ * espera, para que una activación o un rollback nunca pasen inadvertidos.
+ *
+ * Este script solo hace GET. Nunca envía POST, nunca crea órdenes, nunca pide
+ * un token de Turnstile y nunca llama a Mercado Pago. El análisis es sobre el
+ * HTML servido — no ejecuta JavaScript ni simula clics.
  */
 
 'use strict';
@@ -20,6 +31,24 @@ const BASE_URL       = process.env.SMOKE_BASE_URL       || 'https://www.amadolib
 const MAX_ATTEMPTS   = parseInt(process.env.SMOKE_MAX_ATTEMPTS   || '6',     10);
 const RETRY_DELAY_MS = parseInt(process.env.SMOKE_RETRY_DELAY_MS || '10000', 10);
 const TIMEOUT_MS     = parseInt(process.env.SMOKE_TIMEOUT_MS     || '10000', 10);
+
+const VALID_CHECKOUT_EXPECTATIONS = ['enabled', 'disabled'];
+
+// Site keys públicas de Turnstile (no son secretos: viajan en el HTML).
+const TURNSTILE_SITE_KEY_PRODUCTION = '0x4AAAAAAD_Ul8KGae_hdWwj';
+const TURNSTILE_SITE_KEY_PREVIEW    = '0x4AAAAAAD6E9kz8K3comwjj';
+
+// Nombres/prefijos que jamás deben viajar al navegador. Se busca la marca, no
+// el valor: si algo coincide, se reporta la coincidencia sin imprimir nunca el
+// contenido que la rodea.
+const SECRET_MARKERS = [
+  'MP_ACCESS_TOKEN',
+  'MP_WEBHOOK_SECRET',
+  'TURNSTILE_SECRET_KEY',
+  'CLOUDFLARE_API_TOKEN',
+  'APP_USR-',
+  'access_token=',
+];
 
 // Exact property names that must not appear in JSON responses from API routes.
 // Note: "has_error" is intentionally excluded — it is part of the public contract.
@@ -32,6 +61,7 @@ const ROUTES = [
   { path: '/', kind: 'html', canonical: `${BASE_URL}/`, robots: 'index, follow' },
   { path: '/catalogo', kind: 'html', canonical: `${BASE_URL}/catalogo`, robots: 'index, follow' },
   { path: '/catalogo?q=zzzinexistente999', kind: 'html', canonical: `${BASE_URL}/catalogo`, robots: 'noindex' },
+  { path: '/carrito/', kind: 'cart' },
   { path: '/robots.txt', kind: 'robots' },
   { path: '/sitemap.xml', kind: 'sitemap' },
   { path: '/api/health' },
@@ -81,6 +111,111 @@ function hasCanonical(body, expected) {
   return tags.some(tag => tag.includes(`href="${expected}"`));
 }
 
+// ─── Análisis del estado del checkout en /carrito/ ───────────────────────────
+
+function escapeForRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Detecta un elemento HTML realmente renderizado con ese id.
+ *
+ * Deliberadamente NO alcanza con que el id aparezca en cualquier parte del
+ * documento: el bloque <script> del carrito contiene referencias inertes como
+ * document.getElementById('cf-ts-container') incluso cuando el checkout está
+ * apagado y el elemento nunca se renderiza. Por eso se exige la apertura de una
+ * etiqueta (`<div ... id="...")`, y `[^>]*` no puede cruzar un `>`, así que una
+ * cadena suelta dentro del script jamás satisface el patrón.
+ */
+function hasRenderedElementWithId(html, id) {
+  const re = new RegExp(`<[a-zA-Z][a-zA-Z0-9-]*\\s[^>]*id=["']${escapeForRegExp(id)}["']`, 'i');
+  return re.test(html);
+}
+
+function findSecretMarkers(html) {
+  return SECRET_MARKERS.filter(marker => html.includes(marker));
+}
+
+/**
+ * Analiza el HTML servido de /carrito/ contra el estado esperado del checkout.
+ * Función pura: no hace red ni lee el entorno, para poder ejercitarla con
+ * fixtures en los tests sin tocar Producción.
+ *
+ * @param {string} html          HTML crudo de /carrito/
+ * @param {'enabled'|'disabled'} expectation
+ * @returns {{ok: boolean, reason?: string}}
+ */
+function analyzeCartCheckoutState(html, expectation) {
+  if (!VALID_CHECKOUT_EXPECTATIONS.includes(expectation)) {
+    return {
+      ok: false,
+      reason: `SMOKE_EXPECT_CHECKOUT inválido: se esperaba ${VALID_CHECKOUT_EXPECTATIONS.join(' o ')}`,
+    };
+  }
+
+  if (typeof html !== 'string' || html.trim().length === 0) {
+    return { ok: false, reason: 'empty body' };
+  }
+
+  // Controles válidos en ambos estados.
+  const secrets = findSecretMarkers(html);
+  if (secrets.length > 0) {
+    // Nunca se imprime el contenido: solo qué marcador coincidió.
+    return { ok: false, reason: `posible secreto expuesto (marcador: ${secrets.join(', ')})` };
+  }
+  if (html.includes(TURNSTILE_SITE_KEY_PREVIEW)) {
+    return { ok: false, reason: 'la Site key de Turnstile Preview aparece en Producción' };
+  }
+  // El cierre por WhatsApp nunca debe desaparecer: es la vía de compra que
+  // funciona con el checkout online prendido o apagado.
+  if (!hasRenderedElementWithId(html, 'btn-wa-order')) {
+    return { ok: false, reason: 'falta el cierre por WhatsApp (btn-wa-order)' };
+  }
+
+  const marker           = `data-online-checkout="${expectation}"`;
+  const hasPrepareButton = hasRenderedElementWithId(html, 'btn-prepare-order');
+  const hasTurnstileBox  = hasRenderedElementWithId(html, 'cf-ts-container');
+
+  if (!html.includes(marker)) {
+    return { ok: false, reason: `falta ${marker}` };
+  }
+
+  if (expectation === 'enabled') {
+    if (!hasPrepareButton) {
+      return { ok: false, reason: 'falta el botón renderizado id="btn-prepare-order"' };
+    }
+    if (!hasTurnstileBox) {
+      return { ok: false, reason: 'falta el contenedor renderizado de Turnstile (cf-ts-container)' };
+    }
+    if (!html.includes(TURNSTILE_SITE_KEY_PRODUCTION)) {
+      return { ok: false, reason: 'falta la Site key de Turnstile Production' };
+    }
+    return { ok: true };
+  }
+
+  // expectation === 'disabled'
+  if (hasPrepareButton) {
+    return { ok: false, reason: 'btn-prepare-order sigue renderizado con el checkout apagado' };
+  }
+  if (hasTurnstileBox) {
+    return { ok: false, reason: 'el contenedor de Turnstile sigue renderizado con el checkout apagado' };
+  }
+  return { ok: true };
+}
+
+function resolveCheckoutExpectation(rawValue) {
+  const value = typeof rawValue === 'string' ? rawValue.trim() : '';
+  if (!VALID_CHECKOUT_EXPECTATIONS.includes(value)) {
+    return {
+      ok: false,
+      reason:
+        'SMOKE_EXPECT_CHECKOUT debe valer exactamente "enabled" o "disabled" ' +
+        `(recibido: ${value === '' ? '<sin definir>' : JSON.stringify(value)})`,
+    };
+  }
+  return { ok: true, value };
+}
+
 function writeGitHubOutputs(attemptsUsed, result) {
   const outputFile = process.env.GITHUB_OUTPUT;
   if (!outputFile) return;
@@ -90,7 +225,7 @@ function writeGitHubOutputs(attemptsUsed, result) {
 
 // ─── Route validators ─────────────────────────────────────────────────────────
 
-async function checkRoute(path) {
+async function checkRoute(path, checkoutExpectation) {
   const url = BASE_URL + path;
   let resp;
 
@@ -123,6 +258,22 @@ async function checkRoute(path) {
     }
     if (!hasHtmlMeta(body, 'robots', route.robots)) {
       return { ok: false, path, reason: `missing robots meta "${route.robots}"` };
+    }
+    return { ok: true, path };
+  }
+
+  // ── /carrito/ — estado del checkout (solo lectura del HTML) ──────────────
+  if (route && route.kind === 'cart') {
+    if (status !== 200) {
+      return { ok: false, path, reason: `HTTP ${status} (expected 200)` };
+    }
+    if (!hasContentType(resp.headers, 'text/html')) {
+      return { ok: false, path, reason: `Content-Type not text/html (got: ${resp.headers.get('content-type') || 'none'})` };
+    }
+    const body = await resp.text();
+    const analysis = analyzeCartCheckoutState(body, checkoutExpectation);
+    if (!analysis.ok) {
+      return { ok: false, path, reason: `checkout esperado "${checkoutExpectation}": ${analysis.reason}` };
     }
     return { ok: true, path };
   }
@@ -226,10 +377,18 @@ async function checkRoute(path) {
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
+  const expectation = resolveCheckoutExpectation(process.env.SMOKE_EXPECT_CHECKOUT);
+  if (!expectation.ok) {
+    console.error(`[smoke] ${expectation.reason}`);
+    process.exit(1);
+  }
+  const checkoutExpectation = expectation.value;
+
   console.log(`[smoke] Base URL:       ${BASE_URL}`);
   console.log(`[smoke] Max attempts:   ${MAX_ATTEMPTS}`);
   console.log(`[smoke] Retry delay:    ${RETRY_DELAY_MS}ms`);
   console.log(`[smoke] Timeout/route:  ${TIMEOUT_MS}ms`);
+  console.log(`[smoke] Checkout esperado: ${checkoutExpectation}`);
   console.log('');
 
   const lastStatus = {};
@@ -241,7 +400,7 @@ async function main() {
     attemptsUsed = attempt;
     console.log(`[smoke] ── Attempt ${attempt}/${MAX_ATTEMPTS} ─────────────────────────`);
 
-    const results = await Promise.all(ROUTES.map(r => checkRoute(r.path)));
+    const results = await Promise.all(ROUTES.map(r => checkRoute(r.path, checkoutExpectation)));
 
     let allPassed = true;
     for (const r of results) {
@@ -277,4 +436,18 @@ async function main() {
   process.exit(1);
 }
 
-main();
+// Exportado para poder ejercitar el análisis con fixtures en los tests, sin
+// red y sin tocar Producción. El smoke solo corre cuando se invoca el archivo
+// directamente (node scripts/smoke-production.js).
+module.exports = {
+  analyzeCartCheckoutState,
+  resolveCheckoutExpectation,
+  hasRenderedElementWithId,
+  VALID_CHECKOUT_EXPECTATIONS,
+  TURNSTILE_SITE_KEY_PRODUCTION,
+  TURNSTILE_SITE_KEY_PREVIEW,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -50,7 +50,12 @@ binding = "ORDERS_DB"
 database_name = "amadolibros-orders-production"
 database_id = "6dc8dc3a-2d4f-4045-b428-14323c7b0bcd"
 
-# CHECKOUT_ENABLED en "false": el kill switch queda apagado a propósito.
+# CHECKOUT_ENABLED en "true" (2-N-H1): el kill switch queda encendido, así que
+# POST /api/orders y POST /api/preferences aceptan pedidos reales. Para apagar
+# los cobros de forma inmediata, cambiar esta variable a "false" en el
+# dashboard de Cloudflare Pages (Production) — el webhook y /api/orders/status
+# siguen funcionando igual, así que un pago ya iniciado se confirma sin
+# problemas. Ver docs/environments.md, "Procedimiento operativo".
 # MP_COLLECTOR_ID confirmado en 2-N-G2 (440298103) — NO es el número de
 # aplicación de Mercado Pago (6816864196905927, solo informativo, no se usa
 # en runtime). MP_ACCESS_TOKEN, MP_WEBHOOK_SECRET y TURNSTILE_SECRET_KEY
@@ -58,7 +63,7 @@ database_id = "6dc8dc3a-2d4f-4045-b428-14323c7b0bcd"
 # de Cloudflare Pages.
 [env.production.vars]
 APP_ENV           = "production"
-CHECKOUT_ENABLED  = "false"
+CHECKOUT_ENABLED  = "true"
 CANONICAL_ORIGIN  = "https://www.amadolibros.com"
 ALLOWED_HOSTS     = "amadolibros.com,www.amadolibros.com"
 MP_COLLECTOR_ID   = "440298103"


### PR DESCRIPTION
## Lote 2-N-H1

Prepara la activación controlada del checkout de Mercado Pago en Producción.

### Cambios

- habilita CHECKOUT_ENABLED en el entorno Production;
- habilita PUBLIC_CHECKOUT_ENABLED en el build productivo;
- agrega smoke post-deploy consciente del estado enabled/disabled;
- valida que el checkout productivo renderice los controles esperados;
- conserva Turnstile Production y la restricción exacta de hosts;
- actualiza los tests de configuración;
- agrega pruebas específicas del smoke del checkout;
- corrige el texto de estado de /pedido/;
- documenta kill switch, rollback y riesgos operativos.

### Validación

- 231 tests aprobados;
- build local con checkout OFF aprobado;
- build local con checkout ON aprobado;
- smoke distingue correctamente enabled y disabled;
- Site key Preview ausente;
- sin secretos en el repositorio;
- sin llamadas reales a Mercado Pago;
- sin órdenes ni pagos;
- sin escrituras ni migraciones D1;
- sin deploy.

### Importante

Este PR contiene los interruptores en true.

Mergearlo a main disparará el despliegue productivo y hará visible el checkout online.

No mergear sin autorización explícita.
No desplegar manualmente.

### Riesgos operativos conocidos

- no existe reserva automática de stock;
- no existe aviso interno automático de pagos;
- las credenciales LIVE se validarán end-to-end mediante una única compra real controlada después del deploy.