### PR TITLE
SEO: redirigir URLs históricas con equivalencia actual

### DIFF
--- a/functions/__tests__/legacy-redirects.test.js
+++ b/functions/__tests__/legacy-redirects.test.js
@@ -2,6 +2,10 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { onRequest as redirectLegacyBook365 } from '../365.js';
+import {
+    legacyRedirectForRequest,
+    onRequest as middlewareRequest,
+} from '../_middleware.js';
 
 test('/365 redirige permanentemente a la ficha actual', () => {
     const response = redirectLegacyBook365();
@@ -11,4 +15,111 @@ test('/365 redirige permanentemente a la ficha actual', () => {
         response.headers.get('location'),
         'https://www.amadolibros.com/libro/MLU1330191560/libro-club-de-brujas-mel-knarik-ayelen-romano',
     );
+});
+
+const request = (path, host = 'www.amadolibros.com') =>
+    new Request(`https://${host}${path}`);
+
+test('SEO-P3 redirige las rutas históricas de tienda al catálogo', () => {
+    const paths = [
+        '/shop',
+        '/shop/',
+        '/tienda',
+        '/tienda/',
+        '/tienda/page/2',
+        '/tienda/page/43/',
+        '/page/1',
+        '/page/122/',
+        '/mas-vendidos',
+        '/mas-vendidos/',
+    ];
+
+    for (const path of paths) {
+        const response = legacyRedirectForRequest(request(path));
+        assert.equal(response?.status, 301, path);
+        assert.equal(
+            response?.headers.get('location'),
+            'https://www.amadolibros.com/catalogo',
+            path,
+        );
+    }
+});
+
+test('SEO-P3 redirige el historial de pedidos antiguo a contacto', () => {
+    for (const path of ['/my-orders', '/my-orders/']) {
+        const response = legacyRedirectForRequest(request(path));
+        assert.equal(response?.status, 301, path);
+        assert.equal(
+            response?.headers.get('location'),
+            'https://www.amadolibros.com/contacto',
+            path,
+        );
+    }
+});
+
+test('SEO-P3 descarta parámetros viejos y evita una cadena desde non-www', () => {
+    const response = legacyRedirectForRequest(
+        request('/shop/?add-to-cart=123&utm_source=legacy', 'amadolibros.com'),
+    );
+
+    assert.equal(response?.status, 301);
+    assert.equal(
+        response?.headers.get('location'),
+        'https://www.amadolibros.com/catalogo',
+    );
+});
+
+test('SEO-P3 conserva el host aislado de Preview', () => {
+    const host = 'agent-seo-p3.amadolibros-web.pages.dev';
+    const response = legacyRedirectForRequest(
+        request('/tienda/page/43/?orden=precio', host),
+    );
+
+    assert.equal(response?.status, 301);
+    assert.equal(
+        response?.headers.get('location'),
+        `https://${host}/catalogo`,
+    );
+});
+
+test('SEO-P3 no captura rutas actuales ni patrones solamente parecidos', async () => {
+    const paths = [
+        '/',
+        '/catalogo',
+        '/contacto',
+        '/pedido',
+        '/page/autores',
+        '/page/2/otra-cosa',
+        '/tienda-nueva',
+        '/tienda/page/dos',
+        '/my-orders-history',
+        '/mas-vendidos-hoy',
+    ];
+
+    for (const path of paths) {
+        assert.equal(legacyRedirectForRequest(request(path)), null, path);
+
+        const response = await middlewareRequest({
+            request: request(path),
+            async next() {
+                return new Response('next');
+            },
+        });
+        assert.equal(await response.text(), 'next', path);
+    }
+});
+
+test('SEO-P3 se ejecuta en el middleware antes del fallback de la SPA', async () => {
+    let reachedNext = false;
+    const response = await middlewareRequest({
+        request: request('/shop/'),
+        async next() {
+            reachedNext = true;
+            return new Response('fallback');
+        },
+    });
+
+    assert.equal(response.status, 301);
+    assert.equal(response.headers.get('location'), 'https://www.amadolibros.com/catalogo');
+    assert.equal(reachedNext, false);
 });

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -16,6 +16,36 @@
 
 import { perfNow } from './_shared/perf.js';
 
+const LEGACY_REDIRECTS = [
+    { pattern: /^\/(?:shop|tienda|mas-vendidos)$/, destination: '/catalogo' },
+    { pattern: /^\/tienda\/page\/\d+$/, destination: '/catalogo' },
+    { pattern: /^\/page\/\d+$/, destination: '/catalogo' },
+    { pattern: /^\/my-orders$/, destination: '/contacto' },
+];
+
+function withoutTrailingSlash(pathname) {
+    return pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
+}
+
+/**
+ * Recupera autoridad de URLs de WordPress con un reemplazo actual claro.
+ *
+ * Los parámetros viejos se descartan deliberadamente. En Producción se
+ * apunta directamente al host canónico para evitar la cadena
+ * non-www -> www -> destino; Preview conserva su propio host.
+ */
+export function legacyRedirectForRequest(request) {
+    const url = new URL(request.url);
+    const path = withoutTrailingSlash(url.pathname);
+    const rule = LEGACY_REDIRECTS.find(({ pattern }) => pattern.test(path));
+
+    if (!rule) return null;
+
+    const isPreview = url.hostname.endsWith('.pages.dev');
+    const base = isPreview ? url.origin : 'https://www.amadolibros.com';
+    return Response.redirect(new URL(rule.destination, base).toString(), 301);
+}
+
 function appendServerTiming(headers, name, duration) {
     const rounded = Math.round(duration * 100) / 100;
     const current = headers.get('Server-Timing');
@@ -30,6 +60,10 @@ export async function onRequest(context) {
     const url = new URL(context.request.url);
     const isPreview = url.hostname.endsWith('.pages.dev');
     const isHashedAstroAsset = /^\/_astro\/[^/]+\.[A-Za-z0-9_-]{6,}\.(?:css|js)$/.test(url.pathname);
+
+    // --- SEO-P3: redirecciones selectivas de la tienda WordPress anterior ---
+    const legacyRedirect = legacyRedirectForRequest(context.request);
+    if (legacyRedirect) return legacyRedirect;
 
     // --- Producción: redirect non-www → www ---
     if (!isPreview && url.hostname === 'amadolibros.com') {


### PR DESCRIPTION
## Qué cambia

- Redirige permanentemente `/shop`, `/tienda`, sus paginaciones, `/page/{n}` y `/mas-vendidos` hacia `/catalogo`.
- Redirige permanentemente `/my-orders` hacia `/contacto`.
- Acepta variantes con barra final y descarta parámetros obsoletos.
- Apunta directamente al host canónico en Producción para evitar cadenas de redirección.
- Conserva el host aislado en Preview.
- No captura rutas actuales ni patrones solamente parecidos.

## Por qué

Search Console de julio de 2026 mostró que nueve URLs antiguas de WordPress aportaron 37 de 303 clics orgánicos (12,2%). Desde la corrección de soft 404 esas URLs responden 404 real; este lote recupera la autoridad histórica únicamente donde existe un destino actual equivalente.

## Impacto

No modifica productos, precios, checkout, Mercado Pago, sitemap, feed Merchant, catálogo base, Worker ni sincronización. Producción no cambia hasta un merge explícitamente autorizado.

## Validación

- Prueba específica de redirecciones: 7/7.
- Worker: 63/63.
- Functions: 250/250.
- Astro: 27/27.
- API: 223/223.
- Total: 563/563.
- Build checkout OFF: correcto.
- Build checkout ON: correcto.
- 404 noindex presente en ambos builds.
- Diff remoto: dos archivos, 145 adiciones, cero eliminaciones.