### PR TITLE
Infra 1: bloquear deploys fuera de main

### DIFF
--- a/.github/workflows/deploy-worker-sync.yml
+++ b/.github/workflows/deploy-worker-sync.yml
@@ -16,8 +16,16 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: production
 
     steps:
+      - name: Block manual deploy outside main
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        run: |
+          echo "Deploy bloqueado: solo se permite ejecutar manualmente desde main."
+          exit 1
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,18 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  guard:
+    name: Guard production ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Block manual deploy outside main
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        run: |
+          echo "Deploy bloqueado: solo se permite ejecutar manualmente desde main."
+          exit 1
+
   # Misma barrera que corre en cada PR (.github/workflows/ci.yml), invocando
   # el mismo script — nunca una copia aparte que pueda desviarse. El build
   # real de más abajo (job `deploy`) no arranca si este job falla: un PR
@@ -21,6 +33,7 @@ jobs:
   # ambos modos de checkout contra el commit que realmente se va a desplegar.
   validate:
     name: Validate before deploy
+    needs: guard
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/functions/__tests__/deploy-branch-guards.test.js
+++ b/functions/__tests__/deploy-branch-guards.test.js
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const pagesWorkflow = readFileSync('.github/workflows/deploy.yml', 'utf8');
+const workerWorkflow = readFileSync(
+  '.github/workflows/deploy-worker-sync.yml',
+  'utf8',
+);
+
+const manualMainGuard =
+  "github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'";
+
+test('deploy.yml bloquea ejecuciones manuales fuera de main antes de validar', () => {
+  assert.match(pagesWorkflow, /^  guard:\n/m);
+  assert.match(pagesWorkflow, new RegExp(`if: ${manualMainGuard}`));
+  assert.match(pagesWorkflow, /^    needs: guard$/m);
+});
+
+test('deploy-worker-sync.yml bloquea ejecuciones manuales fuera de main', () => {
+  assert.match(workerWorkflow, new RegExp(`if: ${manualMainGuard}`));
+});
+
+test('deploy-worker-sync.yml usa el environment production', () => {
+  assert.match(
+    workerWorkflow,
+    /^    environment:\n      name: production$/m,
+  );
+});


### PR DESCRIPTION
## Qué cambia

- Agrega una guardia previa en `deploy.yml` que bloquea cualquier ejecución manual fuera de `main` antes de validar o desplegar.
- Aplica la misma guardia al deploy manual del Worker Sync.
- Asocia el Worker Sync al environment `production` para que la política de ramas del entorno también lo cubra.
- Agrega pruebas automáticas específicas para evitar regresiones de estas barreras.

## Alcance

Sólo modifica dos workflows de GitHub Actions y agrega una prueba. No cambia catálogo, fichas, Mercado Pago, secretos, Cloudflare runtime, Preview ni Producción.

## Validación local

- YAML válido en ambos workflows.
- `git diff --check`: OK.
- 281 pruebas: OK.
- Build con checkout OFF: OK.
- Build con checkout ON y Turnstile de Producción: OK.

## Operación

PR abierto en borrador. No mergear ni desplegar sin autorización expresa.