### PR TITLE
SYNC: reintentos acotados y alertas de ejecución

### DIFF
--- a/worker-sync/__tests__/healthcheck.test.js
+++ b/worker-sync/__tests__/healthcheck.test.js
@@ -1,0 +1,233 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { notifyHealthcheck } from '../healthcheck.js';
+import { runSync } from '../index.js';
+
+const BASE_URL = 'https://hc-ping.com/11111111-2222-3333-4444-555555555555';
+
+function timerDeps() {
+  return {
+    setTimeoutFn: () => 1,
+    clearTimeoutFn: () => {},
+  };
+}
+
+function envWithKv(overrides = {}) {
+  return {
+    SYNC_HEALTHCHECK_URL: BASE_URL,
+    AMADO_KV: {
+      async put() {},
+      async delete() {},
+    },
+    ...overrides,
+  };
+}
+
+function successfulSyncDeps(notifyHealthcheckFn) {
+  return {
+    getAccessTokenFn: async () => 'token',
+    buildCatalogFn: async () => ({
+      total: 1,
+      updated_at: '2026-08-07T12:00:00.000Z',
+      items: [{}],
+    }),
+    publishToR2Fn: async () => {},
+    notifyHealthcheckFn,
+  };
+}
+
+test('sin SYNC_HEALTHCHECK_URL no llama a fetch', async () => {
+  let fetchCalls = 0;
+  const result = await notifyHealthcheck({}, 'success', {
+    fetchFn: async () => { fetchCalls++; },
+    ...timerDeps(),
+  });
+  assert.equal(result.sent, false);
+  assert.equal(result.reason, 'not-configured');
+  assert.equal(fetchCalls, 0);
+});
+test('cron envía start antes del éxito', async () => {
+  const kinds = [];
+  const result = await runSync(
+    envWithKv(),
+    { source: 'cron' },
+    successfulSyncDeps(async (_env, kind) => { kinds.push(kind); }),
+  );
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(kinds, ['start', 'success']);
+});
+
+test('start usa el sufijo /start', async () => {
+  let target;
+  await notifyHealthcheck(envWithKv(), 'start', {
+    fetchFn: async url => { target = url; return { ok: true, status: 200 }; },
+    ...timerDeps(),
+  });
+  assert.equal(target, `${BASE_URL}/start`);
+});
+
+test('success usa exactamente la URL base', async () => {
+  let target;
+  await notifyHealthcheck(envWithKv(), 'success', {
+    fetchFn: async url => { target = url; return { ok: true, status: 200 }; },
+    ...timerDeps(),
+  });
+  assert.equal(target, BASE_URL);
+});
+
+test('fail usa el sufijo /fail', async () => {
+  let target;
+  await notifyHealthcheck(envWithKv(), 'fail', {
+    fetchFn: async url => { target = url; return { ok: true, status: 200 }; },
+    ...timerDeps(),
+  });
+  assert.equal(target, `${BASE_URL}/fail`);
+});
+
+test('ejecución manual no envía start', async () => {
+  const kinds = [];
+  await runSync(
+    envWithKv(),
+    { source: 'manual-await' },
+    successfulSyncDeps(async (_env, kind) => { kinds.push(kind); }),
+  );
+  assert.equal(kinds.includes('start'), false);
+});
+
+test('ejecución manual exitosa envía success', async () => {
+  const kinds = [];
+  const result = await runSync(
+    envWithKv(),
+    { source: 'manual-async' },
+    successfulSyncDeps(async (_env, kind) => { kinds.push(kind); }),
+  );
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(kinds, ['success']);
+});
+
+test('timeout del proveedor no altera un sync exitoso', async () => {
+  const notify = (env, kind) => notifyHealthcheck(env, kind, {
+    fetchFn: async (_url, { signal }) => {
+      if (signal.aborted) {
+        const error = new Error('aborted');
+        error.name = 'AbortError';
+        throw error;
+      }
+      return { ok: true, status: 200 };
+    },
+    setTimeoutFn: callback => { callback(); return 1; },
+    clearTimeoutFn: () => {},
+  });
+  const result = await runSync(
+    envWithKv(),
+    { source: 'manual-await' },
+    successfulSyncDeps(notify),
+  );
+  assert.equal(result.status, 'ok');
+});
+
+for (const status of [404, 503]) {
+  test(`HTTP ${status} del proveedor no altera el resultado del sync`, async () => {
+    const notify = (env, kind) => notifyHealthcheck(env, kind, {
+      fetchFn: async () => ({ ok: false, status }),
+      ...timerDeps(),
+    });
+    const result = await runSync(
+      envWithKv(),
+      { source: 'manual-await' },
+      successfulSyncDeps(notify),
+    );
+    assert.equal(result.status, 'ok');
+  });
+}
+
+test('fallo de la alarma no oculta el error original', async () => {
+  const result = await runSync(envWithKv(), { source: 'manual-await' }, {
+    getAccessTokenFn: async () => 'token',
+    buildCatalogFn: async () => { throw new Error('error ML original'); },
+    publishToR2Fn: async () => {},
+    notifyHealthcheckFn: async () => { throw new Error('alarma rota'); },
+  });
+  assert.equal(result.status, 'error');
+  assert.equal(result.error, 'error ML original');
+});
+
+test('fallo de KV no impide intentar /fail', async () => {
+  const kinds = [];
+  const env = envWithKv({
+    AMADO_KV: {
+      async put() { throw new Error('KV caído'); },
+      async delete() {},
+    },
+  });
+  const result = await runSync(env, { source: 'manual-await' }, {
+    getAccessTokenFn: async () => { throw new Error('auth caída'); },
+    buildCatalogFn: async () => {},
+    publishToR2Fn: async () => {},
+    notifyHealthcheckFn: async (_env, kind) => { kinds.push(kind); },
+  });
+  assert.equal(result.status, 'error');
+  assert.deepEqual(kinds, ['fail']);
+});
+
+test('logs y errores no contienen la URL secreta', async () => {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = message => warnings.push(String(message));
+  try {
+    const result = await notifyHealthcheck(envWithKv(), 'success', {
+      fetchFn: async () => ({ ok: false, status: 500 }),
+      ...timerDeps(),
+    });
+    assert.equal(result.sent, false);
+    assert.equal(warnings.join('\n').includes(BASE_URL), false);
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test('no envía token de ML, catálogo ni cuerpo de error', async () => {
+  let request;
+  await notifyHealthcheck({
+    SYNC_HEALTHCHECK_URL: BASE_URL,
+    ML_ACCESS_TOKEN: 'TOKEN_ML',
+    catalog: { title: 'CATALOGO_SECRETO' },
+  }, 'fail', {
+    fetchFn: async (url, options) => {
+      request = { url, options };
+      return { ok: true, status: 200 };
+    },
+    ...timerDeps(),
+  });
+  const serialized = JSON.stringify(request);
+  assert.equal(serialized.includes('TOKEN_ML'), false);
+  assert.equal(serialized.includes('CATALOGO_SECRETO'), false);
+  assert.equal(Object.hasOwn(request.options, 'body'), false);
+});
+
+test('rechaza configuración que no sea HTTPS o use otro host', async () => {
+  let fetchCalls = 0;
+  for (const url of [
+    'http://hc-ping.com/id',
+    'https://example.com/id',
+    'https://hc-ping.com.evil.example/id',
+  ]) {
+    const result = await notifyHealthcheck({ SYNC_HEALTHCHECK_URL: url }, 'success', {
+      fetchFn: async () => { fetchCalls++; },
+      ...timerDeps(),
+    });
+    assert.equal(result.reason, 'invalid-config');
+  }
+  assert.equal(fetchCalls, 0);
+});
+
+test('el timeout queda limitado a 5 segundos', async () => {
+  let scheduledMs;
+  await notifyHealthcheck(envWithKv(), 'success', {
+    fetchFn: async () => ({ ok: true, status: 200 }),
+    setTimeoutFn: (_callback, ms) => { scheduledMs = ms; return 1; },
+    clearTimeoutFn: () => {},
+    timeoutMs: 60000,
+  });
+  assert.equal(scheduledMs, 5000);
+});

--- a/worker-sync/__tests__/mlget-rate-limit.test.js
+++ b/worker-sync/__tests__/mlget-rate-limit.test.js
@@ -1,0 +1,234 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeBackoffMs,
+  createSyncRetryBudget,
+  mlGet,
+  parseRetryAfterMs,
+  sanitizeEndpoint,
+} from '../meli-catalog.js';
+
+const URL_WITH_SECRETS =
+  'https://api.mercadolibre.com/items/search?access_token=TOKEN-SECRETO&scroll_id=SCROLL-SECRETO';
+
+function fakeResponse(status, data = { ok: true }, retryAfter = null) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: { get: name => name.toLowerCase() === 'retry-after' ? retryAfter : null },
+    async json() { return data; },
+  };
+}
+
+function sequenceFetch(responses, calls = []) {
+  let index = 0;
+  return async (url, options) => {
+    calls.push({ url, options });
+    const response = responses[Math.min(index, responses.length - 1)];
+    index++;
+    return response;
+  };
+}
+
+function deterministicDeps(overrides = {}) {
+  const waits = [];
+  return {
+    waits,
+    deps: {
+      sleepFn: async ms => { waits.push(ms); },
+      random: () => 0,
+      now: () => Date.parse('2026-08-07T12:00:00.000Z'),
+      ...overrides,
+    },
+  };
+}
+
+test('mlGet devuelve JSON en el primer intento y envía Authorization', async () => {
+  const calls = [];
+  const { deps, waits } = deterministicDeps({
+    fetchFn: sequenceFetch([fakeResponse(200, { value: 7 })], calls),
+  });
+  const result = await mlGet(URL_WITH_SECRETS, 'token-real', deps);
+  assert.deepEqual(result, { value: 7 });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].options.headers.Authorization, 'Bearer token-real');
+  assert.deepEqual(waits, []);
+});
+test('429 respeta Retry-After en segundos enteros', async () => {
+  const { deps, waits } = deterministicDeps({
+    fetchFn: sequenceFetch([fakeResponse(429, {}, '3'), fakeResponse(200)]),
+  });
+  await mlGet(URL_WITH_SECRETS, 'token', deps);
+  assert.deepEqual(waits, [3000]);
+});
+
+test('429 respeta Retry-After como fecha HTTP', async () => {
+  const { deps, waits } = deterministicDeps({
+    fetchFn: sequenceFetch([
+      fakeResponse(429, {}, 'Fri, 07 Aug 2026 12:00:04 GMT'),
+      fakeResponse(200),
+    ]),
+  });
+  await mlGet(URL_WITH_SECRETS, 'token', deps);
+  assert.deepEqual(waits, [4000]);
+});
+
+test('Retry-After queda acotado a 30 segundos', () => {
+  assert.equal(parseRetryAfterMs('120', { nowMs: 0 }), 30000);
+});
+
+test('Retry-After ausente usa equal jitter determinista', async () => {
+  const { deps, waits } = deterministicDeps({
+    fetchFn: sequenceFetch([fakeResponse(429), fakeResponse(200)]),
+    random: () => 0.5,
+  });
+  await mlGet(URL_WITH_SECRETS, 'token', deps);
+  assert.deepEqual(waits, [750]);
+});
+
+test('Retry-After inválido usa equal jitter', async () => {
+  const { deps, waits } = deterministicDeps({
+    fetchFn: sequenceFetch([fakeResponse(429, {}, 'mañana'), fakeResponse(200)]),
+  });
+  await mlGet(URL_WITH_SECRETS, 'token', deps);
+  assert.deepEqual(waits, [500]);
+});
+
+test('equal jitter conserva el piso de la mitad', () => {
+  assert.equal(computeBackoffMs(3, { random: () => 0 }), 4000);
+});
+
+test('equal jitter nunca supera el techo exponencial', () => {
+  assert.equal(computeBackoffMs(3, { random: () => 1 }), 8000);
+});
+
+for (const status of [500, 502, 503, 504]) {
+  test(`HTTP ${status} se reintenta y puede recuperarse`, async () => {
+    const calls = [];
+    const { deps, waits } = deterministicDeps({
+      fetchFn: sequenceFetch([fakeResponse(status), fakeResponse(200)], calls),
+    });
+    const result = await mlGet(URL_WITH_SECRETS, 'token', deps);
+    assert.deepEqual(result, { ok: true });
+    assert.equal(calls.length, 2);
+    assert.deepEqual(waits, [500]);
+  });
+}
+
+for (const status of [400, 401, 403, 404, 418]) {
+  test(`HTTP ${status} falla de inmediato sin retry`, async () => {
+    const calls = [];
+    const { deps, waits } = deterministicDeps({
+      fetchFn: sequenceFetch([fakeResponse(status)], calls),
+    });
+    await assert.rejects(mlGet(URL_WITH_SECRETS, 'token', deps), /no reintentable/);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(waits, []);
+  });
+}
+
+test('se detiene tras 7 intentos totales', async () => {
+  const calls = [];
+  const { deps, waits } = deterministicDeps({
+    fetchFn: sequenceFetch([fakeResponse(429, {}, '1')], calls),
+  });
+  await assert.rejects(mlGet(URL_WITH_SECRETS, 'token', deps), /Agotados 6 reintentos/);
+  assert.equal(calls.length, 7);
+  assert.equal(waits.length, 6);
+});
+
+test('el presupuesto por request aborta antes de volver a dormir', async () => {
+  const { deps, waits } = deterministicDeps({
+    fetchFn: sequenceFetch([fakeResponse(429, {}, '30')]),
+    maxCumulativeWaitMs: 40000,
+  });
+  await assert.rejects(
+    mlGet(URL_WITH_SECRETS, 'token', deps),
+    /presupuesto de espera por request agotado/i,
+  );
+  assert.deepEqual(waits, [30000, 10000]);
+});
+
+test('el presupuesto global se comparte entre llamadas distintas', async () => {
+  const budget = createSyncRetryBudget(1500);
+  const first = deterministicDeps({
+    fetchFn: sequenceFetch([fakeResponse(429, {}, '1'), fakeResponse(200)]),
+    retryBudget: budget,
+  });
+  const second = deterministicDeps({
+    fetchFn: sequenceFetch([fakeResponse(429, {}, '1'), fakeResponse(200)]),
+    retryBudget: budget,
+  });
+  await mlGet(URL_WITH_SECRETS, 'token', first.deps);
+  await mlGet(URL_WITH_SECRETS, 'token', second.deps);
+  assert.deepEqual(first.waits, [1000]);
+  assert.deepEqual(second.waits, [500]);
+  assert.equal(budget.remainingMs, 0);
+});
+
+test('reintentos que luego tienen éxito consumen presupuesto global', async () => {
+  const budget = createSyncRetryBudget(5000);
+  const { deps, waits } = deterministicDeps({
+    fetchFn: sequenceFetch([
+      fakeResponse(500, {}, '1'),
+      fakeResponse(503, {}, '2'),
+      fakeResponse(200),
+    ]),
+    retryBudget: budget,
+  });
+  await mlGet(URL_WITH_SECRETS, 'token', deps);
+  assert.deepEqual(waits, [1000, 2000]);
+  assert.equal(budget.remainingMs, 2000);
+});
+
+test('la última espera queda recortada al presupuesto global restante', async () => {
+  const budget = createSyncRetryBudget(750);
+  const { deps, waits } = deterministicDeps({
+    fetchFn: sequenceFetch([fakeResponse(429, {}, '30'), fakeResponse(200)]),
+    retryBudget: budget,
+  });
+  await mlGet(URL_WITH_SECRETS, 'token', deps);
+  assert.deepEqual(waits, [750]);
+  assert.equal(budget.remainingMs, 0);
+});
+
+test('con presupuesto global agotado no llama a sleep', async () => {
+  const budget = createSyncRetryBudget(0);
+  const { deps, waits } = deterministicDeps({
+    fetchFn: sequenceFetch([fakeResponse(429)]),
+    retryBudget: budget,
+  });
+  await assert.rejects(
+    mlGet(URL_WITH_SECRETS, 'token', deps),
+    /presupuesto de espera global del sync agotado/i,
+  );
+  assert.deepEqual(waits, []);
+});
+
+test('Retry-After superior al presupuesto por request queda recortado', async () => {
+  const { deps, waits } = deterministicDeps({
+    fetchFn: sequenceFetch([fakeResponse(429, {}, '30'), fakeResponse(200)]),
+    maxCumulativeWaitMs: 500,
+  });
+  await mlGet(URL_WITH_SECRETS, 'token', deps);
+  assert.deepEqual(waits, [500]);
+});
+
+test('errores y logs no exponen access_token, scroll_id ni query', async () => {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = message => warnings.push(String(message));
+  try {
+    const { deps } = deterministicDeps({
+      fetchFn: sequenceFetch([fakeResponse(429), fakeResponse(403)]),
+    });
+    const error = await mlGet(URL_WITH_SECRETS, 'token', deps).catch(value => value);
+    const output = `${error.message}\n${warnings.join('\n')}`;
+    assert.equal(output.includes('TOKEN-SECRETO'), false);
+    assert.equal(output.includes('SCROLL-SECRETO'), false);
+    assert.equal(output.includes('?'), false);
+    assert.equal(sanitizeEndpoint(URL_WITH_SECRETS), 'https://api.mercadolibre.com/items/search');
+  } finally {
+    console.warn = originalWarn;
+  }
+});

--- a/worker-sync/__tests__/run-sync-no-partial-publish.test.js
+++ b/worker-sync/__tests__/run-sync-no-partial-publish.test.js
@@ -1,0 +1,118 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { runSync } from '../index.js';
+
+function fakeEnv({ putThrows = false } = {}) {
+  const puts = [];
+  const deletes = [];
+  return {
+    puts,
+    deletes,
+    env: {
+      AMADO_KV: {
+        async put(key, value) {
+          puts.push({ key, value });
+          if (putThrows) throw new Error('KV indisponible');
+        },
+        async delete(key) { deletes.push(key); },
+      },
+    },
+  };
+}
+
+const noHealthcheck = async () => {};
+
+test('si falla la descarga, publishToR2 se llama cero veces y registra error', async () => {
+  const { env, puts } = fakeEnv();
+  let publishCalls = 0;
+  const result = await runSync(env, { source: 'manual-await' }, {
+    getAccessTokenFn: async () => 'token',
+    buildCatalogFn: async () => { throw new Error('descarga interrumpida'); },
+    publishToR2Fn: async () => { publishCalls++; },
+    notifyHealthcheckFn: noHealthcheck,
+  });
+
+  assert.equal(result.status, 'error');
+  assert.match(result.error, /descarga interrumpida/);
+  assert.equal(publishCalls, 0);
+  assert.ok(puts.some(entry => entry.key === 'sync:last_error'));
+});
+test('runSync conserva el filtro público statuses active', async () => {
+  const { env } = fakeEnv();
+  let receivedOptions;
+  const result = await runSync(env, { source: 'manual-await' }, {
+    getAccessTokenFn: async () => 'token',
+    buildCatalogFn: async (_env, _token, options) => {
+      receivedOptions = options;
+      return { total: 1, updated_at: '2026-08-07T12:00:00.000Z', items: [{}] };
+    },
+    publishToR2Fn: async () => {},
+    notifyHealthcheckFn: noHealthcheck,
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(receivedOptions, { statuses: ['active'] });
+});
+
+test('un sync exitoso publica una vez y registra sync:last_ok', async () => {
+  const { env, puts, deletes } = fakeEnv();
+  let publishCalls = 0;
+  const result = await runSync(env, { source: 'cron' }, {
+    getAccessTokenFn: async () => 'token',
+    buildCatalogFn: async () => ({
+      total: 2,
+      updated_at: '2026-08-07T12:00:00.000Z',
+      items: [{}, {}],
+    }),
+    publishToR2Fn: async () => { publishCalls++; },
+    notifyHealthcheckFn: noHealthcheck,
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.equal(publishCalls, 1);
+  assert.ok(puts.some(entry => entry.key === 'sync:last_ok'));
+  assert.deepEqual(deletes, ['sync:last_error']);
+});
+
+test('si falla autenticación tampoco intenta publicar', async () => {
+  const { env } = fakeEnv();
+  let buildCalls = 0;
+  let publishCalls = 0;
+  const result = await runSync(env, { source: 'cron' }, {
+    getAccessTokenFn: async () => { throw new Error('auth falló'); },
+    buildCatalogFn: async () => { buildCalls++; },
+    publishToR2Fn: async () => { publishCalls++; },
+    notifyHealthcheckFn: noHealthcheck,
+  });
+
+  assert.equal(result.status, 'error');
+  assert.equal(buildCalls, 0);
+  assert.equal(publishCalls, 0);
+});
+
+test('un fallo de KV no impide devolver el error de descarga', async () => {
+  const { env, puts } = fakeEnv({ putThrows: true });
+  const result = await runSync(env, { source: 'manual-await' }, {
+    getAccessTokenFn: async () => 'token',
+    buildCatalogFn: async () => { throw new Error('error original'); },
+    publishToR2Fn: async () => {},
+    notifyHealthcheckFn: noHealthcheck,
+  });
+
+  assert.equal(result.status, 'error');
+  assert.equal(result.error, 'error original');
+  assert.ok(puts.some(entry => entry.key === 'sync:last_error'));
+});
+
+test('si falla publishToR2 el resultado final conserva ese error', async () => {
+  const { env } = fakeEnv();
+  const result = await runSync(env, { source: 'manual-await' }, {
+    getAccessTokenFn: async () => 'token',
+    buildCatalogFn: async () => ({ total: 1, updated_at: '2026-08-07T12:00:00.000Z' }),
+    publishToR2Fn: async () => { throw new Error('R2 no publicó'); },
+    notifyHealthcheckFn: noHealthcheck,
+  });
+
+  assert.equal(result.status, 'error');
+  assert.equal(result.error, 'R2 no publicó');
+});

--- a/worker-sync/__tests__/run-sync-no-partial-publish.test.js
+++ b/worker-sync/__tests__/run-sync-no-partial-publish.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { runSync } from '../index.js';
+import { buildCatalog } from '../meli-catalog.js';
 
 function fakeEnv({ putThrows = false } = {}) {
   const puts = [];
@@ -37,6 +38,57 @@ test('si falla la descarga, publishToR2 se llama cero veces y registra error', a
   assert.equal(publishCalls, 0);
   assert.ok(puts.some(entry => entry.key === 'sync:last_error'));
 });
+
+test('si un lote de detalles agota sus reintentos, el catálogo real aborta y no publica parcialmente', async () => {
+  const { env, puts } = fakeEnv();
+  env.USER_ID = '123';
+  env.MIN_ACTIVE_ITEMS = '1';
+
+  const ids = Array.from({ length: 40 }, (_, index) => `MLU${index + 1}`);
+  let detailAttempts = 0;
+  const fetchFn = async url => {
+    if (String(url).includes('/items/search')) {
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        async json() { return { results: ids, scroll_id: null }; },
+      };
+    }
+
+    detailAttempts++;
+    return {
+      ok: false,
+      status: 503,
+      headers: { get: () => null },
+      async json() { return {}; },
+    };
+  };
+
+  let publishCalls = 0;
+  const result = await runSync(env, { source: 'manual-await' }, {
+    getAccessTokenFn: async () => 'token',
+    buildCatalogFn: (buildEnv, token, options) => buildCatalog(buildEnv, token, {
+      ...options,
+      mlGetDeps: {
+        fetchFn,
+        sleepFn: async () => {},
+        random: () => 0,
+        maxRetries: 2,
+      },
+    }),
+    publishToR2Fn: async () => { publishCalls++; },
+    notifyHealthcheckFn: noHealthcheck,
+  });
+
+  assert.equal(detailAttempts, 3);
+  assert.equal(result.status, 'error');
+  assert.match(result.error, /Error definitivo en batch 1\/2/);
+  assert.match(result.error, /Agotados 2 reintentos/);
+  assert.equal(publishCalls, 0);
+  assert.ok(puts.some(entry => entry.key === 'sync:last_error'));
+});
+
 test('runSync conserva el filtro público statuses active', async () => {
   const { env } = fakeEnv();
   let receivedOptions;

--- a/worker-sync/docs/SYNC-ALERT-1-healthchecks-setup.md
+++ b/worker-sync/docs/SYNC-ALERT-1-healthchecks-setup.md
@@ -1,0 +1,34 @@
+# SYNC-ALERT-1 — configuración pendiente de Healthchecks.io
+
+Esta guía documenta la activación posterior. El lote de código no crea la
+cuenta, no configura destinatarios, no carga secretos y no envía pings reales.
+
+## Check
+
+- Nombre: `Amado Libros — Sync catálogo ML`
+- Tipo: cron
+- Expresión: `15 7 * * *`
+- Zona horaria: UTC
+- Equivalencia en Uruguay: 04:15
+- Grace time: 25 minutos
+- Notificación: correo
+- Aviso de recuperación: activado
+- Recordatorio periódico mientras permanezca caído: activarlo si el plan lo permite
+
+## Secreto de Cloudflare
+
+Guardar la Ping URL base generada por Healthchecks.io como secreto del Worker:
+
+`SYNC_HEALTHCHECK_URL`
+
+La URL debe usar HTTPS y el host `hc-ping.com`. No debe copiarse a
+`wrangler.toml`, archivos de documentación, fixtures, commits ni logs.
+
+## Prueba controlada posterior al deploy
+
+1. Confirmar recepción de una señal de inicio.
+2. Confirmar recepción de una señal de éxito.
+3. Ejecutar una prueba de fallo controlada sin publicar catálogo.
+4. Confirmar el aviso de fallo por correo.
+5. Ejecutar una recuperación manual y confirmar el aviso de recuperación.
+6. Verificar el siguiente cron de las 04:15 sin intervención manual.

--- a/worker-sync/healthcheck.js
+++ b/worker-sync/healthcheck.js
@@ -1,0 +1,80 @@
+/**
+ * Heartbeat opcional para el sync de catálogo.
+ *
+ * La Ping URL vive únicamente en SYNC_HEALTHCHECK_URL. Este módulo no la
+ * registra, no lee el cuerpo de respuesta y nunca convierte un sync exitoso
+ * en fallido por un problema del proveedor de monitoreo.
+ */
+
+const ALLOWED_HOSTS = new Set(['hc-ping.com']);
+const HEALTHCHECK_TIMEOUT_MS = 5000;
+const VALID_KINDS = new Set(['start', 'success', 'fail']);
+
+function healthcheckTarget(rawUrl, kind) {
+  if (!VALID_KINDS.has(kind)) return null;
+
+  let base;
+  try {
+    base = new URL(String(rawUrl));
+  } catch {
+    return null;
+  }
+
+  if (
+    base.protocol !== 'https:' ||
+    !ALLOWED_HOSTS.has(base.hostname) ||
+    (base.port && base.port !== '443') ||
+    base.username ||
+    base.password ||
+    base.search ||
+    base.hash
+  ) {
+    return null;
+  }
+
+  const path = base.pathname.replace(/\/+$/, '');
+  if (!path || path === '/') return null;
+  base.pathname = kind === 'success' ? path : `${path}/${kind}`;
+  return base.toString();
+}
+export async function notifyHealthcheck(env, kind, {
+  fetchFn = globalThis.fetch,
+  setTimeoutFn = globalThis.setTimeout,
+  clearTimeoutFn = globalThis.clearTimeout,
+  timeoutMs = HEALTHCHECK_TIMEOUT_MS,
+} = {}) {
+  const rawUrl = env?.SYNC_HEALTHCHECK_URL;
+  if (!rawUrl) return { sent: false, reason: 'not-configured' };
+
+  const target = healthcheckTarget(rawUrl, kind);
+  if (!target) {
+    console.warn('[Healthcheck] Configuración inválida; señal omitida.');
+    return { sent: false, reason: 'invalid-config' };
+  }
+
+  const controller = new AbortController();
+  const effectiveTimeoutMs = Math.min(
+    HEALTHCHECK_TIMEOUT_MS,
+    Math.max(1, Number(timeoutMs) || HEALTHCHECK_TIMEOUT_MS),
+  );
+  const timeoutId = setTimeoutFn(() => controller.abort(), effectiveTimeoutMs);
+
+  try {
+    const response = await fetchFn(target, {
+      method: 'POST',
+      redirect: 'error',
+      signal: controller.signal,
+    });
+    if (!response?.ok) {
+      console.warn(`[Healthcheck] El proveedor respondió HTTP ${response?.status ?? 'desconocido'}.`);
+      return { sent: false, reason: 'http-error' };
+    }
+    return { sent: true };
+  } catch (error) {
+    const reason = error?.name === 'AbortError' ? 'timeout' : 'network-error';
+    console.warn(`[Healthcheck] Señal no enviada (${reason}).`);
+    return { sent: false, reason };
+  } finally {
+    clearTimeoutFn(timeoutId);
+  }
+}

--- a/worker-sync/index.js
+++ b/worker-sync/index.js
@@ -30,6 +30,9 @@
  *   sync:last_ok             — ISO timestamp del último sync exitoso
  *   sync:last_error          — string corto del último error (ausente si el último sync fue ok)
  *
+ * Secret opcional:
+ *   SYNC_HEALTHCHECK_URL     — Ping URL base de Healthchecks.io (nunca se loguea)
+ *
  * KV keys que este Worker NO escribe:
  *   catalog:full, catalog_index, catalog_index:*, item:MLU*  — esquemas obsoletos
  *
@@ -42,6 +45,7 @@
 import { getAccessToken } from './meli-auth.js';
 import { buildCatalog   } from './meli-catalog.js';
 import { publishToR2    } from './r2-publish.js';
+import { notifyHealthcheck } from './healthcheck.js';
 import {
   addCompressedIndexes,
   buildManifest,
@@ -387,21 +391,30 @@ async function verifyCatalogArtifacts(bucket, artifacts) {
 
 // ── Sync principal ────────────────────────────────────────────────────────────
 
-async function runSync(env, options = {}) {
+export async function runSync(env, options = {}, {
+  getAccessTokenFn = getAccessToken,
+  buildCatalogFn = buildCatalog,
+  publishToR2Fn = publishToR2,
+  notifyHealthcheckFn = notifyHealthcheck,
+} = {}) {
   const startedAt = new Date().toISOString();
   const source = options.source || 'unknown';
   console.log(`[Sync] Iniciando sync completo — ${startedAt} | source=${source}`);
+
+  if (source === 'cron') {
+    await safeNotifyHealthcheck(notifyHealthcheckFn, env, 'start');
+  }
   await kvPut(env, 'sync:last_started', startedAt);
 
   try {
     // 1. Auth
-    const accessToken = await getAccessToken(env);
+    const accessToken = await getAccessTokenFn(env);
     console.log('[Sync] Access token obtenido.');
 
     // 2. Catálogo
     // El catálogo público conserva únicamente publicaciones activas. Los
     // pausados se generan por el flujo versionado y aislado de Preview.
-    const catalog = await buildCatalog(env, accessToken, { statuses: ['active'] });
+    const catalog = await buildCatalogFn(env, accessToken, { statuses: ['active'] });
 
     // 3. Publicar en R2 (staging → validación → promote)
     const finishedAt = new Date().toISOString();
@@ -414,11 +427,12 @@ async function runSync(env, options = {}) {
       status:         'ok',
       source,
     };
-    await publishToR2(env, catalog, syncMeta);
+    await publishToR2Fn(env, catalog, syncMeta);
 
     // 4. Estado: éxito
     await kvPut(env, 'sync:last_ok', finishedAt);
     await kvDelete(env, 'sync:last_error');
+    await safeNotifyHealthcheck(notifyHealthcheckFn, env, 'success');
 
     console.log(`[Sync] Completado: ${catalog.total} items en ${Math.round(durationMs / 1000)}s`);
     return {
@@ -439,6 +453,7 @@ async function runSync(env, options = {}) {
     const durationMs = Date.now() - new Date(startedAt).getTime();
     const summary = `${finishedAt} — ${err.message}`.slice(0, 400);
     await kvPut(env, 'sync:last_error', summary);
+    await safeNotifyHealthcheck(notifyHealthcheckFn, env, 'fail');
 
     return {
       status:      'error',
@@ -448,6 +463,15 @@ async function runSync(env, options = {}) {
       duration_ms: durationMs,
       error:       err.message,
     };
+  }
+}
+
+async function safeNotifyHealthcheck(notifyFn, env, kind) {
+  try {
+    await notifyFn(env, kind);
+  } catch {
+    // La observabilidad nunca cambia el resultado del sync ni oculta su error.
+    console.warn(`[Healthcheck] No se pudo enviar la señal ${kind}.`);
   }
 }
 

--- a/worker-sync/meli-catalog.js
+++ b/worker-sync/meli-catalog.js
@@ -20,7 +20,7 @@
  *   }
  *
  * Edge cases manejados:
- *   - Rate limit 429: retry con 2s de delay
+ *   - Rate limit 429 y 5xx transitorios: retry acotado con Retry-After/equal jitter
  *   - scroll_id nulo o results vacíos: fin del scroll, continuar con los IDs que hay
  *   - Errores en batch de detalles: loguear y continuar (no abortar sync completo)
  *   - MIN_ACTIVE_ITEMS: abortar si R2 quedaría con muy pocos items activos
@@ -32,6 +32,18 @@ const DETAIL_BATCH     = 20;   // ML multi-get soporta hasta 20 ids por request
 const ML_ATTRIBUTES    =       // campos que necesita slim_item + AUTHOR + enriched fields
   'id,title,price,status,available_quantity,thumbnail,pictures,permalink,start_time,attributes,condition';
 
+export const ML_MAX_RETRIES = 6;
+export const ML_BASE_BACKOFF_MS = 1000;
+export const ML_MAX_BACKOFF_MS = 30000;
+export const ML_MAX_CUMULATIVE_WAIT_MS = 120000;
+export const ML_SYNC_MAX_RETRY_WAIT_MS = 180000;
+
+const ML_TRANSIENT_STATUSES = new Set([429, 500, 502, 503, 504]);
+
+export function createSyncRetryBudget(maxWaitMs = ML_SYNC_MAX_RETRY_WAIT_MS) {
+  return { remainingMs: Math.max(0, Number(maxWaitMs) || 0) };
+}
+
 // ─── Entrada pública ──────────────────────────────────────────────────────────
 
 /**
@@ -40,7 +52,11 @@ const ML_ATTRIBUTES    =       // campos que necesita slim_item + AUTHOR + enric
  * @param {string} accessToken — ML access token vigente
  * @returns {{ total, updated_at, items }}
  */
-export async function buildCatalog(env, accessToken, { statuses = ['active', 'paused'] } = {}) {
+export async function buildCatalog(env, accessToken, {
+  statuses = ['active', 'paused'],
+  retryBudget = createSyncRetryBudget(),
+  mlGetDeps = {},
+} = {}) {
   const userId         = env.USER_ID;
   const minActiveItems = parseInt(env.MIN_ACTIVE_ITEMS || '500', 10);
 
@@ -50,7 +66,13 @@ export async function buildCatalog(env, accessToken, { statuses = ['active', 'pa
   // activos + pausados; el catálogo público pide únicamente activos.
   const requestedStatuses = statuses.filter(status => ['active', 'paused'].includes(status));
   if (requestedStatuses.length === 0) throw new Error('[Catalog] No se solicitó un estado publicable.');
-  const allIds = await fetchAllIds(userId, accessToken, requestedStatuses);
+  const allIds = await fetchAllIds(
+    userId,
+    accessToken,
+    requestedStatuses,
+    retryBudget,
+    mlGetDeps,
+  );
   console.log(`[Catalog] IDs obtenidos: ${allIds.length}`);
 
   if (allIds.length === 0) {
@@ -58,7 +80,7 @@ export async function buildCatalog(env, accessToken, { statuses = ['active', 'pa
   }
 
   // Paso 2: obtener detalles en batches
-  const rawItems = await fetchDetails(allIds, accessToken);
+  const rawItems = await fetchDetails(allIds, accessToken, retryBudget, mlGetDeps);
   console.log(`[Catalog] Detalles obtenidos: ${rawItems.length} de ${allIds.length}`);
 
   // Paso 3: slim + filtro. Closed/deleted/under_review siguen fuera del sitio.
@@ -98,7 +120,13 @@ export async function buildCatalog(env, accessToken, { statuses = ['active', 'pa
 
 // ─── Scroll de IDs ────────────────────────────────────────────────────────────
 
-async function fetchAllIds(userId, accessToken, statuses = ['active']) {
+async function fetchAllIds(
+  userId,
+  accessToken,
+  statuses = ['active'],
+  retryBudget,
+  mlGetDeps = {},
+) {
   const ids = [];
   for (const status of statuses) {
     let scrollId = null;
@@ -111,7 +139,7 @@ async function fetchAllIds(userId, accessToken, statuses = ['active']) {
         `?limit=100&search_type=scan&status=${encodeURIComponent(status)}`;
       if (scrollId) url += `&scroll_id=${encodeURIComponent(scrollId)}`;
 
-      const data = await mlGet(url, accessToken);
+      const data = await mlGet(url, accessToken, { ...mlGetDeps, retryBudget });
       const batch = data.results || [];
       scrollId = data.scroll_id || null;
       ids.push(...batch);
@@ -134,7 +162,7 @@ async function fetchAllIds(userId, accessToken, statuses = ['active']) {
 
 // ─── Detalles en batch ───────────────────────────────────────────────────────
 
-async function fetchDetails(ids, accessToken) {
+async function fetchDetails(ids, accessToken, retryBudget, mlGetDeps = {}) {
   const items       = [];
   const totalBatches = Math.ceil(ids.length / DETAIL_BATCH);
 
@@ -144,7 +172,7 @@ async function fetchDetails(ids, accessToken) {
     const url       = `https://api.mercadolibre.com/items?ids=${batch.join(',')}&attributes=${ML_ATTRIBUTES}`;
 
     try {
-      const data = await mlGet(url, accessToken);
+      const data = await mlGet(url, accessToken, { ...mlGetDeps, retryBudget });
       // data es un array de { code, body } o directamente el item
       const entries = Array.isArray(data) ? data : [data];
       for (const entry of entries) {
@@ -415,30 +443,122 @@ function normalizePictures(pictures, max = 6) {
 // ─── HTTP helper ──────────────────────────────────────────────────────────────
 
 /**
- * GET a la API de MercadoLibre con retry automático en 429.
+ * Interpreta Retry-After en segundos enteros o fecha HTTP y lo acota al
+ * máximo de espera individual. Devuelve null si el header no es válido.
  */
-async function mlGet(url, accessToken, retries = 3) {
-  for (let attempt = 0; attempt < retries; attempt++) {
-    const resp = await fetch(url, {
+export function parseRetryAfterMs(value, {
+  nowMs = Date.now(),
+  maxBackoffMs = ML_MAX_BACKOFF_MS,
+} = {}) {
+  if (value == null) return null;
+  const raw = String(value).trim();
+  if (!raw) return null;
+
+  if (/^\d+$/.test(raw)) {
+    return Math.min(Number(raw) * 1000, maxBackoffMs);
+  }
+
+  const parsedDate = Date.parse(raw);
+  if (!Number.isFinite(parsedDate)) return null;
+  return Math.min(Math.max(0, parsedDate - nowMs), maxBackoffMs);
+}
+
+/** Equal jitter: conserva un piso de la mitad del backoff exponencial. */
+export function computeBackoffMs(attempt, {
+  random = Math.random,
+  baseBackoffMs = ML_BASE_BACKOFF_MS,
+  maxBackoffMs = ML_MAX_BACKOFF_MS,
+} = {}) {
+  const ceiling = Math.min(maxBackoffMs, baseBackoffMs * (2 ** attempt));
+  const half = ceiling / 2;
+  return Math.floor(half + Math.max(0, Math.min(1, random())) * half);
+}
+
+export function sanitizeEndpoint(value) {
+  try {
+    const url = new URL(String(value));
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return '[endpoint inválido]';
+  }
+}
+
+function retryBudgetError(scope, endpoint) {
+  const label = scope === 'global' ? 'global del sync' : 'por request';
+  return new Error(`[Catalog] Presupuesto de espera ${label} agotado en ${endpoint}`);
+}
+
+/**
+ * GET a la API de MercadoLibre con retry acotado para 429 y 5xx transitorios.
+ */
+export async function mlGet(url, accessToken, {
+  fetchFn = globalThis.fetch,
+  sleepFn = sleep,
+  random = Math.random,
+  now = Date.now,
+  retryBudget = null,
+  maxRetries = ML_MAX_RETRIES,
+  baseBackoffMs = ML_BASE_BACKOFF_MS,
+  maxBackoffMs = ML_MAX_BACKOFF_MS,
+  maxCumulativeWaitMs = ML_MAX_CUMULATIVE_WAIT_MS,
+} = {}) {
+  const endpoint = sanitizeEndpoint(url);
+  let cumulativeWaitMs = 0;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const resp = await fetchFn(url, {
       headers: { 'Authorization': `Bearer ${accessToken}` },
     });
 
-    if (resp.status === 429) {
-      // Rate limit: esperar 2 segundos antes de reintentar
-      const delay = 2000 * (attempt + 1);
-      console.warn(`[Catalog] Rate limit 429 en ${url.slice(0, 80)}. Esperando ${delay}ms.`);
-      await sleep(delay);
-      continue;
+    if (resp.ok) return await resp.json();
+
+    if (!ML_TRANSIENT_STATUSES.has(resp.status)) {
+      throw new Error(`[Catalog] HTTP ${resp.status} no reintentable en ${endpoint}`);
     }
 
-    if (!resp.ok) {
-      throw new Error(`[Catalog] HTTP ${resp.status} en ${url.slice(0, 100)}`);
+    if (attempt >= maxRetries) {
+      throw new Error(
+        `[Catalog] Agotados ${maxRetries} reintentos tras HTTP ${resp.status} en ${endpoint}`
+      );
     }
 
-    return await resp.json();
+    const requestRemainingMs = maxCumulativeWaitMs - cumulativeWaitMs;
+    if (requestRemainingMs <= 0) throw retryBudgetError('request', endpoint);
+
+    const globalRemainingMs = retryBudget == null
+      ? Number.POSITIVE_INFINITY
+      : Number(retryBudget.remainingMs);
+    if (globalRemainingMs <= 0) throw retryBudgetError('global', endpoint);
+
+    const retryAfterMs = parseRetryAfterMs(resp.headers?.get?.('Retry-After'), {
+      nowMs: now(),
+      maxBackoffMs,
+    });
+    const calculatedDelayMs = retryAfterMs ?? computeBackoffMs(attempt, {
+      random,
+      baseBackoffMs,
+      maxBackoffMs,
+    });
+    const delayMs = Math.max(0, Math.floor(Math.min(
+      calculatedDelayMs,
+      maxBackoffMs,
+      requestRemainingMs,
+      globalRemainingMs,
+    )));
+
+    console.warn(
+      `[Catalog] HTTP ${resp.status} transitorio en ${endpoint}. ` +
+      `Reintento ${attempt + 1}/${maxRetries} en ${delayMs}ms.`
+    );
+
+    if (delayMs > 0) {
+      await sleepFn(delayMs);
+      cumulativeWaitMs += delayMs;
+      if (retryBudget != null) retryBudget.remainingMs -= delayMs;
+    }
   }
 
-  throw new Error(`[Catalog] Agotados ${retries} reintentos por rate limit en ${url.slice(0, 100)}`);
+  throw new Error(`[Catalog] Reintentos agotados en ${endpoint}`);
 }
 
 function sleep(ms) {

--- a/worker-sync/meli-catalog.js
+++ b/worker-sync/meli-catalog.js
@@ -22,7 +22,7 @@
  * Edge cases manejados:
  *   - Rate limit 429 y 5xx transitorios: retry acotado con Retry-After/equal jitter
  *   - scroll_id nulo o results vacíos: fin del scroll, continuar con los IDs que hay
- *   - Errores en batch de detalles: loguear y continuar (no abortar sync completo)
+ *   - Errores definitivos en batch de detalles: abortar para no publicar un catálogo parcial
  *   - MIN_ACTIVE_ITEMS: abortar si R2 quedaría con muy pocos items activos
  */
 
@@ -180,9 +180,11 @@ async function fetchDetails(ids, accessToken, retryBudget, mlGetDeps = {}) {
         if (item && item.id) items.push(item);
       }
     } catch (err) {
-      // Error en un batch individual: loguear y continuar
-      // Perder un batch de 20 items es preferible a abortar todo el sync
-      console.error(`[Catalog] Error en batch ${batchNum}/${totalBatches} (offset ${i}): ${err.message}`);
+      const message =
+        `[Catalog] Error definitivo en batch ${batchNum}/${totalBatches} ` +
+        `(offset ${i}). Abortando para no publicar un catálogo parcial: ${err.message}`;
+      console.error(message);
+      throw new Error(message, { cause: err });
     }
 
     if (batchNum % 100 === 0 || batchNum === totalBatches) {


### PR DESCRIPTION
## Qué cambia

- Reintenta respuestas 429 y 500/502/503/504 respetando `Retry-After` o usando equal jitter.
- Limita la espera a 120 s por request y 180 s globales por ejecución del sync.
- Conserva el catálogo público limitado a `statuses: ['active']` de STOCK-1.
- Aborta el sync si un lote de detalles agota sus reintentos, para impedir que R2 reciba un catálogo parcial.
- Hace inyectable la coordinación `buildCatalog → publishToR2` y prueba con el `buildCatalog()` real que un lote fallido publica cero veces.
- Agrega heartbeats opcionales de Healthchecks.io para inicio, éxito y fallo, sin exponer la Ping URL ni hacer fallar el sync si el proveedor no responde.
- Documenta la configuración externa pendiente; no incluye secretos ni activa monitoreo.

## Motivo

El sync diario podía abortar ante rate limiting transitorio de Mercado Libre y el fallo quedaba registrado sin una notificación automática. Además, el manejo anterior de un lote de detalles definitivamente fallido continuaba con los lotes restantes y podía construir un catálogo incompleto.

## Validación

- `bash scripts/validate-ci.sh` → validación completa OK.
- Suite Worker: 63/63.
- Resto de suites: 235/235 + 27/27 + 223/223.
- Build Astro con checkout OFF: OK.
- Build Astro con checkout ON y configuración pública de Turnstile: OK.
- Prueba integrada: 40 IDs, primer lote HTTP 503, reintentos agotados, resultado final `error`, `publishToR2` llamado 0 veces y `sync:last_error` registrado.
- Sin llamadas reales a Mercado Libre, R2, KV ni Healthchecks.

## Operación

Este PR no despliega, no dispara el sync y no modifica producción. `SYNC_HEALTHCHECK_URL` es opcional y, mientras no se configure, el monitoreo funciona como no-op.