### PR TITLE
HOME-CATEGORIAS: acceso visual compacto a categorias debajo del bloque comercial

### DIFF
--- a/astro-front/src/components/CategoryAccess.astro
+++ b/astro-front/src/components/CategoryAccess.astro
@@ -163,16 +163,19 @@ try {
     }
   }
 
-  @media (min-width: 1024px) {
-    .ca-row {
-      grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
-    }
+  /* "Ver todo el catálogo" como noveno ítem, en su propia fila, centrado —
+     evita desbordes de una columna "auto" combinada con row-span (bug
+     encontrado en QA visual: el chip se salía del contenedor). */
+  .ca-chip-all {
+    justify-content: center;
+    text-align: center;
+  }
 
+  @media (min-width: 700px) {
     .ca-chip-all {
-      grid-column: 4 / 5;
-      grid-row: 1 / 4;
-      justify-content: center;
-      text-align: center;
+      grid-column: 1 / -1;
+      max-width: 260px;
+      margin: 0 auto;
     }
   }
 </style>

--- a/astro-front/src/components/CategoryAccess.astro
+++ b/astro-front/src/components/CategoryAccess.astro
@@ -1,0 +1,178 @@
+---
+// HOME — ACCESO A CATEGORÍAS
+// Acceso visual compacto a las categorías principales, conectado con el
+// filtro ?categoria= de /catalogo. Mismo patrón de BestsellerSection: lee
+// un JSON estático en build time (fs), sin JS cliente, sin llamada nueva
+// en runtime. No toca checkout, Mercado Pago ni fichas individuales.
+//
+// Fuente: astro-front/public/data/active-categories.json — el mismo
+// artefacto que consume functions/catalogo.js (scripts/categorize/
+// export-active-categories.js). No se regenera en cada deploy: se
+// actualiza cuando se vuelve a correr el pipeline de clasificación y se
+// commitea, igual que en el catálogo.
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CATEGORIES_JSON = path.resolve(process.cwd(), 'public/data/active-categories.json');
+
+interface Category {
+  id: string;
+  name: string;
+  count: number;
+}
+
+const MAX_CATEGORIES = 8;
+
+let categories: Category[] = [];
+let missing = false;
+
+try {
+  const raw = fs.readFileSync(CATEGORIES_JSON, 'utf-8');
+  const data = JSON.parse(raw) as { categories: Category[] };
+  // "otros-libros" es el catch-all interno de libros sin materia
+  // específica, y "otros-productos" agrupa discos/revistas/objetos de
+  // colección — ninguno de los dos es un punto de entrada útil para
+  // descubrir por tema en la home.
+  const EXCLUDED_IDS = new Set(['otros-libros', 'otros-productos']);
+  categories = (data.categories || [])
+    .filter(c => !EXCLUDED_IDS.has(c.id))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, MAX_CATEGORIES);
+} catch (e: unknown) {
+  missing = true;
+  const msg = e instanceof Error ? e.message : String(e);
+  console.warn('[CategoryAccess] active-categories.json no disponible en build:', msg);
+}
+---
+
+{missing
+  ? <Fragment set:html="<!-- acceso a categorías: active-categories.json no encontrado en build — sección omitida -->" />
+  : (categories.length > 0 && (
+      <section class="ca-section" aria-label="Categorías del catálogo">
+        <div class="ca-inner">
+          <h2 class="ca-heading">Explorá por categoría</h2>
+          <div class="ca-row" role="list">
+            {categories.map(cat => (
+              <a
+                class="ca-chip"
+                href={`/catalogo?categoria=${encodeURIComponent(cat.id)}`}
+                role="listitem"
+              >
+                <span class="ca-chip-name">{cat.name}</span>
+                <span class="ca-chip-count">{cat.count}</span>
+              </a>
+            ))}
+            <a class="ca-chip ca-chip-all" href="/catalogo">
+              Ver todo el catálogo →
+            </a>
+          </div>
+        </div>
+      </section>
+    ))
+}
+
+<style>
+  .ca-section {
+    background: var(--surface);
+    border-top: 1px solid var(--border);
+  }
+
+  .ca-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1.75rem 1.5rem;
+  }
+
+  @media (min-width: 768px) {
+    .ca-inner { padding: 2.25rem 2rem; }
+  }
+
+  .ca-heading {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: clamp(1.125rem, 2.4vw, 1.375rem);
+    color: var(--ink);
+    letter-spacing: -0.01em;
+    margin-bottom: 1rem;
+  }
+
+  /* Mobile: fila con scroll horizontal — compacta, sin "chorizo" de
+     categorías ocupando media pantalla. */
+  .ca-row {
+    display: flex;
+    gap: 0.6rem;
+    overflow-x: auto;
+    scroll-snap-type: x proximity;
+    padding-bottom: 0.25rem;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+  }
+
+  .ca-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-shrink: 0;
+    scroll-snap-align: start;
+    padding: 0.6rem 1rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    color: var(--ink);
+    font-family: var(--font-ui);
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background 0.15s, border-color 0.15s, transform 0.15s;
+  }
+
+  .ca-chip:hover {
+    background: rgba(228, 153, 130, 0.12);
+    border-color: var(--salmon);
+    transform: translateY(-1px);
+  }
+
+  .ca-chip-count {
+    color: var(--ink-2);
+    font-weight: 500;
+    font-size: 0.78rem;
+  }
+
+  .ca-chip-all {
+    background: var(--ink);
+    border-color: var(--ink);
+    color: #fff;
+  }
+
+  .ca-chip-all:hover {
+    background: var(--salmon-hover);
+    border-color: var(--salmon-hover);
+  }
+
+  /* Desktop: grid compacto, sin scroll */
+  @media (min-width: 700px) {
+    .ca-row {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      overflow-x: visible;
+    }
+
+    .ca-chip {
+      justify-content: space-between;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .ca-row {
+      grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+    }
+
+    .ca-chip-all {
+      grid-column: 4 / 5;
+      grid-row: 1 / 4;
+      justify-content: center;
+      text-align: center;
+    }
+  }
+</style>

--- a/astro-front/src/pages/index.astro
+++ b/astro-front/src/pages/index.astro
@@ -4,6 +4,7 @@
 import BaseLayout          from '../layouts/BaseLayout.astro';
 import Header              from '../components/Header.astro';
 import Hero                from '../components/Hero.astro';
+import CategoryAccess      from '../components/CategoryAccess.astro';
 import BestsellerSection   from '../components/BestsellerSection.astro';
 import Footer              from '../components/Footer.astro';
 import WAFloat             from '../components/WAFloat.astro';
@@ -17,6 +18,7 @@ import NotFoundCTA         from '../components/NotFoundCTA.astro';
   <Header showSearch={false} showMobileDeliveryBanner={true} />
   <main>
     <Hero />
+    <CategoryAccess />
     <BestsellerSection />
     <HowToBuy />
     <ShippingPayments />


### PR DESCRIPTION
## Resumen

Nueva sección "Explorá por categoría" en la home, entre el bloque comercial del Hero y "Incorporaciones recientes": 8 chips con las categorías de mayor volumen (excluye `otros-libros` y `otros-productos`), cada uno enlazando a `/catalogo?categoria=<id>`, más un CTA "Ver todo el catálogo" a `/catalogo` sin filtro.

- Lee `astro-front/public/data/active-categories.json` en build time (mismo patrón que `BestsellerSection` con `home.json`) — sin JS cliente, sin llamada nueva en runtime.
- Mobile: fila con scroll horizontal compacto. Desktop: grid de 3 columnas + CTA centrado en su propia fila.
- Si el artefacto de categorías no está disponible en build, la sección se omite sola sin romper el sitio (mismo criterio que `BestsellerSection`).

Incluye un fix de un bug de desborde encontrado en la verificación visual (el CTA "Ver todo el catálogo" se salía del contenedor en desktop por un uso incorrecto de `grid-column`/`grid-row`).

No toca catálogo, fichas individuales, checkout, Mercado Pago ni Header.

## Test plan
- [x] Tests del repo en verde (424/426 — 2 fallos preexistentes de CRLF en Windows sin relación)
- [x] Build de Astro sin errores
- [x] Verificado en Preview: los 8 nombres/conteos coinciden con el artefacto vigente, los 8 enlaces navegan a `/catalogo?categoria=<id>` con 200 y `<h1>` correcto
- [x] Captura real desktop confirmando el layout corregido
- [x] Cero errores de consola, cero requests fallidos
- [ ] Captura mobile real pendiente (limitación de la herramienta de navegador en esta sesión, ya documentada)

🤖 Generated with [Claude Code](https://claude.com/claude-code)