### PR TITLE
Merchant 2A: alinear precio principal y envío gratis

### DIFF
--- a/astro-front/src/components/BookCard.astro
+++ b/astro-front/src/components/BookCard.astro
@@ -62,8 +62,8 @@ const installment   = fmt.format(Math.ceil(book.price / 12));
     {book.author && <p class="bc-author">{book.author}</p>}
 
     <div class="bc-prices">
-      <span class="bc-price-transfer"><span class="bc-price-label">Transferencia -12%:</span> {transferPrice}</span>
-      <span class="bc-price-base">Precio: {basePrice}</span>
+      <span class="bc-price-base"><span class="bc-price-label">Precio web / tarjeta:</span> {basePrice}</span>
+      <span class="bc-price-transfer">Transferencia: {transferPrice} · ahorrás 12%</span>
       <span class="bc-cuotas">12 cuotas de {installment}</span>
     </div>
 
@@ -186,23 +186,28 @@ const installment   = fmt.format(Math.ceil(book.price / 12));
   .bc-price-transfer,
   .bc-price-base,
   .bc-cuotas {
-    font-size: 0.8125rem;
     line-height: 1.25;
   }
 
-  .bc-price-transfer {
+  .bc-price-base {
     color: var(--ink);
-    font-weight: 500;
-  }
-
-  .bc-price-label {
-    font-style: italic;
+    font-size: 0.875rem;
     font-weight: 700;
   }
 
-  .bc-price-base,
+  .bc-price-transfer {
+    color: #267a42;
+    font-size: 0.75rem;
+    font-weight: 600;
+  }
+
+  .bc-price-label {
+    font-weight: 700;
+  }
+
   .bc-cuotas {
     color: var(--ink-2);
+    font-size: 0.75rem;
   }
 
   .bc-actions {

--- a/functions/__tests__/catalog-display.test.js
+++ b/functions/__tests__/catalog-display.test.js
@@ -88,5 +88,26 @@ test('la ficha activa conserva precio y carrito en producción', async () => {
 
   assert.match(html, /index, follow/);
   assert.match(html, /Agregar al carrito/);
-  assert.match(html, /Transferencia:/);
+  assert.match(html, /Precio web \/ tarjeta:<\/span> \$1[.,]000 UYU/);
+  assert.match(html, /Transferencia: \$880 UYU · ahorrás 12%/);
+  assert.ok(
+    html.indexOf('Precio web / tarjeta:') < html.indexOf('Transferencia:'),
+    'el precio cobrable debe aparecer antes que el beneficio por transferencia'
+  );
+  assert.match(html, /"price":"1000"/);
+  assert.match(html, /data-price="1000"/);
+});
+
+test('el catálogo muestra primero el mismo precio base que usa la compra', async () => {
+  const response = await catalogRequest(
+    context('https://www.amadolibros.com/catalogo?q=Alpha+disponible')
+  );
+  const html = await response.text();
+
+  assert.match(html, /Precio web \/ tarjeta:<\/span> \$1[.,]000/);
+  assert.match(html, /Transferencia: \$880 · ahorrás 12%/);
+  assert.ok(
+    html.indexOf('Precio web / tarjeta:') < html.indexOf('Transferencia:'),
+    'el catálogo debe priorizar el precio web'
+  );
 });

--- a/functions/__tests__/merchant-price-consistency.test.js
+++ b/functions/__tests__/merchant-price-consistency.test.js
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const root = new URL('../../', import.meta.url);
+const read = (path) => readFileSync(new URL(path, root), 'utf8');
+
+test('las cards priorizan el precio web y dejan transferencia como beneficio', () => {
+  const card = read('astro-front/src/components/BookCard.astro');
+  const base = card.indexOf('Precio web / tarjeta:');
+  const transfer = card.indexOf('Transferencia:');
+
+  assert.ok(base !== -1, 'falta el precio web en la card');
+  assert.ok(transfer !== -1, 'falta el precio de transferencia en la card');
+  assert.ok(base < transfer, 'transferencia no debe ser el precio principal');
+  assert.match(card, /data-price=\{book\.price\}/);
+  assert.match(card, /ahorrás 12%/);
+});
+
+test('feed, datos estructurados, carrito y Mercado Pago parten del precio base', () => {
+  const feed = read('functions/feed.xml.js');
+  const book = read('functions/libro/[[path]].js');
+  const cart = read('astro-front/src/pages/carrito.astro');
+  const orders = read('functions/api/_orders_logic.js');
+  const mp = read('functions/api/_mp_handler.js');
+
+  assert.match(feed, /const price = item\.price \? `\$\{item\.price\} \$\{currency\}`/);
+  assert.match(book, /'price':\s+String\(price\)/);
+  assert.match(book, /data-price="\$\{price\}"/);
+  assert.match(cart, /item\.price \* item\.quantity/);
+  assert.match(orders, /const rawPrice = Number\(catalogItem\.price\)/);
+  assert.match(mp, /unit_price:\s+order\.payable_total_uyu/);
+});
+
+test('el umbral público de envío gratis queda unificado en 2.000 pesos', () => {
+  const catalog = read('functions/catalogo.js');
+  const book = read('functions/libro/[[path]].js');
+  const shipping = read('astro-front/src/pages/envios.astro');
+  const cart = read('astro-front/src/pages/carrito.astro');
+  const logic = read('functions/api/_orders_logic.js');
+
+  assert.match(catalog, /envío gratis desde \$2\.000/);
+  assert.match(book, /Envío gratis desde \$2\.000/);
+  assert.match(shipping, /gratis desde \$2\.000 UYU/);
+  assert.match(cart, /FREE_SHIPPING_THRESHOLD_UYU = 2000/);
+  assert.match(logic, /FREE_SHIPPING_THRESHOLD = 2000/);
+
+  for (const source of [catalog, book, shipping, cart, logic]) {
+    assert.doesNotMatch(source, /envío gratis desde \$1\.500/i);
+  }
+});

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -104,7 +104,7 @@ export async function onRequest(ctx) {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Comprar libros online en Uruguay | Amado Libros</title>
-  <meta name="description" content="${activeItems.length} libros para comprar online en Uruguay. 12% de descuento por transferencia y envío gratis desde $1.500. Envíos a todo el país.">
+  <meta name="description" content="${activeItems.length} libros para comprar online en Uruguay. 12% de descuento por transferencia y envío gratis desde $2.000. Envíos a todo el país.">
   <link rel="canonical" href="${BASE}/catalogo">
   <meta name="robots" content="index, follow">
   <script type="application/ld+json">${JSON.stringify({
@@ -209,8 +209,8 @@ ${rows}
     ${author}
     ${available
       ? `<div class="rc-prices">
-      <span class="rc-transfer"><span class="rc-lbl">Transferencia:</span> $${escapeHtml(transfer)}</span>
-      <span class="rc-base">Precio: $${escapeHtml(priceStr)}</span>
+      <span class="rc-base"><span class="rc-lbl">Precio web / tarjeta:</span> $${escapeHtml(priceStr)}</span>
+      <span class="rc-transfer">Transferencia: $${escapeHtml(transfer)} · ahorrás 12%</span>
     </div>
     <a href="${href}" class="rc-cta">Ver ficha →</a>`
       : `<div class="rc-order-info">
@@ -272,10 +272,10 @@ ${rows}
     .rc-author{font-size:.82rem;color:#6b6157;
                white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
     .rc-prices{display:flex;flex-direction:column;gap:.2rem;margin-top:.35rem}
-    .rc-transfer,.rc-base{font-size:.875rem;line-height:1.3}
-    .rc-transfer{color:#18120e;font-weight:600}
+    .rc-transfer,.rc-base{line-height:1.3}
+    .rc-base{font-size:.95rem;color:#18120e;font-weight:700}
+    .rc-transfer{font-size:.8rem;color:#267a42;font-weight:600}
     .rc-lbl{font-weight:700}
-    .rc-base{color:#6b6157}
     .search-bar{display:flex;gap:.5rem;margin-bottom:1.5rem}
     .search-bar input{flex:1;padding:.55rem .875rem;border:1px solid #d1c8be;border-radius:.5rem;
                       font-size:.9rem;color:#1e293b;background:#fff;outline:none}

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -256,8 +256,8 @@ function renderPage(item, slug, isPreview) {
 
     const metaDesc = inStock
         ? (safeAuthor
-            ? `Comprá &quot;${safeTitle}&quot; de ${safeAuthor} en Amado Libros. Transferencia: $${transferPrice} UYU. Envíos a todo Uruguay.`
-            : `Comprá &quot;${safeTitle}&quot; en Amado Libros. Transferencia: $${transferPrice} UYU. Envíos a todo Uruguay.`)
+            ? `Comprá &quot;${safeTitle}&quot; de ${safeAuthor} en Amado Libros. Precio web: $${priceUY} UYU. Envíos a todo Uruguay.`
+            : `Comprá &quot;${safeTitle}&quot; en Amado Libros. Precio web: $${priceUY} UYU. Envíos a todo Uruguay.`)
         : `Consultá disponibilidad de &quot;${safeTitle}&quot; por encargo en Amado Libros. Entrega estimada de 15–20 días, sujeta a confirmación.`;
 
     // JSON-LD — generado con JSON.stringify, nunca concatenación
@@ -300,8 +300,8 @@ function renderPage(item, slug, isPreview) {
 
     const priceHtml = inStock
         ? `<div class="price-box">
-      <div class="price-transfer"><span class="price-label">Transferencia:</span> $${transferPrice} UYU</div>
-      <div class="price-base">Precio: $${priceUY} UYU</div>
+      <div class="price-base"><span class="price-label">Precio web / tarjeta:</span> $${priceUY} UYU</div>
+      <div class="price-transfer">Transferencia: $${transferPrice} UYU · ahorrás 12%</div>
       <div class="price-installment">12 cuotas de aprox. $${installment} UYU</div>
     </div>`
         : `<div class="order-box">
@@ -435,9 +435,10 @@ function renderPage(item, slug, isPreview) {
     .detail-row dd{color:#475569}
     .price-box{background:#f5f3ff;border:1px solid #ddd6fe;border-radius:.5rem;
                padding:1rem 1.25rem;margin:.875rem 0}
-    .price-transfer,.price-base,.price-installment{font-size:1rem;font-weight:700;line-height:1.35}
-    .price-transfer{color:#0f172a}
-    .price-base,.price-installment{color:#374151;margin-top:.15rem}
+    .price-transfer,.price-base,.price-installment{font-weight:700;line-height:1.35}
+    .price-base{font-size:1.2rem;color:#0f172a}
+    .price-transfer{font-size:.95rem;color:#267a42;margin-top:.2rem}
+    .price-installment{font-size:.95rem;color:#374151;margin-top:.15rem}
     .order-box{display:flex;flex-direction:column;gap:.25rem;background:#fff7e8;
                border:1px solid #efd2a6;border-radius:.5rem;padding:1rem 1.25rem;
                margin:.875rem 0;color:#6b4218}


### PR DESCRIPTION
## Qué cambia

- Presenta **Precio web / tarjeta** como precio principal en fichas y cards.
- Mantiene **Transferencia · ahorrás 12%** como beneficio secundario.
- Conserva el mismo precio base en feed preliminar, JSON-LD, carrito y checkout de Mercado Pago.
- Corrige la referencia pública de envío gratis a **desde $2.000**.
- Agrega controles de regresión específicos para coherencia de precio y umbral de envío.

## Por qué

Google Merchant Center exige coherencia entre el precio destacado de la página, los datos estructurados, el feed y el importe cobrable en checkout. El orden anterior destacaba primero el precio por transferencia aunque el checkout online cobraba el precio web/tarjeta.

## Impacto

Cambio de jerarquía visual y textos. No modifica fórmulas, importes, stock, descuentos ni lógica de pagos.

## Validación

- 282/282 pruebas aprobadas.
- Build con checkout OFF: aprobado.
- Build con checkout ON: aprobado.
- `git diff --check`: correcto.
- Rama 1 commit por delante de `main`, 0 por detrás.
- Alcance: 5 archivos.