### PR TITLE
CATALOGO: alinear jerarquía comercial de precios

### DIFF
--- a/functions/__tests__/catalog-display.test.js
+++ b/functions/__tests__/catalog-display.test.js
@@ -142,12 +142,36 @@ test('la búsqueda Preview usa el índice activo compacto y conserva el precio',
 
   assert.match(html, /Alpha disponible/);
   assert.match(html, /Transferencia:/);
-  assert.match(html, /Precio:/);
+  assert.match(html, /Precio web\/tarjeta:/);
   assert.equal(requests.includes(CATALOG_URL), false);
   assert.match(response.headers.get('server-timing'), /active_index_parse/);
   assert.match(response.headers.get('server-timing'), /search;dur=/);
   assert.match(response.headers.get('server-timing'), /render;dur=/);
   assert.match(response.headers.get('server-timing'), /total;dur=/);
+});
+
+test('el catálogo prioriza precio web y cuotas antes que transferencia', async () => {
+  const response = await catalogRequest(
+    context('https://preview.example/catalogo?q=Alpha+disponible')
+  );
+  const html = await response.text();
+  const prices = html.match(/<div class="rc-prices">([\s\S]*?)<\/div>/)?.[1] || '';
+
+  assert.match(prices, /Precio web\/tarjeta:<\/span> \$1[.,]000 UYU/);
+  assert.match(prices, /Hasta 12 cuotas de aprox\. \$83 UYU/);
+  assert.match(prices, /Transferencia: \$880 UYU/);
+  assert.ok(prices.indexOf('Precio web/tarjeta:') < prices.indexOf('Hasta 12 cuotas'));
+  assert.ok(prices.indexOf('Hasta 12 cuotas') < prices.indexOf('Transferencia:'));
+});
+
+test('el precio principal del catálogo tiene más fuerza visual que transferencia', async () => {
+  const response = await catalogRequest(
+    context('https://preview.example/catalogo?q=Alpha+disponible')
+  );
+  const html = await response.text();
+
+  assert.match(html, /\.rc-base\{font-size:\.95rem[^}]*font-weight:700\}/);
+  assert.match(html, /\.rc-transfer\{font-size:\.78rem[^}]*font-weight:600\}/);
 });
 
 test('una búsqueda sin coincidencias reales termina en cero resultados', async () => {

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -420,6 +420,7 @@ export async function onRequest(ctx) {
         const price     = Number(b.price) || 0;
         const transfer  = Math.round(price * 0.88).toLocaleString('es-UY');
         const priceStr  = price.toLocaleString('es-UY');
+        const installment = Math.round(price / 12).toLocaleString('es-UY');
         const loading  = idx < 8 ? 'eager' : 'lazy';
         const waHref = `${WA}?text=${encodeURIComponent(`Hola Amado Libros, quiero consultar por encargo: ${b.title}`)}`;
         const orderWaHref = `${WA}?text=${encodeURIComponent(buildOrderWaMessage(b, href))}`;
@@ -435,8 +436,9 @@ export async function onRequest(ctx) {
 
         const bodyCta = available
             ? `<div class="rc-prices">
-      <span class="rc-transfer"><span class="rc-lbl">Transferencia:</span> $${escapeHtml(transfer)}</span>
-      <span class="rc-base">Precio: $${escapeHtml(priceStr)}</span>
+      <span class="rc-base"><span class="rc-lbl">Precio web/tarjeta:</span> $${escapeHtml(priceStr)} UYU</span>
+      <span class="rc-installment">Hasta 12 cuotas de aprox. $${escapeHtml(installment)} UYU</span>
+      <span class="rc-transfer">Transferencia: $${escapeHtml(transfer)} UYU</span>
     </div>
     <a href="${href}" class="rc-cta">Ver ficha →</a>`
             : isPaused
@@ -563,10 +565,11 @@ export async function onRequest(ctx) {
     .rc-author{font-size:.82rem;color:#6b6157;
                white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
     .rc-prices{display:flex;flex-direction:column;gap:.2rem;margin-top:.35rem}
-    .rc-transfer,.rc-base{font-size:.875rem;line-height:1.3}
-    .rc-transfer{color:#18120e;font-weight:600}
+    .rc-base,.rc-installment,.rc-transfer{line-height:1.3}
+    .rc-base{font-size:.95rem;color:#18120e;font-weight:700}
+    .rc-installment{font-size:.82rem;color:#374151;font-weight:600}
+    .rc-transfer{font-size:.78rem;color:#a94e3d;font-weight:600}
     .rc-lbl{font-weight:700}
-    .rc-base{color:#6b6157}
     .wa-link{color:#15803d;font-weight:500}
     .rc-badge{display:inline-flex;align-self:flex-start;padding:.18rem .55rem;
               border-radius:999px;font-size:.68rem;font-weight:800;


### PR DESCRIPTION
## Qué cambia

- Pone **Precio web/tarjeta** como precio principal en las cards disponibles de `/catalogo`.
- Muestra inmediatamente debajo **Hasta 12 cuotas de aprox.**
- Deja **Transferencia** como beneficio secundario con menor peso visual.
- Mantiene sin precio las cards pausadas o por encargo.

## Por qué

El catálogo conservaba la jerarquía anterior y contradecía la home y la corrección de ficha del PR #58. El precio cobrable en la web debe ser el ancla; cuotas y transferencia son argumentos secundarios.

## Alcance

Solo modifica:

- `functions/catalogo.js`
- `functions/__tests__/catalog-display.test.js`

No toca ficha, home, carrito, checkout, Mercado Pago, feed, Merchant Center ni producción.

## Validación

- `node --check functions/catalogo.js`: aprobado.
- Prueba específica del catálogo: 14/14.
- Suite completa: 403/403.
- Build Astro: aprobado, 9 páginas generadas.

## Estado

Preview únicamente. Sin merge ni deploy a producción hasta aprobación visual de Seba.