### PR TITLE
SEO: responder rutas inexistentes con 404 real

### DIFF
--- a/astro-front/src/pages/404.astro
+++ b/astro-front/src/pages/404.astro
@@ -1,0 +1,108 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import WAFloat from '../components/WAFloat.astro';
+import CatalogSearchOverlay from '../components/CatalogSearchOverlay.astro';
+---
+
+<BaseLayout
+  title="Página no encontrada — Amado Libros"
+  description="La página que buscás no existe o cambió de dirección."
+  indexable={false}
+>
+  <Header />
+  <main class="not-found-page">
+    <section class="not-found-card" aria-labelledby="not-found-title">
+      <p class="not-found-code" aria-hidden="true">404</p>
+      <h1 id="not-found-title">No encontramos esta página</h1>
+      <p>
+        Es posible que el enlace haya cambiado o que la página ya no exista.
+        Podés buscar el libro en nuestro catálogo o volver al inicio.
+      </p>
+      <div class="not-found-actions">
+        <a class="not-found-primary" href="/catalogo">Buscar en el catálogo</a>
+        <a class="not-found-secondary" href="/">Volver al inicio</a>
+      </div>
+    </section>
+  </main>
+  <Footer />
+  <WAFloat />
+  <CatalogSearchOverlay />
+</BaseLayout>
+
+<style>
+  .not-found-page {
+    display: grid;
+    place-items: center;
+    padding: clamp(2.5rem, 8vw, 6rem) 1rem;
+  }
+
+  .not-found-card {
+    width: min(100%, 680px);
+    padding: clamp(1.5rem, 5vw, 3.5rem);
+    text-align: center;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    box-shadow: 0 12px 32px rgba(24, 18, 14, 0.06);
+  }
+
+  .not-found-code {
+    margin-bottom: 0.5rem;
+    color: var(--salmon-hover);
+    font-size: 0.875rem;
+    font-weight: 800;
+    letter-spacing: 0.18em;
+  }
+
+  h1 {
+    margin-bottom: 1rem;
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 8vw, 3.25rem);
+    line-height: 1.08;
+  }
+
+  .not-found-card > p:not(.not-found-code) {
+    max-width: 52ch;
+    margin: 0 auto;
+    color: var(--ink-2);
+  }
+
+  .not-found-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-top: 2rem;
+  }
+
+  .not-found-actions a {
+    display: inline-flex;
+    min-height: 48px;
+    align-items: center;
+    justify-content: center;
+    padding: 0.8rem 1.25rem;
+    border-radius: var(--r);
+    font-weight: 700;
+  }
+
+  .not-found-primary {
+    background: var(--ink);
+    color: var(--surface);
+  }
+
+  .not-found-secondary {
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--ink);
+  }
+
+  .not-found-actions a:hover { opacity: 0.85; }
+
+  @media (min-width: 520px) {
+    .not-found-actions {
+      flex-direction: row;
+      justify-content: center;
+    }
+  }
+</style>

--- a/scripts/validate-ci.sh
+++ b/scripts/validate-ci.sh
@@ -54,6 +54,20 @@ has_rendered_element_with_id() {
   grep -Eq "<[a-zA-Z][a-zA-Z0-9-]*[[:space:]][^>]*id=[\"']${id}[\"']" "$file"
 }
 
+# Cloudflare Pages deja de aplicar el fallback SPA cuando el artefacto incluye
+# 404.html. Este guard evita volver a publicar la portada con HTTP 200 para
+# rutas inexistentes y exige que la página de error nunca sea indexable.
+assert_404_page() {
+  local file='astro-front/dist/404.html'
+  test -f "$file"
+  grep -Eq '<meta name="robots" content="noindex, nofollow">' "$file"
+  grep -Eq '<h1[^>]*id="not-found-title"' "$file"
+  grep -Eq '<a[^>]*href="/catalogo"' "$file"
+  grep -Eq '<a[^>]*href="/"' "$file"
+  ! grep -Eq '<link rel="canonical"' "$file"
+  echo "  OK: 404.html presente, no indexable y con salidas útiles."
+}
+
 # ── 1. Sintaxis ───────────────────────────────────────────────────────────
 step "Sintaxis JS (functions, scripts, worker-sync)"
 find functions scripts worker-sync -type f -name '*.js' -print0 |
@@ -83,6 +97,8 @@ step "Build — checkout OFF"
   npm run build
 )
 
+assert_404_page
+
 CART_OFF=astro-front/dist/carrito/index.html
 test -f "$CART_OFF"
 grep -q 'data-online-checkout="disabled"' "$CART_OFF"
@@ -106,6 +122,8 @@ step "Build — checkout ON (config pública de Turnstile igual a Producción)"
   PUBLIC_TURNSTILE_ALLOWED_HOSTS="$PRODUCTION_TURNSTILE_ALLOWED_HOSTS" \
   npm run build
 )
+
+assert_404_page
 
 CART_ON=astro-front/dist/carrito/index.html
 test -f "$CART_ON"


### PR DESCRIPTION
## Qué cambia

- agrega `astro-front/src/pages/404.astro` con una salida clara hacia catálogo e inicio;
- fuerza `noindex, nofollow` y omite canonical en la página inexistente;
- amplía el validador compartido para exigir `404.html` en builds con checkout ON y OFF.

## Causa

Sin `404.html`, Cloudflare Pages aplicaba el fallback SPA y servía la portada con HTTP 200 para URLs desconocidas, generando soft 404.

## Validación

- 548/548 tests;
- builds con checkout OFF y ON correctos;
- ambos builds generan `404.html` con `noindex, nofollow`, sin canonical y con enlaces de salida;
- Astro Preview: una ruta inexistente responde HTTP 404.

## Alcance

No toca fichas, catálogo, checkout, sitemap, Merchant Center, Worker, secretos ni producción. Sin merge ni deploy.