### PR TITLE
PAUSADOS-1: recuperación comercial en fichas pausadas

### DIFF
--- a/functions/__tests__/catalog-display.test.js
+++ b/functions/__tests__/catalog-display.test.js
@@ -4,7 +4,7 @@ import { onRequest as catalogRequest } from '../catalogo.js';
 import { onRequest as bookRequest } from '../libro/[[path]].js';
 
 const CATALOG = {
-  total: 2,
+  total: 3,
   items: [
     {
       id: 'MLU1', title: 'Alpha disponible', author: 'Autora Uno',
@@ -16,6 +16,11 @@ const CATALOG = {
       id: 'MLU2', title: 'Alpha raro', author: 'Autor Dos',
       price: 98765, status: 'paused', available_quantity: 0,
       thumbnail: '', pictures: [], permalink: 'https://articulo.mercadolibre.com.uy/MLU2',
+    },
+    {
+      id: 'MLU3', title: 'Beta sin autor', author: null, isbn: '9789998887776',
+      price: 500, status: 'active', available_quantity: 0,
+      thumbnail: '', pictures: [], permalink: 'https://articulo.mercadolibre.com.uy/MLU3',
     },
   ],
 };
@@ -71,11 +76,43 @@ test('la ficha pausada queda noindex, sin precio ni compra directa', async () =>
   const html = await response.text();
 
   assert.match(html, /noindex, follow/);
-  assert.match(html, /Entrega estimada: 15–20 días/);
-  assert.match(html, /Consultar disponibilidad/);
+  assert.match(html, /Vendimos todos los ejemplares disponibles\./);
+  assert.match(html, /Si querés, lo buscamos para vos\./);
+  assert.match(html, /Consultar si podemos conseguirlo/);
   assert.doesNotMatch(html, /98[.,]765/);
   assert.doesNotMatch(html, /Agregar al carrito/);
   assert.doesNotMatch(html, /Comprar en MercadoLibre/);
+});
+
+test('la ficha pausada arma el mensaje de WhatsApp con título, autor e ISBN cuando existen', async () => {
+  const response = await bookRequest(
+    context('https://www.amadolibros.com/libro/MLU2/alpha-raro', {
+      path: ['MLU2', 'alpha-raro'],
+    })
+  );
+  const html = await response.text();
+
+  const expected = encodeURIComponent(
+    'Hola, me interesa conseguir “Alpha raro”, de Autor Dos. ¿Podrían buscarlo por encargo?'
+  );
+  assert.ok(html.includes(`https://wa.me/59899841325?text=${expected}`));
+});
+
+test('la ficha sin ejemplares (activa, stock 0) también muestra el bloque comercial sin autor cuando falta', async () => {
+  const response = await bookRequest(
+    context('https://www.amadolibros.com/libro/MLU3/beta-sin-autor', {
+      path: ['MLU3', 'beta-sin-autor'],
+    })
+  );
+  const html = await response.text();
+
+  assert.match(html, /Vendimos todos los ejemplares disponibles\./);
+  assert.doesNotMatch(html, /Agregar al carrito/);
+
+  const expected = encodeURIComponent(
+    'Hola, me interesa conseguir “Beta sin autor” (9789998887776). ¿Podrían buscarlo por encargo?'
+  );
+  assert.ok(html.includes(`https://wa.me/59899841325?text=${expected}`));
 });
 
 test('la ficha activa conserva precio y carrito en producción', async () => {

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -84,6 +84,14 @@ function formatDimensions(dimensions) {
     return rows.length ? rows.join(' · ') : null;
 }
 
+function buildPausedWaMessage(item) {
+    let msg = `Hola, me interesa conseguir “${item.title}”`;
+    if (item.author) msg += `, de ${item.author}`;
+    if (item.isbn) msg += ` (${item.isbn})`;
+    msg += '. ¿Podrían buscarlo por encargo?';
+    return msg;
+}
+
 function detailRow(label, value) {
     if (value == null || value === '') return '';
     return `<div class="detail-row"><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`;
@@ -236,7 +244,7 @@ function renderPage(item, slug, isPreview) {
     const waMsg         = encodeURIComponent(
         inStock
             ? `Hola! Me interesa: ${item.title}`
-            : `Hola Amado Libros, quiero consultar disponibilidad de: ${item.title}`
+            : buildPausedWaMessage(item)
     );
 
     const detailRows = [
@@ -250,7 +258,7 @@ function renderPage(item, slug, isPreview) {
             'Disponibilidad',
             inStock
                 ? `${stockQty} disponible${stockQty === 1 ? '' : 's'}`
-                : 'Por encargo — entrega estimada 15–20 días'
+                : 'Sin ejemplares disponibles'
         ),
     ].filter(Boolean).join('\n');
 
@@ -305,9 +313,8 @@ function renderPage(item, slug, isPreview) {
       <div class="price-installment">12 cuotas de aprox. $${installment} UYU</div>
     </div>`
         : `<div class="order-box">
-      <strong>Por encargo</strong>
-      <span>Entrega estimada: 15–20 días</span>
-      <small>Sujeto a confirmación de disponibilidad.</small>
+      <strong>Vendimos todos los ejemplares disponibles.</strong>
+      <span>Si querés, lo buscamos para vos.</span>
     </div>`;
 
     const actionHtml = inStock
@@ -330,7 +337,7 @@ function renderPage(item, slug, isPreview) {
         💬 Consultar por WhatsApp
       </a>`
         : `<a class="btn btn-wa" href="https://wa.me/${WA}?text=${waMsg}" target="_blank" rel="noopener noreferrer">
-        💬 Consultar disponibilidad
+        💬 Consultar si podemos conseguirlo
       </a>`;
 
     const schemaBreadcrumb = {


### PR DESCRIPTION
## Resumen
- Cuando una ficha de libro no está disponible para compra inmediata (misma condición ya usada por la ficha: `item.status !== 'active'` o `available_quantity <= 0`), el bloque comercial pasa de "Por encargo — entrega estimada 15–20 días" a **"Vendimos todos los ejemplares disponibles. Si querés, lo buscamos para vos."**, con el estilo visual ya existente (`.order-box`).
- El CTA pasa a **"Consultar si podemos conseguirlo"** y abre WhatsApp con: `Hola, me interesa conseguir "{título}"{, de {autor}}{ ({ISBN})}. ¿Podrían buscarlo por encargo?` — autor e ISBN solo si existen.
- No se promete stock, precio ni plazo en ningún texto nuevo.
- "Agregar al carrito" y "Comprar en MercadoLibre" siguen ausentes en el estado no disponible (ya lo estaban).
- "Avisame cuando vuelva" **no se incluye**: esa función solo existe completa en la rama sin mergear `agent/stock-1-preview`, no en `main` (de donde parte esta rama) — sin evidencia de código funcionando acá, no se muestra ni se simula.
- Las fichas disponibles no cambian (precio, carrito, MercadoLibre, WhatsApp de disponibles intactos).

## Fuera de alcance (no tocado)
Home, categorías, fichas disponibles, checkout, carrito de productos disponibles, Mercado Pago/Mercado Libre, Merchant Center, precios, SEO (meta description/JSON-LD/canonical/robots), R2, cachés, Workers, CF-R2-1, `agent/stock-1-preview`, PR #47, `main`, producción.

## Archivos tocados
- `functions/libro/[[path]].js`
- `functions/__tests__/catalog-display.test.js`

## Test plan
- [x] `node --test functions/__tests__/catalog-display.test.js` → 6/6 verde
- [x] Suite completa (`worker-sync` + `functions/__tests__` + `astro-front/src/lib` + `functions/api/__tests__`) → 291/293, los 2 fallos son el artefacto CRLF conocido de `deploy-branch-guards.test.js` (no relacionado, ya documentado en otra rama)
- [x] `npm run build` en `astro-front` → OK
- [x] Confirmado por diff: la rama `inStock=true` (fichas disponibles) queda sin cambios

🤖 Generated with [Claude Code](https://claude.com/claude-code)