### PR TITLE
SEO-GMC-FEED-1: improve ISBN identifiers and feed coverage

### DIFF
--- a/functions/__tests__/feed-gtin-and-coverage.test.js
+++ b/functions/__tests__/feed-gtin-and-coverage.test.js
@@ -1,0 +1,386 @@
+// SEO-GMC-FEED-1: cobertura completa del feed (sin corte de 5.000) + GTIN
+// desde ISBN validado + eliminación de <g:brand>Amado Libros</g:brand>.
+// Sin dependencias externas de XML — se valida balance de tags a mano
+// (el feed es simple: sin namespaces anidados raros, sin CDATA, sin
+// atributos en los tags de item), evitando instalar una librería pesada
+// solo para este test.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    onRequest,
+    isEligibleForFeed,
+    cleanIsbnRaw,
+    isValidIsbn13,
+    isValidIsbn10,
+    isbn10to13,
+    normalizeIsbnToGtin,
+    normalizePublisherForDescription,
+    buildFeedDescription,
+    renderFeedItem,
+    pickRepresentativeItem,
+    dedupeByGtinAndCondition,
+    escapeXml,
+} from '../feed.xml.js';
+
+function book(overrides = {}) {
+    return {
+        id: 'MLU1', title: 'Un Libro', author: 'Autor Real', price: 1000,
+        status: 'active', available_quantity: 1, condition: 'new',
+        thumbnail: 'http://http2.mlstatic.com/D_1-I.jpg',
+        permalink: 'https://articulo.mercadolibre.com.uy/MLU-1',
+        isbn: null, publisher: null,
+        ...overrides,
+    };
+}
+
+function fakeContext(items) {
+    return {
+        env: {},
+        request: { url: 'https://www.amadolibros.com/feed.xml' },
+    };
+}
+
+// fetchCatalog depende de `caches.default` / `fetch` global (Cloudflare
+// Workers runtime) — no está disponible en `node --test`. Para testear
+// onRequest de punta a punta sin mockear todo ese runtime, se prueban las
+// funciones puras exportadas (isEligibleForFeed, renderFeedItem, etc.) que
+// concentran toda la lógica nueva; onRequest en sí es un ensamblador fino
+// alrededor de ellas, ya cubierto indirectamente.
+
+// ── XML: balance de tags, sin dependencias ─────────────────────────────────
+function isBalancedXml(xml) {
+    const tagPattern = /<\/?([a-zA-Z0-9:_-]+)[^>]*?(\/?)>/g;
+    const stack = [];
+    let match;
+    while ((match = tagPattern.exec(xml))) {
+        const [full, name, selfClose] = match;
+        if (full.startsWith('<?')) continue; // declaración XML
+        if (selfClose === '/') continue; // self-closing, no abre contexto
+        if (full.startsWith('</')) {
+            const expected = stack.pop();
+            if (expected !== name) return false;
+        } else {
+            stack.push(name);
+        }
+    }
+    return stack.length === 0;
+}
+
+function buildFeedXmlFromItems(items) {
+    const eligible = items.filter(isEligibleForFeed);
+    const deduped = dedupeByGtinAndCondition(eligible);
+    const sorted = [...deduped].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+    const feedItems = sorted.map(renderFeedItem).join('');
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:g="http://base.google.com/ns/1.0" version="2.0">
+<channel>
+    <title>Amado Libros</title>
+    <link>https://www.amadolibros.com</link>
+    <description>Catálogo de libros de Amado Libros - Uruguay</description>${feedItems}
+</channel>
+</rss>`;
+}
+
+test('1. XML bien formado (tags balanceados) con un pool mixto', () => {
+    const items = [
+        book({ id: 'MLU1', isbn: '9788499809991' }),
+        book({ id: 'MLU2', condition: 'used', isbn: null }),
+        book({ id: 'MLU3', author: null, publisher: 'Marca' }),
+    ];
+    const xml = buildFeedXmlFromItems(items);
+    assert.equal(isBalancedXml(xml), true);
+});
+
+test('2. Sin corte fijo de 5.000: un pool de 5.500 elegibles produce 5.500 <item>', () => {
+    const items = Array.from({ length: 5500 }, (_, i) => book({
+        id: `MLU${1000000 + i}`, isbn: null,
+    }));
+    const eligible = items.filter(isEligibleForFeed);
+    assert.equal(eligible.length, 5500);
+});
+
+test('3. La cantidad del feed coincide exactamente con el universo elegible calculado', () => {
+    const items = [
+        book({ id: 'MLU1' }),
+        book({ id: 'MLU2', status: 'paused' }), // no elegible
+        book({ id: 'MLU3', available_quantity: 0 }), // no elegible
+        book({ id: 'MLU4', price: 0 }), // no elegible
+        book({ id: 'MLU5' }),
+    ];
+    const xml = buildFeedXmlFromItems(items);
+    const itemCount = (xml.match(/<item>/g) || []).length;
+    const eligibleCount = items.filter(isEligibleForFeed).length;
+    assert.equal(itemCount, eligibleCount);
+    assert.equal(itemCount, 2);
+});
+
+test('4. IDs únicos y estables: sin duplicados de <g:id> en la salida', () => {
+    const items = [book({ id: 'MLU1' }), book({ id: 'MLU2' }), book({ id: 'MLU3' })];
+    const xml = buildFeedXmlFromItems(items);
+    const ids = [...xml.matchAll(/<g:id>(.*?)<\/g:id>/g)].map(m => m[1]);
+    assert.deepEqual(ids, [...new Set(ids)]);
+    assert.equal(ids.length, 3);
+});
+
+test('5. Ningún <g:brand> aparece en la salida (ni "Amado Libros" ni ningún otro valor)', () => {
+    const items = [
+        book({ id: 'MLU1', publisher: 'Editorial Real' }),
+        book({ id: 'MLU2', publisher: 'AMADO LIBROS' }),
+        book({ id: 'MLU3', publisher: 'Marca' }),
+    ];
+    const xml = buildFeedXmlFromItems(items);
+    assert.doesNotMatch(xml, /<g:brand>/);
+    assert.doesNotMatch(xml, /Amado Libros<\/g:brand>/);
+});
+
+test('6. Todo <g:gtin> emitido pasa la validación de ISBN-13', () => {
+    const items = [
+        book({ id: 'MLU1', isbn: '9788499809991' }),
+        book({ id: 'MLU2', isbn: '0-8044-2957-X' }), // ISBN-10 con guiones
+        book({ id: 'MLU3', isbn: 'no-es-un-isbn' }),
+    ];
+    const xml = buildFeedXmlFromItems(items);
+    const gtins = [...xml.matchAll(/<g:gtin>(.*?)<\/g:gtin>/g)].map(m => m[1]);
+    assert.ok(gtins.length >= 1);
+    for (const gtin of gtins) assert.equal(isValidIsbn13(gtin), true);
+});
+
+test('7. ISBN-13 con checksum correcto se conserva tal cual', () => {
+    const result = normalizeIsbnToGtin('9788499809991');
+    assert.equal(result.valid, true);
+    assert.equal(result.gtin, '9788499809991');
+});
+
+test('8. ISBN con guiones y espacios se normaliza antes de validar', () => {
+    assert.equal(cleanIsbnRaw(' 978-84-9980-999-1 '), '9788499809991');
+    assert.equal(cleanIsbnRaw('ISBN 978-84-9980-999-1'), '9788499809991');
+    assert.equal(cleanIsbnRaw('ISBN-13: 9788499809991'), '9788499809991');
+});
+
+test('9. ISBN-10 válido se convierte correctamente a ISBN-13', () => {
+    // 0-8044-2957-X es un ISBN-10 válido de ejemplo (checksum verificado).
+    assert.equal(isValidIsbn10('080442957X'), true);
+    const isbn13 = isbn10to13('080442957X');
+    assert.equal(isValidIsbn13(isbn13), true);
+    const result = normalizeIsbnToGtin('0-8044-2957-X');
+    assert.equal(result.valid, true);
+    assert.equal(result.gtin, isbn13);
+});
+
+test('10. ISBN inválido (checksum incorrecto) nunca se publica como GTIN', () => {
+    const result = normalizeIsbnToGtin('9788499809990'); // último dígito alterado
+    assert.equal(result.valid, false);
+    assert.equal(result.gtin, null);
+    assert.equal(result.hadValue, true);
+});
+
+test('11. Producto con GTIN válido no lleva <g:identifier_exists>no</g:identifier_exists>', () => {
+    const xml = renderFeedItem(book({ id: 'MLU1', isbn: '9788499809991' }));
+    assert.doesNotMatch(xml, /identifier_exists/);
+    assert.match(xml, /<g:gtin>9788499809991<\/g:gtin>/);
+});
+
+test('12. Producto sin identificador válido lleva <g:identifier_exists>no</g:identifier_exists>', () => {
+    const xmlEmpty = renderFeedItem(book({ id: 'MLU1', isbn: null }));
+    const xmlInvalid = renderFeedItem(book({ id: 'MLU2', isbn: 'xxx-no-valido' }));
+    for (const xml of [xmlEmpty, xmlInvalid]) {
+        assert.match(xml, /<g:identifier_exists>no<\/g:identifier_exists>/);
+        assert.doesNotMatch(xml, /<g:gtin>/);
+    }
+});
+
+test('13. Productos nuevos mantienen condition=new', () => {
+    const xml = renderFeedItem(book({ id: 'MLU1', condition: 'new' }));
+    assert.match(xml, /<g:condition>new<\/g:condition>/);
+});
+
+test('14. Productos usados mantienen condition=used (nunca se excluyen)', () => {
+    const xml = renderFeedItem(book({ id: 'MLU1', condition: 'used' }));
+    assert.match(xml, /<g:condition>used<\/g:condition>/);
+    const items = [book({ id: 'MLU1', condition: 'used' }), book({ id: 'MLU2', condition: 'new' })];
+    assert.equal(items.filter(isEligibleForFeed).length, 2);
+});
+
+test('15. La descripción no es una repetición exacta del título', () => {
+    const item = book({ id: 'MLU1', title: 'Cien Años De Soledad', author: 'García Márquez', condition: 'new' });
+    const desc = buildFeedDescription(item);
+    assert.notEqual(desc, item.title);
+    assert.match(desc, /Cien Años De Soledad/);
+    assert.match(desc, /García Márquez/);
+    assert.match(desc, /Ejemplar nuevo/);
+});
+
+test('15b. Descripción sin autor ni editorial sigue siendo válida y no vacía', () => {
+    const item = book({ id: 'MLU1', title: 'Sin Datos', author: null, publisher: null, condition: 'used' });
+    const desc = buildFeedDescription(item);
+    assert.ok(desc.length > 0);
+    assert.match(desc, /Sin Datos/);
+    assert.match(desc, /Ejemplar usado/);
+});
+
+test('15c. normalizePublisherForDescription descarta el placeholder del vendedor', () => {
+    assert.equal(normalizePublisherForDescription('AMADO LIBROS'), null);
+    assert.equal(normalizePublisherForDescription('  amado libros  '), null);
+    assert.equal(normalizePublisherForDescription('Editorial Graó'), 'Editorial Graó');
+    assert.equal(normalizePublisherForDescription(null), null);
+});
+
+test('16. Caracteres especiales quedan correctamente escapados en título, descripción y precio', () => {
+    const item = book({
+        id: 'MLU1',
+        title: `El "Rey" & <su> Reino`,
+        author: `O'Brien`,
+        price: 1500,
+    });
+    const xml = renderFeedItem(item);
+    assert.match(xml, /El &quot;Rey&quot; &amp; &lt;su&gt; Reino/);
+    assert.match(xml, /O&apos;Brien/);
+    assert.doesNotMatch(xml, /<su>/); // nunca sin escapar
+});
+
+test('17. Precio, disponibilidad, link e imagen no quedan vacíos para un ítem elegible', () => {
+    const item = book({ id: 'MLU1', price: 999, thumbnail: 'http://x.mlstatic.com/a-I.jpg' });
+    const xml = renderFeedItem(item);
+    assert.match(xml, /<g:price>999 UYU<\/g:price>/);
+    assert.match(xml, /<g:availability>in stock<\/g:availability>/);
+    assert.match(xml, /<g:link>https:\/\/www\.amadolibros\.com\/libro\/MLU1\//);
+    assert.match(xml, /<g:image_link>https:\/\/x\.mlstatic\.com\/a-O\.jpg<\/g:image_link>/);
+});
+
+test('18. Los libros "por encargo" (pausados) continúan fuera del feed', () => {
+    const items = [
+        book({ id: 'MLU1', status: 'active' }),
+        book({ id: 'MLU2', status: 'paused' }),
+        book({ id: 'MLU3', status: 'paused', available_quantity: 0 }),
+    ];
+    const eligible = items.filter(isEligibleForFeed);
+    assert.deepEqual(eligible.map(b => b.id), ['MLU1']);
+});
+
+test('19. Sin IDs duplicados en un pool con IDs repetidos (medición, no dedup silenciosa)', () => {
+    const items = [book({ id: 'MLU1' }), book({ id: 'MLU1' }), book({ id: 'MLU2' })];
+    const ids = items.map(b => b.id);
+    const dupCount = ids.length - new Set(ids).size;
+    assert.equal(dupCount, 1); // el feed no debe recibir catalog.json con IDs duplicados;
+    // esta prueba documenta que, si ocurriera, sería detectable — no es la
+    // deduplicación por GTIN+condition (ver tests 20-27), que sí es una
+    // decisión comercial explícita y autorizada (ver informe).
+});
+
+test('escapeXml exportado se comporta igual que antes (regresión mínima)', () => {
+    assert.equal(escapeXml('<a>&"\'</a>'), '&lt;a&gt;&amp;&quot;&apos;&lt;/a&gt;');
+    assert.equal(escapeXml(null), '');
+});
+
+// ── Deduplicación GTIN+condition (decisión SEO-GMC-FEED-1) ─────────────────
+
+test('20. No queda ninguna combinación duplicada GTIN+condition en la salida', () => {
+    const items = [
+        book({ id: 'MLU1', isbn: '9788499809991', condition: 'new', available_quantity: 3, price: 772 }),
+        book({ id: 'MLU2', isbn: '9788499809991', condition: 'new', available_quantity: 1, price: 772 }),
+        book({ id: 'MLU3', isbn: '9789681313173', condition: 'new' }),
+    ];
+    const deduped = dedupeByGtinAndCondition(items);
+    const keys = deduped
+        .map(it => normalizeIsbnToGtin(it.isbn))
+        .filter(r => r.valid)
+        .map((r, i) => `${r.gtin}|${deduped[i].condition}`);
+    assert.equal(keys.length, new Set(keys).size);
+    assert.equal(deduped.length, 2); // MLU1 (gana por stock) + MLU3
+    assert.deepEqual(deduped.map(b => b.id).sort(), ['MLU1', 'MLU3']);
+});
+
+test('21. El mismo GTIN puede aparecer una vez como new y otra como used', () => {
+    const items = [
+        book({ id: 'MLU1', isbn: '9788499809991', condition: 'new' }),
+        book({ id: 'MLU2', isbn: '9788499809991', condition: 'used' }),
+    ];
+    const deduped = dedupeByGtinAndCondition(items);
+    assert.equal(deduped.length, 2);
+    assert.deepEqual(deduped.map(b => b.id).sort(), ['MLU1', 'MLU2']);
+    const conditions = deduped.map(b => b.condition).sort();
+    assert.deepEqual(conditions, ['new', 'used']);
+});
+
+test('22. Dentro de un grupo duplicado, gana el producto con mayor stock', () => {
+    const group = [
+        book({ id: 'MLU-LOW', isbn: '9788499809991', available_quantity: 1, price: 1000 }),
+        book({ id: 'MLU-HIGH', isbn: '9788499809991', available_quantity: 5, price: 1000 }),
+    ];
+    const winner = pickRepresentativeItem(group);
+    assert.equal(winner.id, 'MLU-HIGH');
+});
+
+test('23. Ante igual stock, gana el producto de menor precio vigente', () => {
+    const group = [
+        book({ id: 'MLU-EXPENSIVE', isbn: '9788499809991', available_quantity: 2, price: 2000 }),
+        book({ id: 'MLU-CHEAP', isbn: '9788499809991', available_quantity: 2, price: 1500 }),
+    ];
+    const winner = pickRepresentativeItem(group);
+    assert.equal(winner.id, 'MLU-CHEAP');
+});
+
+test('24. Ante igual stock y precio, el desempate por id es determinista', () => {
+    const group = [
+        book({ id: 'MLU999', isbn: '9788499809991', available_quantity: 2, price: 1000 }),
+        book({ id: 'MLU111', isbn: '9788499809991', available_quantity: 2, price: 1000 }),
+    ];
+    const winner = pickRepresentativeItem(group);
+    assert.equal(winner.id, 'MLU111'); // menor id alfanumérico
+    // Estable sin importar el orden de entrada:
+    const reversed = pickRepresentativeItem([...group].reverse());
+    assert.equal(reversed.id, 'MLU111');
+});
+
+test('25. Productos sin GTIN y con IDs distintos se conservan todos (sin dedup por título)', () => {
+    const items = [
+        book({ id: 'MLU1', isbn: null, title: 'Mismo Titulo Exacto' }),
+        book({ id: 'MLU2', isbn: null, title: 'Mismo Titulo Exacto' }),
+        book({ id: 'MLU3', isbn: 'no-valido-123' }),
+    ];
+    const deduped = dedupeByGtinAndCondition(items);
+    assert.equal(deduped.length, 3);
+    assert.deepEqual(deduped.map(b => b.id).sort(), ['MLU1', 'MLU2', 'MLU3']);
+});
+
+test('26. El resultado no depende del orden del array de entrada', () => {
+    const group = [
+        book({ id: 'MLU-A', isbn: '9788499809991', available_quantity: 2, price: 900 }),
+        book({ id: 'MLU-B', isbn: '9788499809991', available_quantity: 5, price: 900 }),
+        book({ id: 'MLU-C', isbn: '9788499809991', available_quantity: 5, price: 850 }),
+    ];
+    const forward = dedupeByGtinAndCondition(group);
+    const shuffled = dedupeByGtinAndCondition([group[2], group[0], group[1]]);
+    const reversed = dedupeByGtinAndCondition([...group].reverse());
+    assert.equal(forward.length, 1);
+    assert.equal(forward[0].id, 'MLU-C');
+    assert.equal(shuffled[0].id, 'MLU-C');
+    assert.equal(reversed[0].id, 'MLU-C');
+});
+
+test('27. Ningún dato de una publicación descartada se mezcla con la seleccionada', () => {
+    const items = [
+        book({
+            id: 'MLU-WINNER', isbn: '9788499809991', available_quantity: 5, price: 700,
+            title: 'Título Correcto Del Ganador', author: 'Autor Ganador',
+            thumbnail: 'http://x.mlstatic.com/winner-I.jpg',
+        }),
+        book({
+            id: 'MLU-LOSER', isbn: '9788499809991', available_quantity: 1, price: 999,
+            title: 'Título De Otra Publicación', author: 'Otro Autor',
+            thumbnail: 'http://x.mlstatic.com/loser-I.jpg',
+        }),
+    ];
+    const deduped = dedupeByGtinAndCondition(items);
+    assert.equal(deduped.length, 1);
+    const winner = deduped[0];
+    assert.equal(winner.id, 'MLU-WINNER');
+    assert.equal(winner.title, 'Título Correcto Del Ganador');
+    assert.equal(winner.author, 'Autor Ganador');
+    assert.equal(winner.available_quantity, 5); // nunca se suman cantidades (5+1=6 sería incorrecto)
+    assert.equal(winner.thumbnail, 'http://x.mlstatic.com/winner-I.jpg');
+
+    const xml = renderFeedItem(winner);
+    assert.match(xml, /Título Correcto Del Ganador/);
+    assert.doesNotMatch(xml, /Título De Otra Publicación/);
+});

--- a/functions/__tests__/home-recent-new-only-scope.test.js
+++ b/functions/__tests__/home-recent-new-only-scope.test.js
@@ -26,6 +26,13 @@ test('functions/libro/[[path]].js solo usa `condition` para mostrarla, nunca par
 
 test('functions/feed.xml.js sigue incluyendo ítems usados en el feed (con su <g:condition> correspondiente, no excluidos)', () => {
   const src = read('functions/feed.xml.js');
-  assert.doesNotMatch(src, /condition\s*===?\s*['"]new['"]/);
+  // SEO-GMC-FEED-1: la descripción del feed distingue "Ejemplar nuevo."/
+  // "Ejemplar usado." por texto (item.condition === 'new'/'used'), sin
+  // excluir nada — igual que libro/[[path]].js (línea de abajo), el
+  // patrón prohibido es específicamente un filtro exclusorio
+  // (`condition === 'new' && <algo que corta la lista>`), no cualquier
+  // lectura de `condition` para mostrarla.
+  assert.doesNotMatch(src, /condition\s*===?\s*['"]new['"]\s*&&/);
+  assert.doesNotMatch(src, /\.filter\([^)]*condition/);
   assert.match(src, /g:condition/);
 });

--- a/functions/feed.xml.js
+++ b/functions/feed.xml.js
@@ -1,35 +1,64 @@
 /**
  * functions/feed.xml.js
  *
- * Feed RSS para Google Merchant Center (v4 — fuente única: R2 catalog.json)
+ * Feed RSS para Google Merchant Center (v5 — cobertura completa + GTIN/ISBN)
  *
- * CAMBIO v4:
- *   Migrado de KV (catalog_index + item:MLU...) a R2 catalog.json.
- *   Razón: el catálogo real está en R2. La fuente KV estaba desactualizada
- *   porque el sync actual (Pages Function) escribe catalog:full, no catalog_index
- *   + item:*, que era el esquema de una versión anterior del Worker.
- *   Resultado: el feed leía datos vacíos o stale de KV.
+ * SEO-GMC-FEED-1:
+ *   - Elimina el tope artificial de 5.000 ítems (v4). El feed ahora publica
+ *     TODO el universo elegible calculado en tiempo real desde catalog.json
+ *     — nunca un número hardcodeado. El tamaño real del catálogo elegible
+ *     varía con cada sync; no se asume ni se fija ningún valor.
+ *   - Usa el ISBN ya presente en catalog.json (worker-sync/meli-catalog.js
+ *     lo extrae de los atributos ISBN/EAN/GTIN/BAR_CODE de MercadoLibre)
+ *     como <g:gtin>, validando el dígito de control antes de publicarlo.
+ *     Nunca se usa el ID interno (MLU...) como GTIN.
+ *   - Elimina <g:brand>Amado Libros</g:brand>: Amado Libros es el vendedor,
+ *     no la marca/editorial del libro. No se reemplaza automáticamente por
+ *     la editorial: `catalog.json.items[].publisher` combina de forma
+ *     indistinguible los atributos PUBLISHER/EDITORIAL/BRAND de ML
+ *     (worker-sync/meli-catalog.js:extractPublisher — getAttrValue no
+ *     conserva cuál de los tres matcheó), así que no hay ninguna señal
+ *     confiable de "esto es la marca real" separable de "esto es la
+ *     editorial". Mientras esa ambigüedad exista en el origen de datos,
+ *     <g:brand> se omite para todos los ítems — no se inventa ni se
+ *     adivina. La editorial sí puede aparecer en <g:description> (texto
+ *     bibliográfico, no una declaración de marca).
+ *   - La descripción deja de repetir el título: se arma con campos reales
+ *     ya presentes en catalog.json (título, autor, editorial, condición),
+ *     nunca inventados.
+ *   - Deduplicación controlada por GTIN+condition (decisión de Seba tras
+ *     revisar el hallazgo): el 89% de los activos elegibles comparte ISBN
+ *     con al menos otro MLU activo (mismo libro publicado más de una vez
+ *     en MercadoLibre). Google prohíbe enviar más de una oferta con el
+ *     mismo GTIN+atributos de variante (condition cuenta como atributo de
+ *     variante) al mismo país/idioma, y item_group_id es solo para
+ *     variantes reales — no aplica acá, son publicaciones repetidas del
+ *     mismo producto, no variantes. Por cada grupo de mismo GTIN+condition
+ *     se publica una sola oferta representante (ver pickRepresentativeItem);
+ *     el resto de las publicaciones de ese grupo no entra al feed, pero no
+ *     se toca en MercadoLibre, en catalog.json ni en la ficha — solo se
+ *     excluye de /feed.xml. Un mismo GTIN puede seguir apareciendo una vez
+ *     como `new` y otra como `used`: son grupos distintos. Los ítems sin
+ *     GTIN válido nunca se deduplican entre sí (no hay deduplicación por
+ *     semejanza de título).
  *
- *   Ahora usa exactamente la misma fuente que catalogo.js, sitemap.xml.js
- *   y libro/[[path]].js: R2 catalog.json vía URL pública + CF edge cache.
- *   Esto elimina la posibilidad de desincronía de slugs entre feed y fichas.
- *
- * ESTRUCTURA DE catalog.json (R2):
+ * ESTRUCTURA DE catalog.json (R2) — sin cambios:
  *   { "items": [ { id, title, author, price, status, available_quantity,
- *                  thumbnail, pictures, permalink, start_time }, ... ] }
- *   Contiene activos y pausados; el feed publica únicamente activos con stock.
- *
+ *                  thumbnail, pictures, permalink, start_time, condition,
+ *                  isbn, publisher, pages, dimensions }, ... ] }
+ *   Contiene únicamente activos (worker-sync/index.js runSync llama a
+ *   buildCatalog con statuses:['active']). Los libros "por encargo"
+ *   (pausados) viven en un manifest/índice separado y quedan
+ *   deliberadamente fuera de este feed.
  */
 
 import { slugify } from './_shared/slug.js';
 import { fetchCatalog } from './_shared/catalog.js';
 
-export async function onRequest(context) {
-    const CANONICAL_BASE_URL = "https://www.amadolibros.com";
-    const SITE_TITLE = "Amado Libros";
-    // Límite de items para el feed (Google procesa hasta 10M pero el Worker tiene límite de CPU)
-    const MAX_ITEMS = 5000;
+const CANONICAL_BASE_URL = "https://www.amadolibros.com";
+const SITE_TITLE = "Amado Libros";
 
+export async function onRequest(context) {
     try {
         const catalog = await fetchCatalog(context);
         const items = (catalog && Array.isArray(catalog.items)) ? catalog.items : [];
@@ -40,40 +69,30 @@ export async function onRequest(context) {
             });
         }
 
-        const itemsToProcess = items
-            .filter(item => item.status === 'active' && Number(item.available_quantity) > 0)
-            .slice(0, MAX_ITEMS);
+        // Universo elegible: activo + con stock + comprable (precio válido) +
+        // con ficha válida (id + permalink). Calculado siempre desde los
+        // datos actuales — nunca cortado a un número fijo. Los libros "por
+        // encargo" (pausados) ya no llegan en `items` (ver comentario de
+        // arriba), así que no hace falta filtrarlos acá explícitamente.
+        const eligibleItems = items.filter(isEligibleForFeed);
+
+        // Deduplicación controlada: una sola oferta por GTIN+condition (ver
+        // comentario de cabecera). Los ítems sin GTIN válido pasan todos,
+        // sin deduplicar entre sí.
+        const dedupedItems = dedupeByGtinAndCondition(eligibleItems);
+
+        // Orden determinístico por id ascendente. No es un criterio
+        // comercial (no prioriza ni excluye nada más allá de la
+        // deduplicación de arriba); solo evita que el feed cambie de orden
+        // entre syncs por variaciones no garantizadas en el orden de
+        // scroll de la API de MercadoLibre.
+        const sortedItems = [...dedupedItems].sort((a, b) =>
+            a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+        );
+
         let feedItems = '';
-
-        for (const item of itemsToProcess) {
-            if (!item || !item.id || !item.permalink) continue;
-
-            // catalog.json usa available_quantity (no stock); currency no está presente en R2
-            const stock    = item.available_quantity ?? item.stock ?? 0;
-            const currency = item.currency ?? 'UYU';
-            const cond     = item.condition ?? 'used';
-
-            const availability = (stock > 0) ? 'in stock' : 'out of stock';
-            const price = item.price ? `${item.price} ${currency}` : null;
-            if (!price) continue; // Omitir items sin precio
-
-            const imageLink = item.thumbnail
-                ? item.thumbnail.replace('http://', 'https://').replace('-I.jpg', '-O.jpg')
-                : '';
-
-            feedItems += `
-    <item>
-        <g:id>${escapeXml(item.id)}</g:id>
-        <g:title>${escapeXml(item.title || '')}</g:title>
-        <g:description>${escapeXml(item.title || '')}</g:description>
-        <g:link>${escapeXml(`${CANONICAL_BASE_URL}/libro/${item.id}/${slugify(item.title || '')}`)}</g:link>
-        ${imageLink ? `<g:image_link>${escapeXml(imageLink)}</g:image_link>` : ''}
-        <g:availability>${availability}</g:availability>
-        <g:price>${escapeXml(price)}</g:price>
-        <g:condition>${escapeXml(cond)}</g:condition>
-        <g:identifier_exists>no</g:identifier_exists>
-        <g:brand>Amado Libros</g:brand>
-    </item>`;
+        for (const item of sortedItems) {
+            feedItems += renderFeedItem(item);
         }
 
         const feed = `<?xml version="1.0" encoding="UTF-8"?>
@@ -93,13 +112,242 @@ export async function onRequest(context) {
         });
 
     } catch (error) {
-        console.error("Error generando el feed GMC (v4):", error);
+        console.error("Error generando el feed GMC (v5):", error);
         return new Response(generateEmptyFeed(CANONICAL_BASE_URL, SITE_TITLE), {
             status: 500,
             headers: { "content-type": "application/xml;charset=UTF-8" },
         });
     }
 }
+
+// ---------------------------------------------------------------------------
+// Elegibilidad
+// ---------------------------------------------------------------------------
+
+/**
+ * Reglas comerciales del feed — sin cambios respecto a v4, salvo que ahora
+ * no hay corte de cantidad. Activo, con stock, con precio válido, con id y
+ * permalink. No excluye por condición: los usados (`condition: 'used'`)
+ * siguen publicándose con su condición real.
+ */
+export function isEligibleForFeed(item) {
+    if (!item || !item.id || !item.permalink) return false;
+    if (item.status !== 'active') return false;
+    if (!(Number(item.available_quantity) > 0)) return false;
+    if (!(Number(item.price) > 0)) return false;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// ISBN → GTIN
+// ---------------------------------------------------------------------------
+
+/**
+ * Limpia un ISBN crudo de MercadoLibre: espacios, guiones y prefijos como
+ * "ISBN", "ISBN-13", "ISBN-10". No corrige ni completa dígitos — solo quita
+ * separadores y prefijos textuales conocidos.
+ */
+export function cleanIsbnRaw(raw) {
+    if (raw == null) return '';
+    return String(raw)
+        .trim()
+        .toUpperCase()
+        .replace(/^ISBN(-1[03])?:?\s*/, '')
+        .replace(/[\s-]+/g, '');
+}
+
+/** Valida el dígito de control de un ISBN-13 (o EAN-13 de libro). */
+export function isValidIsbn13(digits) {
+    if (!/^\d{13}$/.test(digits)) return false;
+    let sum = 0;
+    for (let i = 0; i < 12; i++) sum += Number(digits[i]) * (i % 2 === 0 ? 1 : 3);
+    const check = (10 - (sum % 10)) % 10;
+    return check === Number(digits[12]);
+}
+
+/** Valida el dígito de control de un ISBN-10 (último carácter puede ser X). */
+export function isValidIsbn10(value) {
+    if (!/^\d{9}[\dX]$/.test(value)) return false;
+    let sum = 0;
+    for (let i = 0; i < 9; i++) sum += Number(value[i]) * (10 - i);
+    sum += value[9] === 'X' ? 10 : Number(value[9]);
+    return sum % 11 === 0;
+}
+
+/** Convierte un ISBN-10 ya validado a ISBN-13 (prefijo 978 + checksum nuevo). */
+export function isbn10to13(isbn10) {
+    const base = '978' + isbn10.slice(0, 9);
+    let sum = 0;
+    for (let i = 0; i < 12; i++) sum += Number(base[i]) * (i % 2 === 0 ? 1 : 3);
+    const check = (10 - (sum % 10)) % 10;
+    return base + String(check);
+}
+
+/**
+ * Normaliza un ISBN crudo a un GTIN publicable.
+ * - hadValue: había algo no vacío en el campo isbn (para reportar cuántos
+ *   son "no vacíos pero inválidos", sin publicarlos).
+ * - valid: el valor limpio pasó la validación de ISBN-13 o ISBN-10.
+ * - gtin: ISBN-13 listo para <g:gtin> (ISBN-10 válido ya convertido).
+ * Nunca inventa, completa ni corrige dígitos — un ISBN inválido queda
+ * simplemente sin GTIN, con la causa medible aparte.
+ */
+export function normalizeIsbnToGtin(rawIsbn) {
+    const cleaned = cleanIsbnRaw(rawIsbn);
+    if (!cleaned) return { gtin: null, hadValue: false, valid: false };
+    if (isValidIsbn13(cleaned)) return { gtin: cleaned, hadValue: true, valid: true };
+    if (isValidIsbn10(cleaned)) return { gtin: isbn10to13(cleaned), hadValue: true, valid: true };
+    return { gtin: null, hadValue: true, valid: false };
+}
+
+// ---------------------------------------------------------------------------
+// Deduplicación por GTIN + condition
+// ---------------------------------------------------------------------------
+
+/**
+ * Dentro de un grupo de ítems con el mismo GTIN+condition, elige la oferta
+ * representante con un criterio 100% determinista (no depende de la
+ * posición en el array de entrada ni de `start_time`):
+ *   1. mayor `available_quantity`;
+ *   2. empate → menor `price`;
+ *   3. empate → menor `id` (orden alfanumérico), como desempate estable.
+ * Devuelve el ítem elegido tal cual — nunca mezcla campos de dos
+ * publicaciones distintas ni suma cantidades entre ellas.
+ */
+export function pickRepresentativeItem(group) {
+    return [...group].sort((a, b) => {
+        const qtyA = Number(a.available_quantity) || 0;
+        const qtyB = Number(b.available_quantity) || 0;
+        if (qtyB !== qtyA) return qtyB - qtyA;
+
+        const priceA = Number(a.price);
+        const priceB = Number(b.price);
+        if (priceA !== priceB) return priceA - priceB;
+
+        return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    })[0];
+}
+
+/**
+ * Agrupa los ítems elegibles por GTIN+condition y deja pasar una sola
+ * oferta por grupo (ver pickRepresentativeItem). Los ítems sin GTIN válido
+ * nunca se agrupan entre sí — cada uno se conserva individualmente,
+ * siempre que tenga id/URL propios (ya garantizado por isEligibleForFeed).
+ * No toca MercadoLibre, catalog.json ni las fichas: la exclusión es
+ * exclusivamente de /feed.xml.
+ */
+export function dedupeByGtinAndCondition(eligibleItems) {
+    const noGtinItems = [];
+    const groups = new Map();
+
+    for (const item of eligibleItems) {
+        const gtinResult = normalizeIsbnToGtin(item.isbn);
+        if (!gtinResult.valid) {
+            noGtinItems.push(item);
+            continue;
+        }
+        const key = `${gtinResult.gtin}|${item.condition ?? 'used'}`;
+        if (!groups.has(key)) groups.set(key, []);
+        groups.get(key).push(item);
+    }
+
+    const deduped = [];
+    for (const group of groups.values()) {
+        deduped.push(group.length === 1 ? group[0] : pickRepresentativeItem(group));
+    }
+
+    return [...noGtinItems, ...deduped];
+}
+
+// ---------------------------------------------------------------------------
+// Editorial (solo para texto de descripción — nunca para <g:brand>)
+// ---------------------------------------------------------------------------
+
+/**
+ * Mismo criterio que la ficha (functions/libro/[[path]].js:normalizePublisher):
+ * descarta el placeholder "Amado Libros" cuando el atributo de origen
+ * resolvió al vendedor en vez de a una editorial real. No inventa una
+ * editorial cuando no hay dato.
+ */
+export function normalizePublisherForDescription(publisher) {
+    if (!publisher) return null;
+    const s = String(publisher).trim();
+    if (!s || s.toUpperCase() === 'AMADO LIBROS') return null;
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+// Descripción
+// ---------------------------------------------------------------------------
+
+/**
+ * Arma una descripción breve con campos reales del catálogo, sin repetir
+ * el título tal cual. catalog.json no trae hoy un campo `description`
+ * propio (solo título) — si en el futuro lo tuviera, se preferiría acá
+ * siempre que sea distinto del título; hasta entonces esta rama nunca se
+ * activa, no es código especulativo agregado por este lote sino el primer
+ * paso del algoritmo pedido.
+ */
+export function buildFeedDescription(item) {
+    const title = (item.title || '').trim();
+    if (item.description && item.description.trim() && item.description.trim() !== title) {
+        return item.description.trim();
+    }
+
+    const parts = [title ? `Libro "${title}"` : 'Libro'];
+    if (item.author) parts.push(`de ${item.author}`);
+    const publisher = normalizePublisherForDescription(item.publisher);
+    if (publisher) parts.push(`publicado por ${publisher}`);
+
+    let sentence = parts.join(', ');
+    if (item.condition === 'new') sentence += '. Ejemplar nuevo.';
+    else if (item.condition === 'used') sentence += '. Ejemplar usado.';
+    return sentence;
+}
+
+// ---------------------------------------------------------------------------
+// Render de un <item>
+// ---------------------------------------------------------------------------
+
+export function renderFeedItem(item) {
+    const stock = Number(item.available_quantity) || 0;
+    const currency = item.currency ?? 'UYU';
+    const cond = item.condition ?? 'used';
+    const availability = stock > 0 ? 'in stock' : 'out of stock';
+    const price = `${item.price} ${currency}`;
+
+    const imageLink = item.thumbnail
+        ? item.thumbnail.replace('http://', 'https://').replace('-I.jpg', '-O.jpg')
+        : '';
+
+    const isbnResult = normalizeIsbnToGtin(item.isbn);
+    // GTIN válido: se omite identifier_exists (default = yes, según spec de
+    // Google). Sin GTIN válido: identifier_exists=no, sin inventar uno.
+    const gtinTag = isbnResult.valid
+        ? `\n        <g:gtin>${escapeXml(isbnResult.gtin)}</g:gtin>`
+        : '';
+    const identifierExistsTag = isbnResult.valid
+        ? ''
+        : `\n        <g:identifier_exists>no</g:identifier_exists>`;
+
+    const description = buildFeedDescription(item);
+
+    return `
+    <item>
+        <g:id>${escapeXml(item.id)}</g:id>
+        <g:title>${escapeXml(item.title || '')}</g:title>
+        <g:description>${escapeXml(description)}</g:description>
+        <g:link>${escapeXml(`${CANONICAL_BASE_URL}/libro/${item.id}/${slugify(item.title || '')}`)}</g:link>
+        ${imageLink ? `<g:image_link>${escapeXml(imageLink)}</g:image_link>` : ''}
+        <g:availability>${availability}</g:availability>
+        <g:price>${escapeXml(price)}</g:price>
+        <g:condition>${escapeXml(cond)}</g:condition>${gtinTag}${identifierExistsTag}
+    </item>`;
+}
+
+// ---------------------------------------------------------------------------
+// Utilidades
+// ---------------------------------------------------------------------------
 
 function generateEmptyFeed(baseUrl, siteTitle) {
     return `<?xml version="1.0" encoding="UTF-8"?>
@@ -112,7 +360,7 @@ function generateEmptyFeed(baseUrl, siteTitle) {
 </rss>`;
 }
 
-function escapeXml(unsafe) {
+export function escapeXml(unsafe) {
     if (typeof unsafe !== 'string') return '';
     return unsafe.replace(/[<>&'"]/g, function (c) {
         switch (c) {


### PR DESCRIPTION
## Resumen

- Elimina el corte artificial de `MAX_ITEMS=5000` en `/feed.xml` — el feed ahora publica todo el universo elegible calculado en tiempo real (activo + stock>0 + precio válido), sin ningún número hardcodeado.
- Usa el ISBN ya presente en `catalog.json` como `g:gtin`, validando matemáticamente el checksum (ISBN-13 directo, ISBN-10 convertido a ISBN-13). Nunca se usa el ID interno (MLU) como GTIN, nunca se inventa ni corrige un dígito.
- Elimina `g:brand=Amado Libros` sin reemplazo automático por editorial: `catalog.json.items[].publisher` mezcla de forma indistinguible los atributos `PUBLISHER`/`EDITORIAL`/`BRAND` de MercadoLibre, así que no hay una señal confiable de "esto es la marca real" — mientras esa ambigüedad exista en el origen de datos, `g:brand` se omite para todos los ítems.
- Deduplicación controlada por `GTIN + condition`: el 89% de los activos elegibles comparte ISBN con al menos otro MLU activo (mismo libro publicado más de una vez en MercadoLibre). Por decisión explícita de Seba (Google prohíbe más de una oferta con el mismo GTIN+atributos de variante, y `item_group_id` es solo para variantes reales, no publicaciones repetidas), se publica una sola oferta por grupo `GTIN+condition`, elegida con criterio 100% determinista: **mayor stock → menor precio → menor ID**. La oferta descartada nunca se toca en MercadoLibre, `catalog.json` ni la ficha — solo se excluye de `/feed.xml`.
- La descripción deja de repetir el título: se arma con título/autor/editorial/condición reales, sin inventar nada.

## Métricas (universo real de producción, medidas con las funciones del código)

| Métrica | Valor |
|---|---:|
| Productos finales en el feed | **3.944** |
| Con GTIN válido | 3.634 |
| Con `identifier_exists=no` (sin GTIN) | 310 |
| `brand=Amado Libros` | 0 |
| Ofertas excluidas únicamente por deduplicación GTIN+condition | 3.188 |

Criterio de selección dentro de cada grupo duplicado: mayor `available_quantity` → empate: menor `price` → empate: menor `id` (desempate estable, no depende del orden del array).

## Tests y build

- 30/30 tests específicos del feed (`functions/__tests__/feed-gtin-and-coverage.test.js`), incluyendo cobertura sin corte de 5.000, validación/normalización ISBN completa, deduplicación GTIN+condition con los 8 casos pedidos (desempate por stock/precio/id, orden del array irrelevante, sin mezcla de campos entre publicaciones descartadas y ganadoras), ausencia de `g:brand`, escape XML, `condition` new/used preservada.
- 489/491 de la suite completa del repo. Los 2 fallos son preexistentes y ajenos a este cambio: `deploy-branch-guards.test.js` falla por line-endings CRLF en `.github/workflows/deploy.yml` y `deploy-worker-sync.yml` — confirmado que fallan igual contra `origin/main` sin este diff aplicado.
- Build de `astro-front` sin errores (9 páginas).

## Preview

`https://agent-seo-gmc-feed-1-preview.amadolibros-web.pages.dev/feed.xml` — verificado en vivo: 3.944 `<item>`, 3.944 `<g:id>` únicos, 3.634 combinaciones `GTIN+condition` todas únicas (cero duplicados), 0 `<g:brand>`, ningún libro "por encargo" presente, consola sin errores.

## Confirmado intacto

`main` sin otros commits; `www.amadolibros.com/feed.xml` (producción) sigue en 5.000 ítems con `brand=Amado Libros` al 100%, sin cambios; Merchant Center no fue tocado ni conectado a este feed; `catalog.json`, sitemap, fichas y Worker sin modificar.

## Alcance

Exclusivamente 3 archivos: `functions/feed.xml.js`, `functions/__tests__/feed-gtin-and-coverage.test.js` (nuevo), `functions/__tests__/home-recent-new-only-scope.test.js` (ajuste mínimo de una aserción de test, sin debilitar la garantía que protege).

**Este PR queda en Draft. No se mergea, no se despliega a producción, no se conecta a Merchant Center.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)