### PR TITLE
EMAIL-1: notificar ventas web por email

### DIFF
--- a/docs/email-notifications.md
+++ b/docs/email-notifications.md
@@ -1,0 +1,55 @@
+# Notificaciones por email
+
+## EMAIL-1 — aviso interno de venta web
+
+Cuando el webhook de Mercado Pago valida un pago `approved` en Producción:
+
+1. el pedido se marca primero como `paid/approved` en D1;
+2. se registra un evento `sale_notification` en `order_events`;
+3. se envía el aviso interno mediante Resend;
+4. el evento queda en `sent` o `failed`.
+
+El correo incluye código de pedido, comprador, teléfono, libros, importe,
+identificador de pago y datos de entrega.
+
+El envío usa dos barreras contra duplicados:
+
+- un evento único en D1 por pedido (`sale-email:<order_id>`);
+- el header `Idempotency-Key` de Resend (`sale-notification/<order_id>`).
+
+Un fallo de correo nunca revierte ni degrada un pago aprobado. Los fallos
+transitorios de Resend (HTTP 429/5xx o timeout) se reintentan hasta tres veces.
+Si no se recuperan, D1 conserva `status: failed` para que un webhook posterior
+pueda volver a intentarlo.
+
+Preview no envía correos internos.
+
+## Configuración requerida
+
+Antes de mergear/desplegar EMAIL-1, configurar en Cloudflare Pages,
+exclusivamente en el ambiente Production:
+
+| Variable | Tipo | Uso |
+|---|---|---|
+| `RESEND_API_KEY` | Secret | API key de Resend con permiso de envío |
+| `SALES_NOTIFICATION_FROM` | Variable | Remitente en un dominio verificado, por ejemplo `Amado Libros <ventas@amadolibros.com>` |
+| `SALES_NOTIFICATION_TO` | Variable | Destino interno; acepta varios correos separados por coma |
+
+No escribir la API key en `wrangler.toml`, GitHub, logs, tests ni documentación.
+
+El dominio usado en `SALES_NOTIFICATION_FROM` debe estar verificado en Resend.
+Si falta cualquiera de las tres variables, el pago sigue funcionando pero el
+correo se omite y se registra un warning sin exponer secretos.
+
+## Validación segura
+
+Las pruebas usan un `fetch` simulado. No llaman a Resend, Mercado Pago, D1
+remoto ni Cloudflare.
+
+Antes de habilitar en Producción:
+
+1. confirmar las tres variables en Cloudflare Pages Production;
+2. desplegar primero a Preview no dispara emails por diseño;
+3. hacer una venta real controlada;
+4. verificar el correo recibido y el evento `sale_notification` en D1;
+5. repetir el webhook y confirmar que no llega un segundo correo.

--- a/functions/api/__tests__/mp_webhook.test.js
+++ b/functions/api/__tests__/mp_webhook.test.js
@@ -99,9 +99,24 @@ function baseMerchantOrder(patch = {}) {
 function baseOrder(patch = {}) {
   return {
     id:                     'order-uuid',
+    public_code:            'AL-TEST',
     status:                 'open',
     payment_status:         'not_started',
+    buyer_name:             'Ana Pérez',
+    buyer_phone:            '099123456',
+    delivery_type:          'pickup',
+    address:                null,
+    locality:               null,
+    department:             null,
+    requested_delivery_date: null,
+    requested_delivery_from: null,
+    requested_delivery_to:   null,
+    delivery_notes:          null,
+    products_total_uyu:      3250,
+    pickup_discount_uyu:     150,
+    shipping_cost_uyu:       0,
     payable_total_uyu:      3100,
+    currency:               'UYU',
     payment_preference_id:  'pref-1',
     ...patch,
   };
@@ -142,8 +157,16 @@ function env(opts = {}) {
   };
 }
 
-function handler({ getPayment = async () => basePayment(), getMerchantOrder = async () => ({ ok: false, code: 'NOT_FOUND' }) } = {}) {
-  return createMpWebhookHandler({ mpClient: { getPayment, getMerchantOrder }, getNow: () => NOW });
+function handler({
+  getPayment = async () => basePayment(),
+  getMerchantOrder = async () => ({ ok: false, code: 'NOT_FOUND' }),
+  saleNotifier = async () => ({ ok: true }),
+} = {}) {
+  return createMpWebhookHandler({
+    mpClient: { getPayment, getMerchantOrder },
+    getNow: () => NOW,
+    saleNotifier,
+  });
 }
 
 async function call(reqOpts = {}, mpOpts = {}, envOpts = {}) {
@@ -679,4 +702,78 @@ test('origin-1: request sin encabezado Origin funciona normalmente', async () =>
   assert.equal(req.headers.get('Origin'), null, 'precondición: la request de prueba no manda Origin');
   const { res } = await call();
   assert.equal(res.status, 200);
+});
+
+// ── EMAIL-1: aviso interno de venta aprobada ────────────────────────────────
+test('email-1: pago aprobado en producción agenda una notificación con la orden completa', async () => {
+  const calls = [];
+  const db_ = dbMock({ order: baseOrder() });
+  const h = handler({
+    getPayment: async () => basePayment({ collector_id: PROD_COLLECTOR_ID, live_mode: true }),
+    saleNotifier: async args => {
+      calls.push(args);
+      return { ok: true };
+    },
+  });
+  const res = await h({
+    request: makeReq({ host: 'www.amadolibros.com' }),
+    env: {
+      ...PRODUCTION_ENV_CONFIG,
+      MP_WEBHOOK_SECRET: TEST_SECRET,
+      MP_ACCESS_TOKEN: TEST_TOKEN,
+      ORDERS_DB: db_,
+    },
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].order.public_code, 'AL-TEST');
+  assert.equal(calls[0].order.buyer_name, 'Ana Pérez');
+  assert.equal(calls[0].payment.id, 123);
+  assert.equal(calls[0].now.toISOString(), NOW.toISOString());
+});
+
+test('email-2: pago aprobado en preview no envía notificación interna', async () => {
+  let calls = 0;
+  const h = handler({
+    saleNotifier: async () => {
+      calls += 1;
+      return { ok: true };
+    },
+  });
+  const res = await h({
+    request: makeReq(),
+    env: env(),
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(calls, 0);
+});
+
+test('email-3: un fallo de notificación no revierte ni degrada el pago aprobado', async () => {
+  const db_ = dbMock({ order: baseOrder() });
+  const h = handler({
+    getPayment: async () => basePayment({ collector_id: PROD_COLLECTOR_ID, live_mode: true }),
+    saleNotifier: async () => {
+      throw new Error('Resend unavailable');
+    },
+  });
+  const originalError = console.error;
+  console.error = () => {};
+  try {
+    const res = await h({
+      request: makeReq({ host: 'www.amadolibros.com' }),
+      env: {
+        ...PRODUCTION_ENV_CONFIG,
+        MP_WEBHOOK_SECRET: TEST_SECRET,
+        MP_ACCESS_TOKEN: TEST_TOKEN,
+        ORDERS_DB: db_,
+      },
+    });
+
+    assert.equal(res.status, 200);
+    assert.equal(db_.batches.length, 1, 'el pago debe quedar aplicado antes del correo');
+  } finally {
+    console.error = originalError;
+  }
 });

--- a/functions/api/__tests__/sale_notification.test.js
+++ b/functions/api/__tests__/sale_notification.test.js
@@ -1,0 +1,265 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildSaleEmail,
+  createSaleNotificationSender,
+} from '../_sale_notification.js';
+
+const NOW = new Date('2026-07-30T02:00:00.000Z');
+
+function baseOrder(patch = {}) {
+  return {
+    id: 'order-uuid',
+    public_code: 'AL-260729-TEST',
+    buyer_name: 'Ana <Pérez>',
+    buyer_phone: '099 123 456',
+    delivery_type: 'shipping',
+    address: 'Rincón 608',
+    locality: 'Ciudad Vieja',
+    department: 'Montevideo',
+    requested_delivery_date: '2026-07-31',
+    requested_delivery_from: '10:00',
+    requested_delivery_to: '13:00',
+    delivery_notes: 'Tocar timbre',
+    products_total_uyu: 3000,
+    pickup_discount_uyu: 0,
+    shipping_cost_uyu: 250,
+    payable_total_uyu: 3250,
+    currency: 'UYU',
+    ...patch,
+  };
+}
+
+function baseItems() {
+  return [
+    {
+      title: 'Libro <especial>',
+      quantity: 2,
+      unit_price_uyu: 1000,
+      line_total_uyu: 2000,
+    },
+    {
+      title: 'Segundo libro',
+      quantity: 1,
+      unit_price_uyu: 1000,
+      line_total_uyu: 1000,
+    },
+  ];
+}
+
+function baseEnv(patch = {}) {
+  return {
+    RESEND_API_KEY: 're_test_secret',
+    SALES_NOTIFICATION_FROM: 'Amado Libros <ventas@amadolibros.com>',
+    SALES_NOTIFICATION_TO: 'operaciones@amadolibros.com',
+    ...patch,
+  };
+}
+
+function memoryDb({ items = baseItems() } = {}) {
+  const events = new Map();
+
+  return {
+    events,
+    prepare(sql) {
+      return {
+        bind(...args) {
+          return {
+            async run() {
+              if (sql.startsWith('INSERT OR IGNORE INTO order_events')) {
+                const [id, orderId, payload, createdAt] = args;
+                if (events.has(id)) return { success: true, meta: { changes: 0 } };
+                events.set(id, {
+                  id,
+                  order_id: orderId,
+                  event_type: 'sale_notification',
+                  payload_json: payload,
+                  created_at: createdAt,
+                });
+                return { success: true, meta: { changes: 1 } };
+              }
+
+              if (sql.startsWith('UPDATE order_events SET payload_json=')) {
+                const [nextPayload, id, expectedPayload] = args;
+                const current = events.get(id);
+                if (!current || current.payload_json !== expectedPayload) {
+                  return { success: true, meta: { changes: 0 } };
+                }
+                current.payload_json = nextPayload;
+                return { success: true, meta: { changes: 1 } };
+              }
+
+              throw new Error(`SQL run inesperado: ${sql}`);
+            },
+            async first() {
+              if (sql.startsWith('SELECT payload_json FROM order_events')) {
+                const event = events.get(args[0]);
+                return event ? { payload_json: event.payload_json } : null;
+              }
+              throw new Error(`SQL first inesperado: ${sql}`);
+            },
+            async all() {
+              if (sql.startsWith('SELECT title,quantity')) return { results: items };
+              throw new Error(`SQL all inesperado: ${sql}`);
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+function eventState(db, orderId = 'order-uuid') {
+  const event = db.events.get(`sale-email:${orderId}`);
+  return event ? JSON.parse(event.payload_json) : null;
+}
+
+test('sale-email-1: arma asunto, texto y HTML con datos de venta y escape seguro', () => {
+  const email = buildSaleEmail({
+    order: baseOrder(),
+    items: baseItems(),
+    payment: { id: 123 },
+  });
+
+  assert.equal(email.subject, 'Nueva venta web — AL-260729-TEST');
+  assert.match(email.text, /Ana <Pérez>/);
+  assert.match(email.text, /2 × Libro <especial>/);
+  assert.match(email.text, /Total pagado: \$3\.250 UYU/);
+  assert.match(email.text, /Rincón 608/);
+  assert.match(email.html, /Ana &lt;Pérez&gt;/);
+  assert.match(email.html, /Libro &lt;especial&gt;/);
+  assert.ok(!email.html.includes('Ana <Pérez>'));
+});
+
+test('sale-email-2: envía por Resend con clave idempotente y marca D1 como sent', async () => {
+  const db = memoryDb();
+  const requests = [];
+  const sender = createSaleNotificationSender({
+    fetchFn: async (url, options) => {
+      requests.push({ url, options });
+      return Response.json({ id: 'email-provider-1' });
+    },
+    sleep: async () => {},
+  });
+
+  const result = await sender({
+    db,
+    env: baseEnv(),
+    order: baseOrder(),
+    payment: { id: 123 },
+    now: NOW,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.providerId, 'email-provider-1');
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, 'https://api.resend.com/emails');
+  assert.equal(requests[0].options.headers['Idempotency-Key'], 'sale-notification/order-uuid');
+  assert.equal(requests[0].options.headers.Authorization, 'Bearer re_test_secret');
+
+  const body = JSON.parse(requests[0].options.body);
+  assert.deepEqual(body.to, ['operaciones@amadolibros.com']);
+  assert.equal(body.subject, 'Nueva venta web — AL-260729-TEST');
+
+  const state = eventState(db);
+  assert.equal(state.status, 'sent');
+  assert.equal(state.provider, 'resend');
+  assert.equal(state.provider_id, 'email-provider-1');
+});
+
+test('sale-email-3: un webhook repetido no vuelve a enviar si D1 ya dice sent', async () => {
+  const db = memoryDb();
+  let requests = 0;
+  const sender = createSaleNotificationSender({
+    fetchFn: async () => {
+      requests += 1;
+      return Response.json({ id: 'email-provider-1' });
+    },
+    sleep: async () => {},
+  });
+  const args = {
+    db,
+    env: baseEnv(),
+    order: baseOrder(),
+    payment: { id: 123 },
+    now: NOW,
+  };
+
+  const first = await sender(args);
+  const second = await sender(args);
+
+  assert.equal(first.ok, true);
+  assert.equal(second.ok, true);
+  assert.equal(second.skipped, true);
+  assert.equal(second.reason, 'already_sent');
+  assert.equal(requests, 1);
+});
+
+test('sale-email-4: fallo transitorio reintenta, deja constancia y permite un webhook posterior', async () => {
+  const db = memoryDb();
+  let requests = 0;
+  const sender = createSaleNotificationSender({
+    fetchFn: async () => {
+      requests += 1;
+      if (requests <= 3) return Response.json({ message: 'temporary' }, { status: 500 });
+      return Response.json({ id: 'email-provider-retry' });
+    },
+    sleep: async () => {},
+  });
+  const args = {
+    db,
+    env: baseEnv(),
+    order: baseOrder(),
+    payment: { id: 123 },
+    now: NOW,
+  };
+
+  const originalError = console.error;
+  console.error = () => {};
+  try {
+    const failed = await sender(args);
+    assert.equal(failed.ok, false);
+    assert.equal(failed.code, 'RESEND_HTTP_500');
+    assert.equal(eventState(db).status, 'failed');
+    assert.equal(eventState(db).failure_code, 'RESEND_HTTP_500');
+
+    const retried = await sender({ ...args, now: new Date(NOW.getTime() + 60_000) });
+    assert.equal(retried.ok, true);
+    assert.equal(eventState(db).status, 'sent');
+    assert.equal(eventState(db).attempt, 2);
+    assert.equal(requests, 4);
+  } finally {
+    console.error = originalError;
+  }
+});
+
+test('sale-email-5: sin configuración no llama a Resend ni crea un evento engañoso', async () => {
+  const db = memoryDb();
+  let requests = 0;
+  const sender = createSaleNotificationSender({
+    fetchFn: async () => {
+      requests += 1;
+      return Response.json({ id: 'unexpected' });
+    },
+  });
+
+  const originalWarn = console.warn;
+  console.warn = () => {};
+  try {
+    const result = await sender({
+      db,
+      env: {},
+      order: baseOrder(),
+      payment: { id: 123 },
+      now: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.skipped, true);
+    assert.equal(result.code, 'EMAIL_CONFIG_MISSING');
+    assert.equal(requests, 0);
+    assert.equal(db.events.size, 0);
+  } finally {
+    console.warn = originalWarn;
+  }
+});

--- a/functions/api/_mp_webhook_handler.js
+++ b/functions/api/_mp_webhook_handler.js
@@ -3,6 +3,7 @@ import {
   getMerchantOrder as defaultGetMerchantOrder,
 } from './_mp_client.js';
 import { resolveConfig } from './_env_config.js';
+import { sendSaleNotification as defaultSendSaleNotification } from './_sale_notification.js';
 
 const MAX_BODY_BYTES = 32768;
 
@@ -119,7 +120,8 @@ async function applyRefunded(db, order, payment, now) {
 
 export function createMpWebhookHandler({
   mpClient = { getPayment: defaultGetPayment, getMerchantOrder: defaultGetMerchantOrder },
-  getNow   = () => new Date(),
+  getNow       = () => new Date(),
+  saleNotifier = defaultSendSaleNotification,
 } = {}) {
   return async function onRequest(context) {
     const { request, env } = context;
@@ -215,7 +217,13 @@ export function createMpWebhookHandler({
     if (!publicCode || typeof publicCode !== 'string') return json({ ok: true });
 
     const order = await db
-      .prepare('SELECT id,status,payment_status,payable_total_uyu,payment_preference_id FROM orders WHERE public_code=?')
+      .prepare(
+        'SELECT id,public_code,status,payment_status,buyer_name,buyer_phone,delivery_type,' +
+        'address,locality,department,requested_delivery_date,requested_delivery_from,' +
+        'requested_delivery_to,delivery_notes,products_total_uyu,pickup_discount_uyu,' +
+        'shipping_cost_uyu,payable_total_uyu,currency,payment_preference_id ' +
+        'FROM orders WHERE public_code=?'
+      )
       .bind(publicCode)
       .first();
     if (!order) return json({ ok: true });
@@ -265,6 +273,24 @@ export function createMpWebhookHandler({
       else if (normalized === 'refunded')  await applyRefunded(db, order, payment, now);
     } catch {
       return json({ error: 'Error temporal.' }, 500);
+    }
+
+    // La notificación interna nunca forma parte de la confirmación del pago:
+    // primero D1 queda en paid/approved y después se envía en segundo plano.
+    // Un fallo de Resend se registra en order_events, pero Mercado Pago recibe
+    // 200 para no degradar una venta ya validada.
+    if (normalized === 'approved' && config.isProduction) {
+      const notification = Promise.resolve(
+        saleNotifier({ db, env, order, payment, now })
+      ).catch(error => {
+        console.error('[mp_webhook] falló la tarea de notificación', {
+          order_id: order.id,
+          error: error?.name || 'Error',
+        });
+      });
+
+      if (typeof context.waitUntil === 'function') context.waitUntil(notification);
+      else await notification;
     }
 
     return json({ ok: true });

--- a/functions/api/_sale_notification.js
+++ b/functions/api/_sale_notification.js
@@ -1,0 +1,330 @@
+const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+const REQUEST_TIMEOUT_MS = 7000;
+const MAX_SEND_ATTEMPTS = 3;
+const CLAIM_STALE_MS = 5 * 60 * 1000;
+
+function cleanString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function formatMoney(value) {
+  return `$${new Intl.NumberFormat('es-UY', { maximumFractionDigits: 0 }).format(Number(value) || 0)}`;
+}
+
+function resolveEmailConfig(env) {
+  const apiKey = cleanString(env?.RESEND_API_KEY);
+  const from = cleanString(env?.SALES_NOTIFICATION_FROM);
+  const to = cleanString(env?.SALES_NOTIFICATION_TO)
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean);
+
+  if (!apiKey || !from || to.length === 0) return null;
+  return { apiKey, from, to };
+}
+
+function deliveryLines(order) {
+  if (order.delivery_type === 'pickup') {
+    return ['Entrega: Retiro en el punto de entrega'];
+  }
+
+  const lines = [
+    'Entrega: Envío',
+    `Dirección: ${cleanString(order.address) || 'Sin dato'}`,
+    `Localidad: ${cleanString(order.locality) || 'Sin dato'}`,
+    `Departamento: ${cleanString(order.department) || 'Sin dato'}`,
+  ];
+
+  if (order.requested_delivery_date) {
+    const time = order.requested_delivery_from && order.requested_delivery_to
+      ? `, de ${order.requested_delivery_from} a ${order.requested_delivery_to}`
+      : '';
+    lines.push(`Fecha solicitada: ${order.requested_delivery_date}${time}`);
+  }
+  if (order.delivery_notes) lines.push(`Notas: ${order.delivery_notes}`);
+  return lines;
+}
+
+export function buildSaleEmail({ order, items, payment }) {
+  const itemLines = items.map(item =>
+    `${item.quantity} × ${item.title} — ${formatMoney(item.line_total_uyu)}`
+  );
+  const delivery = deliveryLines(order);
+  const subject = `Nueva venta web — ${order.public_code}`;
+
+  const text = [
+    `Nueva venta web confirmada: ${order.public_code}`,
+    '',
+    `Cliente: ${order.buyer_name}`,
+    `Teléfono: ${order.buyer_phone}`,
+    '',
+    'Libros:',
+    ...itemLines.map(line => `- ${line}`),
+    '',
+    `Productos: ${formatMoney(order.products_total_uyu)}`,
+    `Descuento por retiro: ${formatMoney(order.pickup_discount_uyu)}`,
+    `Envío: ${formatMoney(order.shipping_cost_uyu)}`,
+    `Total pagado: ${formatMoney(order.payable_total_uyu)} UYU`,
+    `Mercado Pago: aprobado (pago ${payment.id})`,
+    '',
+    ...delivery,
+  ].join('\n');
+
+  const itemRows = items.map(item => `
+    <tr>
+      <td style="padding:8px;border-bottom:1px solid #ddd">${escapeHtml(item.title)}</td>
+      <td style="padding:8px;border-bottom:1px solid #ddd;text-align:center">${escapeHtml(item.quantity)}</td>
+      <td style="padding:8px;border-bottom:1px solid #ddd;text-align:right">${escapeHtml(formatMoney(item.line_total_uyu))}</td>
+    </tr>`).join('');
+
+  const deliveryHtml = delivery
+    .map(line => `<li style="margin:4px 0">${escapeHtml(line)}</li>`)
+    .join('');
+
+  const html = `<!doctype html>
+<html lang="es">
+  <body style="font-family:Arial,sans-serif;color:#222;line-height:1.45">
+    <h1 style="font-size:22px">Nueva venta web confirmada</h1>
+    <p><strong>Pedido:</strong> ${escapeHtml(order.public_code)}</p>
+    <p><strong>Cliente:</strong> ${escapeHtml(order.buyer_name)}<br>
+       <strong>Teléfono:</strong> ${escapeHtml(order.buyer_phone)}</p>
+    <table style="border-collapse:collapse;width:100%;max-width:700px">
+      <thead>
+        <tr>
+          <th style="padding:8px;text-align:left;border-bottom:2px solid #999">Libro</th>
+          <th style="padding:8px;text-align:center;border-bottom:2px solid #999">Cant.</th>
+          <th style="padding:8px;text-align:right;border-bottom:2px solid #999">Total</th>
+        </tr>
+      </thead>
+      <tbody>${itemRows}</tbody>
+    </table>
+    <p>
+      Productos: ${escapeHtml(formatMoney(order.products_total_uyu))}<br>
+      Descuento por retiro: ${escapeHtml(formatMoney(order.pickup_discount_uyu))}<br>
+      Envío: ${escapeHtml(formatMoney(order.shipping_cost_uyu))}<br>
+      <strong>Total pagado: ${escapeHtml(formatMoney(order.payable_total_uyu))} UYU</strong><br>
+      Mercado Pago: aprobado (pago ${escapeHtml(payment.id)})
+    </p>
+    <ul>${deliveryHtml}</ul>
+  </body>
+</html>`;
+
+  return { subject, text, html };
+}
+
+function parseEventState(payload) {
+  try {
+    const value = JSON.parse(payload);
+    return value && typeof value === 'object' ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+async function claimNotification(db, orderId, now) {
+  const eventId = `sale-email:${orderId}`;
+  const initialPayload = JSON.stringify({
+    status: 'sending',
+    attempt: 1,
+    attempted_at: now.toISOString(),
+  });
+  const inserted = await db.prepare(
+    "INSERT OR IGNORE INTO order_events (id,order_id,event_type,payload_json,created_at) VALUES (?,?,'sale_notification',?,?)"
+  ).bind(eventId, orderId, initialPayload, now.toISOString()).run();
+
+  if (Number(inserted?.meta?.changes) > 0) {
+    return { claimed: true, eventId, attempt: 1, claimPayload: initialPayload };
+  }
+
+  const existing = await db.prepare(
+    'SELECT payload_json FROM order_events WHERE id=?'
+  ).bind(eventId).first();
+  if (!existing) return { claimed: false, reason: 'claim_missing' };
+
+  const state = parseEventState(existing.payload_json);
+  if (state?.status === 'sent') return { claimed: false, reason: 'already_sent' };
+
+  const attemptedAt = Date.parse(state?.attempted_at || '');
+  const isFreshClaim = state?.status === 'sending' &&
+    Number.isFinite(attemptedAt) &&
+    now.getTime() - attemptedAt < CLAIM_STALE_MS;
+  if (isFreshClaim) return { claimed: false, reason: 'in_progress' };
+
+  const attempt = Number.isInteger(state?.attempt) && state.attempt > 0
+    ? state.attempt + 1
+    : 1;
+  const retryPayload = JSON.stringify({
+    status: 'sending',
+    attempt,
+    attempted_at: now.toISOString(),
+  });
+  const updated = await db.prepare(
+    'UPDATE order_events SET payload_json=? WHERE id=? AND payload_json=?'
+  ).bind(retryPayload, eventId, existing.payload_json).run();
+
+  if (Number(updated?.meta?.changes) === 0) {
+    return { claimed: false, reason: 'claim_lost' };
+  }
+  return { claimed: true, eventId, attempt, claimPayload: retryPayload };
+}
+
+async function updateClaim(db, claim, payload) {
+  const nextPayload = JSON.stringify(payload);
+  await db.prepare(
+    'UPDATE order_events SET payload_json=? WHERE id=? AND payload_json=?'
+  ).bind(nextPayload, claim.eventId, claim.claimPayload).run();
+}
+
+function safeFailureCode(value) {
+  const code = cleanString(value);
+  return /^[A-Z0-9_:-]{1,80}$/.test(code) ? code : 'RESEND_ERROR';
+}
+
+async function postToResend({ config, email, idempotencyKey, fetchFn, timeoutMs }) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchFn(RESEND_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        'Content-Type': 'application/json',
+        'Idempotency-Key': idempotencyKey,
+      },
+      body: JSON.stringify({
+        from: config.from,
+        to: config.to,
+        subject: email.subject,
+        text: email.text,
+        html: email.html,
+      }),
+      signal: controller.signal,
+    });
+
+    let data = null;
+    try { data = await response.json(); } catch { /* body opcional */ }
+
+    if (response.ok && typeof data?.id === 'string' && data.id) {
+      return { ok: true, providerId: data.id };
+    }
+    return {
+      ok: false,
+      retryable: response.status === 429 || response.status >= 500,
+      code: `RESEND_HTTP_${response.status}`,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      retryable: true,
+      code: error?.name === 'AbortError' ? 'RESEND_TIMEOUT' : 'RESEND_NETWORK_ERROR',
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function createSaleNotificationSender({
+  fetchFn = globalThis.fetch,
+  sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
+  timeoutMs = REQUEST_TIMEOUT_MS,
+} = {}) {
+  return async function sendSaleNotification({ db, env, order, payment, now }) {
+    const config = resolveEmailConfig(env);
+    if (!config) {
+      console.warn('[sale-notification] configuración ausente', {
+        order_id: order.id,
+      });
+      return { ok: false, skipped: true, code: 'EMAIL_CONFIG_MISSING' };
+    }
+
+    let claim;
+    try {
+      claim = await claimNotification(db, order.id, now);
+    } catch (error) {
+      console.error('[sale-notification] no se pudo registrar el intento', {
+        order_id: order.id,
+        error: error?.name || 'Error',
+      });
+      return { ok: false, code: 'EMAIL_CLAIM_ERROR' };
+    }
+    if (!claim.claimed) return { ok: true, skipped: true, reason: claim.reason };
+
+    let items;
+    try {
+      const result = await db.prepare(
+        'SELECT title,quantity,unit_price_uyu,line_total_uyu FROM order_items WHERE order_id=? ORDER BY created_at,id'
+      ).bind(order.id).all();
+      items = Array.isArray(result?.results) ? result.results : [];
+      if (items.length === 0) throw new Error('OrderItemsMissing');
+    } catch (error) {
+      await updateClaim(db, claim, {
+        status: 'failed',
+        attempt: claim.attempt,
+        attempted_at: now.toISOString(),
+        failure_code: 'ORDER_ITEMS_UNAVAILABLE',
+      }).catch(() => {});
+      console.error('[sale-notification] no se pudieron leer los libros', {
+        order_id: order.id,
+        error: error?.name || 'Error',
+      });
+      return { ok: false, code: 'ORDER_ITEMS_UNAVAILABLE' };
+    }
+
+    const email = buildSaleEmail({ order, items, payment });
+    const idempotencyKey = `sale-notification/${order.id}`;
+    let result = null;
+
+    for (let attempt = 1; attempt <= MAX_SEND_ATTEMPTS; attempt++) {
+      result = await postToResend({
+        config,
+        email,
+        idempotencyKey,
+        fetchFn,
+        timeoutMs,
+      });
+      if (result.ok || !result.retryable || attempt === MAX_SEND_ATTEMPTS) break;
+      await sleep(250 * (2 ** (attempt - 1)));
+    }
+
+    if (result?.ok) {
+      await updateClaim(db, claim, {
+        status: 'sent',
+        attempt: claim.attempt,
+        attempted_at: now.toISOString(),
+        sent_at: now.toISOString(),
+        provider: 'resend',
+        provider_id: result.providerId,
+      }).catch(error => {
+        console.error('[sale-notification] correo enviado pero no se pudo confirmar en D1', {
+          order_id: order.id,
+          error: error?.name || 'Error',
+        });
+      });
+      return { ok: true, providerId: result.providerId };
+    }
+
+    const failureCode = safeFailureCode(result?.code);
+    await updateClaim(db, claim, {
+      status: 'failed',
+      attempt: claim.attempt,
+      attempted_at: now.toISOString(),
+      failure_code: failureCode,
+    }).catch(() => {});
+    console.error('[sale-notification] Resend no confirmó el correo', {
+      order_id: order.id,
+      code: failureCode,
+    });
+    return { ok: false, code: failureCode };
+  };
+}
+
+export const sendSaleNotification = createSaleNotificationSender();


### PR DESCRIPTION
## Qué cambia

- Envía un aviso interno por Resend cuando Mercado Pago confirma una venta web en Producción.
- Incluye pedido, cliente, teléfono, libros, importe, pago y entrega.
- Registra el estado del aviso en `order_events` y usa una clave idempotente para evitar correos duplicados.
- Reintenta fallos transitorios de Resend y permite un reintento posterior desde un webhook repetido.
- Mantiene el pago `paid/approved` aunque el correo falle.
- Preview no envía correos.

## Motivo

El webhook ya confirmaba el pago y actualizaba D1, pero Amado Libros no recibía ninguna notificación interna de la venta.

## Configuración requerida antes de merge/deploy

En Cloudflare Pages Production:

- secret `RESEND_API_KEY`;
- variable `SALES_NOTIFICATION_FROM` con un dominio verificado en Resend;
- variable `SALES_NOTIFICATION_TO` con el correo interno receptor.

Este PR no agrega valores reales ni secretos al repositorio.

## Validación

- `scripts/validate-ci.sh`: OK.
- 192 pruebas de API: OK.
- Builds Astro con checkout OFF y ON: OK.
- Pruebas específicas de envío, escape HTML, idempotencia, reintento y configuración ausente: OK.

## Alcance

Rama y PR en borrador únicamente. Sin merge, deploy, ejecución de sync ni cambios en Cloudflare, D1 remoto o Mercado Pago.