### PR TITLE
SEO — redirigir ficha legacy /365

### DIFF
--- a/functions/365.js
+++ b/functions/365.js
@@ -1,0 +1,12 @@
+/**
+ * Redirección permanente de la ficha legacy indexada por Google.
+ *
+ * Cloudflare Pages enruta tanto /365 como /365/ a esta Function.
+ */
+
+const CURRENT_BOOK_URL =
+    'https://www.amadolibros.com/libro/MLU1330191560/libro-club-de-brujas-mel-knarik-ayelen-romano';
+
+export function onRequest() {
+    return Response.redirect(CURRENT_BOOK_URL, 301);
+}

--- a/functions/__tests__/legacy-redirects.test.js
+++ b/functions/__tests__/legacy-redirects.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { onRequest as redirectLegacyBook365 } from '../365.js';
+
+test('/365 redirige permanentemente a la ficha actual', () => {
+    const response = redirectLegacyBook365();
+
+    assert.equal(response.status, 301);
+    assert.equal(
+        response.headers.get('location'),
+        'https://www.amadolibros.com/libro/MLU1330191560/libro-club-de-brujas-mel-knarik-ayelen-romano',
+    );
+});


### PR DESCRIPTION
## Qué cambia

- Agrega una Cloudflare Pages Function específica para `/365` y `/365/`.
- Devuelve un `301` permanente hacia la ficha vigente de *Club de brujas*.
- Agrega una prueba que verifica el estado y el encabezado `Location` exacto.

## Por qué

Search Console conserva indexada la ficha legacy `/365/`. El fallback general devolvía la portada con estado `200`, en lugar de conservar la relación con la ficha actual.

## Impacto

El cambio afecta únicamente `/365` y `/365/`. No modifica catálogo, checkout, Mercado Pago, webhook, D1, precios, stock ni otras rutas.

## Validación

- 272/272 pruebas aprobadas.
- Build con checkout OFF: correcto.
- Build con checkout ON: correcto.
- Prueba específica: respuesta `301` y `Location` exacto hacia `MLU1330191560`.

## Límites

Este PR no autoriza merge ni deploy.