### PR TITLE
SEO-LEGACY-URL-CLEANUP-1: normalize historical URLs

### DIFF
--- a/functions/__tests__/legacy-redirects.test.js
+++ b/functions/__tests__/legacy-redirects.test.js
@@ -3,9 +3,30 @@ import assert from 'node:assert/strict';
 
 import { onRequest as redirectLegacyBook365 } from '../365.js';
 import {
-    legacyRedirectForRequest,
+    LEGACY_CATEGORY_MAP,
+    legacyResponseForRequest,
     onRequest as middlewareRequest,
 } from '../_middleware.js';
+import { findLegacyProductMatch } from '../producto/[[path]].js';
+
+const request = (path, host = 'www.amadolibros.com') =>
+    new Request(`https://${host}${path}`);
+
+const contextFor = (path, host = 'www.amadolibros.com', env = { APP_ENV: 'test' }) => ({
+    request: request(path, host),
+    env,
+    async next() {
+        return new Response('next');
+    },
+});
+
+const foundBook = title => async () => ({
+    state: 'found',
+    item: { id: 'MLU651601362', title },
+});
+
+const missingBook = async () => ({ state: 'missing' });
+const unavailableBook = async () => ({ state: 'unavailable' });
 
 test('/365 redirige permanentemente a la ficha actual', () => {
     const response = redirectLegacyBook365();
@@ -17,72 +38,189 @@ test('/365 redirige permanentemente a la ficha actual', () => {
     );
 });
 
-const request = (path, host = 'www.amadolibros.com') =>
-    new Request(`https://${host}${path}`);
+test('?book=MLU existente redirige directo a la ficha canónica', async () => {
+    const response = await legacyResponseForRequest(
+        contextFor('/?book=MLU651601362'),
+        { lookupBook: foundBook('El Acuerdo Mary Balogh') },
+    );
 
-test('SEO-P3 redirige las rutas históricas de tienda al catálogo', () => {
-    const paths = [
-        '/shop',
-        '/shop/',
-        '/tienda',
-        '/tienda/',
-        '/tienda/page/2',
-        '/tienda/page/43/',
+    assert.equal(response.status, 301);
+    assert.equal(
+        response.headers.get('location'),
+        'https://www.amadolibros.com/libro/MLU651601362/el-acuerdo-mary-balogh',
+    );
+});
+
+test('?book=MLU pausado existente usa el mismo 301 canónico', async () => {
+    const response = await legacyResponseForRequest(
+        contextFor('/?book=MLU651601362'),
+        { lookupBook: foundBook('Libro Pausado de Prueba') },
+    );
+
+    assert.equal(response.status, 301);
+    assert.equal(
+        response.headers.get('location'),
+        'https://www.amadolibros.com/libro/MLU651601362/libro-pausado-de-prueba',
+    );
+});
+
+test('?book inexistente devuelve 410', async () => {
+    const response = await legacyResponseForRequest(
+        contextFor('/?book=MLU999999999'),
+        { lookupBook: missingBook },
+    );
+
+    assert.equal(response.status, 410);
+    assert.match(response.headers.get('x-robots-tag'), /noindex/i);
+});
+
+test('?book con catálogo temporalmente inaccesible devuelve 503, nunca 410', async () => {
+    const response = await legacyResponseForRequest(
+        contextFor('/?book=MLU651601362'),
+        { lookupBook: unavailableBook },
+    );
+
+    assert.equal(response.status, 503);
+    assert.equal(response.headers.get('retry-after'), '60');
+});
+
+test('?book gana sobre add-to-cart y evita perder un producto resoluble', async () => {
+    const response = await legacyResponseForRequest(
+        contextFor('/page/94/?book=MLU651601362&add-to-cart=156903'),
+        { lookupBook: foundBook('El Acuerdo') },
+    );
+
+    assert.equal(response.status, 301);
+    assert.equal(
+        response.headers.get('location'),
+        'https://www.amadolibros.com/libro/MLU651601362/el-acuerdo',
+    );
+});
+
+test('add-to-cart sin mapping WooCommerce → MLU devuelve 410', async () => {
+    for (const path of [
+        '/?add-to-cart=115745',
+        '/page/94/?add-to-cart=156903',
+        '/shop/?add-to-cart=123&utm_source=legacy',
+    ]) {
+        const response = await legacyResponseForRequest(contextFor(path));
+        assert.equal(response.status, 410, path);
+    }
+});
+
+test('paginaciones históricas /page, /tienda/page y /shop/page devuelven 410', async () => {
+    for (const path of [
         '/page/1',
         '/page/122/',
-        '/mas-vendidos',
-        '/mas-vendidos/',
-    ];
+        '/tienda/page/2',
+        '/tienda/page/43/',
+        '/shop/page/8/',
+    ]) {
+        const response = await legacyResponseForRequest(contextFor(path));
+        assert.equal(response.status, 410, path);
+    }
+});
 
-    for (const path of paths) {
-        const response = legacyRedirectForRequest(request(path));
-        assert.equal(response?.status, 301, path);
+test('raíces legacy con equivalente real mantienen 301', async () => {
+    const cases = new Map([
+        ['/shop', '/catalogo'],
+        ['/shop/', '/catalogo'],
+        ['/tienda', '/catalogo'],
+        ['/tienda/', '/catalogo'],
+        ['/mas-vendidos', '/catalogo'],
+        ['/mas-vendidos/', '/catalogo'],
+        ['/my-orders', '/contacto'],
+        ['/my-orders/', '/contacto'],
+        ['/categoria-producto/', '/catalogo'],
+    ]);
+
+    for (const [path, destination] of cases) {
+        const response = await legacyResponseForRequest(contextFor(path));
+        assert.equal(response.status, 301, path);
         assert.equal(
-            response?.headers.get('location'),
-            'https://www.amadolibros.com/catalogo',
+            response.headers.get('location'),
+            `https://www.amadolibros.com${destination}`,
             path,
         );
     }
 });
 
-test('SEO-P3 redirige el historial de pedidos antiguo a contacto', () => {
-    for (const path of ['/my-orders', '/my-orders/']) {
-        const response = legacyRedirectForRequest(request(path));
-        assert.equal(response?.status, 301, path);
-        assert.equal(
-            response?.headers.get('location'),
-            'https://www.amadolibros.com/contacto',
-            path,
-        );
-    }
-});
+test('categorías legacy mapeadas redirigen a una landing SEO real', async () => {
+    assert.equal(LEGACY_CATEGORY_MAP.novelas, '/libros/literatura-ficcion');
 
-test('SEO-P3 descarta parámetros viejos y evita una cadena desde non-www', () => {
-    const response = legacyRedirectForRequest(
-        request('/shop/?add-to-cart=123&utm_source=legacy', 'amadolibros.com'),
+    const response = await legacyResponseForRequest(
+        contextFor('/categoria-producto/novelas/'),
     );
 
-    assert.equal(response?.status, 301);
+    assert.equal(response.status, 301);
     assert.equal(
-        response?.headers.get('location'),
-        'https://www.amadolibros.com/catalogo',
+        response.headers.get('location'),
+        'https://www.amadolibros.com/libros/literatura-ficcion',
     );
 });
 
-test('SEO-P3 conserva el host aislado de Preview', () => {
+test('categoría legacy sin equivalencia confiable devuelve 410', async () => {
+    const response = await legacyResponseForRequest(
+        contextFor('/categoria-producto/categoria-imposible/'),
+    );
+    assert.equal(response.status, 410);
+});
+
+test('paginación de categoría legacy devuelve 410 aunque la raíz esté mapeada', async () => {
+    const response = await legacyResponseForRequest(
+        contextFor('/categoria-producto/novelas/page/261/?layout=list'),
+    );
+    assert.equal(response.status, 410);
+});
+
+test('layout sobre URL actual elimina solo layout y conserva parámetros útiles', async () => {
+    const response = await legacyResponseForRequest(
+        contextFor('/catalogo?q=tarot&layout=list'),
+    );
+
+    assert.equal(response.status, 301);
+    assert.equal(
+        response.headers.get('location'),
+        'https://www.amadolibros.com/catalogo?q=tarot',
+    );
+});
+
+test('layout sobre URL legacy aplica primero la política legacy', async () => {
+    const response = await legacyResponseForRequest(
+        contextFor('/categoria-producto/novelas/?layout=list'),
+    );
+
+    assert.equal(response.status, 301);
+    assert.equal(
+        response.headers.get('location'),
+        'https://www.amadolibros.com/libros/literatura-ficcion',
+    );
+});
+
+test('legacy desde non-www va directo al destino final en un solo redirect', async () => {
+    const response = await legacyResponseForRequest(
+        contextFor('/?book=MLU651601362', 'amadolibros.com'),
+        { lookupBook: foundBook('El Acuerdo') },
+    );
+
+    assert.equal(response.status, 301);
+    assert.equal(
+        response.headers.get('location'),
+        'https://www.amadolibros.com/libro/MLU651601362/el-acuerdo',
+    );
+});
+
+test('legacy conserva el host aislado de Preview', async () => {
     const host = 'agent-seo-p3.amadolibros-web.pages.dev';
-    const response = legacyRedirectForRequest(
-        request('/tienda/page/43/?orden=precio', host),
+    const response = await legacyResponseForRequest(
+        contextFor('/tienda/', host, { APP_ENV: 'preview' }),
     );
 
-    assert.equal(response?.status, 301);
-    assert.equal(
-        response?.headers.get('location'),
-        `https://${host}/catalogo`,
-    );
+    assert.equal(response.status, 301);
+    assert.equal(response.headers.get('location'), `https://${host}/catalogo`);
 });
 
-test('SEO-P3 no captura rutas actuales ni patrones solamente parecidos', async () => {
+test('no captura rutas actuales ni patrones solamente parecidos', async () => {
     const paths = [
         '/',
         '/catalogo',
@@ -94,32 +232,41 @@ test('SEO-P3 no captura rutas actuales ni patrones solamente parecidos', async (
         '/tienda/page/dos',
         '/my-orders-history',
         '/mas-vendidos-hoy',
+        '/libro/MLU699916310/juego-educativo',
     ];
 
     for (const path of paths) {
-        assert.equal(legacyRedirectForRequest(request(path)), null, path);
+        assert.equal(await legacyResponseForRequest(contextFor(path)), null, path);
 
-        const response = await middlewareRequest({
-            request: request(path),
-            async next() {
-                return new Response('next');
-            },
-        });
+        const response = await middlewareRequest(contextFor(path));
         assert.equal(await response.text(), 'next', path);
     }
 });
 
-test('SEO-P3 se ejecuta en el middleware antes del fallback de la SPA', async () => {
+test('cleanup se ejecuta antes de context.next()', async () => {
     let reachedNext = false;
-    const response = await middlewareRequest({
-        request: request('/shop/'),
-        async next() {
-            reachedNext = true;
-            return new Response('fallback');
-        },
-    });
+    const context = contextFor('/page/43/');
+    context.next = async () => {
+        reachedNext = true;
+        return new Response('fallback');
+    };
 
-    assert.equal(response.status, 301);
-    assert.equal(response.headers.get('location'), 'https://www.amadolibros.com/catalogo');
+    const response = await middlewareRequest(context);
+    assert.equal(response.status, 410);
     assert.equal(reachedNext, false);
+});
+
+test('/producto conserva match por slug y rechaza el resto', () => {
+    const catalog = {
+        items: [
+            { id: 'MLU1', title: 'El Acuerdo Mary Balogh' },
+            { id: 'MLU2', title: 'Otro Libro' },
+        ],
+    };
+
+    assert.equal(
+        findLegacyProductMatch(catalog, 'el-acuerdo-mary-balogh')?.id,
+        'MLU1',
+    );
+    assert.equal(findLegacyProductMatch(catalog, 'slug-inexistente'), null);
 });

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -3,47 +3,201 @@
  *
  * Middleware global — se ejecuta antes que cualquier otro Function o asset.
  *
- * 1. Enforza el host canónico www.amadolibros.com con 301 permanente.
- *    (solo en producción; en preview .pages.dev el redirect no aplica)
+ * SEO-LEGACY-URL-CLEANUP-1:
+ * - normaliza URLs históricas de WordPress/WooCommerce antes del routing actual;
+ * - 301 únicamente cuando existe un reemplazo inequívoco;
+ * - 410 cuando el contenido legacy no tiene equivalente;
+ * - evita cadenas non-www -> www -> destino;
+ * - no modifica URLs actuales salvo quitar el parámetro de presentación `layout`.
  *
- * 2. En preview (hostname termina en .pages.dev):
- *    - Bloquea el webhook de Mercado Libre con 403 para evitar escrituras
- *      accidentales al KV de producción.
- *    - Inyecta X-Robots-Tag: noindex y Cache-Control: no-store en todas
- *      las respuestas de Pages Functions (los assets estáticos ya quedan
- *      cubiertos por astro-front/public/_headers).
+ * Además conserva las protecciones existentes de Preview y cache de assets Astro.
  */
 
 import { perfNow } from './_shared/perf.js';
+import { BASE, fetchCatalog, fetchPausedItem } from './_shared/catalog.js';
+import { slugify } from './_shared/slug.js';
+import { goneResponse } from './_shared/gone.js';
 
-const LEGACY_REDIRECTS = [
-    { pattern: /^\/(?:shop|tienda|mas-vendidos)$/, destination: '/catalogo' },
-    { pattern: /^\/tienda\/page\/\d+$/, destination: '/catalogo' },
-    { pattern: /^\/page\/\d+$/, destination: '/catalogo' },
-    { pattern: /^\/my-orders$/, destination: '/contacto' },
+const LEGACY_ROOT_REDIRECTS = [
+    { pattern: /^\/(?:shop|tienda|mas-vendidos)$/, destination: '/catalogo', name: 'legacy_root_catalog' },
+    { pattern: /^\/my-orders$/, destination: '/contacto', name: 'legacy_my_orders' },
 ];
+
+/**
+ * Mapa deliberadamente conservador: solo equivalencias inequívocas.
+ * Los IDs SEO actuales se mapean a sí mismos; "novelas" es una equivalencia
+ * histórica conocida; la categoría genérica WooCommerce apunta al catálogo.
+ */
+export const LEGACY_CATEGORY_MAP = Object.freeze({
+    'libros-revistas-y-comics': '/catalogo',
+    'novelas': '/libros/literatura-ficcion',
+    'infantil-juvenil': '/libros/infantil-juvenil',
+    'esoterismo-tarot': '/libros/esoterismo-tarot',
+    'medicina-salud': '/libros/medicina-salud',
+    'literatura-ficcion': '/libros/literatura-ficcion',
+    'idiomas-aprendizaje': '/libros/idiomas-aprendizaje',
+    'psicologia': '/libros/psicologia',
+    'desarrollo-personal': '/libros/desarrollo-personal',
+    'religion-espiritualidad': '/libros/religion-espiritualidad',
+});
 
 function withoutTrailingSlash(pathname) {
     return pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
 }
 
+function safeDecodeURIComponent(value) {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+}
+
+function isPreviewUrl(url) {
+    return url.hostname.endsWith('.pages.dev');
+}
+
+function navigationBase(url) {
+    return isPreviewUrl(url) ? url.origin : BASE;
+}
+
+function redirectTo(url, destination) {
+    return Response.redirect(new URL(destination, navigationBase(url)).toString(), 301);
+}
+
+function logLegacy(request, pattern, response, destination = null) {
+    const userAgent = request.headers.get('user-agent') || '';
+    console.log(JSON.stringify({
+        event: 'seo_legacy_url_cleanup',
+        pattern,
+        path: new URL(request.url).pathname,
+        status: response.status,
+        destination,
+        googlebotUa: /Googlebot/i.test(userAgent),
+    }));
+}
+
+function goneFor(request, pattern) {
+    const response = goneResponse();
+    logLegacy(request, pattern, response);
+    return response;
+}
+
+function redirectFor(request, pattern, destination) {
+    const url = new URL(request.url);
+    const response = redirectTo(url, destination);
+    logLegacy(request, pattern, response, response.headers.get('location'));
+    return response;
+}
+
 /**
- * Recupera autoridad de URLs de WordPress con un reemplazo actual claro.
- *
- * Los parámetros viejos se descartan deliberadamente. En Producción se
- * apunta directamente al host canónico para evitar la cadena
- * non-www -> www -> destino; Preview conserva su propio host.
+ * Resuelve un MLU contra el mismo origen de datos usado por las fichas.
+ * Si el catálogo activo falla, devolvemos "unavailable" para NO convertir una
+ * caída transitoria de R2 en un 410 permanente.
  */
-export function legacyRedirectForRequest(request) {
+async function lookupLegacyBook(context, id) {
+    let catalog;
+    try {
+        catalog = await fetchCatalog(context);
+    } catch {
+        return { state: 'unavailable' };
+    }
+
+    if (!catalog || !Array.isArray(catalog.items)) {
+        return { state: 'unavailable' };
+    }
+
+    const active = catalog.items.find(item => item?.id === id);
+    if (active) return { state: 'found', item: active };
+
+    if (['preview', 'production'].includes(context.env?.APP_ENV)) {
+        try {
+            const paused = await fetchPausedItem(context, id);
+            if (paused) return { state: 'found', item: paused };
+        } catch {
+            return { state: 'unavailable' };
+        }
+    }
+
+    return { state: 'missing' };
+}
+
+/**
+ * Devuelve una respuesta solo cuando la request es legacy/normalizable.
+ * `options.lookupBook` existe para tests y evita dependencias de red.
+ */
+export async function legacyResponseForRequest(context, options = {}) {
+    const request = context.request;
     const url = new URL(request.url);
     const path = withoutTrailingSlash(url.pathname);
-    const rule = LEGACY_REDIRECTS.find(({ pattern }) => pattern.test(path));
+    const lookupBook = options.lookupBook || lookupLegacyBook;
 
-    if (!rule) return null;
+    // 1) ?book=MLU tiene máxima prioridad: identifica exactamente una entidad.
+    if (url.searchParams.has('book')) {
+        const id = String(url.searchParams.get('book') || '').trim().toUpperCase();
+        if (!/^MLU\d+$/.test(id)) return goneFor(request, 'query_book_invalid');
 
-    const isPreview = url.hostname.endsWith('.pages.dev');
-    const base = isPreview ? url.origin : 'https://www.amadolibros.com';
-    return Response.redirect(new URL(rule.destination, base).toString(), 301);
+        const result = await lookupBook(context, id);
+        if (result?.state === 'unavailable') {
+            const response = new Response('Servicio temporalmente no disponible', {
+                status: 503,
+                headers: {
+                    'content-type': 'text/plain;charset=UTF-8',
+                    'cache-control': 'no-store',
+                    'retry-after': '60',
+                },
+            });
+            logLegacy(request, 'query_book_catalog_unavailable', response);
+            return response;
+        }
+        if (result?.state !== 'found' || !result.item?.title) {
+            return goneFor(request, 'query_book_missing');
+        }
+
+        const destination = `/libro/${id}/${slugify(result.item.title)}`;
+        return redirectFor(request, 'query_book_resolved', destination);
+    }
+
+    // 2) IDs WooCommerce sin mapping no pueden resolverse de forma segura.
+    if (url.searchParams.has('add-to-cart')) {
+        return goneFor(request, 'query_add_to_cart');
+    }
+
+    // 3) Paginaciones históricas: no representan una página actual equivalente.
+    if (/^\/(?:tienda|shop)\/page\/\d+$/.test(path) || /^\/page\/\d+$/.test(path)) {
+        return goneFor(request, 'legacy_pagination');
+    }
+
+    // 4) Categorías WooCommerce: raíz equivalente -> 301; paginación/resto -> 410.
+    if (path === '/categoria-producto') {
+        return redirectFor(request, 'legacy_category_root', '/catalogo');
+    }
+    const categoryMatch = path.match(/^\/categoria-producto\/([^/]+)$/);
+    if (categoryMatch) {
+        const legacySlug = safeDecodeURIComponent(categoryMatch[1]).toLowerCase();
+        const destination = LEGACY_CATEGORY_MAP[legacySlug];
+        if (destination) return redirectFor(request, 'legacy_category_mapped', destination);
+        return goneFor(request, 'legacy_category_unmapped');
+    }
+    if (/^\/categoria-producto(?:\/|$)/.test(path)) {
+        return goneFor(request, 'legacy_category_pagination_or_nested');
+    }
+
+    // 5) Raíces legacy con reemplazo real.
+    const rootRule = LEGACY_ROOT_REDIRECTS.find(({ pattern }) => pattern.test(path));
+    if (rootRule) {
+        return redirectFor(request, rootRule.name, rootRule.destination);
+    }
+
+    // 6) `layout` solo cambia presentación: sobre una URL actual se elimina.
+    if (url.searchParams.has('layout')) {
+        const clean = new URL(url.toString());
+        clean.searchParams.delete('layout');
+        const destination = `${clean.pathname}${clean.search}`;
+        return redirectFor(request, 'query_layout_normalized', destination);
+    }
+
+    return null;
 }
 
 function appendServerTiming(headers, name, duration) {
@@ -58,12 +212,12 @@ function appendServerTiming(headers, name, duration) {
 export async function onRequest(context) {
     const workerStartedAt = perfNow();
     const url = new URL(context.request.url);
-    const isPreview = url.hostname.endsWith('.pages.dev');
+    const isPreview = isPreviewUrl(url);
     const isHashedAstroAsset = /^\/_astro\/[^/]+\.[A-Za-z0-9_-]{6,}\.(?:css|js)$/.test(url.pathname);
 
-    // --- SEO-P3: redirecciones selectivas de la tienda WordPress anterior ---
-    const legacyRedirect = legacyRedirectForRequest(context.request);
-    if (legacyRedirect) return legacyRedirect;
+    // --- SEO-LEGACY-URL-CLEANUP-1: resolver antes del redirect de host ---
+    const legacyResponse = await legacyResponseForRequest(context);
+    if (legacyResponse) return legacyResponse;
 
     // --- Producción: redirect non-www → www ---
     if (!isPreview && url.hostname === 'amadolibros.com') {

--- a/functions/_shared/gone.js
+++ b/functions/_shared/gone.js
@@ -1,0 +1,38 @@
+import { BASE } from './catalog.js';
+
+/**
+ * Respuesta compartida para URLs legacy eliminadas sin equivalente actual.
+ * 410 permite a crawlers entender que la desaparición es permanente.
+ */
+export function goneResponse({
+    message = 'Esta página ya no existe. Buscá el libro en el catálogo actualizado.',
+    cacheSeconds = 86400,
+} = {}) {
+    const html = `<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Página no disponible — Amado Libros</title>
+  <meta name="robots" content="noindex, nofollow">
+  <style>
+    body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;max-width:600px;margin:4rem auto;padding:1rem;text-align:center;color:#1e293b}
+    a{color:#3b82f6;text-decoration:none}a:hover{text-decoration:underline}
+  </style>
+</head>
+<body>
+  <h1 style="font-size:1.5rem;margin-bottom:1rem">Esta página ya no existe</h1>
+  <p style="color:#64748b;margin-bottom:1.5rem">${message}</p>
+  <a href="${BASE}/catalogo">Ir al catálogo de Amado Libros</a>
+</body>
+</html>`;
+
+    return new Response(html, {
+        status: 410,
+        headers: {
+            'content-type': 'text/html;charset=UTF-8',
+            'cache-control': `public, max-age=${cacheSeconds}`,
+            'x-robots-tag': 'noindex, nofollow',
+        },
+    });
+}

--- a/functions/producto/[[path]].js
+++ b/functions/producto/[[path]].js
@@ -8,14 +8,18 @@
  * el slug de la URL con el slug generado a partir del título de cada item.
  * Si hay coincidencia → 301 a /libro/:id/:slug (canonical).
  * Sin coincidencia → 410 Gone (página permanentemente eliminada, sin equivalente).
- *
  */
 
 import { slugify } from '../_shared/slug.js';
 import { BASE, fetchCatalog } from '../_shared/catalog.js';
+import { goneResponse } from '../_shared/gone.js';
+
+export function findLegacyProductMatch(catalog, incomingSlug) {
+    if (!incomingSlug || !catalog || !Array.isArray(catalog.items)) return null;
+    return catalog.items.find(item => slugify(item.title) === incomingSlug) || null;
+}
 
 export async function onRequest(context) {
-    // Extract the slug from the incoming /producto/:slug URL
     const pathParts = Array.isArray(context.params.path)
         ? context.params.path
         : [context.params.path].filter(Boolean);
@@ -23,45 +27,12 @@ export async function onRequest(context) {
 
     if (incomingSlug) {
         const catalog = await fetchCatalog(context);
-        if (catalog && Array.isArray(catalog.items)) {
-            const match = catalog.items.find(
-                item => slugify(item.title) === incomingSlug
-            );
-            if (match) {
-                const canonicalSlug = slugify(match.title);
-                return Response.redirect(`${BASE}/libro/${match.id}/${canonicalSlug}`, 301);
-            }
+        const match = findLegacyProductMatch(catalog, incomingSlug);
+        if (match) {
+            const canonicalSlug = slugify(match.title);
+            return Response.redirect(`${BASE}/libro/${match.id}/${canonicalSlug}`, 301);
         }
     }
 
-    const html = `<!DOCTYPE html>
-<html lang="es">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Página no disponible — Amado Libros</title>
-  <meta name="robots" content="noindex">
-  <style>
-    body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
-         max-width:600px;margin:4rem auto;padding:1rem;text-align:center;color:#1e293b}
-    a{color:#3b82f6;text-decoration:none}
-    a:hover{text-decoration:underline}
-  </style>
-</head>
-<body>
-  <h1 style="font-size:1.5rem;margin-bottom:1rem">Esta página ya no existe</h1>
-  <p style="color:#64748b;margin-bottom:1.5rem">
-    El catálogo fue actualizado. Buscá tu libro en el catálogo completo.
-  </p>
-  <a href="/">← Ir al catálogo de Amado Libros</a>
-</body>
-</html>`;
-
-    return new Response(html, {
-        status: 410,
-        headers: {
-            'content-type': 'text/html;charset=UTF-8',
-            'cache-control': 'public, max-age=86400',
-        },
-    });
+    return goneResponse();
 }


### PR DESCRIPTION
## Qué cambia

Centraliza en `functions/_middleware.js` la limpieza de URLs históricas de WordPress/WooCommerce detectadas en Search Console.

- `?book=MLU...` resoluble → 301 directo a `/libro/:id/:slug` (activos y pausados).
- `?book=MLU...` no resoluble → 410.
- caída temporal del catálogo durante resolución de `?book` → 503, nunca 410 accidental.
- `?add-to-cart=` sin mapping WooCommerce→MLU → 410.
- `/page/N`, `/tienda/page/N`, `/shop/page/N` → 410.
- raíces `/shop`, `/tienda`, `/mas-vendidos` → 301 `/catalogo`; `/my-orders` → 301 `/contacto`.
- `/categoria-producto/{slug}` usa un mapa explícito y conservador; paginaciones/no mapeadas → 410.
- `layout=` sobre URLs actuales se elimina mediante 301 conservando otros parámetros útiles.
- legacy non-www redirige directamente al destino final www para evitar cadenas.
- logging JSON estructurado con `googlebotUa` basado únicamente en User-Agent.
- respuesta 410 reutilizable en `_shared/gone.js`.
- `/producto/{slug}` conserva su lógica actual y reutiliza la respuesta 410 compartida.

## Por qué

Search Console sigue rastreando miles de URLs legacy (`?book`, `add-to-cart`, paginaciones y categorías WooCommerce). Algunas devolvían 200 de la home o 301 genérico a `/catalogo`, lo que mantiene ruido de crawl, duplicados y señales ambiguas después de la migración.

## Scope

No toca Home, diseño, contenido de fichas, sitemap, robots.txt ni solicitudes de indexación. El sitemap y canonical actuales se mantienen.

## Validación

Se amplía `functions/__tests__/legacy-redirects.test.js` para cubrir:

- book existente/pausado/inexistente/unavailable;
- precedencia book sobre add-to-cart;
- add-to-cart;
- paginaciones legacy;
- categorías mapeadas/no mapeadas/paginadas;
- layout actual vs legacy;
- non-www sin cadenas;
- Preview;
- no captura de rutas actuales;
- matcher de `/producto`.

Este PR queda en borrador hasta que CI (`scripts/validate-ci.sh`) termine correctamente.