### PR TITLE
COPY: aclarar punto de retiro coordinado

### DIFF
--- a/astro-front/src/components/Footer.astro
+++ b/astro-front/src/components/Footer.astro
@@ -41,8 +41,9 @@ const YEAR = new Date().getFullYear();
         WhatsApp · 099 841 325
       </a>
       <a href="mailto:adm@amadolibros.com" class="footer-text-link">adm@amadolibros.com</a>
-      <a href="/contacto" class="footer-text-link">Rincón 608 · Montevideo</a>
-      <p class="footer-hours">Lun–Vie 9:30–17:30</p>
+      <a href="/contacto" class="footer-text-link">Punto de retiro: Rincón 608 · Montevideo</a>
+      <p class="footer-hours">Únicamente con coordinación previa</p>
+      <p class="footer-hours">Atención: Lun–Vie 9:30–17:30</p>
     </div>
 
   </div>


### PR DESCRIPTION
## Qué cambia

Aclara en el pie del sitio que Rincón 608 es únicamente un punto de retiro con coordinación previa y separa el horario de atención.

## Motivo

Evitar que clientes interpreten la dirección como un local de atención presencial sin coordinación.

## Alcance

- Un solo archivo: `astro-front/src/components/Footer.astro`
- Sin cambios de diseño, checkout, catálogo ni rendimiento

## Validación

- `ASTRO_TELEMETRY_DISABLED=1 npm run build`
- 9 páginas generadas correctamente
- Diff remoto: 3 líneas agregadas y 2 eliminadas