### PR TITLE
2-N-I1 — Checkout single-step

### DIFF
--- a/astro-front/public/orders-guard.js
+++ b/astro-front/public/orders-guard.js
@@ -87,8 +87,16 @@
     if (!validation) return;
     event.preventDefault();
     event.stopImmediatePropagation();
-    window.alert(validation.message);
-    focusField(validation.field);
+    // carrito.astro expone este hook para mostrar el error debajo del campo
+    // (accesible, sin bloquear la pantalla) — si por algún motivo no está
+    // disponible (script no cargado todavía, u otra página), alert() sigue
+    // funcionando como respaldo.
+    if (typeof window.__amadoCheckoutShowFieldError === 'function') {
+      window.__amadoCheckoutShowFieldError(validation.field, validation.message);
+    } else {
+      window.alert(validation.message);
+      focusField(validation.field);
+    }
   }, true);
 
   var nativeFetch = window.fetch.bind(window);

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -96,18 +96,23 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
               <label for="delivery-address" class="form-label">Dirección <span class="form-req" aria-hidden="true">*</span></label>
               <input type="text" id="delivery-address" class="form-input"
                 placeholder="Ej: Av. Italia 2000, Apto 3"
-                autocomplete="shipping street-address">
+                autocomplete="shipping street-address"
+                aria-describedby="err-delivery-address">
+              <span class="field-error" id="err-delivery-address" role="alert" hidden></span>
             </div>
             <div class="form-field">
               <label for="delivery-barrio" class="form-label">Barrio / Localidad</label>
               <input type="text" id="delivery-barrio" class="form-input"
                 placeholder="Ej: Pocitos, Centro, Malvín"
-                autocomplete="shipping address-level3">
+                autocomplete="shipping address-level3"
+                aria-describedby="err-delivery-barrio">
+              <span class="field-error" id="err-delivery-barrio" role="alert" hidden></span>
             </div>
             <div class="form-field">
               <label for="delivery-departamento" class="form-label">Departamento <span class="form-req" aria-hidden="true">*</span></label>
               <select id="delivery-departamento" class="form-input"
-                autocomplete="shipping address-level1">
+                autocomplete="shipping address-level1"
+                aria-describedby="err-delivery-departamento">
                 <option value="">Seleccioná tu departamento</option>
                 <option>Artigas</option>
                 <option>Canelones</option>
@@ -129,19 +134,24 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
                 <option>Tacuarembó</option>
                 <option>Treinta y Tres</option>
               </select>
+              <span class="field-error" id="err-delivery-departamento" role="alert" hidden></span>
             </div>
             <div class="form-field">
               <label for="delivery-date" class="form-label">Fecha preferida</label>
-              <input type="date" id="delivery-date" class="form-input" autocomplete="off">
+              <input type="date" id="delivery-date" class="form-input" autocomplete="off"
+                aria-describedby="err-delivery-date">
+              <span class="field-error" id="err-delivery-date" role="alert" hidden></span>
             </div>
             <div class="form-row">
               <div class="form-field">
                 <label for="delivery-from" class="form-label">Desde <span class="form-req" aria-hidden="true">*</span></label>
-                <input type="time" id="delivery-from" class="form-input">
+                <input type="time" id="delivery-from" class="form-input" aria-describedby="err-delivery-from">
+                <span class="field-error" id="err-delivery-from" role="alert" hidden></span>
               </div>
               <div class="form-field">
                 <label for="delivery-to" class="form-label">Hasta <span class="form-req" aria-hidden="true">*</span></label>
-                <input type="time" id="delivery-to" class="form-input">
+                <input type="time" id="delivery-to" class="form-input" aria-describedby="err-delivery-to">
+                <span class="field-error" id="err-delivery-to" role="alert" hidden></span>
               </div>
             </div>
             <div class="form-field">
@@ -159,59 +169,74 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
           <div class="form-grid">
             <div class="form-field">
               <label for="buyer-name" class="form-label">Nombre</label>
-              <input type="text" id="buyer-name" class="form-input" autocomplete="name">
+              <input type="text" id="buyer-name" class="form-input" autocomplete="name"
+                aria-describedby="err-buyer-name">
+              <span class="field-error" id="err-buyer-name" role="alert" hidden></span>
             </div>
             <div class="form-field">
               <label for="buyer-phone" class="form-label">WhatsApp / Teléfono</label>
               <input type="tel" id="buyer-phone" class="form-input"
                 placeholder="Ej: 099 123 456"
                 autocomplete="tel"
-                inputmode="tel">
+                inputmode="tel"
+                aria-describedby="err-buyer-phone">
+              <span class="field-error" id="err-buyer-phone" role="alert" hidden></span>
             </div>
           </div>
         </section>
 
-        <!-- Acciones de pago -->
-        <section class="cart-pay-section">
+        <!-- Acciones de pago — pantalla única: un solo botón principal -->
+        <section class="cart-pay-section" aria-label="Confirmar y pagar">
           {checkoutEnabled && <div id="cf-ts-container"></div>}
+
+          <div id="checkout-error" class="checkout-error" role="alert" hidden></div>
+
           {checkoutEnabled && (
-            <button type="button" id="btn-prepare-order" class="btn-prepare-order">
+            <div class="checkout-sticky-total" aria-hidden="true">
+              <span class="checkout-sticky-total-label">Total</span>
+              <strong id="checkout-sticky-total-value">$&nbsp;0</strong>
+            </div>
+          )}
+
+          {checkoutEnabled ? (
+            <button type="button" id="btn-prepare-order" class="btn-checkout-primary" aria-describedby="checkout-error">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" stroke-width="2" aria-hidden="true">
                 <rect x="1" y="4" width="22" height="16" rx="2" ry="2"/>
                 <line x1="1" y1="10" x2="23" y2="10"/>
               </svg>
-              Preparar pago online
+              <span class="btn-checkout-primary-text">Continuar a Mercado Pago</span>
+            </button>
+          ) : (
+            <button type="button" id="btn-wa-order" class="btn-wa-order">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z"/>
+              </svg>
+              Enviar pedido por WhatsApp
             </button>
           )}
+
           {checkoutEnabled && (
-            <p class="pay-note">
-              Registramos tu pedido y te contactamos por WhatsApp para coordinar
-              el pago y la entrega.
+            <>
+              <p class="checkout-reassurance">
+                Vas a pagar en el sitio seguro de Mercado Pago. Tu carrito se
+                mantiene hasta que el pago quede aprobado.
+              </p>
+              <button type="button" id="btn-wa-order" class="btn-wa-secondary">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z"/>
+                </svg>
+                O coordinar por WhatsApp
+              </button>
+            </>
+          )}
+
+          {!checkoutEnabled && (
+            <p class="checkout-reassurance">
+              No pagás ahora. Te enviamos los datos para transferencia o un link de Mercado Pago.
             </p>
           )}
-          <button type="button" id="btn-wa-order" class="btn-wa-order">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z"/>
-            </svg>
-            Enviar pedido por WhatsApp
-          </button>
-          <p class="checkout-reassurance">
-            No pagás ahora. Te enviamos los datos para transferencia o un link de Mercado Pago.
-          </p>
         </section>
-
-        {checkoutEnabled && (
-          <div id="order-result" class="order-result" hidden>
-            <p class="order-result-h">Pedido preparado</p>
-            <p>Código: <strong id="order-public-code"></strong></p>
-            <p>Total confirmado: <strong id="order-total-confirmed"></strong></p>
-            <p id="order-result-note" class="order-result-note">El pago online se habilitará en la siguiente etapa.</p>
-            <button type="button" id="btn-pay-mp" class="btn-pay-mp" hidden>
-              Pagar con Mercado Pago
-            </button>
-          </div>
-        )}
 
       </div><!-- /#cart-content -->
     </div><!-- /.cart-wrap -->
@@ -424,6 +449,17 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     border-color: var(--salmon);
   }
 
+  .form-input[aria-invalid="true"] {
+    border-color: #b42318;
+  }
+
+  .field-error {
+    display: block;
+    font-size: 0.78rem;
+    color: #b42318;
+    line-height: 1.4;
+  }
+
   .form-row {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -442,15 +478,40 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     margin-top: 0.25rem;
   }
 
-  /* ── Sección de pago ───────────────────────────── */
+  /* ── Sección de pago — pantalla única ──────────── */
   .cart-pay-section {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.75rem;
     padding-top: 0.5rem;
   }
 
-  .btn-prepare-order {
+  .checkout-error {
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    color: #b42318;
+    border-radius: var(--r);
+    padding: 0.75rem 1rem;
+    font-size: 0.85rem;
+    line-height: 1.5;
+  }
+
+  /* Mini-total mostrado junto al CTA — solo visible en la barra sticky de
+     mobile (ver media query más abajo); en flujo normal/desktop queda oculto
+     porque el resumen detallado ya está visible más arriba. */
+  .checkout-sticky-total {
+    display: none;
+    align-items: baseline;
+    justify-content: space-between;
+    font-size: 0.85rem;
+    color: var(--ink-2);
+  }
+  .checkout-sticky-total strong {
+    font-size: 1.1rem;
+    color: var(--ink);
+  }
+
+  .btn-checkout-primary {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -465,33 +526,43 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     font-weight: 700;
     cursor: pointer;
     width: 100%;
+    min-height: 48px;
     transition: background 0.15s;
   }
-  .btn-prepare-order:hover { background: var(--salmon-hover); }
-  .btn-prepare-order:disabled {
+  .btn-checkout-primary:hover { background: var(--salmon-hover); }
+  .btn-checkout-primary:disabled {
     background: #9ca3af;
     cursor: not-allowed;
   }
-
-  .order-result {
-    background: #f0fdf4;
-    border: 1px solid #86efac;
-    border-radius: var(--r);
-    padding: 1rem 1.25rem;
-    margin-top: 0.5rem;
+  .btn-checkout-primary:focus-visible {
+    outline: 3px solid var(--ink);
+    outline-offset: 3px;
   }
 
-  .order-result-h {
-    font-weight: 700;
-    color: #166534;
-    font-size: 1rem;
-    margin-bottom: 0.4rem;
-  }
-
-  .order-result-note {
+  /* WhatsApp como alternativa secundaria — nunca compite visualmente con el
+     botón principal de pago. */
+  .btn-wa-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 0.6rem 1rem;
+    background: transparent;
+    color: var(--ink-2);
+    border: none;
+    font-family: var(--font-ui);
     font-size: 0.82rem;
-    color: #15803d;
-    margin-top: 0.4rem;
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    cursor: pointer;
+    min-height: 44px;
+    align-self: center;
+  }
+  .btn-wa-secondary:hover { color: var(--ink); }
+  .btn-wa-secondary:focus-visible {
+    outline: 2px solid var(--ink);
+    outline-offset: 2px;
   }
 
   .cart-shipping-cost-line {
@@ -505,13 +576,6 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     border-top: 1px solid var(--border);
     padding-top: 0.2rem;
     margin-top: 0.1rem;
-  }
-
-  .pay-note {
-    font-size: 0.875rem;
-    color: var(--ink-2);
-    line-height: 1.5;
-    text-align: center;
   }
 
   .btn-wa-order {
@@ -716,26 +780,35 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     color: #267a42;
   }
 
-  .btn-pay-mp {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    padding: 0.75rem 1.25rem;
-    background: #009ee3;
-    color: #fff;
-    border: none;
-    border-radius: var(--r);
-    font-family: var(--font-ui);
-    font-size: 0.9rem;
-    font-weight: 700;
-    cursor: pointer;
-    width: 100%;
-    margin-top: 0.75rem;
-    transition: background 0.15s;
+  /* ── Barra inferior sticky (mobile, checkout ON) ──────────────────────
+     position: sticky (no fixed): se ancla al fondo del viewport mientras se
+     recorre #cart-content, y se libera naturalmente al llegar al final de su
+     propio contenedor — por construcción nunca tapa el footer ni WAFloat,
+     sin necesidad de reservar padding extra. También evita los problemas de
+     `position: fixed` con el teclado virtual en iOS/Android. */
+  @media (max-width: 640px) {
+    .cart-page[data-online-checkout="enabled"] .cart-pay-section {
+      position: sticky;
+      bottom: 0;
+      z-index: 10;
+      background: var(--bg);
+      border-top: 1px solid var(--border);
+      box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.06);
+      padding: 0.75rem 1rem calc(0.75rem + env(safe-area-inset-bottom, 0px));
+      margin: 0 -1rem;
+    }
+
+    .cart-page[data-online-checkout="enabled"] .checkout-sticky-total {
+      display: flex;
+    }
+
+    /* La burbuja flotante de WhatsApp (WAFloat, fuera de <main>) competiría
+       visualmente con la barra sticky que ya incluye su propia alternativa
+       de WhatsApp — se oculta solo en este caso puntual. */
+    .cart-page[data-online-checkout="enabled"] ~ :global(.wa-float) {
+      display: none;
+    }
   }
-  .btn-pay-mp:hover { background: #0087c6; }
-  .btn-pay-mp:disabled { background: #9ca3af; cursor: not-allowed; }
 </style>
 
 <script is:inline define:vars={{ turnstileSiteKey, turnstileAllowedHosts }}>
@@ -864,6 +937,8 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     var shippingCostEl       = document.getElementById('cart-shipping-cost');
     var totalShippingLineEl  = document.getElementById('cart-total-shipping-line');
     var totalShippingEl      = document.getElementById('cart-total-shipping');
+    var stickyTotalEl        = document.getElementById('checkout-sticky-total-value');
+    var checkoutErrorEl      = document.getElementById('checkout-error');
 
     // ── Formato moneda ───────────────────────────────────────────────────
     var fmt = new Intl.NumberFormat('es-UY', {
@@ -875,6 +950,44 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       if (!announceEl) return;
       announceEl.textContent = '';
       setTimeout(function () { announceEl.textContent = msg; }, 50);
+    }
+
+    // ── Errores de campo (accesibles, nunca alert()) ─────────────────────
+    // Expuesto en window para que orders-guard.js (guardia global e
+    // independiente de este script) pueda mostrar el mismo tipo de error
+    // inline en vez de un alert() bloqueante, sin duplicar esta lógica.
+    function clearFieldErrors() {
+      var errs = document.querySelectorAll('.field-error');
+      for (var i = 0; i < errs.length; i++) { errs[i].hidden = true; errs[i].textContent = ''; }
+      var invalids = document.querySelectorAll('[aria-invalid="true"]');
+      for (var j = 0; j < invalids.length; j++) { invalids[j].removeAttribute('aria-invalid'); }
+    }
+    function showFieldError(fieldId, message) {
+      var field = document.getElementById(fieldId);
+      var errEl = document.getElementById('err-' + fieldId);
+      if (errEl) { errEl.textContent = message; errEl.hidden = false; }
+      if (field) {
+        field.setAttribute('aria-invalid', 'true');
+        if (typeof field.scrollIntoView === 'function') {
+          field.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+        field.focus();
+      }
+    }
+    window.__amadoCheckoutShowFieldError = showFieldError;
+    window.__amadoCheckoutClearFieldErrors = clearFieldErrors;
+
+    // ── Error general del checkout (Turnstile, red, servidor) ────────────
+    function clearCheckoutError() {
+      if (checkoutErrorEl) { checkoutErrorEl.hidden = true; checkoutErrorEl.textContent = ''; }
+    }
+    function showCheckoutError(message) {
+      if (!checkoutErrorEl) { alert(message); return; }
+      checkoutErrorEl.textContent = message;
+      checkoutErrorEl.hidden = false;
+      if (typeof checkoutErrorEl.scrollIntoView === 'function') {
+        checkoutErrorEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
     }
 
     // ── Tipo de entrega ──────────────────────────────────────────────────
@@ -902,6 +1015,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         if (shippingCostLineEl)  shippingCostLineEl.hidden  = true;
         if (totalShippingLineEl) totalShippingLineEl.hidden = true;
         if (shippingMsgEl)       shippingMsgEl.hidden       = true;
+        if (stickyTotalEl)       stickyTotalEl.textContent  = fmt.format(total);
       } else {
         var shippingCost      = subtotal < FREE_SHIPPING_THRESHOLD_UYU ? SHIPPING_COST : 0;
         var totalWithShipping = subtotal + shippingCost;
@@ -918,6 +1032,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
           if (totalShippingEl) totalShippingEl.textContent = fmt.format(totalWithShipping);
         }
         if (shippingMsgEl) shippingMsgEl.hidden = true;
+        if (stickyTotalEl) stickyTotalEl.textContent = fmt.format(totalWithShipping);
       }
     }
 
@@ -1154,50 +1269,34 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       });
     }
 
-    // ── Pagar con Mercado Pago ────────────────────────────────────────────────
-    var mpPublicCode     = null;
-    var mpIdempotencyKey = null;
-    var btnPayMp         = document.getElementById('btn-pay-mp');
-
-    if (btnPayMp) {
-      btnPayMp.addEventListener('click', async function () {
-        if (!mpPublicCode || !mpIdempotencyKey) return;
-        btnPayMp.disabled    = true;
-        btnPayMp.textContent = 'Iniciando pago…';
-        try {
-          var mpResp = await fetch('/api/preferences', {
-            method:  'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body:    JSON.stringify({ public_code: mpPublicCode, idempotency_key: mpIdempotencyKey }),
-          });
-          var mpData = await mpResp.json();
-          if (mpResp.ok && mpData.checkout_url) {
-            try {
-              sessionStorage.setItem('amado-mp-auth', JSON.stringify({
-                public_code:     mpPublicCode,
-                idempotency_key: mpIdempotencyKey,
-              }));
-            } catch (_) {}
-            window.location.href = mpData.checkout_url;
-            return;
-          }
-          alert('Error al iniciar el pago: ' + (mpData.error || 'Intentá de nuevo.'));
-        } catch (_err) {
-          alert('Error de conexión. Verificá tu internet e intentá de nuevo.');
-        }
-        btnPayMp.disabled    = false;
-        btnPayMp.textContent = 'Pagar con Mercado Pago';
-      });
-    }
-
-    // ── Preparar pago online ─────────────────────────────────────────────────
+    // ── Continuar a Mercado Pago — pantalla única ────────────────────────
+    // Un solo clic encadena: crear/recuperar la orden (POST /api/orders) →
+    // crear/recuperar la preferencia (POST /api/preferences) → redirect.
+    // Ambos endpoints ya son idempotentes por diseño (idempotency_key /
+    // public_code), así que reintentar todo el flujo tras cualquier falla es
+    // siempre seguro: nunca duplica la orden ni la preferencia. No se
+    // modificó el contrato de ninguno de los dos endpoints.
     var btnPrepare  = document.getElementById('btn-prepare-order');
     var origBtnHTML = btnPrepare ? btnPrepare.innerHTML : '';
 
+    function resetPrepareButton() {
+      if (!btnPrepare) return;
+      btnPrepare.disabled = false;
+      btnPrepare.removeAttribute('aria-busy');
+      btnPrepare.innerHTML = origBtnHTML;
+    }
+
     if (btnPrepare) {
       btnPrepare.addEventListener('click', async function () {
+        // Guarda extra contra doble envío — disabled ya lo impide, pero un
+        // reintento de teclado/lector de pantalla podría reordenar eventos.
+        if (btnPrepare.disabled) return;
+
         var cart = window.AmadoCart.get();
         if (cart.items.length === 0) return;
+
+        clearCheckoutError();
+        clearFieldErrors();
 
         var deliveryType = getDeliveryType();
         var prepAddress  = ((document.getElementById('delivery-address')     || {}).value || '').trim();
@@ -1210,66 +1309,34 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         var prepName     = ((document.getElementById('buyer-name')            || {}).value || '').trim();
         var prepPhone    = ((document.getElementById('buyer-phone')           || {}).value || '').trim();
 
+        // Primer campo inválido gana — mismo orden que antes, ahora con
+        // error inline debajo del campo en vez de un alert() bloqueante.
         if (!prepName) {
-          alert('Por favor ingresá tu nombre.');
-          var nameEl = document.getElementById('buyer-name');
-          if (nameEl) nameEl.focus();
+          showFieldError('buyer-name', 'Por favor ingresá tu nombre.');
           return;
         }
         if (!prepPhone) {
-          alert('Por favor ingresá tu teléfono o WhatsApp.');
-          var phoneEl = document.getElementById('buyer-phone');
-          if (phoneEl) phoneEl.focus();
+          showFieldError('buyer-phone', 'Por favor ingresá tu teléfono o WhatsApp.');
           return;
         }
-
         if (deliveryType === 'shipping') {
-          if (!prepAddress) {
-            alert('Por favor ingresá la dirección de entrega.');
-            var addrEl = document.getElementById('delivery-address');
-            if (addrEl) addrEl.focus();
-            return;
-          }
-          if (!prepBarrio) {
-            alert('Por favor ingresá la localidad.');
-            var barrioEl = document.getElementById('delivery-barrio');
-            if (barrioEl) barrioEl.focus();
-            return;
-          }
-          if (!prepDepto) {
-            alert('Por favor seleccioná el departamento.');
-            var deptEl = document.getElementById('delivery-departamento');
-            if (deptEl) deptEl.focus();
-            return;
-          }
-          if (!prepDate) {
-            alert('Por favor ingresá la fecha preferida de entrega.');
-            var dateEl = document.getElementById('delivery-date');
-            if (dateEl) dateEl.focus();
-            return;
-          }
-          if (!prepFrom) {
-            alert('Por favor ingresá la hora de inicio del horario.');
-            var fromEl = document.getElementById('delivery-from');
-            if (fromEl) fromEl.focus();
-            return;
-          }
-          if (!prepTo) {
-            alert('Por favor ingresá la hora de fin del horario.');
-            var toEl = document.getElementById('delivery-to');
-            if (toEl) toEl.focus();
-            return;
-          }
+          if (!prepAddress) { showFieldError('delivery-address', 'Por favor ingresá la dirección de entrega.'); return; }
+          if (!prepBarrio)  { showFieldError('delivery-barrio', 'Por favor ingresá la localidad.'); return; }
+          if (!prepDepto)   { showFieldError('delivery-departamento', 'Por favor seleccioná el departamento.'); return; }
+          if (!prepDate)    { showFieldError('delivery-date', 'Por favor ingresá la fecha preferida de entrega.'); return; }
+          if (!prepFrom)    { showFieldError('delivery-from', 'Por favor ingresá la hora de inicio del horario.'); return; }
+          if (!prepTo)      { showFieldError('delivery-to', 'Por favor ingresá la hora de fin del horario.'); return; }
         }
 
         btnPrepare.disabled = true;
+        btnPrepare.setAttribute('aria-busy', 'true');
 
         // Fail closed: si el checkout está habilitado pero Turnstile no
         // pudo configurarse (site key ausente, o este host no está
         // permitido), nunca se manda la request sin verificación.
         if (turnstileBlocked) {
-          alert('El pago online no está disponible en este momento. Probá más tarde o escribinos por WhatsApp.');
-          btnPrepare.disabled = false;
+          showCheckoutError('El pago online no está disponible en este momento. Probá más tarde o escribinos por WhatsApp.');
+          resetPrepareButton();
           return;
         }
 
@@ -1278,21 +1345,20 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         var cfTsResponse = null;
         if (turnstileConfigured) {
           if (tsWidgetId == null) {
-            alert('La verificación aún no cargó. Esperá un momento y reintentá.');
-            btnPrepare.disabled = false;
-            btnPrepare.innerHTML = origBtnHTML;
+            showCheckoutError('La verificación aún no cargó. Esperá un momento y reintentá.');
+            resetPrepareButton();
             return;
           }
           try {
             cfTsResponse = await tsGetToken();
           } catch (_tsErr) {
-            alert('Error en la verificación. Recargá la página e intentá de nuevo.');
-            btnPrepare.disabled = false;
-            btnPrepare.innerHTML = origBtnHTML;
+            showCheckoutError('Error en la verificación. Recargá la página e intentá de nuevo.');
+            resetPrepareButton();
             return;
           }
-          btnPrepare.textContent = 'Procesando…';
         }
+
+        btnPrepare.textContent = 'Preparando tu pedido…';
 
         var payload = {
           idempotency_key: cart.idempotency_key,
@@ -1315,40 +1381,59 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
           if (prepNotes) payload.shipping.notes = prepNotes;
         }
 
+        var orderData;
         try {
           var resp = await fetch('/api/orders', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
           });
-          var data = await resp.json();
-
+          orderData = await resp.json();
           if (!resp.ok) {
-            alert('Error: ' + (data.error || 'Intentá de nuevo.'));
-            btnPrepare.disabled = false;
-            btnPrepare.innerHTML = origBtnHTML;
+            showCheckoutError('Error: ' + (orderData.error || 'Intentá de nuevo.'));
+            resetPrepareButton();
             return;
           }
-
-          var resultEl    = document.getElementById('order-result');
-          var codeEl      = document.getElementById('order-public-code');
-          var totalConfEl = document.getElementById('order-total-confirmed');
-          if (codeEl)      codeEl.textContent     = data.order.public_code;
-          if (totalConfEl) totalConfEl.textContent = fmt.format(data.order.payable_total_uyu) + ' UYU';
-          if (resultEl)    resultEl.hidden = false;
-          btnPrepare.textContent = 'Pedido preparado';
-
-          if (turnstileConfigured) {
-            mpPublicCode     = data.order.public_code;
-            mpIdempotencyKey = cart.idempotency_key;
-            var noteEl = document.getElementById('order-result-note');
-            if (noteEl)    noteEl.hidden   = true;
-            if (btnPayMp)  btnPayMp.hidden = false;
-          }
         } catch (_fetchErr) {
-          alert('Error de conexión. Verificá tu internet e intentá de nuevo.');
-          btnPrepare.disabled = false;
-          btnPrepare.innerHTML = origBtnHTML;
+          showCheckoutError('Error de conexión. Verificá tu internet e intentá de nuevo.');
+          resetPrepareButton();
+          return;
+        }
+
+        // Sin CTA de pago online (Turnstile no configurado para este host):
+        // la orden ya quedó registrada, coordinar el resto por WhatsApp.
+        if (!turnstileConfigured) {
+          btnPrepare.textContent = 'Pedido preparado';
+          return;
+        }
+
+        btnPrepare.textContent = 'Redirigiendo a Mercado Pago…';
+
+        try {
+          var mpResp = await fetch('/api/preferences', {
+            method:  'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body:    JSON.stringify({
+              public_code:     orderData.order.public_code,
+              idempotency_key: cart.idempotency_key,
+            }),
+          });
+          var mpData = await mpResp.json();
+          if (mpResp.ok && mpData.checkout_url) {
+            try {
+              sessionStorage.setItem('amado-mp-auth', JSON.stringify({
+                public_code:     orderData.order.public_code,
+                idempotency_key: cart.idempotency_key,
+              }));
+            } catch (_) {}
+            window.location.href = mpData.checkout_url;
+            return;
+          }
+          showCheckoutError('Error al iniciar el pago: ' + (mpData.error || 'Intentá de nuevo.'));
+          resetPrepareButton();
+        } catch (_err) {
+          showCheckoutError('Error de conexión. Verificá tu internet e intentá de nuevo.');
+          resetPrepareButton();
         }
       });
     }

--- a/astro-front/src/pages/pedido.astro
+++ b/astro-front/src/pages/pedido.astro
@@ -85,6 +85,15 @@ const WA_HREF =
           if (iconEl) iconEl.textContent = '✓';
           if (h1El)   h1El.textContent   = 'Pago confirmado';
           if (leadEl) leadEl.textContent = 'Tu pedido está confirmado. Te contactaremos por WhatsApp para coordinar la entrega.';
+          // Único punto donde se vacía el carrito: recién acá hay
+          // confirmación real de pago aprobado, leída de D1 vía
+          // /api/orders/status (nunca del simple regreso del navegador ni
+          // del parámetro ?result= de la URL). Nunca se vacía al hacer clic
+          // en "Continuar a Mercado Pago" ni por un retorno pending/rejected/
+          // abandonado — ver el polling más abajo.
+          if (window.AmadoCart && typeof window.AmadoCart.clear === 'function') {
+            window.AmadoCart.clear();
+          }
         } else if (paymentStatus === 'rejected') {
           if (iconEl) iconEl.textContent = '✗';
           if (h1El)   h1El.textContent   = 'Pago rechazado.';

--- a/functions/__tests__/checkout-single-step.test.js
+++ b/functions/__tests__/checkout-single-step.test.js
@@ -1,0 +1,235 @@
+// Pruebas de contrato del rediseño single-step del checkout (2-N-I1 v2).
+//
+// carrito.astro y pedido.astro son componentes Astro con script inline — no
+// hay forma de importarlos como módulo ES y ejecutar su JS aislado con
+// node --test. Siguiendo el mismo criterio ya establecido en
+// wrangler-config.test.js (leer el archivo fuente como texto y verificar su
+// estructura con regex), estos tests comprueban que el rediseño preserva las
+// reglas de negocio obligatorias sin necesitar un navegador real.
+//
+// Ninguno de estos tests llama a /api/orders, /api/preferences, al servicio
+// real de Turnstile ni a Mercado Pago — son puramente estructurales sobre el
+// código fuente.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const carritoAstro = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'pages', 'carrito.astro'),
+  'utf8',
+);
+const pedidoAstro = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'pages', 'pedido.astro'),
+  'utf8',
+);
+const ordersGuardJs = readFileSync(
+  path.join(ROOT, 'astro-front', 'public', 'orders-guard.js'),
+  'utf8',
+);
+
+const REQUIRED_FIELD_IDS = [
+  'buyer-name',
+  'buyer-phone',
+  'delivery-address',
+  'delivery-barrio',
+  'delivery-departamento',
+  'delivery-date',
+  'delivery-from',
+  'delivery-to',
+];
+
+// ── Una sola pantalla, un solo botón principal ──────────────────────────────
+
+test('carrito.astro: el checkout de dos pasos (order-result / btn-pay-mp) ya no existe', () => {
+  assert.doesNotMatch(carritoAstro, /id="order-result"/);
+  assert.doesNotMatch(carritoAstro, /id="btn-pay-mp"/);
+  assert.doesNotMatch(carritoAstro, /getElementById\('btn-pay-mp'\)/);
+});
+
+test('carrito.astro: exactamente un botón principal id="btn-prepare-order" en el markup', () => {
+  const matches = carritoAstro.match(/id="btn-prepare-order"/g) || [];
+  assert.equal(matches.length, 1);
+});
+
+test('carrito.astro: el CTA principal dice "Continuar a Mercado Pago"', () => {
+  assert.match(carritoAstro, /Continuar a Mercado Pago/);
+});
+
+test('carrito.astro: un solo listener de click maneja todo el pago (no hay un segundo botón/handler de "pagar")', () => {
+  const clickListeners = carritoAstro.match(/btnPrepare\.addEventListener\('click'/g) || [];
+  assert.equal(clickListeners.length, 1);
+  assert.doesNotMatch(carritoAstro, /btnPayMp\.addEventListener/);
+});
+
+test('carrito.astro: el mismo click crea la orden y la preferencia, sin un segundo clic', () => {
+  const handlerStart = carritoAstro.indexOf("btnPrepare.addEventListener('click'");
+  assert.notEqual(handlerStart, -1);
+  const handlerBlock = carritoAstro.slice(handlerStart, handlerStart + 6000);
+  assert.match(handlerBlock, /fetch\('\/api\/orders'/);
+  assert.match(handlerBlock, /fetch\('\/api\/preferences'/);
+  // El orden importa: primero se crea/recupera la orden, después la preferencia.
+  const ordersIdx = handlerBlock.indexOf("fetch('/api/orders'");
+  const prefsIdx  = handlerBlock.indexOf("fetch('/api/preferences'");
+  assert.ok(ordersIdx < prefsIdx, '/api/orders debe llamarse antes que /api/preferences');
+});
+
+// ── WhatsApp subordinado, no competidor ─────────────────────────────────────
+
+test('carrito.astro: con checkout ON, WhatsApp usa estilo secundario (no compite con el CTA principal)', () => {
+  assert.match(carritoAstro, /class="btn-wa-secondary"/);
+});
+
+test('carrito.astro: con checkout OFF, WhatsApp sigue siendo la única acción disponible', () => {
+  assert.match(carritoAstro, /class="btn-wa-order"/);
+});
+
+// ── Validación inline y accesibilidad ───────────────────────────────────────
+
+for (const fieldId of REQUIRED_FIELD_IDS) {
+  test(`carrito.astro: el campo #${fieldId} tiene su span de error inline asociado`, () => {
+    assert.match(carritoAstro, new RegExp(`id="err-${fieldId}"`));
+    assert.match(carritoAstro, new RegExp(`id="${fieldId}"[^>]*aria-describedby="err-${fieldId}"`));
+  });
+}
+
+test('carrito.astro: ya no usa alert() para errores de validación de campos', () => {
+  const handlerStart = carritoAstro.indexOf("btnPrepare.addEventListener('click'");
+  const handlerBlock = carritoAstro.slice(handlerStart, handlerStart + 3000);
+  assert.doesNotMatch(handlerBlock, /alert\(\s*'Por favor/);
+});
+
+test('carrito.astro: showFieldError enfoca el campo y lo desplaza a la vista (scrollIntoView)', () => {
+  assert.match(carritoAstro, /function showFieldError/);
+  const fnStart = carritoAstro.indexOf('function showFieldError');
+  const fnBody = carritoAstro.slice(fnStart, fnStart + 700);
+  assert.match(fnBody, /scrollIntoView/);
+  assert.match(fnBody, /\.focus\(\)/);
+  assert.match(fnBody, /aria-invalid/);
+});
+
+test('carrito.astro: expone el hook de error inline en window para que orders-guard.js lo use', () => {
+  assert.match(carritoAstro, /window\.__amadoCheckoutShowFieldError\s*=\s*showFieldError/);
+});
+
+test('orders-guard.js: usa el hook inline en vez de alert() como primera opción', () => {
+  const idx = ordersGuardJs.indexOf("document.addEventListener('click'");
+  assert.notEqual(idx, -1);
+  const block = ordersGuardJs.slice(idx, idx + 900);
+  assert.match(block, /window\.__amadoCheckoutShowFieldError/);
+  // alert() se conserva solo como respaldo, no como camino principal.
+  assert.match(block, /else\s*\{[\s\S]*window\.alert/);
+});
+
+// ── Prevención de doble envío / creación duplicada ──────────────────────────
+
+test('carrito.astro: el botón se deshabilita antes de cualquier operación async', () => {
+  const handlerStart = carritoAstro.indexOf("btnPrepare.addEventListener('click'");
+  const handlerBlock = carritoAstro.slice(handlerStart, handlerStart + 4000);
+  const disableIdx = handlerBlock.indexOf('btnPrepare.disabled = true;');
+  const firstAwaitIdx = handlerBlock.indexOf('await ');
+  assert.notEqual(disableIdx, -1, 'no se encontró "btnPrepare.disabled = true;"');
+  assert.notEqual(firstAwaitIdx, -1, 'no se encontró ningún await en el handler');
+  assert.ok(disableIdx < firstAwaitIdx, 'el botón debe deshabilitarse antes del primer await');
+});
+
+test('carrito.astro: guarda explícita de reentrancia al inicio del handler', () => {
+  const handlerStart = carritoAstro.indexOf("btnPrepare.addEventListener('click'");
+  const handlerBlock = carritoAstro.slice(handlerStart, handlerStart + 300);
+  assert.match(handlerBlock, /if\s*\(\s*btnPrepare\.disabled\s*\)\s*return;/);
+});
+
+// ── Turnstile sigue protegiendo la creación del pago ────────────────────────
+
+test('carrito.astro: turnstileBlocked sigue impidiendo el envío sin verificación', () => {
+  assert.match(carritoAstro, /if\s*\(\s*turnstileBlocked\s*\)\s*\{/);
+});
+
+test('carrito.astro: cf_turnstile_response sigue viajando en el payload de /api/orders', () => {
+  assert.match(carritoAstro, /cf_turnstile_response:\s*cfTsResponse/);
+});
+
+// ── Sin secretos ─────────────────────────────────────────────────────────
+
+test('carrito.astro: no expone TURNSTILE_SECRET_KEY, MP_ACCESS_TOKEN ni MP_WEBHOOK_SECRET', () => {
+  assert.doesNotMatch(carritoAstro, /TURNSTILE_SECRET_KEY/);
+  assert.doesNotMatch(carritoAstro, /MP_ACCESS_TOKEN/);
+  assert.doesNotMatch(carritoAstro, /MP_WEBHOOK_SECRET/);
+});
+
+// ── Barra inferior sticky (mobile) ──────────────────────────────────────────
+
+test('carrito.astro: la barra de pago usa position: sticky en mobile, condicionada a checkout ON', () => {
+  assert.match(
+    carritoAstro,
+    /\.cart-page\[data-online-checkout="enabled"\]\s+\.cart-pay-section\s*\{[^}]*position:\s*sticky/,
+  );
+});
+
+test('carrito.astro: el total se refleja en la barra sticky (mismo valor que el resumen, sin recalcular)', () => {
+  assert.match(carritoAstro, /id="checkout-sticky-total-value"/);
+  assert.match(carritoAstro, /stickyTotalEl\.textContent\s*=\s*fmt\.format/);
+});
+
+test('carrito.astro: el bubble flotante de WhatsApp no compite con la barra sticky en mobile', () => {
+  assert.match(
+    carritoAstro,
+    /\.cart-page\[data-online-checkout="enabled"\]\s*~\s*:global\(\.wa-float\)\s*\{\s*display:\s*none;/,
+  );
+});
+
+// ── Carrito conservado antes de pago aprobado (2-N-I1 v2) ───────────────────
+
+test('carrito.astro: el flujo de pago nunca vacía el carrito (ni al hacer click, ni en ningún retorno)', () => {
+  const handlerStart = carritoAstro.indexOf("btnPrepare.addEventListener('click'");
+  const handlerEnd = carritoAstro.indexOf('renderCart();', handlerStart);
+  const handlerBlock = carritoAstro.slice(handlerStart, handlerEnd);
+  assert.doesNotMatch(handlerBlock, /AmadoCart\.clear\(\)/);
+});
+
+test('carrito.astro: AmadoCart.clear() solo se llama desde el botón manual "Vaciar carrito"', () => {
+  const matches = [...carritoAstro.matchAll(/AmadoCart\.clear\(\)/g)];
+  assert.equal(matches.length, 1);
+  const idx = matches[0].index;
+  const before = carritoAstro.slice(Math.max(0, idx - 400), idx);
+  assert.match(before, /btnClear\.addEventListener\('click'/);
+});
+
+test('pedido.astro: el carrito se vacía únicamente en la rama de pago aprobado', () => {
+  const fnStart = pedidoAstro.indexOf('function applyFinalState');
+  assert.notEqual(fnStart, -1);
+  const fnEnd = pedidoAstro.indexOf('\n      }\n\n      function onTimeout', fnStart);
+  const fnBody = pedidoAstro.slice(fnStart, fnEnd === -1 ? fnStart + 1500 : fnEnd);
+
+  const branches = {
+    approved:  fnBody.slice(fnBody.indexOf("'approved'"), fnBody.indexOf("'rejected'") > -1 ? fnBody.indexOf("} else if (paymentStatus === 'rejected'") : undefined),
+  };
+  assert.match(branches.approved, /AmadoCart\.clear\(\)/);
+
+  // Fuera de la rama approved (rejected/cancelled/refunded), nunca se limpia.
+  const rejectedOnward = fnBody.slice(fnBody.indexOf("paymentStatus === 'rejected'"));
+  assert.doesNotMatch(rejectedOnward, /AmadoCart\.clear\(\)/);
+});
+
+test('pedido.astro: el regreso del navegador (?result=) nunca por sí solo dispara el vaciado', () => {
+  // El bloque que reacciona a ?result= al cargar la página (antes del
+  // polling) es puramente informativo ("Estamos verificando…") y no debe
+  // contener ninguna limpieza de carrito — solo applyFinalState(), llamado
+  // exclusivamente desde el resultado real del polling a /api/orders/status,
+  // puede hacerlo.
+  const urlBlockStart = pedidoAstro.indexOf("if (result === 'success' || result === 'pending')");
+  const urlBlockEnd   = pedidoAstro.indexOf('// ── Polling de estado real en D1');
+  assert.notEqual(urlBlockStart, -1);
+  assert.notEqual(urlBlockEnd, -1);
+  const urlBlock = pedidoAstro.slice(urlBlockStart, urlBlockEnd);
+  assert.doesNotMatch(urlBlock, /AmadoCart\.clear\(\)/);
+});
+
+test('pedido.astro: el vaciado depende del estado real leído de D1, no del parámetro de URL', () => {
+  assert.match(pedidoAstro, /fetch\('\/api\/orders\/status'/);
+  const pollIdx = pedidoAstro.indexOf("fetch('/api/orders/status'");
+  assert.ok(pollIdx > 0);
+});


### PR DESCRIPTION
## Objetivo
Simplifica el checkout a una sola pantalla y un único CTA principal: **Continuar a Mercado Pago**.

## Cambios
- Unifica resumen, datos del comprador, entrega/retiro y pago en un solo flujo.
- Mantiene WhatsApp como alternativa secundaria.
- Agrega validaciones inline accesibles y foco/scroll al primer campo inválido.
- Agrega barra sticky mobile con total y CTA.
- Bloquea doble envío y restablece el botón ante errores.
- Conserva el carrito hasta que `/api/orders/status` confirme `payment_status === "approved"`.
- Agrega pruebas de contrato específicas del checkout single-step.

## Seguridad y contratos preservados
- Sin cambios en webhook, D1, migraciones, endpoints, idempotencia, precios, stock ni credenciales.
- Turnstile continúa protegiendo la creación del pago.
- No se confía en `?result=` para aprobar ni vaciar el carrito.
- Checkout OFF mantiene WhatsApp y no renderiza controles activos de Mercado Pago.

## Evidencia previa
- 268/268 pruebas aprobadas.
- Builds checkout OFF y ON aprobados.
- Validaciones adicionales de doble envío, recuperación e idempotencia revisadas directamente en el código.
- Rama basada exactamente en `8b9e3c8e6aa51cc1527e18e8b96fa5b996f3683d`.
- Commit: `a48b2ebe548b949363a2fbab05a7ae93fb27487e`.

Este PR no autoriza merge ni deploy.