### PR TITLE
AL-WEB: corregir jerarquía de precios y orden de CTA en ficha

### DIFF
--- a/functions/__tests__/ficha-pricing-cta-order.test.js
+++ b/functions/__tests__/ficha-pricing-cta-order.test.js
@@ -1,0 +1,131 @@
+// AL-WEB: jerarquía de precios y orden de acciones en la ficha individual
+// (functions/libro/[[path]].js). Cubre las dos correcciones comerciales:
+// 1. Precio web/tarjeta primero, cuotas debajo, transferencia como
+//    beneficio secundario.
+// 2. Agregar al carrito → WhatsApp → Mercado Libre, con Mercado Libre
+//    visualmente subordinado (sin el relleno amarillo dominante que tenía).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { renderPage } from '../libro/[[path]].js';
+
+function book(overrides = {}) {
+    return {
+        id: 'MLU1', title: 'Un Libro De Prueba', author: 'Autor De Prueba',
+        price: 1200, status: 'active', available_quantity: 3,
+        condition: 'new', isbn: '9788499809991', publisher: null,
+        pages: null, dimensions: null,
+        thumbnail: 'http://http2.mlstatic.com/D_1-I.jpg', pictures: [],
+        permalink: 'https://articulo.mercadolibre.com.uy/MLU-1-un-libro',
+        ...overrides,
+    };
+}
+
+function indexOfAll(html, needles) {
+    return needles.map(n => html.indexOf(n));
+}
+
+// El documento completo trae el <head> antes que el <body> — el meta
+// description menciona "Transferencia" como gancho de SEO, y el <style>
+// define .btn-wa/.btn-ml antes de que el <body> los use. Las comparaciones
+// de orden deben mirar solo el bloque real del <body> donde se renderizan
+// los CTA/precio, no el documento entero.
+function extractBlock(html, className) {
+    const match = html.match(new RegExp(`<div class="${className}">[\\s\\S]*?\\n    </div>`));
+    if (!match) throw new Error(`Bloque .${className} no encontrado en el HTML`);
+    return match[0];
+}
+
+test('1. Precio web/tarjeta aparece antes que transferencia, con el texto exacto aprobado (dentro del price-box, no en meta description)', () => {
+    const html = renderPage(book({ price: 1200 }), 'un-libro-de-prueba', false, '');
+    assert.match(html, /Precio web\/tarjeta:<\/span> \$1\.200 UYU/);
+    assert.match(html, /Transferencia: \$1\.056 UYU/); // 1200 * 0.88 = 1056
+    const priceBox = extractBlock(html, 'price-box');
+    const priceIdx = priceBox.indexOf('Precio web/tarjeta:');
+    const transferIdx = priceBox.indexOf('Transferencia:');
+    assert.ok(priceIdx > -1 && transferIdx > -1);
+    assert.ok(priceIdx < transferIdx, 'el precio principal debe aparecer antes que la transferencia');
+});
+
+test('2. Cuotas visibles, con el texto aprobado, entre precio y transferencia', () => {
+    const html = renderPage(book({ price: 1200 }), 'un-libro-de-prueba', false, '');
+    assert.match(html, /Hasta 12 cuotas de aprox\. \$100 UYU/); // 1200 / 12 = 100
+    const priceBox = extractBlock(html, 'price-box');
+    const priceIdx = priceBox.indexOf('Precio web/tarjeta:');
+    const installmentIdx = priceBox.indexOf('Hasta 12 cuotas');
+    const transferIdx = priceBox.indexOf('Transferencia:');
+    assert.ok(priceIdx < installmentIdx, 'el precio principal debe ir antes que las cuotas');
+    assert.ok(installmentIdx < transferIdx, 'las cuotas deben ir antes que la transferencia');
+});
+
+test('3. Precio principal usa una clase visualmente más fuerte que transferencia', () => {
+    const html = renderPage(book({ price: 1200 }), 'un-libro-de-prueba', false, '');
+    assert.match(html, /class="price-main"/);
+    assert.match(html, /class="price-transfer"/);
+    assert.match(html, /\.price-main\{font-size:1\.35rem;font-weight:800/);
+    assert.match(html, /\.price-transfer\{font-size:\.85rem;font-weight:600/);
+});
+
+test('4. Orden de botones: Agregar al carrito → WhatsApp → Mercado Libre (dentro del bloque .cta, no de la hoja de estilos)', () => {
+    const html = renderPage(book(), 'un-libro-de-prueba', false, '');
+    const cta = extractBlock(html, 'cta');
+    const cartIdx = cta.indexOf('data-action="add-to-cart"');
+    const waIdx = cta.indexOf('btn-wa');
+    const mlIdx = cta.indexOf('btn-ml');
+    assert.ok(cartIdx > -1 && waIdx > -1 && mlIdx > -1, 'los tres CTA deben estar presentes');
+    assert.ok(cartIdx < waIdx, 'Carrito debe aparecer antes que WhatsApp');
+    assert.ok(waIdx < mlIdx, 'WhatsApp debe aparecer antes que Mercado Libre');
+});
+
+test('5. Mercado Libre no usa el estilo visual principal (sin relleno amarillo dominante)', () => {
+    const html = renderPage(book(), 'un-libro-de-prueba', false, '');
+    // Antes: .btn-ml{background:#ffe600;color:#1e293b} (relleno amarillo sólido,
+    // mismo peso que carrito). Ahora: outline claro, fuente más chica.
+    assert.doesNotMatch(html, /\.btn-ml\{background:#ffe600/);
+    assert.match(html, /\.btn-ml\{background:#fff;color:#7a6a1f;border:1\.5px solid #e8dfa0;\s*font-size:\.82rem;font-weight:600/);
+    // Carrito sigue siendo el más fuerte: fondo sólido + ancho completo.
+    assert.match(html, /\.btn-cart\{background:#e49982;color:#fff;border:none;font-family:inherit;\s*cursor:pointer;width:100%\}/);
+});
+
+test('6. El enlace de WhatsApp sigue siendo válido (wa.me + mensaje codificado)', () => {
+    const html = renderPage(book({ title: 'Un Libro & Su Título' }), 'un-libro', false, '');
+    assert.match(html, /href="https:\/\/wa\.me\/59899841325\?text=/);
+    assert.match(html, /Hola!%20Me%20interesa/);
+});
+
+test('7. El enlace de Mercado Libre sigue siendo válido (permalink real, escapado)', () => {
+    const permalink = 'https://articulo.mercadolibre.com.uy/MLU-999-otro-libro';
+    const html = renderPage(book({ permalink }), 'otro-libro', false, '');
+    assert.match(html, new RegExp(`href="${permalink.replace(/\//g, '\\/')}"`));
+    assert.match(html, /target="_blank" rel="noopener noreferrer">\s*Comprar en MercadoLibre/);
+});
+
+test('8. Ficha con Mercado Libre: los tres botones están presentes', () => {
+    const html = renderPage(book({ permalink: 'https://articulo.mercadolibre.com.uy/MLU-1' }), 'un-libro', false, '');
+    assert.match(html, /data-action="add-to-cart"/);
+    assert.match(html, /class="btn btn-wa"/);
+    assert.match(html, /class="btn btn-ml"/);
+});
+
+test('9. Ficha sin stock ("por encargo"): no hay precio web/tarjeta ni botón de Mercado Libre, solo WhatsApp/aviso', () => {
+    const html = renderPage(book({ status: 'paused', available_quantity: 0 }), 'un-libro', false, 'site-key-fake');
+    assert.doesNotMatch(html, /Precio web\/tarjeta/);
+    assert.doesNotMatch(html, /class="btn btn-ml"/);
+    assert.doesNotMatch(html, /data-action="add-to-cart"/);
+    assert.match(html, /class="btn btn-wa"/);
+});
+
+test('10. No cambia el cálculo de precio, cuotas ni transferencia (solo texto/orden/estilo)', () => {
+    const html = renderPage(book({ price: 999 }), 'un-libro', false, '');
+    assert.match(html, /\$999 UYU/); // precio base sin redondeo especial
+    assert.match(html, /\$879 UYU/); // 999 * 0.88 = 879.12 -> Math.round = 879 (transferencia)
+    assert.match(html, /\$83 UYU/);  // Math.round(999/12) = 83 (cuotas)
+});
+
+test('11. Responsive: no hay reglas que oculten o reordenen los CTA por media query (mismo orden en mobile y desktop)', () => {
+    const html = renderPage(book(), 'un-libro', false, '');
+    // El contenedor .cta es un flex-column simple, sin @media que reordene o
+    // esconda btn-ml/btn-wa/btn-cart — el orden del DOM (ya verificado en el
+    // test 4) es el que se ve en cualquier ancho de viewport.
+    assert.match(html, /\.cta\{display:flex;flex-direction:column;gap:\.75rem;margin-top:1rem\}/);
+    assert.doesNotMatch(html, /@media[^{]*\{[^}]*\.btn-(ml|wa|cart)/s);
+});

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -227,7 +227,7 @@ function notFound() {
 // Render HTML completo de la ficha
 // ---------------------------------------------------------------------------
 
-function renderPage(item, slug, isPreview, waitlistSiteKey) {
+export function renderPage(item, slug, isPreview, waitlistSiteKey) {
     const canonicalUrl = `${BASE}/libro/${item.id}/${slug}`;
     const safeTitle    = escapeHtml(item.title);
     const safeAuthor   = item.author ? escapeHtml(item.author) : null;
@@ -309,9 +309,9 @@ function renderPage(item, slug, isPreview, waitlistSiteKey) {
 
     const priceHtml = inStock
         ? `<div class="price-box">
-      <div class="price-transfer"><span class="price-label">Transferencia:</span> $${transferPrice} UYU</div>
-      <div class="price-base">Precio: $${priceUY} UYU</div>
-      <div class="price-installment">12 cuotas de aprox. $${installment} UYU</div>
+      <div class="price-main"><span class="price-label">Precio web/tarjeta:</span> $${priceUY} UYU</div>
+      <div class="price-installment">Hasta 12 cuotas de aprox. $${installment} UYU</div>
+      <div class="price-transfer">Transferencia: $${transferPrice} UYU</div>
     </div>`
         : `<div class="order-box">
       <strong>¿Buscás este libro?</strong>
@@ -331,11 +331,11 @@ function renderPage(item, slug, isPreview, waitlistSiteKey) {
       >
         <span data-cart-label>🛒 Agregar al carrito</span>
       </button>
-      <a class="btn btn-ml" href="${escapeHtml(item.permalink)}" target="_blank" rel="noopener noreferrer">
-        🛒 Comprar en MercadoLibre
-      </a>
       <a class="btn btn-wa" href="https://wa.me/${WA}?text=${waMsg}" target="_blank" rel="noopener noreferrer">
         💬 Consultar por WhatsApp
+      </a>
+      <a class="btn btn-ml" href="${escapeHtml(item.permalink)}" target="_blank" rel="noopener noreferrer">
+        Comprar en MercadoLibre
       </a>`
         : `<a class="btn btn-wa" href="https://wa.me/${WA}?text=${waMsg}" target="_blank" rel="noopener noreferrer">
         Consultar si podemos conseguirlo
@@ -457,9 +457,10 @@ function renderPage(item, slug, isPreview, waitlistSiteKey) {
     .detail-row dd{color:#475569}
     .price-box{background:#f5f3ff;border:1px solid #ddd6fe;border-radius:.5rem;
                padding:1rem 1.25rem;margin:.875rem 0}
-    .price-transfer,.price-base,.price-installment{font-size:1rem;font-weight:700;line-height:1.35}
-    .price-transfer{color:#0f172a}
-    .price-base,.price-installment{color:#374151;margin-top:.15rem}
+    .price-main{font-size:1.35rem;font-weight:800;color:#0f172a;line-height:1.3}
+    .price-label{font-weight:800}
+    .price-installment{font-size:1rem;font-weight:600;color:#374151;margin-top:.35rem}
+    .price-transfer{font-size:.85rem;font-weight:600;color:#a94e3d;margin-top:.35rem}
     .order-box{display:flex;flex-direction:column;gap:.25rem;background:#fff7e8;
                border:1px solid #efd2a6;border-radius:.5rem;padding:1rem 1.25rem;
                margin:.875rem 0;color:#6b4218}
@@ -470,11 +471,16 @@ function renderPage(item, slug, isPreview, waitlistSiteKey) {
     .btn{display:block;padding:.875rem 1.25rem;border-radius:.5rem;font-size:.95rem;
          font-weight:700;text-align:center;text-decoration:none;transition:opacity .15s}
     .btn:hover{opacity:.85}
-    .btn-ml{background:#ffe600;color:#1e293b}
     .btn-wa{background:#25d366;color:white}
     .btn-cart{background:#e49982;color:#fff;border:none;font-family:inherit;
               cursor:pointer;width:100%}
     .btn-cart:disabled{opacity:.7;cursor:default}
+    /* AL-WEB: Mercado Libre queda tercero y subordinado — sin relleno
+       amarillo dominante, fuente más chica y peso menor que carrito/WhatsApp.
+       Sigue siendo un enlace funcional, solo pierde peso visual. */
+    .btn-ml{background:#fff;color:#7a6a1f;border:1.5px solid #e8dfa0;
+            font-size:.82rem;font-weight:600;padding:.65rem 1.25rem}
+    .btn-ml:hover{background:#fdf9e8;opacity:1}
     .waitlist-form{background:#fff;border:1px solid #d8d1c7;border-radius:.65rem;
                    padding:1rem;scroll-margin-top:1rem}
     .waitlist-form label{display:block;font-size:.82rem;font-weight:700;color:#334155;


### PR DESCRIPTION
## Diagnóstico

HOME-COMERCIAL-1 (PR #54) aprobó y aplicó la jerarquía nueva (precio principal → cuotas → transferencia como beneficio, carrito como acción principal) únicamente en los componentes de la home (`BookCard.astro`, `BestsellerSection.astro`, `HowToBuy.astro`, etc.). La ficha individual (`functions/libro/[[path]].js`) nunca formó parte de ese lote y quedó con el diseño anterior: `Transferencia` primero, `Precio` segundo, `12 cuotas` tercero; y el orden de botones era Carrito → MercadoLibre → WhatsApp, con MercadoLibre en amarillo sólido (`#ffe600`) compitiendo visualmente con "Agregar al carrito". No es una regresión — es contenido que simplemente no fue tocado por el lote anterior.

**Hallazgo fuera de alcance, informado y no tocado en este lote:** `functions/catalogo.js` (la página `/catalogo`) también conserva la jerarquía vieja de precio (`Transferencia` antes que `Precio`, ver `rc-transfer`/`rc-base` en el CSS del archivo). No se incluyó en este PR — queda pendiente de un lote aparte si se aprueba.

## Corrección 1 — Jerarquía de precios

- **Antes:** Transferencia → Precio → 12 cuotas.
- **Ahora:** "Precio web/tarjeta: $X UYU" (principal, `font-size:1.35rem;font-weight:800`) → "Hasta 12 cuotas de aprox. $X UYU" → "Transferencia: $X UYU" (beneficio secundario, `font-size:.85rem`, color acento en vez de negro).
- Mismos cálculos de siempre (`price`, `Math.round(price*0.88)`, `Math.round(price/12)`) — solo cambia texto, orden y estilo.

## Corrección 2 — Orden y peso visual de los CTA

- **Antes:** Carrito → MercadoLibre (amarillo sólido) → WhatsApp.
- **Ahora:** Carrito → WhatsApp → MercadoLibre (outline claro, `border:1.5px solid #e8dfa0`, sin relleno amarillo, fuente más chica).
- "Agregar al carrito" sigue siendo el botón más fuerte (fondo sólido, ancho completo). MercadoLibre sigue siendo un enlace funcional real al mismo `permalink` — solo pierde peso visual, no se oculta.
- Sin `@media` que reordene o esconda los CTA — el orden es el mismo en desktop y mobile (verificado con `getComputedStyle` en un iframe de 390px en el Preview).

## Tests

11 tests nuevos (`functions/__tests__/ficha-pricing-cta-order.test.js`): orden precio/cuotas/transferencia dentro del bloque real (no del meta description ni del CSS), clases visuales correctas, orden Carrito→WhatsApp→MercadoLibre dentro del bloque `.cta` real, ausencia del amarillo dominante, enlaces de WhatsApp/MercadoLibre válidos, ficha con y sin MercadoLibre/stock, cálculos sin cambios, sin reordenamiento por media query.

- 11/11 tests nuevos ✅
- 500/502 de la suite completa (2 fallos preexistentes y ajenos: CRLF en `deploy.yml`/`deploy-worker-sync.yml`)
- Build de `astro-front` sin errores

## Fuera de alcance (no tocado)

Títulos, ISBN, editorial, medidas, stock, imágenes, descuentos/fórmulas, carrito, checkout, Mercado Pago, feed XML, datos estructurados, Merchant Center, home, `/catalogo` (ver hallazgo arriba), producción.

**Este PR queda en Draft. No se mergea ni se despliega a producción.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)