### PR TITLE
EMAIL-TEST: hacer visible el diagnóstico seguro

### DIFF
--- a/functions/api/__tests__/email_test.test.js
+++ b/functions/api/__tests__/email_test.test.js
@@ -107,8 +107,8 @@ test('email-test-6: un fallo muestra sólo un código seguro, nunca secretos', a
   try {
     const result = await onRequest({ request: request('POST'), env: env() });
     const body = await result.text();
-    assert.equal(result.status, 502);
-    assert.equal(body, 'No se pudo enviar la prueba: RESEND_HTTP_401');
+    assert.equal(result.status, 200);
+    assert.equal(body, 'FALLO — No se pudo enviar la prueba: RESEND_HTTP_401');
     assert.ok(!body.includes('re_test_secret'));
     assert.ok(!body.includes('uno@example.com'));
   } finally {

--- a/functions/api/email-test.js
+++ b/functions/api/email-test.js
@@ -85,7 +85,10 @@ export async function onRequest(context) {
     console.error('[email-test] Resend no confirmó el correo', {
       code: safeCode,
     });
-    return response(`No se pudo enviar la prueba: ${safeCode}`, 502);
+    // Cloudflare reemplaza respuestas 502 por su página genérica y oculta el
+    // código seguro. Esta ruta es temporal: responde 200 para que el operador
+    // pueda leer el diagnóstico y distingue el fallo con un prefijo explícito.
+    return response(`FALLO — No se pudo enviar la prueba: ${safeCode}`);
   }
 
   return response('Prueba enviada correctamente.');


### PR DESCRIPTION
Cloudflare reemplaza las respuestas 502 de Pages por una pantalla genérica. Esta ruta temporal devuelve el fallo como texto explícito con HTTP 200 para que el operador vea únicamente el código normalizado de Resend. No expone API keys, destinatarios ni respuestas del proveedor.

Validación: 6/6 pruebas específicas aprobadas.