### PR TITLE
MOBILE-STAB-1: estabilizar catálogo móvil y logo

### DIFF
--- a/functions/__tests__/ficha-header-search.test.js
+++ b/functions/__tests__/ficha-header-search.test.js
@@ -1,6 +1,8 @@
 // HEADER-FICHA-1: identidad y búsqueda consistentes en la ficha individual.
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { access } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import { renderPage } from '../libro/[[path]].js';
 
 function render() {
@@ -17,9 +19,15 @@ function render() {
 test('1. La ficha muestra el logo gráfico real y la marca enlaza al inicio', () => {
     const html = render();
     assert.match(html, /<a href="\/" class="brand-link"[^>]*>/);
-    assert.match(html, /<img src="\/images\/logo-amado\.png" alt="" class="brand-logo"[^>]*fetchpriority="high">/);
+    assert.match(html, /<img src="\/images\/logo-amado\.webp" alt="" class="brand-logo"[^>]*fetchpriority="high">/);
+    assert.doesNotMatch(html, /logo-amado\.png/);
     assert.match(html, /<span class="brand-name">AMADO LIBROS<\/span>/);
     assert.doesNotMatch(html, />📚 Amado Libros<\/a>/);
+});
+
+test('1b. El logo de la ficha existe dentro del public que Astro despliega', async () => {
+    const logo = fileURLToPath(new URL('../../astro-front/public/images/logo-amado.webp', import.meta.url));
+    await assert.doesNotReject(access(logo));
 });
 
 test('2. El buscador de la ficha envía la consulta al catálogo', () => {

--- a/functions/__tests__/mobile-stability.test.js
+++ b/functions/__tests__/mobile-stability.test.js
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { onRequest as catalogRequest } from '../catalogo.js';
+import { CATALOG_URL, PAUSED_MANIFEST_URL } from '../_shared/catalog.js';
+
+const CATALOG = {
+  total: 2,
+  items: [
+    {
+      id: 'MLU1', title: 'Título extraordinariamente largo para comprobar el ancho móvil',
+      author: 'Autora Uno', price: 123456, status: 'active', available_quantity: 2,
+      thumbnail: '', pictures: [],
+    },
+    {
+      id: 'MLU2', title: 'Segundo libro', author: 'Autor Dos', price: 1500,
+      status: 'active', available_quantity: 1, thumbnail: '', pictures: [],
+    },
+  ],
+};
+
+function context() {
+  return {
+    request: new Request('https://preview.example/catalogo'),
+    env: { APP_ENV: 'preview' },
+    waitUntil() {},
+  };
+}
+
+test.beforeEach(() => {
+  globalThis.caches = {
+    default: {
+      async match(request) {
+        if (request.url === CATALOG_URL) return Response.json(CATALOG);
+        if (request.url === PAUSED_MANIFEST_URL) {
+          return Response.json({ schema_version: 1, current: null, previous: null });
+        }
+        return null;
+      },
+      async put() {},
+    },
+  };
+});
+
+test('MOBILE-STAB-1: el catálogo usa una columna móvil, dos desde 500 y cuatro desde 900', async () => {
+  const html = await (await catalogRequest(context())).text();
+
+  assert.match(html, /\.grid\{display:grid;grid-template-columns:minmax\(0,1fr\);/);
+  assert.match(html, /@media\(min-width:500px\)\{\.grid\{grid-template-columns:repeat\(2,minmax\(0,1fr\)\)\}\}/);
+  assert.match(html, /@media\(min-width:900px\)\{\.grid\{grid-template-columns:repeat\(4,1fr\)\}\}/);
+  assert.doesNotMatch(html, /auto-fill,minmax\(160px,1fr\)/);
+});
+
+test('MOBILE-STAB-1: 360, 393 y 412 px quedan cubiertos por la tarjeta horizontal estable', async () => {
+  const html = await (await catalogRequest(context())).text();
+
+  assert.match(html, /@media\(max-width:499px\)\{/);
+  assert.match(html, /\.rc-card\{display:grid;grid-template-columns:minmax\(108px,34%\) minmax\(0,1fr\)\}/);
+  assert.match(html, /\.rc-body\{padding:\.75rem;gap:\.38rem\}/);
+  assert.match(html, /html,body\{max-width:100%;overflow-x:hidden\}/);
+  assert.match(html, /\.rc-card\{display:flex;flex-direction:column;min-width:0;/);
+  assert.match(html, /\.rc-base,\.rc-installment,\.rc-transfer\{line-height:1\.3;overflow-wrap:anywhere\}/);
+});
+
+test('MOBILE-STAB-1: buscador, selector y botón son táctiles, de ancho completo y no desbordan', async () => {
+  const html = await (await catalogRequest(context())).text();
+
+  assert.match(html, /\.filters-bar input\[type=search\],\.cat-select-wrap select,\.filters-bar button\{\s*min-height:44px/);
+  assert.match(html, /\.filters-bar button\{padding:\.55rem 1rem;border-color:#1e293b;background:#1e293b;/);
+  assert.match(html, /@media \(max-width: 480px\)\{\s*\.filters-bar\{display:grid;grid-template-columns:minmax\(0,1fr\)\}/);
+  assert.match(html, /\.filters-bar input\[type=search\],\.cat-select-wrap,\.cat-select-wrap select,\.filters-bar button\{\s*width:100%;min-width:0\}/);
+});

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -263,11 +263,18 @@ function filtersBarHtml({ categories, categoria, subcategoria, rawQ, safeQ, sele
 }
 
 const CAT_SELECT_STYLES = `
-    .filters-bar{display:flex;flex-wrap:wrap;gap:.5rem;margin-bottom:.6rem}
-    .filters-bar input[type=search]{flex:1;min-width:180px}
-    .cat-select-wrap{display:flex}
-    .cat-select-wrap select{padding:.55rem .75rem;border:1px solid #d1c8be;border-radius:.5rem;
-                      font-size:.85rem;color:#1e293b;background:#fff;outline:none;max-width:100%}
+    .filters-bar{display:flex;flex-wrap:wrap;align-items:stretch;gap:.5rem;margin-bottom:.6rem;min-width:0}
+    .filters-bar input[type=search],.cat-select-wrap select,.filters-bar button{
+                      min-height:44px;border:1px solid #d1c8be;border-radius:.5rem;
+                      font:inherit;font-size:.9rem;outline:none}
+    .filters-bar input[type=search]{flex:1;min-width:180px;padding:.6rem .75rem;color:#1e293b;background:#fff}
+    .cat-select-wrap{display:flex;min-width:0}
+    .cat-select-wrap select{width:100%;padding:.55rem 2rem .55rem .75rem;
+                      color:#1e293b;background:#fff;max-width:100%}
+    .filters-bar button{padding:.55rem 1rem;border-color:#1e293b;background:#1e293b;
+                        color:#fff;font-weight:700;cursor:pointer}
+    .filters-bar button:hover{background:#334155}
+    .filters-bar input[type=search]:focus,.filters-bar button:focus-visible,
     .cat-select-wrap select:focus{border-color:#a8957e;box-shadow:0 0 0 3px rgba(168,149,126,.15)}
     .clear-filters{display:inline-block;margin-bottom:1.25rem;font-size:.82rem;
                     color:#a94e3d;text-decoration:none;font-weight:600}
@@ -278,8 +285,9 @@ const CAT_SELECT_STYLES = `
     .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
              clip:rect(0,0,0,0);white-space:nowrap;border:0}
     @media (max-width: 480px){
-      .filters-bar{flex-direction:column}
-      .filters-bar input[type=search],.cat-select-wrap select{width:100%}
+      .filters-bar{display:grid;grid-template-columns:minmax(0,1fr)}
+      .filters-bar input[type=search],.cat-select-wrap,.cat-select-wrap select,.filters-bar button{
+        width:100%;min-width:0}
     }
 `;
 
@@ -533,19 +541,19 @@ export async function onRequest(ctx) {
   ${jsonLd}
   <style>
     *{box-sizing:border-box;margin:0;padding:0}
+    html,body{max-width:100%;overflow-x:hidden}
     body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
          background:#faf7f2;color:#1e293b;line-height:1.5}
-    .wrap{max-width:1100px;margin:0 auto;padding:1.25rem 1rem 3rem}
+    .wrap{width:100%;max-width:1100px;min-width:0;margin:0 auto;padding:1.25rem 1rem 3rem}
     nav{font-size:.875rem;margin-bottom:1.25rem}
     nav a{color:#3b82f6;text-decoration:none}
     nav a:hover{text-decoration:underline}
     h1{font-size:1.35rem;font-weight:800;margin-bottom:.3rem}
     .sub{color:#64748b;font-size:.875rem;margin-bottom:.75rem}
-    .grid{display:grid;gap:1rem;
-          grid-template-columns:repeat(auto-fill,minmax(160px,1fr))}
-    @media(min-width:500px){.grid{grid-template-columns:repeat(auto-fill,minmax(180px,1fr))}}
+    .grid{display:grid;grid-template-columns:minmax(0,1fr);gap:1rem;min-width:0}
+    @media(min-width:500px){.grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
     @media(min-width:900px){.grid{grid-template-columns:repeat(4,1fr)}}
-    .rc-card{display:flex;flex-direction:column;background:#fff;
+    .rc-card{display:flex;flex-direction:column;min-width:0;background:#fff;
              border:1px solid #e2dbd0;border-radius:.75rem;overflow:hidden;
              color:inherit;
              transition:box-shadow .15s}
@@ -557,7 +565,7 @@ export async function onRequest(ctx) {
     .rc-card:hover .rc-img img{transform:scale(1.04)}
     .rc-no-img{width:100%;height:100%;display:flex;align-items:center;
                justify-content:center;font-size:2.5rem;color:#c4b9ad}
-    .rc-body{padding:.875rem 1rem;display:flex;flex-direction:column;gap:.45rem;flex:1}
+    .rc-body{padding:.875rem 1rem;display:flex;flex-direction:column;gap:.45rem;flex:1;min-width:0}
     .rc-title{font-size:.95rem;font-weight:700;color:#18120e;line-height:1.25;
               display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}
     .rc-title-link{text-decoration:none;color:inherit}
@@ -565,7 +573,7 @@ export async function onRequest(ctx) {
     .rc-author{font-size:.82rem;color:#6b6157;
                white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
     .rc-prices{display:flex;flex-direction:column;gap:.2rem;margin-top:.35rem}
-    .rc-base,.rc-installment,.rc-transfer{line-height:1.3}
+    .rc-base,.rc-installment,.rc-transfer{line-height:1.3;overflow-wrap:anywhere}
     .rc-base{font-size:.95rem;color:#18120e;font-weight:700}
     .rc-installment{font-size:.82rem;color:#374151;font-weight:600}
     .rc-transfer{font-size:.78rem;color:#a94e3d;font-weight:600}
@@ -587,6 +595,20 @@ export async function onRequest(ctx) {
     .rc-cta.rc-wa{color:#117a37;border-color:#b9dfc7;background:#effaf3}
     .rc-card:hover .rc-cta.rc-wa{background:#dcf5e5}
     .empty{padding:2rem 0;color:#64748b;font-size:.95rem}
+    @media(max-width:499px){
+      .wrap{padding:1rem .75rem 2.5rem}
+      .grid{gap:.75rem}
+      .rc-card{display:grid;grid-template-columns:minmax(108px,34%) minmax(0,1fr)}
+      .rc-img{height:100%;min-height:184px;aspect-ratio:auto}
+      .rc-img img{object-fit:contain}
+      .rc-body{padding:.75rem;gap:.38rem}
+      .rc-title{font-size:.9rem;-webkit-line-clamp:3}
+      .rc-author{font-size:.78rem}
+      .rc-base{font-size:.9rem}
+      .rc-installment{font-size:.77rem}
+      .rc-transfer{font-size:.74rem}
+      .rc-cta{max-width:100%;text-align:center;white-space:normal}
+    }
     footer{margin-top:2.5rem;padding-top:1rem;border-top:1px solid #e2e8f0;
            font-size:.78rem;color:#94a3b8}
     footer a{color:#cbd5e1;text-decoration:none}

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -543,7 +543,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey) {
 <header class="product-header">
   <div class="header-inner">
     <a href="/" class="brand-link" aria-label="Amado Libros — ir al inicio">
-      <img src="/images/logo-amado.png" alt="" class="brand-logo" width="44" height="44" fetchpriority="high">
+      <img src="/images/logo-amado.webp" alt="" class="brand-logo" width="44" height="44" fetchpriority="high">
       <span class="brand-copy">
         <span class="brand-name">AMADO LIBROS</span>
         <span class="brand-tagline">Tu librería para libros difíciles de ubicar</span>


### PR DESCRIPTION
## Qué cambia

- corrige el logo roto de la ficha usando el recurso WebP que sí se despliega
- estabiliza el catálogo móvil en una columna hasta 499 px
- usa tarjetas horizontales legibles en 360, 393 y 412 px
- pasa a dos columnas desde 500 px y cuatro desde 900 px
- evita desbordes horizontales
- da estilos y tamaño táctil correctos a buscador, selector y botón

## Causa

La ficha referenciaba un PNG inexistente en el paquete desplegado. El catálogo forzaba dos columnas demasiado angostas en celulares, lo que partía precios, deformaba botones y daba apariencia de página rota.

## Validación

- sintaxis JavaScript: OK
- worker-sync: 15/15
- funciones: OK, incluidas pruebas MOBILE-STAB-1
- frontend: 27/27
- API/checkout: 223/223
- build checkout OFF: OK
- build checkout ON: OK
- árbol remoto idéntico al árbol validado localmente

## Límites

No modifica precios, textos comerciales, buscador funcional, carrito, checkout, IMG-H1 ni PERF-H1. No debe mergearse hasta validar el Preview móvil.