### PR TITLE
GA4-D1: extracción manual de Analytics

### DIFF
--- a/.github/workflows/ga4-export.yml
+++ b/.github/workflows/ga4-export.yml
@@ -1,0 +1,78 @@
+name: GA4 manual export
+
+on:
+  workflow_dispatch:
+    inputs:
+      start_date:
+        description: Fecha inicial (YYYY-MM-DD)
+        required: true
+        default: '2026-07-01'
+      end_date:
+        description: Fecha final (YYYY-MM-DD)
+        required: true
+        default: '2026-07-31'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ga4-export
+  cancel-in-progress: false
+
+jobs:
+  export:
+    name: Extract GA4 data
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Validate required secrets
+        env:
+          GA4_SERVICE_ACCOUNT_JSON: ${{ secrets.GA4_SERVICE_ACCOUNT_JSON }}
+          GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
+        run: |
+          test -n "$GA4_SERVICE_ACCOUNT_JSON" || { echo "::error::Falta GA4_SERVICE_ACCOUNT_JSON"; exit 1; }
+          test -n "$GA4_PROPERTY_ID" || { echo "::error::Falta GA4_PROPERTY_ID"; exit 1; }
+
+      - name: Authenticate with Google
+        id: google_auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GA4_SERVICE_ACCOUNT_JSON }}
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/analytics.readonly
+
+      - name: Extract GA4 reports
+        env:
+          GA4_ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
+          GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
+          GA4_START_DATE: ${{ inputs.start_date }}
+          GA4_END_DATE: ${{ inputs.end_date }}
+          GA4_OUTPUT_DIR: artifacts/ga4
+        run: node scripts/ga4-export.js
+
+      - name: Upload JSON and CSV
+        uses: actions/upload-artifact@v4
+        with:
+          name: ga4-${{ inputs.start_date }}-${{ inputs.end_date }}
+          path: artifacts/ga4/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Write run summary
+        if: always()
+        run: |
+          echo "## GA4 manual export" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Property: configured through GA4_PROPERTY_ID" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Period: ${{ inputs.start_date }} to ${{ inputs.end_date }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Claude API: not called" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Deploy: not triggered" >> "$GITHUB_STEP_SUMMARY"

--- a/functions/__tests__/ga4-export.test.js
+++ b/functions/__tests__/ga4-export.test.js
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const { assertDate, buildRequest, normalizeReport, toCsv } = require('../../scripts/ga4-export.js');
+
+test('valida fechas reales en formato ISO', () => {
+  assert.doesNotThrow(() => assertDate('2026-07-31', 'fecha'));
+  assert.throws(() => assertDate('31/07/2026', 'fecha'), /YYYY-MM-DD/);
+  assert.throws(() => assertDate('2026-02-30', 'fecha'), /fecha válida/);
+});
+
+test('construye el request sin credenciales y conserva el filtro orgánico', () => {
+  const request = buildRequest(
+    {
+      dimensions: ['deviceCategory'],
+      metrics: ['sessions'],
+      filter: { filter: { fieldName: 'sessionDefaultChannelGroup' } },
+    },
+    '2026-07-01',
+    '2026-07-31',
+  );
+  assert.deepEqual(request.dateRanges, [
+    { startDate: '2026-07-01', endDate: '2026-07-31' },
+  ]);
+  assert.deepEqual(request.dimensions, [{ name: 'deviceCategory' }]);
+  assert.deepEqual(request.metrics, [{ name: 'sessions' }]);
+  assert.equal(request.dimensionFilter.filter.fieldName, 'sessionDefaultChannelGroup');
+  assert.equal(JSON.stringify(request).includes('token'), false);
+});
+
+test('normaliza la respuesta exacta de GA4 y genera CSV seguro', () => {
+  const normalized = normalizeReport(
+    { id: 'example' },
+    {
+      dimensionHeaders: [{ name: 'landingPage' }],
+      metricHeaders: [{ name: 'sessions', type: 'TYPE_INTEGER' }],
+      rows: [
+        {
+          dimensionValues: [{ value: '=malicious' }],
+          metricValues: [{ value: '17' }],
+        },
+      ],
+      rowCount: 1,
+    },
+    {
+      property: 'properties/123',
+      startDate: '2026-07-01',
+      endDate: '2026-07-31',
+      extractedAt: '2026-08-04T00:00:00.000Z',
+    },
+  );
+  assert.equal(normalized.rows[0].metrics.sessions, '17');
+  assert.match(toCsv(normalized), /"'=malicious","17"/);
+});

--- a/scripts/ga4-export.js
+++ b/scripts/ga4-export.js
@@ -1,0 +1,244 @@
+'use strict';
+
+const { mkdir, writeFile } = require('node:fs/promises');
+const path = require('node:path');
+
+const API_ROOT = 'https://analyticsdata.googleapis.com/v1beta';
+const ORGANIC_FILTER = {
+  filter: {
+    fieldName: 'sessionDefaultChannelGroup',
+    stringFilter: { matchType: 'EXACT', value: 'Organic Search' },
+  },
+};
+
+const REPORTS = [
+  {
+    id: 'organic-summary',
+    metrics: [
+      'sessions',
+      'totalUsers',
+      'engagedSessions',
+      'engagementRate',
+      'keyEvents',
+      'sessionKeyEventRate',
+      'ecommercePurchases',
+      'purchaseRevenue',
+    ],
+    filter: ORGANIC_FILTER,
+  },
+  {
+    id: 'organic-landing-pages',
+    dimensions: ['landingPagePlusQueryString'],
+    metrics: [
+      'sessions',
+      'totalUsers',
+      'engagedSessions',
+      'engagementRate',
+      'keyEvents',
+      'sessionKeyEventRate',
+      'ecommercePurchases',
+      'purchaseRevenue',
+    ],
+    filter: ORGANIC_FILTER,
+  },
+  {
+    id: 'organic-devices',
+    dimensions: ['deviceCategory'],
+    metrics: [
+      'sessions',
+      'totalUsers',
+      'engagedSessions',
+      'engagementRate',
+      'ecommercePurchases',
+      'purchaseRevenue',
+    ],
+    filter: ORGANIC_FILTER,
+  },
+  {
+    id: 'organic-source-medium',
+    dimensions: ['sessionSourceMedium'],
+    metrics: ['sessions', 'totalUsers', 'engagedSessions', 'engagementRate'],
+    filter: ORGANIC_FILTER,
+  },
+  {
+    id: 'event-inventory',
+    dimensions: ['eventName'],
+    metrics: ['eventCount', 'totalUsers'],
+  },
+  {
+    id: 'organic-ecommerce-events',
+    dimensions: ['eventName'],
+    metrics: ['eventCount', 'totalUsers'],
+    filter: {
+      andGroup: {
+        expressions: [
+          ORGANIC_FILTER,
+          {
+            filter: {
+              fieldName: 'eventName',
+              inListFilter: {
+                values: ['view_item', 'add_to_cart', 'begin_checkout', 'purchase'],
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+];
+
+function assertDate(value, label) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value || '')) {
+    throw new Error(`${label} debe usar formato YYYY-MM-DD.`);
+  }
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+    throw new Error(`${label} no es una fecha válida.`);
+  }
+}
+
+function buildRequest(report, startDate, endDate) {
+  return {
+    dateRanges: [{ startDate, endDate }],
+    dimensions: (report.dimensions || []).map((name) => ({ name })),
+    metrics: report.metrics.map((name) => ({ name })),
+    ...(report.filter ? { dimensionFilter: report.filter } : {}),
+    keepEmptyRows: true,
+    limit: '100000',
+    returnPropertyQuota: true,
+  };
+}
+
+function normalizeReport(report, response, context) {
+  const dimensions = (response.dimensionHeaders || []).map(({ name }) => name);
+  const metrics = (response.metricHeaders || []).map(({ name, type }) => ({ name, type }));
+  const rows = (response.rows || []).map((row) => ({
+    dimensions: Object.fromEntries(
+      dimensions.map((name, index) => [name, row.dimensionValues?.[index]?.value ?? '']),
+    ),
+    metrics: Object.fromEntries(
+      metrics.map(({ name }, index) => [name, row.metricValues?.[index]?.value ?? '']),
+    ),
+  }));
+
+  return {
+    report: report.id,
+    property: context.property,
+    dateRange: { startDate: context.startDate, endDate: context.endDate },
+    extractedAt: context.extractedAt,
+    rowCount: Number(response.rowCount || rows.length),
+    dimensions,
+    metrics,
+    rows,
+    totals: response.totals || [],
+    propertyQuota: response.propertyQuota || null,
+  };
+}
+
+function csvCell(value) {
+  let text = String(value ?? '');
+  if (/^[=+\-@]/.test(text)) text = `'${text}`;
+  return `"${text.replaceAll('"', '""')}"`;
+}
+
+function toCsv(report) {
+  const metricNames = report.metrics.map(({ name }) => name);
+  const headers = [...report.dimensions, ...metricNames];
+  const lines = [headers.map(csvCell).join(',')];
+  for (const row of report.rows) {
+    lines.push(
+      headers
+        .map((name) => csvCell(row.dimensions[name] ?? row.metrics[name] ?? ''))
+        .join(','),
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+async function fetchWithRetry(url, options, maxAttempts = 4) {
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const response = await fetch(url, options);
+      if (response.ok) return response.json();
+      const body = await response.text();
+      const error = new Error(`GA4 Data API respondió HTTP ${response.status}: ${body}`);
+      if (![429, 500, 502, 503, 504].includes(response.status)) throw error;
+      lastError = error;
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxAttempts) break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000 * 2 ** (attempt - 1)));
+  }
+  throw lastError;
+}
+
+async function main() {
+  const propertyId = process.env.GA4_PROPERTY_ID;
+  const accessToken = process.env.GA4_ACCESS_TOKEN;
+  const startDate = process.env.GA4_START_DATE || '2026-07-01';
+  const endDate = process.env.GA4_END_DATE || '2026-07-31';
+  const outputDir = process.env.GA4_OUTPUT_DIR || 'artifacts/ga4';
+
+  if (!/^\d+$/.test(propertyId || '')) throw new Error('Falta GA4_PROPERTY_ID numérico.');
+  if (!accessToken) throw new Error('Falta GA4_ACCESS_TOKEN.');
+  assertDate(startDate, 'GA4_START_DATE');
+  assertDate(endDate, 'GA4_END_DATE');
+  if (startDate > endDate) throw new Error('GA4_START_DATE no puede ser posterior a GA4_END_DATE.');
+
+  const extractedAt = new Date().toISOString();
+  const context = {
+    property: `properties/${propertyId}`,
+    startDate,
+    endDate,
+    extractedAt,
+  };
+  await mkdir(outputDir, { recursive: true });
+
+  const manifest = {
+    property: context.property,
+    dateRange: { startDate, endDate },
+    extractedAt,
+    reports: [],
+  };
+
+  for (const report of REPORTS) {
+    process.stdout.write(`Extrayendo ${report.id}... `);
+    const response = await fetchWithRetry(
+      `${API_ROOT}/${context.property}:runReport`,
+      {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(buildRequest(report, startDate, endDate)),
+      },
+    );
+    const normalized = normalizeReport(report, response, context);
+    await Promise.all([
+      writeFile(path.join(outputDir, `${report.id}.json`), `${JSON.stringify(normalized, null, 2)}\n`),
+      writeFile(path.join(outputDir, `${report.id}.csv`), toCsv(normalized)),
+    ]);
+    manifest.reports.push({
+      id: report.id,
+      rowCount: normalized.rowCount,
+      json: `${report.id}.json`,
+      csv: `${report.id}.csv`,
+    });
+    console.log(`${normalized.rowCount} filas.`);
+  }
+
+  await writeFile(path.join(outputDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(`Extracción terminada en ${outputDir}.`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { REPORTS, assertDate, buildRequest, normalizeReport, toCsv };


### PR DESCRIPTION
## Qué cambia

- Agrega un workflow manual para extraer GA4 mediante Google Analytics Data API.
- Usa `GA4_SERVICE_ACCOUNT_JSON` y `GA4_PROPERTY_ID` desde GitHub Secrets sin exponer sus valores.
- El rango predeterminado es 2026-07-01 a 2026-07-31 y puede editarse al ejecutar el workflow.
- Genera JSON y CSV para resumen orgánico, landing pages, dispositivos, fuente/medio, inventario de eventos y embudo ecommerce orgánico.
- Conserva los artefactos durante 30 días.
- No llama a Claude, no ejecuta deploy y no modifica producción.

## Por qué

GA4 ya recibe tráfico, pero faltaba una extracción reproducible por API para cruzar comportamiento real con el informe de Search Console de julio de 2026.

## Seguridad

- Permiso del workflow: solo `contents: read`.
- Autenticación con alcance `analytics.readonly`.
- Las credenciales permanecen en GitHub Secrets.
- El CSV neutraliza valores que podrían interpretarse como fórmulas.

## Validación

- `node --check scripts/ga4-export.js`: aprobado.
- 3 pruebas específicas: aprobadas.
- `git diff --check`: aprobado.
- El validador completo local quedó bloqueado por la restricción de red del entorno al intentar una prueba existente contra `preview.example`; el CI remoto del PR es la validación definitiva.

## Fuera de alcance

- Merge.
- Deploy.
- Instrumentación de eventos GA4 en la web.
- Llamadas a la API de Claude.
- Automatización programada.