### PR TITLE
EMAIL-TEST: mostrar código de error seguro

### DIFF
--- a/functions/api/__tests__/email_test.test.js
+++ b/functions/api/__tests__/email_test.test.js
@@ -100,3 +100,18 @@ test('email-test-5: método ajeno queda rechazado', async () => {
   assert.equal(result.status, 405);
   assert.equal(result.headers.get('Allow'), 'GET, POST');
 });
+
+test('email-test-6: un fallo muestra sólo un código seguro, nunca secretos', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => Response.json({ message: 'invalid api key' }, { status: 401 });
+  try {
+    const result = await onRequest({ request: request('POST'), env: env() });
+    const body = await result.text();
+    assert.equal(result.status, 502);
+    assert.equal(body, 'No se pudo enviar la prueba: RESEND_HTTP_401');
+    assert.ok(!body.includes('re_test_secret'));
+    assert.ok(!body.includes('uno@example.com'));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/functions/api/email-test.js
+++ b/functions/api/email-test.js
@@ -79,10 +79,13 @@ export async function onRequest(context) {
 
   const result = await sendSafeTestNotification({ env });
   if (!result.ok) {
+    const safeCode = /^[A-Z0-9_:-]{1,80}$/.test(result.code || '')
+      ? result.code
+      : 'RESEND_ERROR';
     console.error('[email-test] Resend no confirmó el correo', {
-      code: result.code || 'RESEND_ERROR',
+      code: safeCode,
     });
-    return response('No se pudo enviar la prueba.', 502);
+    return response(`No se pudo enviar la prueba: ${safeCode}`, 502);
   }
 
   return response('Prueba enviada correctamente.');


### PR DESCRIPTION
El primer envío controlado llegó a Resend pero no fue aceptado. Este ajuste temporal muestra únicamente el código normalizado del fallo (`RESEND_HTTP_...`, timeout o configuración ausente), sin exponer API keys ni destinatarios.

Validación: 6/6 pruebas específicas aprobadas; el nuevo test confirma que la respuesta no contiene secretos ni correos.