### PR TITLE
CF-STOCK-1-UX-FIX: jerarquía comercial positiva + fix de duplicado en producción

### DIFF
--- a/functions/__tests__/catalog-display.test.js
+++ b/functions/__tests__/catalog-display.test.js
@@ -165,8 +165,8 @@ test('la ficha pausada queda noindex, sin precio ni compra directa', async () =>
   const html = await response.text();
 
   assert.match(html, /noindex, follow/);
-  assert.match(html, /Vendimos todos los ejemplares disponibles\./);
-  assert.match(html, /Si querés, lo buscamos para vos\./);
+  assert.match(html, /¿Buscás este libro\?/);
+  assert.match(html, /Podemos intentar conseguirlo por encargo\./);
   assert.match(html, /Consultar si podemos conseguirlo/);
   assert.match(html, /Avisame cuando llegue/);
   assert.match(html, /data-action="stock_waitlist"/);
@@ -174,6 +174,13 @@ test('la ficha pausada queda noindex, sin precio ni compra directa', async () =>
   assert.doesNotMatch(html, /98[.,]765/);
   assert.doesNotMatch(html, /Agregar al carrito/);
   assert.doesNotMatch(html, /Comprar en MercadoLibre/);
+  // CF-STOCK-1-UX-FIX: no repetir el problema — sin badge "No disponible"
+  // ni fila "Disponibilidad" en la ficha técnica.
+  assert.doesNotMatch(html, /No disponible/);
+  assert.doesNotMatch(html, /<dt>Disponibilidad<\/dt>/);
+  // Jerarquía: el WhatsApp principal debe aparecer antes que el
+  // formulario de aviso secundario.
+  assert.ok(html.indexOf('Consultar si podemos conseguirlo') < html.indexOf('id="aviso-stock"'));
 
   const expectedWaMsg = encodeURIComponent(
     'Hola, me interesa conseguir “Alpha raro”, de Autor Dos. ¿Podrían buscarlo por encargo?'
@@ -365,7 +372,7 @@ test('CF-R2-2-BRIDGE: ficha productiva por ID encuentra un libro pausado', async
   assert.equal(response.status, 200);
   const html = await response.text();
   assert.match(html, /noindex, follow/);
-  assert.match(html, /Vendimos todos los ejemplares disponibles\./);
+  assert.match(html, /¿Buscás este libro\?/);
   assert.doesNotMatch(html, /Agregar al carrito/);
   assert.doesNotMatch(html, /Comprar en MercadoLibre/);
   assert.equal(requestedUrls.includes(PAUSED_MANIFEST_URL), false);

--- a/functions/api/__tests__/stock_waitlist.test.js
+++ b/functions/api/__tests__/stock_waitlist.test.js
@@ -186,6 +186,34 @@ test('stock-1: valida un pausado desde su bloque cuando no está en catalog.json
   assert.equal([...db.rows.values()][0].product_id, PAUSED.id);
 });
 
+test('CF-STOCK-1-UX-FIX: en producción también valida un pausado desde su bloque cuando no está en catalog.json', async () => {
+  // Regresión: el fallback a fetchPausedItem estaba hardcodeado a
+  // APP_ENV==='preview' y nunca se actualizó cuando CF-R2-2-BRIDGE
+  // generalizó el resto del catálogo pausado a producción. Un libro
+  // genuinamente pausado devolvía 404 "Libro no encontrado" en
+  // producción antes de llegar a D1 — confirmado con 0 filas reales en
+  // producción tras dos envíos humanos.
+  const db = memoryDb();
+  const hooks = {};
+  const handler = makeHandler({
+    catalog: { items: [ACTIVE] },
+    pausedItem: PAUSED,
+    hooks,
+  });
+  const { response, data } = await call(
+    handler,
+    db,
+    validBody(),
+    { APP_ENV: 'production', ALLOWED_HOSTS: 'www.amadolibros.com' },
+    { url: 'https://www.amadolibros.com/api/stock-waitlist' },
+  );
+
+  assert.equal(response.status, 201);
+  assert.equal(data.registered, true);
+  assert.equal(hooks.pausedItemCalls, 1);
+  assert.equal([...db.rows.values()][0].product_id, PAUSED.id);
+});
+
 test('stock-1: Producción nunca intenta crear el esquema en runtime', async () => {
   const db = memoryDb();
   const originalPrepare = db.prepare;

--- a/functions/api/_stock_waitlist_handler.js
+++ b/functions/api/_stock_waitlist_handler.js
@@ -276,7 +276,13 @@ export function createStockWaitlistHandler({
     let product = activeCatalogAvailable
       ? catalog.items.find(item => item?.id === productId)
       : null;
-    if (!product && cleanString(env?.APP_ENV) === 'preview' && typeof fetchPausedItem === 'function') {
+    // CF-STOCK-1-UX-FIX: fetchPausedItem ya resuelve el manifest correcto por
+    // entorno (manifestUrlFor en _shared/catalog.js, desde CF-R2-2-BRIDGE) —
+    // este handler se había quedado atado a 'preview' y nunca se actualizó,
+    // por lo que un libro genuinamente pausado (no presente en catalog.json)
+    // devolvía 404 "Libro no encontrado" en producción antes de llegar a D1.
+    if (!product && ['preview', 'production'].includes(cleanString(env?.APP_ENV)) &&
+      typeof fetchPausedItem === 'function') {
       product = await fetchPausedItem(context, productId).catch(() => null);
     }
     if (!product && !activeCatalogAvailable) {

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -254,12 +254,13 @@ function renderPage(item, slug, isPreview, waitlistSiteKey) {
         item.pages ? detailRow('Páginas', `${item.pages}`) : '',
         detailRow('Medidas', dimensions),
         detailRow('Condición', condition),
-        detailRow(
-            'Disponibilidad',
-            inStock
-                ? `${stockQty} disponible${stockQty === 1 ? '' : 's'}`
-                : 'No disponible por el momento'
-        ),
+        // CF-STOCK-1-UX-FIX: la fila "Disponibilidad" solo tiene sentido
+        // cuando hay stock que mostrar. Para no disponibles, la jerarquía
+        // comercial (ver más abajo) ya cubre el mensaje — repetirlo acá
+        // sería la tercera vez que la ficha dice "no disponible".
+        inStock
+            ? detailRow('Disponibilidad', `${stockQty} disponible${stockQty === 1 ? '' : 's'}`)
+            : '',
     ].filter(Boolean).join('\n');
 
     const metaDesc = inStock
@@ -313,8 +314,8 @@ function renderPage(item, slug, isPreview, waitlistSiteKey) {
       <div class="price-installment">12 cuotas de aprox. $${installment} UYU</div>
     </div>`
         : `<div class="order-box">
-      <strong>Vendimos todos los ejemplares disponibles.</strong>
-      <span>Si querés, lo buscamos para vos.</span>
+      <strong>¿Buscás este libro?</strong>
+      <span>Podemos intentar conseguirlo por encargo. Consultanos y verificamos disponibilidad, edición y precio.</span>
     </div>`;
 
     const actionHtml = inStock
@@ -447,7 +448,6 @@ function renderPage(item, slug, isPreview, waitlistSiteKey) {
     .badge{display:inline-block;padding:.2rem .7rem;border-radius:2rem;
            font-size:.75rem;font-weight:600;margin-bottom:.875rem}
     .in-stock{background:#dcfce7;color:#16a34a}
-    .out-of-stock{background:#fef9c3;color:#854d0e}
     .details{background:white;border:1px solid #e2e8f0;border-radius:.5rem;
              margin:.25rem 0 .875rem;overflow:hidden}
     .detail-row{display:grid;grid-template-columns:94px 1fr;gap:.75rem;
@@ -525,14 +525,13 @@ function renderPage(item, slug, isPreview, waitlistSiteKey) {
   ${renderGallery(images, safeTitle)}
   <div class="info">
     <h1>${safeTitle}</h1>
-    <span class="badge ${inStock ? 'in-stock' : 'out-of-stock'}">
-      ${inStock ? '✓ En stock' : 'No disponible'}
-    </span>
-    ${detailRows ? `<dl class="details">${detailRows}</dl>` : ''}
+    ${inStock ? `<span class="badge in-stock">✓ En stock</span>` : ''}
+    ${inStock && detailRows ? `<dl class="details">${detailRows}</dl>` : ''}
     ${priceHtml}
     <div class="cta">
       ${actionHtml}
     </div>
+    ${!inStock && detailRows ? `<dl class="details">${detailRows}</dl>` : ''}
     <p class="shipping">${inStock
       ? '🚚 Entrega en 2 horas en Montevideo · Envíos a todo Uruguay · Envío gratis desde $2.000.'
       : '🌎 Si preferís no esperar, también podemos buscarlo por encargo en el exterior.'


### PR DESCRIPTION
## Diagnóstico (antes de tocar código)
La prueba humana en producción no guardó ninguna fila en D1 (0 filas totales, no solo para ese libro). Causa: `_stock_waitlist_handler.js` tenía el fallback a `fetchPausedItem()` hardcodeado a `APP_ENV==='preview'`, nunca actualizado cuando CF-R2-2-BRIDGE generalizó el resto del catálogo pausado a producción. Un libro genuinamente pausado devolvía `404 "Libro no encontrado"` antes de llegar a D1 — no fue un tema de mensaje de UI, no hubo primer envío exitoso que duplicar.

## Fix
- `_stock_waitlist_handler.js`: fallback habilitado en `['preview', 'production']`.
- Test de regresión que reproduce el caso exacto y confirma 201 + fila en D1.

## Jerarquía comercial (aprobada)
Columna derecha de la ficha pausada, nuevo orden: título → bloque comercial positivo ("¿Buscás este libro? Podemos intentar conseguirlo por encargo...") → WhatsApp principal ("Consultar si podemos conseguirlo") → formulario "Avisame cuando llegue" (secundario) → ficha técnica al final.

Se eliminan las repeticiones negativas: sin badge "No disponible", sin fila "Disponibilidad — No disponible por el momento". La ficha pausada pasaba de mencionar la falta de stock 3 veces a 0.

## Fuera de alcance (no tocado)
SEO (meta description, JSON-LD, robots, canonical — siguen igual), schema (sigue sin `offers` en pausados), catálogo, sincronización, checkout, Mercado Pago, Merchant Center. Ficha activa sin cambios.

## Test plan
- [x] Suite completa: 367 tests, 365 pass (2 fallos CRLF conocidos, no relacionados)
- [x] `npm run build` en `astro-front` → OK
- [ ] Capturas desktop/mobile en Preview (pendiente, siguiente paso)

Sin desplegar a producción hasta aprobación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)