### PR TITLE
EMAIL-TEST: identificar variable ausente

### DIFF
--- a/functions/api/__tests__/email_test.test.js
+++ b/functions/api/__tests__/email_test.test.js
@@ -101,7 +101,17 @@ test('email-test-5: método ajeno queda rechazado', async () => {
   assert.equal(result.headers.get('Allow'), 'GET, POST');
 });
 
-test('email-test-6: un fallo muestra sólo un código seguro, nunca secretos', async () => {
+test('email-test-6: identifica exactamente el binding de correo ausente', async () => {
+  const result = await onRequest({
+    request: request('POST'),
+    env: env({ SALES_NOTIFICATION_FROM: '' }),
+  });
+  const body = await result.text();
+  assert.equal(result.status, 200);
+  assert.equal(body, 'FALLO — No se pudo enviar la prueba: EMAIL_CONFIG_MISSING_FROM');
+});
+
+test('email-test-7: un fallo muestra sólo un código seguro, nunca secretos', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () => Response.json({ message: 'invalid api key' }, { status: 401 });
   try {

--- a/functions/api/email-test.js
+++ b/functions/api/email-test.js
@@ -77,6 +77,15 @@ export async function onRequest(context) {
     return response(confirmationPage(token), 200, 'text/html; charset=utf-8');
   }
 
+  const missingBindings = [
+    !String(env?.RESEND_API_KEY || '').trim() && 'API_KEY',
+    !String(env?.SALES_NOTIFICATION_FROM || '').trim() && 'FROM',
+    !String(env?.SALES_NOTIFICATION_TO || '').trim() && 'TO',
+  ].filter(Boolean);
+  if (missingBindings.length > 0) {
+    return response(`FALLO — No se pudo enviar la prueba: EMAIL_CONFIG_MISSING_${missingBindings.join('_')}`);
+  }
+
   let result;
   try {
     result = await sendSafeTestNotification({ env });


### PR DESCRIPTION
## Qué cambia
La ruta temporal de prueba informa cuál binding de correo no está llegando a la Function: `API_KEY`, `FROM` o `TO`.

## Alcance
No modifica pedidos, checkout, Mercado Pago, D1 ni el envío normal de ventas. Sólo mejora el diagnóstico temporal.

## Validación
Agrega una prueba específica para el binding ausente; el CI del repositorio ejecutará sintaxis, suite completa y ambos builds.