### PR TITLE
HOTFIX: enviar búsquedas de ficha al catálogo

### DIFF
--- a/functions/__tests__/ficha-header-search.test.js
+++ b/functions/__tests__/ficha-header-search.test.js
@@ -22,9 +22,9 @@ test('1. La ficha muestra el logo gráfico real y la marca enlaza al inicio', ()
     assert.doesNotMatch(html, />📚 Amado Libros<\/a>/);
 });
 
-test('2. El buscador de la ficha envía una búsqueda GET compatible con la home', () => {
+test('2. El buscador de la ficha envía la consulta al catálogo', () => {
     const html = render();
-    assert.match(html, /<form class="header-search" action="\/" method="get" role="search">/);
+    assert.match(html, /<form class="header-search" action="\/catalogo" method="get" role="search">/);
     assert.match(html, /<input type="search" name="q"/);
     assert.match(html, /placeholder="Buscar por título, autor, temática o ISBN"/);
     assert.match(html, /<button type="submit" aria-label="Buscar libros">Buscar<\/button>/);

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -549,7 +549,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey) {
         <span class="brand-tagline">Tu librería para libros difíciles de ubicar</span>
       </span>
     </a>
-    <form class="header-search" action="/" method="get" role="search">
+    <form class="header-search" action="/catalogo" method="get" role="search">
       <input type="search" name="q" placeholder="Buscar por título, autor, temática o ISBN"
              aria-label="Buscar por título, autor, temática o ISBN" autocomplete="off">
       <button type="submit" aria-label="Buscar libros">Buscar</button>


### PR DESCRIPTION
## Corrección

El buscador agregado por el PR #61 apuntaba a `/?q=...`, pero la ruta funcional de resultados es `/catalogo?q=...`.

Este hotfix cambia únicamente el destino del formulario a `/catalogo` y actualiza la prueba de regresión.

## Validación

- 5/5 pruebas específicas.
- Suite completa del validador: aprobada.
- Build checkout OFF: aprobado, 9 páginas.
- Build checkout ON: aprobado, 9 páginas.

No toca diseño, precios, carrito, checkout, Mercado Pago, SEO-LEGACY-1 ni Merchant Center.