### PR TITLE
SEO: corregir umbral de envío gratis en catálogo

### DIFF
--- a/functions/__tests__/catalog-display.test.js
+++ b/functions/__tests__/catalog-display.test.js
@@ -184,6 +184,17 @@ test('una búsqueda sin coincidencias reales termina en cero resultados', async 
   assert.doesNotMatch(html, /class="rc-card/);
 });
 
+test('el catálogo indexable comunica el umbral real de envío gratis', async () => {
+  const response = await catalogRequest(
+    context('https://preview.example/catalogo')
+  );
+  const html = await response.text();
+  const description = html.match(/<meta name="description" content="([^"]+)">/)?.[1] || '';
+
+  assert.match(description, /envío gratis desde \$2\.000/);
+  assert.doesNotMatch(description, /envío gratis desde \$1\.500/);
+});
+
 test('la ficha pausada queda noindex, sin precio ni compra directa', async () => {
   const response = await bookRequest(
     context('https://www.amadolibros.com/libro/MLU2/alpha-raro', {

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -507,7 +507,7 @@ export async function onRequest(ctx) {
     // contenido delgado/duplicado en resultados de búsqueda/categoría.
     const isIndex = !hasFilter;
     const metaDescription = isIndex
-        ? `${activeItems.length} libros para comprar online en Uruguay. 12% de descuento por transferencia y envío gratis desde $1.500. Envíos a todo el país.`
+        ? `${activeItems.length} libros para comprar online en Uruguay. 12% de descuento por transferencia y envío gratis desde $2.000. Envíos a todo el país.`
         : 'Resultados en Amado Libros.';
     const robotsMeta = isIndex ? 'index, follow' : 'noindex';
     const jsonLd = isIndex


### PR DESCRIPTION
## Qué cambia

- Corrige la meta descripción indexable de `/catalogo`: envío gratis desde $2.000.
- Agrega una prueba de regresión que exige $2.000 y rechaza el texto anterior de $1.500.

## Causa

La regla comercial vigente y el checkout usan $2.000, pero la meta descripción del catálogo conservaba el umbral anterior.

## Impacto

Alinea el mensaje que Google puede mostrar con la regla real. No modifica precios, checkout, catálogo, sitemap, feed ni Worker.

## Validación

- Prueba específica: correcta y aislada de producción.
- Validación integral: 549/549 tests.
- Build con checkout OFF: correcto.
- Build con checkout ON: correcto.
- `git diff --check`: correcto.