### PR TITLE
SEO: crear landings de categorías principales

### DIFF
--- a/astro-front/src/components/CategoryAccess.astro
+++ b/astro-front/src/components/CategoryAccess.astro
@@ -21,7 +21,20 @@ interface Category {
   count: number;
 }
 
-const MAX_CATEGORIES = 8;
+// Allowlist SEO: solo estas categorías tienen una landing limpia e
+// indexable. Mantener cerrada evita enlazar automáticamente categorías
+// débiles o catch-all a páginas que Google no debería indexar.
+const SEO_CATEGORY_IDS = [
+  'infantil-juvenil',
+  'esoterismo-tarot',
+  'medicina-salud',
+  'literatura-ficcion',
+  'idiomas-aprendizaje',
+  'psicologia',
+  'desarrollo-personal',
+  'religion-espiritualidad',
+];
+const seoOrder = new Map(SEO_CATEGORY_IDS.map((id, index) => [id, index]));
 
 let categories: Category[] = [];
 let missing = false;
@@ -29,15 +42,9 @@ let missing = false;
 try {
   const raw = fs.readFileSync(CATEGORIES_JSON, 'utf-8');
   const data = JSON.parse(raw) as { categories: Category[] };
-  // "otros-libros" es el catch-all interno de libros sin materia
-  // específica, y "otros-productos" agrupa discos/revistas/objetos de
-  // colección — ninguno de los dos es un punto de entrada útil para
-  // descubrir por tema en la home.
-  const EXCLUDED_IDS = new Set(['otros-libros', 'otros-productos']);
   categories = (data.categories || [])
-    .filter(c => !EXCLUDED_IDS.has(c.id))
-    .sort((a, b) => b.count - a.count)
-    .slice(0, MAX_CATEGORIES);
+    .filter(c => seoOrder.has(c.id))
+    .sort((a, b) => seoOrder.get(a.id)! - seoOrder.get(b.id)!);
 } catch (e: unknown) {
   missing = true;
   const msg = e instanceof Error ? e.message : String(e);
@@ -55,7 +62,7 @@ try {
             {categories.map(cat => (
               <a
                 class="ca-chip"
-                href={`/catalogo?categoria=${encodeURIComponent(cat.id)}`}
+                href={`/libros/${encodeURIComponent(cat.id)}`}
                 role="listitem"
               >
                 <span class="ca-chip-name">{cat.name}</span>

--- a/functions/__tests__/catalogo-categories.test.js
+++ b/functions/__tests__/catalogo-categories.test.js
@@ -266,6 +266,8 @@ test('en producción, el filtro de categoría también funciona', async () => {
   assert.match(html, /<select/);
   assert.match(html, /Tarot De Los Ángeles/);
   assert.doesNotMatch(html, /El Género En Disputa/);
+  assert.match(html, /<meta name="robots" content="noindex">/);
+  assert.match(html, /<link rel="canonical" href="https:\/\/www\.amadolibros\.com\/catalogo">/);
 });
 
 test('muestra cantidad de resultados', async () => {

--- a/functions/__tests__/seo-category-pages.test.js
+++ b/functions/__tests__/seo-category-pages.test.js
@@ -1,0 +1,157 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { onRequest as categoryRequest } from '../libros/[[path]].js';
+import { onRequest as sitemapRequest } from '../sitemap.xml.js';
+import {
+    CATALOG_URL,
+    PAUSED_MANIFEST_URL,
+    PRODUCTION_MANIFEST_URL,
+} from '../_shared/catalog.js';
+import { SEO_CATEGORIES } from '../_shared/seo-categories.js';
+
+const ITEMS = SEO_CATEGORIES.map((category, index) => ({
+    id: `MLU${index + 1}`,
+    title: `Libro de prueba ${category.name}`,
+    author: `Autor ${index + 1}`,
+    price: 1000 + index,
+    status: 'active',
+    available_quantity: 2,
+    thumbnail: `https://images.example/${index + 1}.jpg`,
+    pictures: [],
+    start_time: '2026-07-01T00:00:00Z',
+}));
+
+const CATEGORY_DATA = {
+    categories: SEO_CATEGORIES.map((category, index) => ({
+        id: category.id,
+        name: category.name,
+        count: 1,
+        subcategories: [],
+    })),
+    items: Object.fromEntries(ITEMS.map((item, index) => [
+        item.id,
+        [SEO_CATEGORIES[index].id],
+    ])),
+};
+
+function context(path, appEnv = 'production', search = '') {
+    return {
+        request: new Request(`https://${appEnv === 'preview' ? 'preview.example' : 'www.amadolibros.com'}/libros/${path}${search}`),
+        params: { path: path ? [path] : [] },
+        env: { APP_ENV: appEnv },
+        data: {},
+        waitUntil() {},
+    };
+}
+
+test.beforeEach(() => {
+    globalThis.caches = {
+        default: {
+            async match(request) {
+                if (request.url.endsWith('/data/active-categories.json')) {
+                    return Response.json(CATEGORY_DATA);
+                }
+                if (request.url === CATALOG_URL) {
+                    return Response.json({ total: ITEMS.length, items: ITEMS });
+                }
+                // Fuerza el fallback seguro al catálogo completo sin red.
+                if ([PRODUCTION_MANIFEST_URL, PAUSED_MANIFEST_URL].includes(request.url)) {
+                    return Response.json({ schema_version: 0 });
+                }
+                return null;
+            },
+            async put() {},
+        },
+    };
+});
+
+test('la allowlist contiene exactamente las ocho categorías SEO aprobadas', () => {
+    assert.equal(SEO_CATEGORIES.length, 8);
+    assert.equal(new Set(SEO_CATEGORIES.map(category => category.id)).size, 8);
+    for (const category of SEO_CATEGORIES) {
+        assert.match(category.title, /Uruguay \| Amado Libros$/);
+        assert.ok(category.description.length >= 100);
+        assert.ok(category.intro.length >= 100);
+    }
+});
+
+test('cada categoría autorizada responde 200 con SEO y contenido diferenciados', async () => {
+    for (const category of SEO_CATEGORIES) {
+        const response = await categoryRequest(context(category.id));
+        const html = await response.text();
+
+        assert.equal(response.status, 200, category.id);
+        assert.ok(html.includes(`<title>${category.title}</title>`), category.id);
+        assert.ok(html.includes(`<h1>${category.h1}</h1>`), category.id);
+        assert.ok(html.includes(`<link rel="canonical" href="https://www.amadolibros.com/libros/${category.id}">`), category.id);
+        assert.match(html, /<meta name="robots" content="index, follow">/);
+        assert.match(html, /"@type":"CollectionPage"/);
+        assert.match(html, /"@type":"ItemList"/);
+        assert.match(html, /"@type":"BreadcrumbList"/);
+        assert.ok(html.includes(`Libro de prueba ${category.name}`), category.id);
+    }
+});
+
+test('la landing filtra productos por la categoría solicitada', async () => {
+    const response = await categoryRequest(context('psicologia'));
+    const html = await response.text();
+
+    assert.match(html, /Libro de prueba Psicología/);
+    assert.doesNotMatch(html, /Libro de prueba Infantil y juvenil/);
+    assert.match(html, /<section class="books-grid"/);
+    assert.match(html, /href="https:\/\/www\.amadolibros\.com\/libro\/MLU6\//);
+});
+
+test('una categoría inventada responde 404 real, noindex y sin canonical', async () => {
+    const response = await categoryRequest(context('categoria-inventada'));
+    const html = await response.text();
+
+    assert.equal(response.status, 404);
+    assert.match(html, /<meta name="robots" content="noindex, nofollow">/);
+    assert.doesNotMatch(html, /<link rel="canonical"/);
+    assert.match(html, /Buscar en el catálogo/);
+});
+
+test('preview queda noindex y conserva enlaces internos del mismo preview', async () => {
+    const response = await categoryRequest(context('infantil-juvenil', 'preview'));
+    const html = await response.text();
+
+    assert.match(html, /<meta name="robots" content="noindex, follow">/);
+    assert.match(html, /href="https:\/\/preview\.example\/libro\/MLU1\//);
+});
+
+test('parámetros arbitrarios no crean otra landing indexable', async () => {
+    const response = await categoryRequest(context('psicologia', 'production', '?orden=precio'));
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(html, /<meta name="robots" content="noindex, follow">/);
+    assert.match(html, /<link rel="canonical" href="https:\/\/www\.amadolibros\.com\/libros\/psicologia">/);
+});
+
+test('la portada enlaza las ocho landings limpias y no filtros con parámetros', () => {
+    const file = fileURLToPath(new URL('../../astro-front/src/components/CategoryAccess.astro', import.meta.url));
+    const source = readFileSync(file, 'utf8');
+
+    assert.match(source, /href={`\/libros\/\$\{encodeURIComponent\(cat\.id\)\}`}/);
+    assert.doesNotMatch(source, /href={`\/catalogo\?categoria=/);
+    for (const category of SEO_CATEGORIES) {
+        assert.ok(source.includes(`'${category.id}'`), category.id);
+    }
+});
+
+test('el sitemap publica las ocho landings SEO', async () => {
+    const response = await sitemapRequest({
+        request: new Request('https://www.amadolibros.com/sitemap.xml'),
+        env: { APP_ENV: 'production' },
+        data: {},
+        waitUntil() {},
+    });
+    const xml = await response.text();
+
+    for (const category of SEO_CATEGORIES) {
+        assert.ok(xml.includes(`<loc>https://www.amadolibros.com/libros/${category.id}</loc>`), category.id);
+    }
+});

--- a/functions/_shared/seo-categories.js
+++ b/functions/_shared/seo-categories.js
@@ -1,0 +1,78 @@
+/**
+ * Categorías con landing SEO autorizada.
+ *
+ * La lista es deliberadamente cerrada: evita convertir automáticamente cada
+ * categoría, subcategoría o filtro del catálogo en una URL indexable.
+ */
+export const SEO_CATEGORIES = [
+    {
+        id: 'infantil-juvenil',
+        name: 'Infantil y juvenil',
+        title: 'Libros infantiles y juveniles en Uruguay | Amado Libros',
+        h1: 'Libros infantiles y juveniles en Uruguay',
+        description: 'Libros infantiles y juveniles disponibles en Uruguay: cuentos, primeras lecturas, actividades y literatura juvenil. Comprá online o pedí títulos por encargo.',
+        intro: 'Encontrá cuentos, primeras lecturas, libros de actividades y literatura juvenil para distintas edades. Seleccionamos títulos disponibles en Uruguay y también buscamos por encargo los libros difíciles de ubicar.',
+    },
+    {
+        id: 'esoterismo-tarot',
+        name: 'Esoterismo y tarot',
+        title: 'Libros de esoterismo y tarot en Uruguay | Amado Libros',
+        h1: 'Libros de esoterismo y tarot en Uruguay',
+        description: 'Libros de tarot, oráculos, astrología y esoterismo disponibles en Uruguay. Comprá online, consultá stock o pedí ediciones difíciles de conseguir.',
+        intro: 'Explorá libros de tarot, oráculos, astrología y otras tradiciones esotéricas. Reunimos opciones disponibles para comprar online y conseguimos ediciones especiales o agotadas por encargo.',
+    },
+    {
+        id: 'medicina-salud',
+        name: 'Medicina y salud',
+        title: 'Libros de medicina y salud en Uruguay | Amado Libros',
+        h1: 'Libros de medicina y salud en Uruguay',
+        description: 'Libros de medicina, anatomía, enfermería, nutrición y salud mental disponibles en Uruguay. Textos para estudiantes y profesionales, con envíos a todo el país.',
+        intro: 'Consultá libros de medicina, anatomía, enfermería, nutrición y salud mental para estudio, formación y práctica profesional. Si el texto que precisás no está disponible, lo buscamos por encargo.',
+    },
+    {
+        id: 'literatura-ficcion',
+        name: 'Literatura y ficción',
+        title: 'Libros de literatura y ficción en Uruguay | Amado Libros',
+        h1: 'Libros de literatura y ficción en Uruguay',
+        description: 'Novelas, cuentos, poesía, policiales, ciencia ficción y fantasía disponibles en Uruguay. Comprá online y recibí en Montevideo o en el interior.',
+        intro: 'Descubrí novelas, cuentos, poesía, teatro, policiales, ciencia ficción y fantasía. Nuestro catálogo combina títulos disponibles con un servicio de búsqueda para ediciones difíciles de conseguir.',
+    },
+    {
+        id: 'idiomas-aprendizaje',
+        name: 'Idiomas y aprendizaje',
+        title: 'Libros para aprender idiomas en Uruguay | Amado Libros',
+        h1: 'Libros para aprender idiomas en Uruguay',
+        description: 'Libros para aprender inglés y otros idiomas en Uruguay: cursos, gramática, vocabulario y diccionarios. Comprá online o pedí el material que necesitás.',
+        intro: 'Encontrá cursos, gramáticas, diccionarios y materiales de vocabulario para aprender inglés y otros idiomas. Trabajamos libros para distintos niveles y conseguimos por encargo materiales específicos.',
+    },
+    {
+        id: 'psicologia',
+        name: 'Psicología',
+        title: 'Libros de psicología en Uruguay | Amado Libros',
+        h1: 'Libros de psicología en Uruguay',
+        description: 'Libros de psicología clínica, psicoanálisis, neuropsicología y psicología infantil disponibles en Uruguay. Comprá online o consultá por encargos.',
+        intro: 'Reunimos libros de psicología clínica, psicoanálisis, neuropsicología y psicología infantil para estudiantes, profesionales y lectores interesados. También buscamos textos académicos y ediciones agotadas por encargo.',
+    },
+    {
+        id: 'desarrollo-personal',
+        name: 'Desarrollo personal',
+        title: 'Libros de desarrollo personal en Uruguay | Amado Libros',
+        h1: 'Libros de desarrollo personal en Uruguay',
+        description: 'Libros de desarrollo personal, hábitos, bienestar y crecimiento disponibles en Uruguay. Comprá online, pagá hasta en 12 cuotas o consultá por encargos.',
+        intro: 'Explorá libros sobre hábitos, bienestar, vínculos y crecimiento personal. Mostramos títulos con disponibilidad real y te ayudamos a conseguir por encargo el libro específico que estás buscando.',
+    },
+    {
+        id: 'religion-espiritualidad',
+        name: 'Religión y espiritualidad',
+        title: 'Libros de religión y espiritualidad en Uruguay | Amado Libros',
+        h1: 'Libros de religión y espiritualidad en Uruguay',
+        description: 'Biblias y libros de religión, teología y espiritualidad disponibles en Uruguay. Consultá ediciones, comprá online o pedí títulos difíciles de conseguir.',
+        intro: 'Consultá Biblias, libros de teología, tradición religiosa y espiritualidad. Indicamos las ediciones disponibles y buscamos por encargo versiones específicas o títulos difíciles de ubicar.',
+    },
+];
+
+export const SEO_CATEGORY_IDS = new Set(SEO_CATEGORIES.map(category => category.id));
+
+export function findSeoCategory(id) {
+    return SEO_CATEGORIES.find(category => category.id === id) || null;
+}

--- a/functions/libros/[[path]].js
+++ b/functions/libros/[[path]].js
@@ -1,0 +1,272 @@
+/**
+ * Landings SEO SSR para las ocho categorías principales.
+ *
+ * URLs autorizadas: /libros/:categoria. La allowlist vive en
+ * _shared/seo-categories.js; cualquier otra ruta responde 404 real.
+ */
+import { slugify } from '../_shared/slug.js';
+import { BASE, fetchActiveIndex, fetchCatalog } from '../_shared/catalog.js';
+import {
+    BRAND,
+    faviconHeadHtml,
+    footerHtml,
+    FOOTER_STYLES,
+    waFloatHtml,
+    WA_FLOAT_STYLES,
+} from '../_shared/brand.js';
+import { findSeoCategory, SEO_CATEGORIES } from '../_shared/seo-categories.js';
+
+const MAX_RESULTS = 48;
+
+function escapeHtml(value) {
+    if (value == null) return '';
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function safeJson(value) {
+    return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+function httpsImg(url) {
+    return String(url || '').replace('http://', 'https://');
+}
+
+async function fetchCategoryData(ctx) {
+    try {
+        const url = new URL('/data/active-categories.json', ctx.request.url).toString();
+        const cache = caches.default;
+        const cacheKey = new Request(url);
+        let response = await cache.match(cacheKey);
+        if (!response) {
+            const fetched = await fetch(url);
+            if (!fetched.ok) return null;
+            response = new Response(fetched.body, {
+                status: fetched.status,
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Cache-Control': 'public, max-age=300',
+                },
+            });
+            if (typeof ctx?.waitUntil === 'function') {
+                ctx.waitUntil(cache.put(cacheKey, response.clone()));
+            }
+        }
+        const data = await response.json();
+        return data && typeof data.items === 'object' ? data : null;
+    } catch {
+        return null;
+    }
+}
+
+function headerHtml() {
+    return `<header class="category-header">
+  <div class="header-inner">
+    <a href="/" class="brand-link" aria-label="Amado Libros — inicio">
+      <img src="${BRAND.logo}" alt="${BRAND.logoAlt}" width="44" height="44" fetchpriority="high">
+      <span><strong>AMADO LIBROS</strong><small>Librería uruguaya</small></span>
+    </a>
+    <form class="header-search" action="/catalogo" method="get" role="search">
+      <input type="search" name="q" placeholder="Título, autor, temática o ISBN" aria-label="Buscar libros">
+      <button type="submit">Buscar</button>
+    </form>
+    <a class="cart-link" href="/carrito" aria-label="Ver carrito">Carrito</a>
+  </div>
+</header>`;
+}
+
+function categoryNavHtml(currentId) {
+    return `<nav class="category-nav" aria-label="Otras categorías de libros">
+  ${SEO_CATEGORIES.map(category => {
+        const current = category.id === currentId ? ' aria-current="page"' : '';
+        return `<a href="/libros/${category.id}"${current}>${escapeHtml(category.name)}</a>`;
+    }).join('\n  ')}
+</nav>`;
+}
+
+function cardHtml(item, index, navigationBase) {
+    const href = `${navigationBase}/libro/${item.id}/${slugify(item.title)}`;
+    const image = httpsImg(item.pictures?.[0] || item.thumbnail || '');
+    const title = escapeHtml(item.title);
+    const author = item.author ? `<p class="book-author">${escapeHtml(item.author)}</p>` : '';
+    const price = Number(item.price) || 0;
+    const priceText = price.toLocaleString('es-UY');
+    const transferText = Math.round(price * 0.88).toLocaleString('es-UY');
+    const installmentText = Math.round(price / 12).toLocaleString('es-UY');
+    const imageHtml = image
+        ? `<img src="${escapeHtml(image)}" alt="Portada de ${title}" loading="${index < 6 ? 'eager' : 'lazy'}" decoding="async">`
+        : '<span class="book-placeholder" aria-hidden="true">📚</span>';
+
+    return `<article class="book-card">
+  <a class="book-image" href="${escapeHtml(href)}">${imageHtml}</a>
+  <div class="book-body">
+    <span class="stock-badge">Disponible</span>
+    <h2><a href="${escapeHtml(href)}">${title}</a></h2>
+    ${author}
+    ${price > 0 ? `<div class="book-prices">
+      <strong>$${escapeHtml(priceText)} UYU</strong>
+      <span>Hasta 12 cuotas de aprox. $${escapeHtml(installmentText)}</span>
+      <span class="transfer">Transferencia: $${escapeHtml(transferText)}</span>
+    </div>` : ''}
+    <a class="book-cta" href="${escapeHtml(href)}">Ver ficha</a>
+  </div>
+</article>`;
+}
+
+function errorPage(status, title, message) {
+    const html = `<!doctype html>
+<html lang="es"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(title)} — Amado Libros</title>
+<meta name="robots" content="noindex, nofollow">
+${faviconHeadHtml()}
+<style>*{box-sizing:border-box}body{margin:0;font-family:system-ui,sans-serif;background:#f8f5ef;color:#18120e}.error{min-height:70vh;display:grid;place-items:center;padding:2rem}.error-card{max-width:640px;background:#fff;border:1px solid #e2dbd0;border-radius:1rem;padding:2rem;text-align:center}.error-card h1{margin:.25rem 0 1rem}.error-actions{display:flex;flex-wrap:wrap;gap:.75rem;justify-content:center;margin-top:1.5rem}.error-actions a{padding:.75rem 1rem;border-radius:.6rem;background:#18120e;color:#fff;text-decoration:none}</style>
+</head><body>${headerHtml()}<main class="error"><section class="error-card"><p>${status}</p><h1>${escapeHtml(title)}</h1><p>${escapeHtml(message)}</p><div class="error-actions"><a href="/catalogo">Buscar en el catálogo</a><a href="/">Volver al inicio</a></div></section></main>${footerHtml()}</body></html>`;
+    return new Response(html, {
+        status,
+        headers: {
+            'content-type': 'text/html;charset=UTF-8',
+            'cache-control': status === 404 ? 'public, max-age=300' : 'no-store',
+        },
+    });
+}
+
+function renderPage({ category, items, isPreview, hasParameters, navigationBase }) {
+    const canonical = `${BASE}/libros/${category.id}`;
+    const visibleItems = items.slice(0, MAX_RESULTS);
+    const itemList = visibleItems.slice(0, 20).map((item, index) => ({
+        '@type': 'ListItem',
+        'position': index + 1,
+        'url': `${BASE}/libro/${item.id}/${slugify(item.title)}`,
+        'name': item.title,
+    }));
+    const collectionSchema = {
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        'name': category.h1,
+        'url': canonical,
+        'description': category.description,
+        'isPartOf': { '@type': 'WebSite', 'name': BRAND.name, 'url': BASE },
+        'publisher': { '@type': 'BookStore', 'name': BRAND.name, 'url': BASE },
+        'mainEntity': {
+            '@type': 'ItemList',
+            'numberOfItems': items.length,
+            'itemListElement': itemList,
+        },
+    };
+    const breadcrumbSchema = {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        'itemListElement': [
+            { '@type': 'ListItem', 'position': 1, 'name': 'Inicio', 'item': `${BASE}/` },
+            { '@type': 'ListItem', 'position': 2, 'name': 'Libros', 'item': `${BASE}/catalogo` },
+            { '@type': 'ListItem', 'position': 3, 'name': category.name, 'item': canonical },
+        ],
+    };
+    const resultText = `${items.length} libro${items.length === 1 ? '' : 's'} disponible${items.length === 1 ? '' : 's'}`;
+    const cards = visibleItems.map((item, index) => cardHtml(item, index, navigationBase)).join('\n');
+    // Parámetros arbitrarios no crean variantes indexables de la landing.
+    // La URL limpia es la única que puede entrar al índice.
+    const robots = isPreview || hasParameters || items.length === 0
+        ? 'noindex, follow'
+        : 'index, follow';
+
+    return `<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>${escapeHtml(category.title)}</title>
+  <meta name="description" content="${escapeHtml(category.description)}">
+  <meta name="robots" content="${robots}">
+  <link rel="canonical" href="${canonical}">
+  ${faviconHeadHtml()}
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="es_UY">
+  <meta property="og:url" content="${canonical}">
+  <meta property="og:title" content="${escapeHtml(category.title)}">
+  <meta property="og:description" content="${escapeHtml(category.description)}">
+  <meta property="og:image" content="${BASE}${BRAND.logo}">
+  <script type="application/ld+json">${safeJson(collectionSchema)}</script>
+  <script type="application/ld+json">${safeJson(breadcrumbSchema)}</script>
+  <style>
+    *{box-sizing:border-box;margin:0;padding:0}body{font-family:Inter,system-ui,-apple-system,sans-serif;background:#f8f5ef;color:#18120e;line-height:1.55}a{color:inherit}.category-header{position:sticky;top:0;z-index:40;background:rgba(18,14,11,.97);color:#fff;border-bottom:1px solid rgba(255,255,255,.08)}.header-inner{max-width:1200px;height:72px;margin:auto;padding:0 1rem;display:grid;grid-template-columns:auto minmax(220px,1fr) auto;align-items:center;gap:1rem}.brand-link{display:flex;align-items:center;gap:.55rem;text-decoration:none}.brand-link img{width:44px;height:44px}.brand-link span{display:flex;flex-direction:column}.brand-link strong{font-size:.92rem}.brand-link small{color:rgba(255,255,255,.55);font-size:.7rem}.header-search{height:42px;display:flex;max-width:620px;width:100%;justify-self:center}.header-search input{min-width:0;flex:1;border:0;border-radius:999px 0 0 999px;padding:0 1rem;font:inherit}.header-search button{border:0;border-radius:0 999px 999px 0;padding:0 1rem;background:#e49982;color:#18120e;font-weight:800;cursor:pointer}.cart-link{min-height:42px;display:inline-flex;align-items:center;padding:0 .9rem;border:1px solid rgba(255,255,255,.2);border-radius:999px;text-decoration:none;font-size:.82rem}.breadcrumbs{max-width:1120px;margin:0 auto;padding:1rem;font-size:.82rem;color:#6b6157}.breadcrumbs a{color:#8f493b}.category-main{max-width:1120px;margin:0 auto;padding:0 1rem 3rem}.intro{padding:clamp(1.25rem,3vw,2rem);background:#fff;border:1px solid #e2dbd0;border-radius:1rem}.intro h1{font-family:Georgia,serif;font-size:clamp(1.75rem,5vw,2.6rem);line-height:1.12;margin-bottom:.8rem}.intro p{max-width:78ch;color:#5f554c}.benefits{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:1rem}.benefits span{padding:.35rem .65rem;border-radius:999px;background:#f5f0ea;color:#50463e;font-size:.75rem;font-weight:700}.results-head{display:flex;align-items:end;justify-content:space-between;gap:1rem;margin:2rem 0 1rem}.results-head h2{font-size:1.15rem}.results-head p{color:#6b6157;font-size:.84rem}.books-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.8rem}.book-card{display:flex;flex-direction:column;min-width:0;background:#fff;border:1px solid #e2dbd0;border-radius:.8rem;overflow:hidden}.book-image{display:grid;place-items:center;aspect-ratio:3/4;background:#eee7de;overflow:hidden}.book-image img{width:100%;height:100%;object-fit:cover;transition:transform .2s}.book-card:hover .book-image img{transform:scale(1.025)}.book-placeholder{font-size:2.5rem}.book-body{display:flex;flex:1;flex-direction:column;align-items:flex-start;gap:.4rem;padding:.8rem}.stock-badge{padding:.16rem .48rem;border-radius:999px;background:#eaf7ee;color:#267a42;font-size:.64rem;font-weight:800;text-transform:uppercase}.book-body h2{font-size:.86rem;line-height:1.3}.book-body h2 a{text-decoration:none}.book-author{width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#6b6157;font-size:.75rem}.book-prices{display:flex;flex-direction:column;gap:.15rem;margin-top:.2rem;font-size:.72rem}.book-prices strong{font-size:.9rem}.book-prices .transfer{color:#a94e3d;font-weight:700}.book-cta{margin-top:auto;padding:.38rem .7rem;border-radius:999px;background:#18120e;color:#fff;text-decoration:none;font-size:.73rem;font-weight:700}.category-nav{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.55rem;margin-top:2.5rem;padding:1rem;background:#fff;border:1px solid #e2dbd0;border-radius:1rem}.category-nav a{padding:.55rem .7rem;border-radius:.55rem;background:#f8f5ef;text-decoration:none;font-size:.78rem}.category-nav a[aria-current="page"]{background:#18120e;color:#fff}.empty{margin-top:1.5rem;padding:1.5rem;background:#fff;border:1px solid #e2dbd0;border-radius:.8rem}${FOOTER_STYLES}${WA_FLOAT_STYLES}@media(min-width:640px){.books-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.category-nav{grid-template-columns:repeat(4,minmax(0,1fr))}}@media(min-width:900px){.books-grid{grid-template-columns:repeat(4,minmax(0,1fr))}}@media(max-width:620px){.header-inner{height:auto;min-height:68px;grid-template-columns:1fr auto;padding:.55rem .8rem}.brand-link small,.cart-link{display:none}.header-search{grid-column:1/-1;grid-row:2;margin-bottom:.2rem}.category-header{position:relative}}
+  </style>
+</head>
+<body>
+${headerHtml()}
+<nav class="breadcrumbs" aria-label="Migas de pan"><a href="/">Inicio</a> › <a href="/catalogo">Libros</a> › <span>${escapeHtml(category.name)}</span></nav>
+<main class="category-main">
+  <section class="intro">
+    <h1>${escapeHtml(category.h1)}</h1>
+    <p>${escapeHtml(category.intro)}</p>
+    <div class="benefits"><span>12% menos por transferencia</span><span>Hasta 12 cuotas</span><span>Envíos a todo Uruguay</span><span>Encargos del exterior</span></div>
+  </section>
+  <div class="results-head"><h2>Libros disponibles</h2><p>${resultText}${items.length > MAX_RESULTS ? ` · mostrando ${MAX_RESULTS}` : ''}</p></div>
+  ${items.length > 0 ? `<section class="books-grid" aria-label="${escapeHtml(category.h1)}">${cards}</section>` : '<p class="empty">No hay títulos disponibles en esta categoría en este momento. Consultanos por WhatsApp y lo buscamos por encargo.</p>'}
+  ${categoryNavHtml(category.id)}
+</main>
+${footerHtml()}
+${waFloatHtml(`Hola, busco un libro de ${category.name}.`)}
+</body>
+</html>`;
+}
+
+export async function onRequest(ctx) {
+    const pathParts = Array.isArray(ctx.params.path)
+        ? ctx.params.path
+        : [ctx.params.path].filter(Boolean);
+    if (pathParts.length !== 1) {
+        return errorPage(404, 'Categoría no encontrada', 'La categoría que buscás no existe.');
+    }
+
+    const category = findSeoCategory(String(pathParts[0] || '').toLowerCase());
+    if (!category) {
+        return errorPage(404, 'Categoría no encontrada', 'La categoría que buscás no existe.');
+    }
+
+    const [categoryData, activeIndex] = await Promise.all([
+        fetchCategoryData(ctx),
+        ['preview', 'production'].includes(ctx.env?.APP_ENV)
+            ? fetchActiveIndex(ctx)
+            : Promise.resolve(null),
+    ]);
+    if (!categoryData) {
+        return errorPage(503, 'Catálogo temporalmente no disponible', 'Intentá nuevamente en unos minutos.');
+    }
+
+    let activeItems = Array.isArray(activeIndex?.items) ? activeIndex.items : null;
+    if (!activeItems) {
+        const catalog = await fetchCatalog(ctx);
+        if (!catalog || !Array.isArray(catalog.items)) {
+            return errorPage(503, 'Catálogo temporalmente no disponible', 'Intentá nuevamente en unos minutos.');
+        }
+        activeItems = catalog.items.filter(item =>
+            item.status === 'active' && Number(item.available_quantity) > 0
+        );
+    }
+
+    const items = activeItems.filter(item =>
+        (categoryData.items[item.id] || [])[0] === category.id
+    );
+    const isPreview = ctx.env?.APP_ENV === 'preview';
+    const navigationBase = isPreview ? new URL(ctx.request.url).origin : BASE;
+    const hasParameters = new URL(ctx.request.url).searchParams.size > 0;
+    const html = renderPage({
+        category,
+        items,
+        isPreview,
+        hasParameters,
+        navigationBase,
+    });
+
+    return new Response(html, {
+        headers: {
+            'content-type': 'text/html;charset=UTF-8',
+            'cache-control': 'public, max-age=3600',
+        },
+    });
+}

--- a/functions/sitemap.xml.js
+++ b/functions/sitemap.xml.js
@@ -8,6 +8,7 @@
 
 import { slugify } from './_shared/slug.js';
 import { BASE, fetchCatalog } from './_shared/catalog.js';
+import { SEO_CATEGORIES } from './_shared/seo-categories.js';
 
 // Convierte un valor de start_time (ISO 8601) a fecha YYYY-MM-DD.
 // Devuelve fallback si el valor es nulo, vacío o inválido.
@@ -30,6 +31,12 @@ export async function onRequest(ctx) {
         { loc: `${BASE}/`,                                    changefreq: 'daily',   priority: '1.0', lastmod: today },
         { loc: `${BASE}/catalogo`,                          changefreq: 'daily',   priority: '0.5', lastmod: today },
         { loc: `${BASE}/libros-maria-montessori-uruguay`,   changefreq: 'weekly',  priority: '0.8', lastmod: today },
+        ...SEO_CATEGORIES.map(category => ({
+            loc: `${BASE}/libros/${category.id}`,
+            changefreq: 'daily',
+            priority: '0.8',
+            lastmod: today,
+        })),
         { loc: `${BASE}/politicas`,                        changefreq: 'monthly', priority: '0.4', lastmod: today },
         { loc: `${BASE}/envios`,                           changefreq: 'monthly', priority: '0.4', lastmod: today },
         { loc: `${BASE}/devoluciones`,                     changefreq: 'monthly', priority: '0.4', lastmod: today },


### PR DESCRIPTION
## Qué cambia

- Crea ocho landings SSR limpias bajo `/libros/:categoria` para las categorías principales.
- Cada página tiene title, H1, meta descripción, canonical e introducción propios.
- Renderiza productos activos con stock en el HTML inicial, sin depender de JavaScript.
- Agrega `CollectionPage`, `ItemList` y `BreadcrumbList` en JSON-LD.
- Enlaza las ocho páginas directamente desde la portada y entre sí.
- Agrega las ocho URLs al sitemap.
- Responde 404 real para categorías no autorizadas.
- Mantiene Preview y variantes con parámetros en `noindex`.
- Mantiene búsquedas y filtros de `/catalogo` en `noindex` con canonical al catálogo limpio.

## Alcance SEO controlado

La allowlist es cerrada. No indexa automáticamente subcategorías, filtros, `otros-libros`, `otros-productos` ni categorías débiles.

## Impacto

No modifica precios, checkout, Mercado Pago, feed Merchant, catálogo base, Worker ni sincronización.

## Validación

- Pruebas específicas de categorías: 8/8.
- Suite total: 557/557.
- Build con checkout OFF: correcto.
- Build con checkout ON: correcto.
- 404 generada correctamente en ambos builds.
- Portada compilada: ocho enlaces `/libros/...` y cero enlaces `?categoria=`.
- Smoke de producción previo del PR #72: 8/8; producción permanece sin cambios de P2.