### PR TITLE
CI: desplegar automáticamente el Worker Sync desde main

### DIFF
--- a/.github/workflows/deploy-worker-sync.yml
+++ b/.github/workflows/deploy-worker-sync.yml
@@ -1,6 +1,11 @@
 name: Deploy Worker Sync
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'worker-sync/**'
+      - '.github/workflows/deploy-worker-sync.yml'
   workflow_dispatch:
     inputs:
       run_trigger:


### PR DESCRIPTION
## Objetivo

Eliminar la dependencia del botón manual de GitHub para desplegar el Worker Sync.

## Cambio

- Ejecuta `Deploy Worker Sync` automáticamente al llegar a `main` un cambio en `worker-sync/**`.
- También se ejecuta si cambia el propio workflow.
- Mantiene el disparo manual existente.
- En el disparo automático `inputs.run_trigger` no está activo, por lo que **despliega el código pero no ejecuta el sync**.

## Alcance y seguridad

- Un único archivo modificado.
- Sin cambios en el Worker ni en la lógica comercial.
- Sin secretos nuevos.
- Sin trigger de catálogo.
- Este merge desplegará el Worker pendiente del PR #69 y dejará resuelto el mecanismo para futuros cambios.