### PR TITLE
IMG-H1: mejorar calidad y carga de portadas del catálogo

### DIFF
--- a/functions/__tests__/catalog-images.test.js
+++ b/functions/__tests__/catalog-images.test.js
@@ -1,0 +1,120 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { onRequest as catalogRequest, catalogImageUrl } from '../catalogo.js';
+import {
+  PAUSED_MANIFEST_URL,
+  R2_BASE,
+} from '../_shared/catalog.js';
+
+const VERSION = '20260805120000000';
+const PREFIX = `stock1-preview/versions/${VERSION}`;
+
+function context(url) {
+  return {
+    request: new Request(url),
+    env: { APP_ENV: 'preview' },
+    waitUntil() {},
+  };
+}
+
+test.beforeEach(() => {
+  const activeRows = Array.from({ length: 7 }, (_, index) => [
+    `MLU${index + 1}`,
+    `Imagen ${index + 1}`,
+    'Autora',
+    `978000000000${index}`,
+    index === 0
+      ? 'http://http2.mlstatic.com/portada-1-I.jpg'
+      : index === 6
+        ? ''
+        : `https://http2.mlstatic.com/portada-${index + 1}-O.jpg`,
+    1000 + index,
+    1,
+  ]);
+
+  globalThis.caches = {
+    default: {
+      async match(request) {
+        if (request.url === 'https://preview.example/data/active-categories.json') {
+          return Response.json({ categories: [], items: {} });
+        }
+        if (request.url === PAUSED_MANIFEST_URL) {
+          return Response.json({
+            schema_version: 1,
+            current: {
+              version: VERSION,
+              index_key: `${PREFIX}/index.json`,
+              active_index_key: `${PREFIX}/active-index.json`,
+              block_prefix: PREFIX,
+              block_count: 128,
+            },
+            previous: null,
+          });
+        }
+        if (request.url === `${R2_BASE}/${PREFIX}/active-index.json`) {
+          return Response.json({
+            schema_version: 1,
+            fields: [
+              'id', 'title', 'author', 'isbn', 'image', 'price', 'available_quantity',
+            ],
+            derived_fields: { slug: 'slugify-v1', status: 'active' },
+            items: activeRows,
+          });
+        }
+        if (request.url === `${R2_BASE}/${PREFIX}/index.json`) {
+          return Response.json({
+            schema_version: 1,
+            fields: ['id', 'title', 'author', 'isbn', 'image'],
+            derived_fields: {
+              slug: 'slugify-v1', status: 'paused', block: 'numeric-id-mod-block-count',
+            },
+            block_count: 128,
+            items: [],
+          });
+        }
+        return null;
+      },
+      async put() {},
+    },
+  };
+});
+
+test('normaliza solamente protocolo http y sufijo final -I.jpg', () => {
+  assert.equal(
+    catalogImageUrl('http://http2.mlstatic.com/portada-I.jpg'),
+    'https://http2.mlstatic.com/portada-O.jpg',
+  );
+  assert.equal(
+    catalogImageUrl('https://example.com/portada.webp'),
+    'https://example.com/portada.webp',
+  );
+  assert.equal(
+    catalogImageUrl('https://example.com/I.jpg?size=small'),
+    'https://example.com/I.jpg?size=small',
+  );
+  assert.equal(catalogImageUrl(), '');
+});
+
+test('el catálogo compacto entrega portadas nítidas con prioridad de carga acotada', async () => {
+  const response = await catalogRequest(
+    context('https://preview.example/catalogo?q=Imagen'),
+  );
+  const html = await response.text();
+  const imageTags = html.match(/<img\b[^>]*>/g) || [];
+
+  assert.equal(imageTags.length, 6);
+  assert.equal(imageTags.filter(tag => /loading="eager"/.test(tag)).length, 4);
+  assert.equal(imageTags.filter(tag => /loading="lazy"/.test(tag)).length, 2);
+  assert.equal(imageTags.filter(tag => /fetchpriority="high"/.test(tag)).length, 1);
+  assert.match(imageTags[0], /portada-1-O\.jpg/);
+  assert.match(imageTags[0], /width="180" height="240"/);
+  assert.doesNotMatch(html, /-I\.jpg/);
+  assert.doesNotMatch(html, /-V\.jpg/);
+  assert.match(html, /class="rc-no-img"/);
+  assert.match(html, /object-fit:contain/);
+  assert.match(
+    html,
+    /<link rel="preconnect" href="https:\/\/http2\.mlstatic\.com" crossorigin>/,
+  );
+  assert.doesNotMatch(html, /srcset=/);
+});

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -173,8 +173,10 @@ function commercialTier(b) {
     return 3;
 }
 
-function httpsImg(url) {
-    return (url || '').replace('http://', 'https://');
+export function catalogImageUrl(url) {
+    return String(url || '')
+        .replace(/^http:\/\//, 'https://')
+        .replace(/-I\.jpg$/, '-O.jpg');
 }
 
 // CF-CATEGORÍAS-2 — artefacto compacto mlu->[categoryId,subcategoryId?],
@@ -405,10 +407,11 @@ export async function onRequest(ctx) {
     const limited   = filtered.slice(0, MAX_RESULTS);
     const truncated = filtered.length > MAX_RESULTS;
 
-    const cards = limited.map((b, idx) => {
+    let renderedImageCount = 0;
+    const cards = limited.map(b => {
         const slug  = slugify(b.title);
         const href  = escapeHtml(`${previewBase}/libro/${b.id}/${slug}`);
-        const img   = escapeHtml(httpsImg(b.pictures?.[0] || b.thumbnail || ''));
+        const img   = escapeHtml(catalogImageUrl(b.pictures?.[0] || b.thumbnail || ''));
         const title = escapeHtml(b.title);
         const author = b.author
             ? `<p class="rc-author">${escapeHtml(b.author)}</p>`
@@ -421,11 +424,13 @@ export async function onRequest(ctx) {
         const transfer  = Math.round(price * 0.88).toLocaleString('es-UY');
         const priceStr  = price.toLocaleString('es-UY');
         const installment = Math.round(price / 12).toLocaleString('es-UY');
-        const loading  = idx < 8 ? 'eager' : 'lazy';
+        const imageIndex = img ? renderedImageCount++ : -1;
+        const loading = imageIndex >= 0 && imageIndex < 4 ? 'eager' : 'lazy';
+        const fetchPriority = imageIndex === 0 ? ' fetchpriority="high"' : '';
         const waHref = `${WA}?text=${encodeURIComponent(`Hola Amado Libros, quiero consultar por encargo: ${b.title}`)}`;
         const orderWaHref = `${WA}?text=${encodeURIComponent(buildOrderWaMessage(b, href))}`;
         const imgTag = img
-            ? `<img src="${img}" alt="${title}" loading="${loading}" decoding="async">`
+            ? `<img src="${img}" alt="${title}" width="180" height="240" loading="${loading}" decoding="async"${fetchPriority}>`
             : `<div class="rc-no-img">📚</div>`;
 
         const badge = available
@@ -529,6 +534,7 @@ export async function onRequest(ctx) {
   <title>${pageTitle}</title>
   <meta name="description" content="${metaDescription}">
   <link rel="canonical" href="${BASE}/catalogo">
+  <link rel="preconnect" href="https://http2.mlstatic.com" crossorigin>
   <meta name="robots" content="${robotsMeta}">
   ${jsonLd}
   <style>
@@ -552,7 +558,7 @@ export async function onRequest(ctx) {
     .rc-card:hover{box-shadow:0 4px 16px rgba(24,18,14,.1)}
     .rc-card.is-order{border-color:#e8c9a0}
     .rc-img{display:block;aspect-ratio:3/4;background:#ede9e1;overflow:hidden}
-    .rc-img img{width:100%;height:100%;object-fit:cover;display:block;
+    .rc-img img{width:100%;height:100%;object-fit:contain;display:block;
                 transition:transform .25s}
     .rc-card:hover .rc-img img{transform:scale(1.04)}
     .rc-no-img{width:100%;height:100%;display:flex;align-items:center;

--- a/worker-sync/__tests__/meli-catalog.test.js
+++ b/worker-sync/__tests__/meli-catalog.test.js
@@ -298,6 +298,44 @@ test('índice pausado compacto y bloques usan una asignación determinista', () 
   assert.ok(artifacts.max_block_bytes < 204800);
 });
 
+test('los índices compactos priorizan pictures[0] y conservan thumbnail como fallback', () => {
+  const artifacts = buildPausedCatalogArtifacts({
+    updated_at: '2026-08-05T12:00:00.000Z',
+    items: [
+      {
+        id: 'MLU1', title: 'Activo principal', status: 'active', available_quantity: 1,
+        pictures: ['https://http2.mlstatic.com/activo-O.jpg'],
+        thumbnail: 'https://http2.mlstatic.com/activo-I.jpg',
+      },
+      {
+        id: 'MLU2', title: 'Activo fallback', status: 'active', available_quantity: 1,
+        pictures: [], thumbnail: 'https://http2.mlstatic.com/activo-fallback-I.jpg',
+      },
+      {
+        id: 'MLU3', title: 'Pausado principal', status: 'paused', available_quantity: 0,
+        pictures: ['https://http2.mlstatic.com/pausado-O.jpg'],
+        thumbnail: 'https://http2.mlstatic.com/pausado-I.jpg',
+      },
+      {
+        id: 'MLU4', title: 'Pausado fallback', status: 'paused', available_quantity: 0,
+        pictures: [], thumbnail: 'https://http2.mlstatic.com/pausado-fallback-I.jpg',
+      },
+    ],
+  });
+
+  const activeImages = JSON.parse(artifacts.active_index.body).items.map(row => row[4]);
+  const pausedImages = JSON.parse(artifacts.index.body).items.map(row => row[4]);
+
+  assert.deepEqual(activeImages, [
+    'https://http2.mlstatic.com/activo-O.jpg',
+    'https://http2.mlstatic.com/activo-fallback-I.jpg',
+  ]);
+  assert.deepEqual(pausedImages, [
+    'https://http2.mlstatic.com/pausado-O.jpg',
+    'https://http2.mlstatic.com/pausado-fallback-I.jpg',
+  ]);
+});
+
 test('genera índices gzip menores y descomprimibles sin modificar los JSON base', async () => {
   const artifacts = buildPausedCatalogArtifacts({
     updated_at: '2026-07-30T12:34:56.789Z',

--- a/worker-sync/paused-catalog.js
+++ b/worker-sync/paused-catalog.js
@@ -74,7 +74,7 @@ export function buildPausedCatalogArtifacts(catalog, {
       item.title || '',
       item.author || '',
       item.isbn || '',
-      item.thumbnail || item.pictures?.[0] || '',
+      item.pictures?.[0] || item.thumbnail || '',
     ]);
   }
 
@@ -84,7 +84,7 @@ export function buildPausedCatalogArtifacts(catalog, {
     item.title || '',
     item.author || '',
     item.isbn || '',
-    item.thumbnail || item.pictures?.[0] || '',
+    item.pictures?.[0] || item.thumbnail || '',
     Number(item.price) || 0,
     Number(item.available_quantity) || 0,
   ]);


### PR DESCRIPTION
## Qué cambia

- prioriza `pictures[0]` sobre `thumbnail` en los índices compactos activos y pausados;
- normaliza miniaturas históricas `-I.jpg` a la variante `-O.jpg` en las tarjetas de `/catalogo`;
- muestra la tapa completa con `object-fit: contain`;
- limita la carga inmediata a cuatro portadas y asigna prioridad alta solo a la primera;
- agrega dimensiones explícitas y preconexión a `http2.mlstatic.com`.

## Causa raíz

El índice compacto guardaba primero `thumbnail`, por lo que búsquedas y recorridos compactos podían agrandar imágenes `-I.jpg` de baja resolución. Además, ocho imágenes se cargaban como `eager` y ninguna tenía prioridad diferenciada.

## Impacto

Mejora la nitidez de las portadas y reduce competencia de red en la primera vista móvil. No cambia precios, textos, buscador, ficha, carrito ni checkout.

## Validación

- `ASTRO_TELEMETRY_DISABLED=1 NPM_CONFIG_CACHE=/tmp/img-h1-npm-cache bash scripts/validate-ci.sh`
- sintaxis completa: OK
- suites de worker, functions, frontend y API: OK
- build checkout OFF: OK
- build checkout ON: OK

## Alcance

PR en borrador. Sin merge ni despliegue a producción.