### PR TITLE
EMAIL-DEPLOY: persistir variables de notificación

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,6 +102,19 @@ jobs:
           PUBLIC_TURNSTILE_ALLOWED_HOSTS: ${{ steps.ts_config.outputs.allowed_hosts }}
         run: npm run build
 
+      - name: Sync Resend secret to Cloudflare Pages
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -z "$RESEND_API_KEY" ]; then
+            echo "::error::Falta el secret RESEND_API_KEY en el environment production de GitHub."
+            exit 1
+          fi
+          printf '%s' "$RESEND_API_KEY" |
+            npx wrangler@3.114.17 pages secret put RESEND_API_KEY --project-name amadolibros-web
+
       - name: Deploy via Wrangler
         run: npx wrangler@3.114.17 pages deploy ./astro-front/dist --project-name amadolibros-web --branch main
         env:

--- a/functions/__tests__/wrangler-config.test.js
+++ b/functions/__tests__/wrangler-config.test.js
@@ -65,10 +65,37 @@ test('wrangler.toml: Producción conserva APP_ENV, CANONICAL_ORIGIN y ALLOWED_HO
   assert.match(productionVars, /ALLOWED_HOSTS\s*=\s*"amadolibros\.com,www\.amadolibros\.com"/);
 });
 
-test('wrangler.toml: Producción no declara secrets (MP_ACCESS_TOKEN, MP_WEBHOOK_SECRET, TURNSTILE_SECRET_KEY)', () => {
+test('wrangler.toml: Producción declara remitente y destinatarios de email', () => {
+  assert.match(
+    productionVars,
+    /SALES_NOTIFICATION_FROM\s*=\s*"Amado Libros <web@notificaciones\.amadolibros\.com>"/,
+  );
+  assert.match(
+    productionVars,
+    /SALES_NOTIFICATION_TO\s*=\s*"undiaes@gmail\.com,adm@amadolibros\.com"/,
+  );
+});
+
+test('wrangler.toml: Producción no declara secrets', () => {
   assert.doesNotMatch(productionVars, /MP_ACCESS_TOKEN/);
   assert.doesNotMatch(productionVars, /MP_WEBHOOK_SECRET/);
   assert.doesNotMatch(productionVars, /TURNSTILE_SECRET_KEY/);
+  assert.doesNotMatch(productionVars, /RESEND_API_KEY/);
+});
+
+test('deploy.yml: sincroniza RESEND_API_KEY cifrada antes de publicar', () => {
+  const secretStepIdx = deployYml.indexOf('Sync Resend secret to Cloudflare Pages');
+  const deployStepIdx = deployYml.indexOf('Deploy via Wrangler');
+  assert.notEqual(secretStepIdx, -1, 'step de sincronización de Resend no encontrado');
+  assert.notEqual(deployStepIdx, -1, 'step de deploy no encontrado');
+  assert.ok(secretStepIdx < deployStepIdx, 'el secret debe sincronizarse antes del deploy');
+  assert.match(deployYml, /RESEND_API_KEY:\s*\$\{\{\s*secrets\.RESEND_API_KEY\s*\}\}/);
+  assert.match(
+    deployYml,
+    /wrangler@3\.114\.17 pages secret put RESEND_API_KEY --project-name amadolibros-web/,
+  );
+  assert.match(deployYml, /if \[ -z "\$RESEND_API_KEY" \]/);
+  assert.doesNotMatch(deployYml, /re_[A-Za-z0-9_-]+/);
 });
 
 test('deploy.yml: build de Producción tiene PUBLIC_CHECKOUT_ENABLED en true (2-N-H1)', () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -59,11 +59,13 @@ database_id = "6dc8dc3a-2d4f-4045-b428-14323c7b0bcd"
 # MP_COLLECTOR_ID confirmado en 2-N-G2 (440298103) — NO es el número de
 # aplicación de Mercado Pago (6816864196905927, solo informativo, no se usa
 # en runtime). MP_ACCESS_TOKEN, MP_WEBHOOK_SECRET y TURNSTILE_SECRET_KEY
-# siguen sin declararse acá — son secrets, viven únicamente en el dashboard
-# de Cloudflare Pages.
+# siguen sin declararse acá — son secrets. RESEND_API_KEY tampoco se declara:
+# el workflow lo sincroniza como secret cifrado antes de cada deploy.
 [env.production.vars]
 APP_ENV           = "production"
 CHECKOUT_ENABLED  = "true"
 CANONICAL_ORIGIN  = "https://www.amadolibros.com"
 ALLOWED_HOSTS     = "amadolibros.com,www.amadolibros.com"
 MP_COLLECTOR_ID   = "440298103"
+SALES_NOTIFICATION_FROM = "Amado Libros <web@notificaciones.amadolibros.com>"
+SALES_NOTIFICATION_TO   = "undiaes@gmail.com,adm@amadolibros.com"


### PR DESCRIPTION
## Qué cambia

- Declara `SALES_NOTIFICATION_FROM` y `SALES_NOTIFICATION_TO` en la configuración de Producción de Wrangler.
- Sincroniza `RESEND_API_KEY` como secreto cifrado de Cloudflare Pages antes de cada deploy.
- Falla antes de publicar si el secreto de GitHub no está disponible.
- Agrega pruebas para impedir que la API key se hardcodee o que el orden de despliegue se rompa.

## Causa

`wrangler.toml` es la fuente de verdad del proyecto Pages. Las variables cargadas manualmente no estaban llegando a la versión publicada.

## Validación

- 199 tests: OK.
- Build Astro con checkout OFF: OK.
- Build Astro con checkout ON: OK.
- `git diff --check`: OK.

## Alcance

No cambia checkout, pedidos, D1, webhook ni Mercado Pago.