### PR TITLE
SEO-LEGACY-1: resolver URLs antiguas de WordPress

### DIFF
--- a/functions/__tests__/legacy-redirects.test.js
+++ b/functions/__tests__/legacy-redirects.test.js
@@ -2,6 +2,10 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { onRequest as redirectLegacyBook365 } from '../365.js';
+import {
+    legacyResponseForRequest,
+    onRequest as middlewareRequest,
+} from '../_middleware.js';
 
 test('/365 redirige permanentemente a la ficha actual', () => {
     const response = redirectLegacyBook365();
@@ -11,4 +15,95 @@ test('/365 redirige permanentemente a la ficha actual', () => {
         response.headers.get('location'),
         'https://www.amadolibros.com/libro/MLU1330191560/libro-club-de-brujas-mel-knarik-ayelen-romano',
     );
+});
+
+const request = (path, host = 'www.amadolibros.com') =>
+    new Request(`https://${host}${path}`);
+
+test('SEO-LEGACY-1 redirige archivos WordPress relevantes a /catalogo', () => {
+    const paths = [
+        '/shop/',
+        '/tienda/',
+        '/tienda/page/43/',
+        '/tienda/page/999/',
+        '/page/88/',
+        '/page/95/',
+        '/page/122/',
+        '/mas-vendidos/',
+        '/categoria-producto/infantil/',
+        '/categoria-producto/religion/biblias/',
+    ];
+
+    for (const path of paths) {
+        const response = legacyResponseForRequest(request(path));
+        assert.equal(response?.status, 301, path);
+        assert.equal(
+            response?.headers.get('location'),
+            'https://www.amadolibros.com/catalogo',
+            path,
+        );
+    }
+});
+
+test('SEO-LEGACY-1 descarta parámetros viejos y evita cadenas desde non-www', () => {
+    const response = legacyResponseForRequest(
+        request('/shop/?add-to-cart=123&utm_source=legacy', 'amadolibros.com'),
+    );
+
+    assert.equal(response?.status, 301);
+    assert.equal(
+        response?.headers.get('location'),
+        'https://www.amadolibros.com/catalogo',
+    );
+});
+
+test('SEO-LEGACY-1 conserva el host de Preview', () => {
+    const response = legacyResponseForRequest(
+        request('/tienda/page/43/', 'agent-seo-legacy-1.amadolibros-web.pages.dev'),
+    );
+
+    assert.equal(response?.status, 301);
+    assert.equal(
+        response?.headers.get('location'),
+        'https://agent-seo-legacy-1.amadolibros-web.pages.dev/catalogo',
+    );
+});
+
+test('SEO-LEGACY-1 devuelve 410 útil para rutas sin reemplazo seguro', async () => {
+    for (const path of ['/my-orders/', '/2/', '/5/', '/30/', '/85/']) {
+        const response = legacyResponseForRequest(request(path));
+        const html = await response?.text();
+
+        assert.equal(response?.status, 410, path);
+        assert.equal(response?.headers.get('x-robots-tag'), 'noindex, follow', path);
+        assert.equal(response?.headers.get('cache-control'), 'no-store', path);
+        assert.match(response?.headers.get('content-type') ?? '', /^text\/html/, path);
+        assert.match(html ?? '', /href="\/catalogo"/, path);
+        assert.match(html ?? '', /href="\/contacto"/, path);
+        assert.match(html ?? '', /https:\/\/wa\.me\/59899841325/, path);
+    }
+});
+
+test('SEO-LEGACY-1 no captura rutas actuales ni patrones parecidos', async () => {
+    const paths = [
+        '/',
+        '/catalogo',
+        '/pedido',
+        '/page/2/',
+        '/tienda-nueva/',
+        '/categoria-productos/infantil/',
+        '/2/otra-cosa',
+    ];
+
+    for (const path of paths) {
+        assert.equal(legacyResponseForRequest(request(path)), null, path);
+
+        const response = await middlewareRequest({
+            request: request(path),
+            async next() {
+                return new Response('next');
+            },
+        });
+        assert.equal(await response.text(), 'next', path);
+    }
 });

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -16,6 +16,88 @@
 
 import { perfNow } from './_shared/perf.js';
 
+const LEGACY_GONE_PATHS = new Set([
+    '/my-orders',
+    '/2',
+    '/5',
+    '/30',
+    '/85',
+]);
+
+function withoutTrailingSlash(pathname) {
+    return pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
+}
+
+function isLegacyCatalogPath(pathname) {
+    const path = withoutTrailingSlash(pathname);
+
+    return path === '/shop'
+        || path === '/tienda'
+        || path === '/mas-vendidos'
+        || /^\/tienda\/page\/\d+$/.test(path)
+        || /^\/page\/(?:88|95|122)$/.test(path)
+        || /^\/categoria-producto(?:\/.*)?$/.test(path);
+}
+
+function legacyGonePage() {
+    return `<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, follow">
+  <title>Página no disponible | Amado Libros</title>
+  <style>
+    body{margin:0;background:#f8f5ef;color:#243047;font-family:Arial,sans-serif}
+    main{max-width:680px;margin:10vh auto;padding:32px 24px;text-align:center}
+    h1{font-size:clamp(1.8rem,5vw,2.6rem);margin:0 0 16px}
+    p{font-size:1.05rem;line-height:1.6;margin:0 0 24px}
+    nav{display:flex;flex-wrap:wrap;justify-content:center;gap:12px}
+    a{display:inline-block;border-radius:8px;padding:12px 18px;background:#173f73;color:#fff;text-decoration:none;font-weight:700}
+    a.secondary{background:#fff;color:#173f73;border:1px solid #173f73}
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Esta página ya no está disponible</h1>
+    <p>El contenido pertenecía a la versión anterior de Amado Libros. Podés buscar el libro en el catálogo o consultarnos y te ayudamos a encontrarlo.</p>
+    <nav aria-label="Opciones para continuar">
+      <a href="/catalogo">Buscar en el catálogo</a>
+      <a class="secondary" href="/contacto">Contacto</a>
+      <a class="secondary" href="https://wa.me/59899841325?text=Hola%20Amado%20Libros%2C%20busco%20un%20libro" rel="noopener noreferrer">WhatsApp</a>
+    </nav>
+  </main>
+</body>
+</html>`;
+}
+
+export function legacyResponseForRequest(request) {
+    const url = new URL(request.url);
+    const path = withoutTrailingSlash(url.pathname);
+    const isPreview = url.hostname.endsWith('.pages.dev');
+
+    if (isLegacyCatalogPath(url.pathname)) {
+        const destination = new URL(
+            '/catalogo',
+            isPreview ? url.origin : 'https://www.amadolibros.com',
+        );
+        return Response.redirect(destination.toString(), 301);
+    }
+
+    if (LEGACY_GONE_PATHS.has(path)) {
+        return new Response(legacyGonePage(), {
+            status: 410,
+            headers: {
+                'Content-Type': 'text/html; charset=utf-8',
+                'X-Robots-Tag': isPreview ? 'noindex, nofollow' : 'noindex, follow',
+                'Cache-Control': 'no-store',
+            },
+        });
+    }
+
+    return null;
+}
+
 function appendServerTiming(headers, name, duration) {
     const rounded = Math.round(duration * 100) / 100;
     const current = headers.get('Server-Timing');
@@ -30,6 +112,13 @@ export async function onRequest(context) {
     const url = new URL(context.request.url);
     const isPreview = url.hostname.endsWith('.pages.dev');
     const isHashedAstroAsset = /^\/_astro\/[^/]+\.[A-Za-z0-9_-]{6,}\.(?:css|js)$/.test(url.pathname);
+
+    // --- SEO-LEGACY-1: resolver rutas WordPress antes del fallback SPA ---
+    // En Producción se apunta directamente al host canónico para evitar una
+    // cadena non-www → www → /catalogo. Los parámetros legacy (por ejemplo
+    // ?add-to-cart=) se descartan deliberadamente.
+    const legacyResponse = legacyResponseForRequest(context.request);
+    if (legacyResponse) return legacyResponse;
 
     // --- Producción: redirect non-www → www ---
     if (!isPreview && url.hostname === 'amadolibros.com') {


### PR DESCRIPTION
## Qué cambia

- Redirige con 301 las rutas legacy con reemplazo relevante hacia `/catalogo`.
- Devuelve 410 real para rutas sin reemplazo seguro: `/my-orders/`, `/2/`, `/5/`, `/30/` y `/85/`.
- Evita cadenas de redirección desde el dominio sin `www`.
- Descarta parámetros antiguos como `?add-to-cart=`.
- Mantiene las redirecciones dentro del host de Preview.
- Agrega una página 410 útil con enlaces al catálogo, contacto y WhatsApp.

## Motivo

El fallback SPA servía la portada con HTTP 200 para estas URLs antiguas. Google podía interpretarlas como contenido duplicado o soft 404.

## Alcance

Solo modifica:

- `functions/_middleware.js`
- `functions/__tests__/legacy-redirects.test.js`

No cambia catálogo, fichas, precios, checkout, Mercado Pago, feed ni Merchant Center.

## Validación

- Sintaxis JS: aprobada.
- Suite completa: 461/461 pruebas.
- Build checkout OFF: aprobado, 9 páginas.
- Build checkout ON: aprobado, 9 páginas.
- `git diff --check`: aprobado.

PR borrador. Sin merge ni producción hasta aprobación.