### PR TITLE
EMAIL-TEST: prueba segura sin pedidos ni Mercado Pago

### DIFF
--- a/functions/api/__tests__/email_test.test.js
+++ b/functions/api/__tests__/email_test.test.js
@@ -1,0 +1,102 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { onRequest } from '../email-test.js';
+
+const TOKEN = '25f663d775d5cc680fbc4e4002d09a8e3523caf32188cba1';
+
+function request(method, token = TOKEN) {
+  if (method === 'GET') {
+    return new Request(`https://www.amadolibros.com/api/email-test?token=${token}`, { method });
+  }
+  return new Request('https://www.amadolibros.com/api/email-test', {
+    method,
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ token }),
+  });
+}
+
+function env(overrides = {}) {
+  return {
+    APP_ENV: 'production',
+    RESEND_API_KEY: 're_test_secret',
+    SALES_NOTIFICATION_FROM: 'Amado Libros <web@notificaciones.amadolibros.com>',
+    SALES_NOTIFICATION_TO: 'uno@example.com,dos@example.com',
+    ...overrides,
+  };
+}
+
+test('email-test-1: token inválido responde 404 y no envía', async () => {
+  let calls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => { calls += 1; };
+  try {
+    const result = await onRequest({ request: request('GET', '0'.repeat(48)), env: env() });
+    assert.equal(result.status, 404);
+    assert.equal(calls, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('email-test-2: preview queda bloqueado aunque el token sea válido', async () => {
+  const result = await onRequest({
+    request: request('GET'),
+    env: env({ APP_ENV: 'preview' }),
+  });
+  assert.equal(result.status, 404);
+});
+
+test('email-test-3: GET válido muestra confirmación y no envía', async () => {
+  let calls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => { calls += 1; };
+  try {
+    const result = await onRequest({ request: request('GET'), env: env() });
+    const body = await result.text();
+    assert.equal(result.status, 200);
+    assert.match(body, /Enviar prueba/);
+    assert.equal(calls, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('email-test-4: POST envía sólo a los destinatarios configurados', async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return new Response(JSON.stringify({ id: 'email-test-id' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+  try {
+    const guardedEnv = new Proxy(env(), {
+      get(target, property) {
+        assert.notEqual(property, 'ORDERS_DB');
+        assert.notEqual(property, 'MP_ACCESS_TOKEN');
+        assert.notEqual(property, 'MP_WEBHOOK_SECRET');
+        return target[property];
+      },
+    });
+    const result = await onRequest({ request: request('POST'), env: guardedEnv });
+    assert.equal(result.status, 200);
+    assert.equal(calls.length, 1);
+    const payload = JSON.parse(calls[0].options.body);
+    assert.deepEqual(payload.to, ['uno@example.com', 'dos@example.com']);
+    assert.equal(payload.subject, 'PRUEBA — Notificación de venta web');
+    assert.equal(calls[0].options.headers['Idempotency-Key'], 'safe-email-test/2026-07-30-v1');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('email-test-5: método ajeno queda rechazado', async () => {
+  const result = await onRequest({
+    request: new Request('https://www.amadolibros.com/api/email-test', { method: 'DELETE' }),
+    env: env(),
+  });
+  assert.equal(result.status, 405);
+  assert.equal(result.headers.get('Allow'), 'GET, POST');
+});

--- a/functions/api/_sale_notification.js
+++ b/functions/api/_sale_notification.js
@@ -20,7 +20,7 @@ function formatMoney(value) {
   return `$${new Intl.NumberFormat('es-UY', { maximumFractionDigits: 0 }).format(Number(value) || 0)}`;
 }
 
-function resolveEmailConfig(env) {
+export function resolveEmailConfig(env) {
   const apiKey = cleanString(env?.RESEND_API_KEY);
   const from = cleanString(env?.SALES_NOTIFICATION_FROM);
   const to = cleanString(env?.SALES_NOTIFICATION_TO)
@@ -189,7 +189,7 @@ function safeFailureCode(value) {
   return /^[A-Z0-9_:-]{1,80}$/.test(code) ? code : 'RESEND_ERROR';
 }
 
-async function postToResend({ config, email, idempotencyKey, fetchFn, timeoutMs }) {
+export async function postToResend({ config, email, idempotencyKey, fetchFn, timeoutMs }) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
@@ -328,3 +328,40 @@ export function createSaleNotificationSender({
 }
 
 export const sendSaleNotification = createSaleNotificationSender();
+
+export async function sendSafeTestNotification({
+  env,
+  fetchFn = globalThis.fetch,
+  timeoutMs = REQUEST_TIMEOUT_MS,
+} = {}) {
+  const config = resolveEmailConfig(env);
+  if (!config) {
+    return { ok: false, code: 'EMAIL_CONFIG_MISSING' };
+  }
+
+  const email = {
+    subject: 'PRUEBA — Notificación de venta web',
+    text: [
+      'Prueba correcta de notificaciones de Amado Libros.',
+      '',
+      'Este correo no corresponde a una venta.',
+      'No se creó ningún pedido y no se contactó a Mercado Pago.',
+    ].join('\n'),
+    html: `<!doctype html>
+<html lang="es">
+  <body style="font-family:Arial,sans-serif;color:#222;line-height:1.45">
+    <h1 style="font-size:22px">Prueba correcta de notificaciones</h1>
+    <p>Este correo no corresponde a una venta.</p>
+    <p>No se creó ningún pedido y no se contactó a Mercado Pago.</p>
+  </body>
+</html>`,
+  };
+
+  return postToResend({
+    config,
+    email,
+    idempotencyKey: 'safe-email-test/2026-07-30-v1',
+    fetchFn,
+    timeoutMs,
+  });
+}

--- a/functions/api/email-test.js
+++ b/functions/api/email-test.js
@@ -1,0 +1,89 @@
+import { sendSafeTestNotification } from './_sale_notification.js';
+
+const TEST_TOKEN_SHA256 = '16585a0999dcdb783f838248803143f3d97a9c175c5a2aaecdca05ea8694360b';
+const SECURITY_HEADERS = {
+  'Cache-Control': 'no-store',
+  'Content-Security-Policy': "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
+  'Referrer-Policy': 'no-referrer',
+  'X-Content-Type-Options': 'nosniff',
+  'X-Robots-Tag': 'noindex, nofollow',
+};
+
+function response(body, status = 200, contentType = 'text/plain; charset=utf-8') {
+  return new Response(body, {
+    status,
+    headers: {
+      ...SECURITY_HEADERS,
+      'Content-Type': contentType,
+    },
+  });
+}
+
+async function sha256(value) {
+  const bytes = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(digest)]
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function tokenIsValid(value) {
+  if (typeof value !== 'string' || !/^[a-f0-9]{48}$/.test(value)) return false;
+  return (await sha256(value)) === TEST_TOKEN_SHA256;
+}
+
+async function readToken(request) {
+  if (request.method === 'GET') {
+    return new URL(request.url).searchParams.get('token') || '';
+  }
+  if (request.method === 'POST') {
+    const contentType = request.headers.get('content-type') || '';
+    if (!contentType.startsWith('application/x-www-form-urlencoded')) return '';
+    const form = await request.formData();
+    return form.get('token') || '';
+  }
+  return '';
+}
+
+function confirmationPage(token) {
+  return `<!doctype html>
+<html lang="es">
+  <head><meta charset="utf-8"><meta name="viewport" content="width=device-width"></head>
+  <body style="font-family:Arial,sans-serif;max-width:620px;margin:48px auto;padding:0 20px">
+    <h1>Prueba segura de email</h1>
+    <p>Enviará un único correo a los destinatarios configurados. No crea pedidos ni contacta a Mercado Pago.</p>
+    <form method="post">
+      <input type="hidden" name="token" value="${token}">
+      <button type="submit" style="padding:12px 18px;font-weight:700">Enviar prueba</button>
+    </form>
+  </body>
+</html>`;
+}
+
+export async function onRequest(context) {
+  const { request, env } = context;
+  if (env?.APP_ENV !== 'production') return response('Not Found', 404);
+  if (request.method !== 'GET' && request.method !== 'POST') {
+    return new Response('Method Not Allowed', {
+      status: 405,
+      headers: { ...SECURITY_HEADERS, Allow: 'GET, POST' },
+    });
+  }
+
+  const token = await readToken(request);
+  if (!(await tokenIsValid(token))) return response('Not Found', 404);
+
+  if (request.method === 'GET') {
+    return response(confirmationPage(token), 200, 'text/html; charset=utf-8');
+  }
+
+  const result = await sendSafeTestNotification({ env });
+  if (!result.ok) {
+    console.error('[email-test] Resend no confirmó el correo', {
+      code: result.code || 'RESEND_ERROR',
+    });
+    return response('No se pudo enviar la prueba.', 502);
+  }
+
+  return response('Prueba enviada correctamente.');
+}


### PR DESCRIPTION
## Qué cambia

Agrega una ruta temporal y protegida para validar el envío real de Resend desde Cloudflare Pages.

- envía únicamente a `SALES_NOTIFICATION_TO`;
- no acepta destinatarios externos;
- no crea pedidos ni consulta D1;
- no llama a Mercado Pago;
- sólo funciona en Production y exige un token cuya forma original no está en el repositorio;
- usa una clave idempotente fija para evitar duplicados.

Después de comprobar la recepción, la ruta se retirará en un lote de limpieza.

## Validación

- 197 pruebas aprobadas, incluidas 5 específicas del endpoint.
- Build Astro con checkout OFF: aprobado.
- Build Astro con checkout ON: aprobado.