### PR TITLE
2-O-R1 — Validación de checkout antes del deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
   validate:
     name: Syntax & Build
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 15 min (antes 10): el validador compartido ahora corre dos builds
+    # completos (checkout OFF y ON) en vez de uno solo.
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
@@ -35,54 +37,13 @@ jobs:
           cache: npm
           cache-dependency-path: astro-front/package-lock.json
 
-      - name: Check JavaScript syntax
-        shell: bash
-        run: |
-          set -euo pipefail
-          find functions scripts worker-sync \
-            -type f \
-            -name '*.js' \
-            -print0 |
-            xargs -0 -r -n1 node --check
-
-      - name: Test catalog sync
-        run: node --test worker-sync/__tests__/*.test.js
-
-      - name: Test catalog display
-        run: node --test functions/__tests__/*.test.js
-
-      - name: Test Turnstile host matching (carrito.astro)
-        run: node --test astro-front/src/lib/__tests__/*.test.js
-
-      - name: Test orders
-        run: node --test functions/api/__tests__/orders.test.js
-
-      - name: Test preferences
-        run: node --test functions/api/__tests__/preferences.test.js
-
-      - name: Test MP webhook
-        run: node --test functions/api/__tests__/mp_webhook.test.js
-
-      - name: Test order status
-        run: node --test functions/api/__tests__/order_status.test.js
-
-      - name: Install Astro dependencies
-        working-directory: astro-front
-        run: npm ci --no-audit --no-fund
-
-      - name: Build production configuration
-        working-directory: astro-front
-        env:
-          PUBLIC_INDEXABLE: 'true'
-          PUBLIC_GA_ID: G-SDX45VEPP3
-          PUBLIC_CHECKOUT_ENABLED: 'false'
-        run: npm run build
-
-      - name: Confirm production checkout remains hidden
-        run: |
-          grep -q 'data-online-checkout="disabled"' astro-front/dist/carrito/index.html
-          ! grep -q 'id="btn-prepare-order"' astro-front/dist/carrito/index.html
-          ! grep -q 'id="btn-pay-mp"' astro-front/dist/carrito/index.html
+      # Único punto de verdad de la validación — el mismo script corre acá y
+      # en el job `validate` de deploy.yml (ver ese archivo). Cubre sintaxis,
+      # la suite completa, build con checkout OFF y build con checkout ON con
+      # la configuración pública de Turnstile de Producción. Ver
+      # scripts/validate-ci.sh para el detalle de cada paso.
+      - name: Validate (shared script — syntax, tests, both checkout builds)
+        run: bash scripts/validate-ci.sh
 
       - name: Check pull request diff
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,34 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Misma barrera que corre en cada PR (.github/workflows/ci.yml), invocando
+  # el mismo script — nunca una copia aparte que pueda desviarse. El build
+  # real de más abajo (job `deploy`) no arranca si este job falla: un PR
+  # pudo haber sido aprobado hace tiempo y el checkout de main pudo cambiar
+  # entretanto, así que esto vuelve a probar sintaxis, la suite completa y
+  # ambos modos de checkout contra el commit que realmente se va a desplegar.
+  validate:
+    name: Validate before deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: astro-front/package-lock.json
+
+      - name: Validate (shared script — syntax, tests, both checkout builds)
+        run: bash scripts/validate-ci.sh
+
   deploy:
     name: Deploy
+    needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -43,6 +69,12 @@ jobs:
         working-directory: astro-front
         run: npm ci --no-audit --no-fund
 
+      - name: Load production Turnstile config
+        id: ts_config
+        # Misma fuente que ya validó el job `validate` — nunca un literal
+        # aparte en este YAML que pueda desviarse del que se acaba de probar.
+        run: bash scripts/validate-ci.sh --print-turnstile-config >> "$GITHUB_OUTPUT"
+
       - name: Build Astro
         working-directory: astro-front
         env:
@@ -53,10 +85,8 @@ jobs:
           # (CHECKOUT_ENABLED en wrangler.toml) — los dos deben estar en true
           # para que se pueda cobrar.
           PUBLIC_CHECKOUT_ENABLED: 'true'
-          # Site key pública de Turnstile Production (no es secreto, puede
-          # versionarse) y los hosts exactos donde se acepta.
-          PUBLIC_TURNSTILE_SITE_KEY: '0x4AAAAAAD_Ul8KGae_hdWwj'
-          PUBLIC_TURNSTILE_ALLOWED_HOSTS: 'amadolibros.com,www.amadolibros.com'
+          PUBLIC_TURNSTILE_SITE_KEY: ${{ steps.ts_config.outputs.site_key }}
+          PUBLIC_TURNSTILE_ALLOWED_HOSTS: ${{ steps.ts_config.outputs.allowed_hosts }}
         run: npm run build
 
       - name: Deploy via Wrangler

--- a/functions/__tests__/wrangler-config.test.js
+++ b/functions/__tests__/wrangler-config.test.js
@@ -8,6 +8,12 @@
 // Los dos interruptores deben moverse juntos: si un rollback baja uno solo,
 // estos tests fallan y avisan de la inconsistencia.
 //
+// Desde 2-O-R1 también verifica la barrera de validación compartida entre
+// ci.yml y deploy.yml (scripts/validate-ci.sh): que el job `deploy` no pueda
+// arrancar sin `needs: validate`, y que ninguno de los dos workflows vuelva a
+// hardcodear la site key de Turnstile por su cuenta — scripts/validate-ci.sh
+// es la única fuente de verdad de ese valor.
+//
 // No hay tests sobre deploy-preview.yml acá a propósito: ese workflow no es
 // actualmente el pipeline efectivo para ningún Preview con checkout (su
 // trigger sigue limitado a la rama `astro-migration`, sin código de pagos),
@@ -22,8 +28,10 @@ import path from 'node:path';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-const wranglerToml = readFileSync(path.join(ROOT, 'wrangler.toml'), 'utf8');
-const deployYml = readFileSync(path.join(ROOT, '.github', 'workflows', 'deploy.yml'), 'utf8');
+const wranglerToml   = readFileSync(path.join(ROOT, 'wrangler.toml'), 'utf8');
+const deployYml      = readFileSync(path.join(ROOT, '.github', 'workflows', 'deploy.yml'), 'utf8');
+const ciYml          = readFileSync(path.join(ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
+const validateCiSh   = readFileSync(path.join(ROOT, 'scripts', 'validate-ci.sh'), 'utf8');
 const carritoAstro = readFileSync(
   path.join(ROOT, 'astro-front', 'src', 'pages', 'carrito.astro'),
   'utf8',
@@ -31,6 +39,7 @@ const carritoAstro = readFileSync(
 
 const PRODUCTION_SITE_KEY = '0x4AAAAAAD_Ul8KGae_hdWwj';
 const PREVIEW_SITE_KEY = '0x4AAAAAAD6E9kz8K3comwjj';
+const VALIDATE_SCRIPT_INVOCATION = /bash\s+scripts\/validate-ci\.sh\b/;
 
 function extractTomlSection(toml, header) {
   const start = toml.indexOf(header);
@@ -83,16 +92,65 @@ test('deploy.yml: los dos interruptores de checkout coinciden entre sí', () => 
   assert.equal(smokeFlag[1], expectedSmoke);
 });
 
-test('deploy.yml: contiene solamente la site key pública de Turnstile de Producción', () => {
-  assert.match(deployYml, new RegExp(`PUBLIC_TURNSTILE_SITE_KEY:\\s*'${PRODUCTION_SITE_KEY}'`));
+test('deploy.yml: no hardcodea la site key de Turnstile — la toma del script compartido', () => {
+  // Desde 2-O-R1 el build real del deploy carga estos dos valores del
+  // step "Load production Turnstile config" (steps.ts_config.outputs), que
+  // a su vez corre `scripts/validate-ci.sh --print-turnstile-config` — nunca
+  // un literal aparte en este YAML que pudiera desviarse del que el job
+  // `validate` ya probó.
+  assert.match(deployYml, /PUBLIC_TURNSTILE_SITE_KEY:\s*\$\{\{\s*steps\.ts_config\.outputs\.site_key\s*\}\}/);
+  assert.match(deployYml, /PUBLIC_TURNSTILE_ALLOWED_HOSTS:\s*\$\{\{\s*steps\.ts_config\.outputs\.allowed_hosts\s*\}\}/);
+  assert.doesNotMatch(deployYml, new RegExp(`PUBLIC_TURNSTILE_SITE_KEY:\\s*'${PRODUCTION_SITE_KEY}'`));
   assert.doesNotMatch(deployYml, new RegExp(PREVIEW_SITE_KEY));
 });
 
-test('deploy.yml: restringe Turnstile a los hosts de Producción', () => {
-  assert.match(
-    deployYml,
-    /PUBLIC_TURNSTILE_ALLOWED_HOSTS:\s*'amadolibros\.com,www\.amadolibros\.com'/,
-  );
+test('deploy.yml: carga la config de Turnstile ejecutando el script compartido con --print-turnstile-config', () => {
+  assert.match(deployYml, /scripts\/validate-ci\.sh\s+--print-turnstile-config/);
+});
+
+test('scripts/validate-ci.sh: única fuente de verdad de la site key de Producción y sus hosts', () => {
+  assert.match(validateCiSh, new RegExp(`PRODUCTION_TURNSTILE_SITE_KEY='${PRODUCTION_SITE_KEY}'`));
+  assert.match(validateCiSh, /PRODUCTION_TURNSTILE_ALLOWED_HOSTS='amadolibros\.com,www\.amadolibros\.com'/);
+  assert.match(validateCiSh, new RegExp(`PREVIEW_TURNSTILE_SITE_KEY='${PREVIEW_SITE_KEY}'`));
+});
+
+test('scripts/validate-ci.sh: --print-turnstile-config no ejecuta tests ni builds (solo imprime)', () => {
+  assert.match(validateCiSh, /--print-turnstile-config/);
+  // El bloque del flag debe salir (exit 0) antes de llegar a los pasos de
+  // sintaxis/tests/build — si alguien borra ese `exit 0`, --print-turnstile-config
+  // dejaría de ser liviano y correría toda la validación solo para leer dos
+  // strings, además de dejar un directorio dist/ a medio construir en un step
+  // que solo debería poblar variables de entorno.
+  const flagIdx = validateCiSh.indexOf('--print-turnstile-config"');
+  const exitIdx = validateCiSh.indexOf('exit 0', flagIdx);
+  const syntaxStepIdx = validateCiSh.indexOf('Sintaxis JS');
+  assert.ok(flagIdx !== -1 && exitIdx !== -1 && syntaxStepIdx !== -1);
+  assert.ok(exitIdx < syntaxStepIdx, 'el flag debe salir antes del paso de sintaxis/tests/builds');
+});
+
+// ── Barrera de validación antes del deploy (2-O-R1) ─────────────────────────
+
+test('deploy.yml: el job "deploy" no puede arrancar sin needs: validate', () => {
+  const deployJobIdx = deployYml.indexOf('\n  deploy:');
+  assert.notEqual(deployJobIdx, -1, 'job "deploy" no encontrado en deploy.yml');
+  const deployJobBlock = deployYml.slice(deployJobIdx, deployJobIdx + 200);
+  assert.match(deployJobBlock, /needs:\s*validate/);
+});
+
+test('deploy.yml: existe un job "validate" que corre el script compartido', () => {
+  const validateJobIdx = deployYml.indexOf('\n  validate:');
+  assert.notEqual(validateJobIdx, -1, 'job "validate" no encontrado en deploy.yml');
+  const validateJobBlock = deployYml.slice(validateJobIdx, deployYml.indexOf('\n  deploy:'));
+  assert.match(validateJobBlock, VALIDATE_SCRIPT_INVOCATION);
+});
+
+test('ci.yml y deploy.yml invocan exactamente el mismo script de validación', () => {
+  assert.match(ciYml, VALIDATE_SCRIPT_INVOCATION);
+  assert.match(deployYml, VALIDATE_SCRIPT_INVOCATION);
+  // Ninguno de los dos debe seguir teniendo su propia copia de los pasos de
+  // sintaxis/tests — eso es exactamente lo que se dejó de duplicar.
+  assert.doesNotMatch(ciYml, /node --check/);
+  assert.doesNotMatch(deployYml, /node --check/);
 });
 
 test('carrito.astro: no contiene ninguna site key de Turnstile hardcodeada', () => {

--- a/scripts/validate-ci.sh
+++ b/scripts/validate-ci.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# scripts/validate-ci.sh — validador único de CI y pre-deploy.
+#
+# Este script es la única fuente de verdad de lo que significa "el checkout
+# está bien" antes de dejar avanzar un build hacia Producción. Lo invocan dos
+# workflows distintos (.github/workflows/ci.yml en cada PR, y el job
+# `validate` de .github/workflows/deploy.yml antes de cada deploy a main) —
+# si algún día divergieran (uno revisando checkout ON y otro no, o con site
+# keys distintas), un PR podría pasar CI en verde y romper igual el deploy.
+# Correr exactamente el mismo script en los dos lugares es lo que evita esa
+# divergencia: cualquier cambio a la validación se edita acá una sola vez.
+#
+# Modos:
+#   scripts/validate-ci.sh                      → corre toda la validación.
+#   scripts/validate-ci.sh --print-turnstile-config
+#       → imprime en formato GITHUB_OUTPUT (site_key=..., allowed_hosts=...)
+#         los valores públicos de Turnstile de Producción, sin correr nada
+#         más. Lo usa el job `deploy` para construir el build real que se
+#         despliega con los MISMOS valores que este script ya validó — nunca
+#         un segundo literal copiado a mano en el YAML que pueda desviarse.
+#
+# No toca D1, no llama a Mercado Pago, no llama al servicio real de
+# Turnstile — los tokens de Turnstile en los tests son siempre mocks.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ── Configuración pública de Turnstile — única fuente de verdad ─────────────
+# La site key no es secreta (viaja en el HTML); el secret vive solo en
+# Cloudflare Pages y nunca se declara acá.
+readonly PRODUCTION_TURNSTILE_SITE_KEY='0x4AAAAAAD_Ul8KGae_hdWwj'
+readonly PRODUCTION_TURNSTILE_ALLOWED_HOSTS='amadolibros.com,www.amadolibros.com'
+readonly PREVIEW_TURNSTILE_SITE_KEY='0x4AAAAAAD6E9kz8K3comwjj'
+
+if [[ "${1:-}" == "--print-turnstile-config" ]]; then
+  echo "site_key=${PRODUCTION_TURNSTILE_SITE_KEY}"
+  echo "allowed_hosts=${PRODUCTION_TURNSTILE_ALLOWED_HOSTS}"
+  exit 0
+fi
+
+step() { printf '\n[validate-ci] ── %s ──────────────────────────\n' "$1"; }
+
+# Detecta un elemento HTML realmente renderizado con ese id — igual que
+# hasRenderedElementWithId() en scripts/smoke-production.js. No alcanza con
+# que el id aparezca en cualquier parte del documento: el bloque <script> de
+# carrito.astro tiene referencias inertes como
+# document.getElementById('cf-ts-container') incluso con el checkout
+# apagado, cuando el elemento nunca se renderiza.
+has_rendered_element_with_id() {
+  local file="$1" id="$2"
+  grep -Eq "<[a-zA-Z][a-zA-Z0-9-]*[[:space:]][^>]*id=[\"']${id}[\"']" "$file"
+}
+
+# ── 1. Sintaxis ───────────────────────────────────────────────────────────
+step "Sintaxis JS (functions, scripts, worker-sync)"
+find functions scripts worker-sync -type f -name '*.js' -print0 |
+  xargs -0 -r -n1 node --check
+
+# ── 2. Suite completa ─────────────────────────────────────────────────────
+step "Suite completa de tests"
+node --test worker-sync/__tests__/*.test.js
+node --test functions/__tests__/*.test.js
+node --test astro-front/src/lib/__tests__/*.test.js
+node --test functions/api/__tests__/*.test.js
+
+# ── 3. Dependencias de Astro ──────────────────────────────────────────────
+step "Instalar dependencias de astro-front"
+(cd astro-front && npm ci --no-audit --no-fund)
+
+# ── 4. Build con checkout OFF ─────────────────────────────────────────────
+step "Build — checkout OFF"
+(
+  cd astro-front
+  rm -rf dist
+  PUBLIC_INDEXABLE=true \
+  PUBLIC_GA_ID=G-SDX45VEPP3 \
+  PUBLIC_CHECKOUT_ENABLED=false \
+  PUBLIC_TURNSTILE_SITE_KEY="$PRODUCTION_TURNSTILE_SITE_KEY" \
+  PUBLIC_TURNSTILE_ALLOWED_HOSTS="$PRODUCTION_TURNSTILE_ALLOWED_HOSTS" \
+  npm run build
+)
+
+CART_OFF=astro-front/dist/carrito/index.html
+test -f "$CART_OFF"
+grep -q 'data-online-checkout="disabled"' "$CART_OFF"
+! has_rendered_element_with_id "$CART_OFF" 'btn-prepare-order'
+! has_rendered_element_with_id "$CART_OFF" 'btn-pay-mp'
+! has_rendered_element_with_id "$CART_OFF" 'cf-ts-container'
+has_rendered_element_with_id "$CART_OFF" 'btn-wa-order'
+echo "  OK: checkout apagado — sin controles de pago, WhatsApp presente."
+
+rm -rf astro-front/dist
+
+# ── 5. Build con checkout ON ──────────────────────────────────────────────
+step "Build — checkout ON (config pública de Turnstile igual a Producción)"
+(
+  cd astro-front
+  rm -rf dist
+  PUBLIC_INDEXABLE=true \
+  PUBLIC_GA_ID=G-SDX45VEPP3 \
+  PUBLIC_CHECKOUT_ENABLED=true \
+  PUBLIC_TURNSTILE_SITE_KEY="$PRODUCTION_TURNSTILE_SITE_KEY" \
+  PUBLIC_TURNSTILE_ALLOWED_HOSTS="$PRODUCTION_TURNSTILE_ALLOWED_HOSTS" \
+  npm run build
+)
+
+CART_ON=astro-front/dist/carrito/index.html
+test -f "$CART_ON"
+grep -q 'data-online-checkout="enabled"' "$CART_ON"
+has_rendered_element_with_id "$CART_ON" 'btn-prepare-order'
+has_rendered_element_with_id "$CART_ON" 'cf-ts-container'
+has_rendered_element_with_id "$CART_ON" 'btn-wa-order'
+grep -q "$PRODUCTION_TURNSTILE_SITE_KEY" "$CART_ON"
+! grep -q "$PREVIEW_TURNSTILE_SITE_KEY" "$CART_ON"
+echo "  OK: checkout encendido — controles y Turnstile de Producción presentes, Preview ausente."
+
+rm -rf astro-front/dist
+
+step "Validación completa OK"


### PR DESCRIPTION
- CI y pre-deploy usan el mismo validador.
- Se ejecutan sintaxis, suite completa y builds checkout OFF y ON.
- El deploy queda bloqueado mediante `needs: validate` si falla cualquier validación.
- La configuración pública de Turnstile se comparte sin duplicarla en los workflows.
- Resultado local informado y verificado: 236/236 pruebas aprobadas.
- YAML, Bash y `git diff --check` aprobados.
- No se tocó webhook, D1, idempotencia, Mercado Pago, precios, stock ni endpoints.