### PR TITLE
SEO-CRAWL-LOGS-3: measure verified Googlebot crawl

### DIFF
--- a/.github/workflows/seo-crawl-logs-control.yml
+++ b/.github/workflows/seo-crawl-logs-control.yml
@@ -1,0 +1,43 @@
+name: SEO crawl logs control
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Entorno del flag
+        required: true
+        type: choice
+        options:
+          - preview
+          - production
+      enabled:
+        description: Habilitar logging
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  set-flag:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Write KV flag
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          TARGET_ENV: ${{ inputs.environment }}
+          ENABLED: ${{ inputs.enabled }}
+        run: |
+          KEY="seo:crawl-logs-3:enabled:${TARGET_ENV}"
+          VALUE="false"
+          if [ "$ENABLED" = "true" ]; then VALUE="true"; fi
+          npx wrangler@3.114.17 kv key put --namespace-id=6ea0ff4682d647118442a24fe384abc4 "$KEY" "$VALUE"
+          echo "Flag $KEY = $VALUE"

--- a/.github/workflows/seo-crawl-report.yml
+++ b/.github/workflows/seo-crawl-report.yml
@@ -1,0 +1,65 @@
+name: SEO crawl report
+
+on:
+  workflow_dispatch:
+    inputs:
+      start_date:
+        description: Fecha inicial UTC (YYYY-MM-DD)
+        required: true
+      end_date:
+        description: Fecha final UTC (YYYY-MM-DD)
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Validate date inputs
+        env:
+          START_DATE: ${{ inputs.start_date }}
+          END_DATE: ${{ inputs.end_date }}
+        run: |
+          [[ "$START_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || { echo "start_date inválida"; exit 1; }
+          [[ "$END_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || { echo "end_date inválida"; exit 1; }
+
+      - name: Query aggregated D1 rows
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          START_DATE: ${{ inputs.start_date }}
+          END_DATE: ${{ inputs.end_date }}
+        run: |
+          mkdir -p artifacts/seo
+          npx wrangler@3.114.17 d1 execute ORDERS_DB --env production --remote --json \
+            --command "SELECT date, pattern, status, verified, ua_googlebot, request_count, bytes_sum, bytes_known_count, duration_ms_sum FROM crawl_stats WHERE date >= '$START_DATE' AND date <= '$END_DATE' ORDER BY date, pattern, status, verified, ua_googlebot" \
+            > artifacts/seo/crawl-stats-raw.json
+
+      - name: Build useful crawl report
+        env:
+          CRAWL_REPORT_INPUT: artifacts/seo/crawl-stats-raw.json
+          CRAWL_REPORT_OUTPUT_DIR: artifacts/seo
+        run: node scripts/seo/crawl-report.mjs
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: seo-crawl-${{ inputs.start_date }}-${{ inputs.end_date }}
+          path: |
+            artifacts/seo/crawl-stats-raw.json
+            artifacts/seo/crawl-summary.json
+            artifacts/seo/crawl-daily.csv
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/seo/crawl-logs-3.md
+++ b/docs/seo/crawl-logs-3.md
@@ -1,0 +1,146 @@
+# SEO-CRAWL-LOGS-3
+
+Observabilidad agregada del rastreo después de `SEO-LEGACY-URL-CLEANUP-1`.
+
+## Objetivo
+
+Medir si Googlebot dedica una proporción creciente de sus visitas a URLs canónicas útiles y una proporción decreciente a legacy, parámetros y variantes.
+
+No es un sistema de access logs general.
+
+## Captura — opción B
+
+Se registran:
+
+1. requests cuyo User-Agent parezca bot/crawler;
+2. todos los patrones legacy;
+3. una muestra aleatoria del 1% del resto del tráfico no-asset.
+
+Los assets (`/_astro/*`, CSS, JS, imágenes y fonts) se excluyen.
+
+## Privacidad / cardinalidad
+
+D1 **no persiste**:
+
+- IP;
+- User-Agent;
+- URL o path crudo;
+- query string;
+- MLU;
+- ISBN;
+- identificadores de cliente.
+
+Solo persiste agregados por:
+
+`date + pattern + status + verified + ua_googlebot`.
+
+## Verificación Googlebot
+
+Un request cuenta como Googlebot verificado únicamente cuando se cumplen las dos condiciones:
+
+1. el User-Agent contiene `Googlebot`;
+2. `CF-Connecting-IP` pertenece a un CIDR publicado por Google en `common-crawlers.json`.
+
+Estados internos del campo `verified`:
+
+- `1`: UA Googlebot + IP dentro de rango oficial;
+- `0`: UA Googlebot + IP válida fuera de los rangos oficiales;
+- `-1`: request que no declara UA Googlebot;
+- `-2`: UA Googlebot pero verificación no disponible (IP/rangos no disponibles o inválidos).
+
+Los CIDR IPv4 e IPv6 se parsean a `BigInt` una vez por isolate y se mantienen en memoria una hora. La fuente se refresca lógicamente cada 24 h. Se guarda la última copia correcta en `AMADO_KV`; si Google no responde, se usa esa copia aunque sea anterior a 24 h.
+
+Fuente oficial:
+
+`https://developers.google.com/static/crawling/ipranges/common-crawlers.json`
+
+## Kill switch
+
+El logger está **apagado por defecto**.
+
+Clave KV por entorno:
+
+- Producción: `seo:crawl-logs-3:enabled:production`
+- Preview: `seo:crawl-logs-3:enabled:preview`
+
+Valor habilitante exacto: `true`.
+
+Cualquier otro valor o ausencia de la clave = apagado.
+
+El flag se cachea por isolate durante 60 segundos. Como KV es eventualmente consistente entre datacenters, el apagado global puede tardar adicionalmente el tiempo de propagación de KV.
+
+## Camino crítico
+
+`functions/_middleware.js` determina primero la respuesta normal. Después llama `scheduleCrawlAnalytics()`.
+
+Toda la lógica de observabilidad queda dentro de `context.waitUntil()`:
+
+- lectura del flag;
+- decisión de muestreo;
+- carga/refresco de rangos de Google;
+- verificación IP;
+- `CREATE TABLE IF NOT EXISTS` por isolate;
+- upsert D1.
+
+El cuerpo de la respuesta **nunca se clona, lee ni bufferea**. `bytes_sum` usa únicamente `Content-Length` cuando existe; `bytes_known_count` permite distinguir bytes medidos de respuestas sin longitud conocida.
+
+## D1
+
+Tabla: `crawl_stats`.
+
+Schema versionado también en `migrations/0004_crawl_stats.sql`.
+
+El runtime hace `CREATE TABLE IF NOT EXISTS` dentro de `waitUntil()` para que activar/desactivar observabilidad no requiera una migración bloqueante antes del deploy.
+
+Cada request capturado ejecuta un único UPSERT agregado, no un INSERT de evento individual.
+
+## useful_crawl_ratio_v1 — definición congelada
+
+Versión: `1`.
+
+Numerador:
+
+> requests Googlebot verificadas (`verified=1`) con HTTP 200 y patrón `home`, `libro`, `libros`, `catalogo` o `static_page`.
+
+Denominador:
+
+> todas las requests Googlebot verificadas clasificadas como páginas de contenido.
+
+Se excluyen del denominador porque son infraestructura/no-página:
+
+- `asset`;
+- `api`;
+- `sitemap`;
+- `robots`.
+
+Legacy, variantes, parámetros y `other` **sí permanecen en el denominador**, porque justamente representan crawl de páginas que queremos reducir.
+
+No cambiar esta definición sin crear `useful_crawl_ratio_v2`.
+
+## Patrones
+
+Principales dimensiones de baja cardinalidad:
+
+- `home`, `home_param`
+- `libro`, `libro_variant`
+- `libros`, `libros_param`
+- `catalogo`, `catalogo_param`
+- `static_page`
+- `legacy_book`
+- `legacy_add_to_cart`
+- `legacy_producto`
+- `legacy_categoria_producto`
+- `legacy_pagination`
+- `legacy_root`
+- `api`, `sitemap`, `robots`, `asset`, `other`
+
+## Criterios de aceptación
+
+- IPv4 e IPv6 cubiertos por tests.
+- Un UA Googlebot con IP ajena a Google queda `verified=0`.
+- Flag apagado no toca D1 ni consulta rangos.
+- Cero path/IP/UA crudo en binds de D1.
+- `waitUntil()` es el único camino de escritura desde middleware.
+- Fallos del logger no cambian la respuesta al usuario.
+- `useful_crawl_ratio_v1` tiene tests de numerador/denominador.
+- Primer reporte real se revisa después de acumular 48 h de Producción.

--- a/functions/__tests__/crawl-analytics.test.js
+++ b/functions/__tests__/crawl-analytics.test.js
@@ -1,0 +1,193 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  USEFUL_CRAWL_RATIO_V1,
+  classifyCrawlRequest,
+  ipMatchesParsedRanges,
+  isUsefulRatioDenominator,
+  isUsefulRatioNumerator,
+  parseCidr,
+  recordCrawlRequest,
+  resetCrawlAnalyticsCachesForTest,
+  shouldCaptureCrawlRequest,
+} from '../_shared/crawl-analytics.js';
+
+const req = (path, headers = {}) => new Request(`https://www.amadolibros.com${path}`, { headers });
+
+function fakeKv(entries = {}) {
+  const map = new Map(Object.entries(entries));
+  return {
+    async get(key) { return map.get(key) ?? null; },
+    async put(key, value) { map.set(key, value); },
+    map,
+  };
+}
+
+function fakeDb() {
+  const calls = [];
+  return {
+    calls,
+    prepare(sql) {
+      return {
+        async run() {
+          calls.push({ sql, args: [] });
+          return { success: true };
+        },
+        bind(...args) {
+          return {
+            async run() {
+              calls.push({ sql, args });
+              return { success: true };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+test('CIDR soporta IPv4 e IPv6', () => {
+  const ranges = [
+    parseCidr('66.249.64.0/19'),
+    parseCidr('2001:4860:4801:10::/64'),
+  ];
+
+  assert.equal(ipMatchesParsedRanges('66.249.66.1', ranges), true);
+  assert.equal(ipMatchesParsedRanges('8.8.8.8', ranges), false);
+  assert.equal(ipMatchesParsedRanges('2001:4860:4801:10::1234', ranges), true);
+  assert.equal(ipMatchesParsedRanges('2001:4860:4801:11::1', ranges), false);
+  assert.equal(ipMatchesParsedRanges('ip-invalida', ranges), null);
+});
+
+test('clasifica URLs sin guardar el path como dimensión', () => {
+  assert.deepEqual(classifyCrawlRequest(req('/?book=MLU123')), {
+    pattern: 'legacy_book', legacy: true, contentPage: true, usefulCandidate: false,
+  });
+  assert.equal(classifyCrawlRequest(req('/page/94/?add-to-cart=1')).pattern, 'legacy_add_to_cart');
+  assert.equal(classifyCrawlRequest(req('/libro/MLU123/un-libro')).pattern, 'libro');
+  assert.equal(classifyCrawlRequest(req('/libros/psicologia?page=2')).pattern, 'libros');
+  assert.equal(classifyCrawlRequest(req('/catalogo?q=tarot')).pattern, 'catalogo_param');
+  assert.equal(classifyCrawlRequest(req('/_astro/app.abcdef.js')).pattern, 'asset');
+});
+
+test('captura siempre bots y legacy, pero solo 1% aproximado del resto', () => {
+  const normal = req('/contacto', { 'user-agent': 'Mozilla/5.0' });
+  const normalClass = classifyCrawlRequest(normal);
+  assert.equal(shouldCaptureCrawlRequest(normal, normalClass, () => 0.009), true);
+  assert.equal(shouldCaptureCrawlRequest(normal, normalClass, () => 0.5), false);
+
+  const bot = req('/contacto', { 'user-agent': 'Googlebot/2.1' });
+  assert.equal(shouldCaptureCrawlRequest(bot, classifyCrawlRequest(bot), () => 0.99), true);
+
+  const legacy = req('/page/94/', { 'user-agent': 'Mozilla/5.0' });
+  assert.equal(shouldCaptureCrawlRequest(legacy, classifyCrawlRequest(legacy), () => 0.99), true);
+});
+
+test('flag apagado corta antes de D1 y de verificar rangos', async () => {
+  resetCrawlAnalyticsCachesForTest();
+  const db = fakeDb();
+  let fetched = false;
+  const env = {
+    APP_ENV: 'production',
+    AMADO_KV: fakeKv({ 'seo:crawl-logs-3:enabled:production': 'false' }),
+    ORDERS_DB: db,
+  };
+  const result = await recordCrawlRequest({
+    request: req('/libro/MLU123/un-libro', {
+      'user-agent': 'Googlebot/2.1',
+      'cf-connecting-ip': '66.249.66.1',
+    }),
+    response: new Response('ok'),
+    env,
+  }, {
+    fetchFn: async () => { fetched = true; throw new Error('no debe llamarse'); },
+    nowFn: () => Date.parse('2026-08-08T13:00:00Z'),
+  });
+
+  assert.equal(result.recorded, false);
+  assert.equal(result.reason, 'disabled');
+  assert.equal(fetched, false);
+  assert.equal(db.calls.length, 0);
+});
+
+test('Googlebot verificado se agrega sin persistir IP, UA ni path crudos', async () => {
+  resetCrawlAnalyticsCachesForTest();
+  const db = fakeDb();
+  const kv = fakeKv({ 'seo:crawl-logs-3:enabled:production': 'true' });
+  const env = { APP_ENV: 'production', AMADO_KV: kv, ORDERS_DB: db };
+  const request = req('/libro/MLU123/un-libro', {
+    'user-agent': 'Mozilla/5.0 compatible; Googlebot/2.1; +http://www.google.com/bot.html',
+    'cf-connecting-ip': '66.249.66.1',
+  });
+
+  const result = await recordCrawlRequest({
+    request,
+    response: new Response('ok', { status: 200, headers: { 'content-length': '321' } }),
+    env,
+    durationMs: 12.5,
+  }, {
+    nowFn: () => Date.parse('2026-08-08T13:00:00Z'),
+    fetchFn: async () => new Response(JSON.stringify({
+      creationTime: '2026-08-08T00:00:00Z',
+      prefixes: [
+        { ipv4Prefix: '66.249.64.0/19' },
+        { ipv6Prefix: '2001:4860:4801:10::/64' },
+      ],
+    }), { status: 200 }),
+  });
+
+  assert.equal(result.recorded, true);
+  assert.equal(result.pattern, 'libro');
+  assert.equal(result.verified, 1);
+  assert.equal(result.usefulNumerator, true);
+  assert.equal(result.usefulDenominator, true);
+
+  const insert = db.calls.find(call => /INSERT INTO crawl_stats/.test(call.sql));
+  assert.ok(insert);
+  assert.deepEqual(insert.args.slice(0, 5), ['2026-08-08', 'libro', 200, 1, 1]);
+  const persisted = JSON.stringify(insert.args);
+  assert.equal(persisted.includes('66.249.66.1'), false);
+  assert.equal(persisted.includes('Googlebot'), false);
+  assert.equal(persisted.includes('/libro/MLU123/un-libro'), false);
+});
+
+test('UA Googlebot fuera de rangos oficiales queda no verificado', async () => {
+  resetCrawlAnalyticsCachesForTest();
+  const db = fakeDb();
+  const env = {
+    APP_ENV: 'production',
+    AMADO_KV: fakeKv({ 'seo:crawl-logs-3:enabled:production': 'true' }),
+    ORDERS_DB: db,
+  };
+  const result = await recordCrawlRequest({
+    request: req('/contacto', {
+      'user-agent': 'Googlebot/2.1',
+      'cf-connecting-ip': '8.8.8.8',
+    }),
+    response: new Response('ok', { status: 200 }),
+    env,
+  }, {
+    nowFn: () => Date.parse('2026-08-08T13:00:00Z'),
+    fetchFn: async () => new Response(JSON.stringify({ prefixes: [{ ipv4Prefix: '66.249.64.0/19' }] }), { status: 200 }),
+  });
+
+  assert.equal(result.verified, 0);
+  assert.equal(result.usefulNumerator, false);
+  assert.equal(result.usefulDenominator, false);
+});
+
+test('definición useful_crawl_ratio_v1 queda congelada y excluye infraestructura', () => {
+  assert.equal(USEFUL_CRAWL_RATIO_V1.version, 1);
+
+  const useful = classifyCrawlRequest(req('/contacto'));
+  assert.equal(isUsefulRatioNumerator({ classification: useful, status: 200, verified: 1 }), true);
+  assert.equal(isUsefulRatioDenominator({ classification: useful, verified: 1 }), true);
+
+  const legacy = classifyCrawlRequest(req('/page/94/'));
+  assert.equal(isUsefulRatioNumerator({ classification: legacy, status: 410, verified: 1 }), false);
+  assert.equal(isUsefulRatioDenominator({ classification: legacy, verified: 1 }), true);
+
+  const sitemap = classifyCrawlRequest(req('/sitemap.xml'));
+  assert.equal(isUsefulRatioDenominator({ classification: sitemap, verified: 1 }), false);
+});

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -10,6 +10,11 @@
  * - evita cadenas non-www -> www -> destino;
  * - no modifica URLs actuales salvo quitar el parámetro de presentación `layout`.
  *
+ * SEO-CRAWL-LOGS-3:
+ * - agenda observabilidad de crawl fuera del camino crítico con waitUntil();
+ * - nunca lee/bufferea el body de respuesta para medir bytes;
+ * - el flag, muestreo, verificación Googlebot y escritura D1 ocurren en background.
+ *
  * Además conserva las protecciones existentes de Preview y cache de assets Astro.
  */
 
@@ -17,17 +22,13 @@ import { perfNow } from './_shared/perf.js';
 import { BASE, fetchCatalog, fetchPausedItem } from './_shared/catalog.js';
 import { slugify } from './_shared/slug.js';
 import { goneResponse } from './_shared/gone.js';
+import { scheduleCrawlAnalytics } from './_shared/crawl-analytics.js';
 
 const LEGACY_ROOT_REDIRECTS = [
     { pattern: /^\/(?:shop|tienda|mas-vendidos)$/, destination: '/catalogo', name: 'legacy_root_catalog' },
     { pattern: /^\/my-orders$/, destination: '/contacto', name: 'legacy_my_orders' },
 ];
 
-/**
- * Mapa deliberadamente conservador: solo equivalencias inequívocas.
- * Los IDs SEO actuales se mapean a sí mismos; "novelas" es una equivalencia
- * histórica conocida; la categoría genérica WooCommerce apunta al catálogo.
- */
 export const LEGACY_CATEGORY_MAP = Object.freeze({
     'libros-revistas-y-comics': '/catalogo',
     'novelas': '/libros/literatura-ficcion',
@@ -90,11 +91,6 @@ function redirectFor(request, pattern, destination) {
     return response;
 }
 
-/**
- * Resuelve un MLU contra el mismo origen de datos usado por las fichas.
- * Si el catálogo activo falla, devolvemos "unavailable" para NO convertir una
- * caída transitoria de R2 en un 410 permanente.
- */
 async function lookupLegacyBook(context, id) {
     let catalog;
     try {
@@ -122,17 +118,12 @@ async function lookupLegacyBook(context, id) {
     return { state: 'missing' };
 }
 
-/**
- * Devuelve una respuesta solo cuando la request es legacy/normalizable.
- * `options.lookupBook` existe para tests y evita dependencias de red.
- */
 export async function legacyResponseForRequest(context, options = {}) {
     const request = context.request;
     const url = new URL(request.url);
     const path = withoutTrailingSlash(url.pathname);
     const lookupBook = options.lookupBook || lookupLegacyBook;
 
-    // 1) ?book=MLU tiene máxima prioridad: identifica exactamente una entidad.
     if (url.searchParams.has('book')) {
         const id = String(url.searchParams.get('book') || '').trim().toUpperCase();
         if (!/^MLU\d+$/.test(id)) return goneFor(request, 'query_book_invalid');
@@ -158,17 +149,14 @@ export async function legacyResponseForRequest(context, options = {}) {
         return redirectFor(request, 'query_book_resolved', destination);
     }
 
-    // 2) IDs WooCommerce sin mapping no pueden resolverse de forma segura.
     if (url.searchParams.has('add-to-cart')) {
         return goneFor(request, 'query_add_to_cart');
     }
 
-    // 3) Paginaciones históricas: no representan una página actual equivalente.
     if (/^\/(?:tienda|shop)\/page\/\d+$/.test(path) || /^\/page\/\d+$/.test(path)) {
         return goneFor(request, 'legacy_pagination');
     }
 
-    // 4) Categorías WooCommerce: raíz equivalente -> 301; paginación/resto -> 410.
     if (path === '/categoria-producto') {
         return redirectFor(request, 'legacy_category_root', '/catalogo');
     }
@@ -183,13 +171,11 @@ export async function legacyResponseForRequest(context, options = {}) {
         return goneFor(request, 'legacy_category_pagination_or_nested');
     }
 
-    // 5) Raíces legacy con reemplazo real.
     const rootRule = LEGACY_ROOT_REDIRECTS.find(({ pattern }) => pattern.test(path));
     if (rootRule) {
         return redirectFor(request, rootRule.name, rootRule.destination);
     }
 
-    // 6) `layout` solo cambia presentación: sobre una URL actual se elimina.
     if (url.searchParams.has('layout')) {
         const clean = new URL(url.toString());
         clean.searchParams.delete('layout');
@@ -215,29 +201,32 @@ export async function onRequest(context) {
     const isPreview = isPreviewUrl(url);
     const isHashedAstroAsset = /^\/_astro\/[^/]+\.[A-Za-z0-9_-]{6,}\.(?:css|js)$/.test(url.pathname);
 
-    // --- SEO-LEGACY-URL-CLEANUP-1: resolver antes del redirect de host ---
-    const legacyResponse = await legacyResponseForRequest(context);
-    if (legacyResponse) return legacyResponse;
+    const finish = response => {
+        if (!isHashedAstroAsset) {
+            scheduleCrawlAnalytics(context, response, perfNow() - workerStartedAt);
+        }
+        return response;
+    };
 
-    // --- Producción: redirect non-www → www ---
+    const legacyResponse = await legacyResponseForRequest(context);
+    if (legacyResponse) return finish(legacyResponse);
+
     if (!isPreview && url.hostname === 'amadolibros.com') {
         url.hostname = 'www.amadolibros.com';
-        return Response.redirect(url.toString(), 301);
+        return finish(Response.redirect(url.toString(), 301));
     }
 
-    // --- Preview: bloquear webhook Mercado Libre ---
     if (isPreview && url.pathname.startsWith('/api/webhooks/mercadolibre')) {
-        return new Response('Forbidden on preview', {
+        return finish(new Response('Forbidden on preview', {
             status: 403,
             headers: {
                 'Content-Type':  'text/plain; charset=utf-8',
                 'X-Robots-Tag':  'noindex, nofollow',
                 'Cache-Control': 'no-store',
             },
-        });
+        }));
     }
 
-    // --- Preview: inyectar noindex en todas las respuestas de functions ---
     if (isPreview) {
         const middlewareBeforeMs = perfNow() - workerStartedAt;
         const response = await context.next();
@@ -251,11 +240,11 @@ export async function onRequest(context) {
                 ? 'public, max-age=31536000, immutable'
                 : 'no-store',
         );
-        return new Response(response.body, {
+        return finish(new Response(response.body, {
             status:     response.status,
             statusText: response.statusText,
             headers:    newHeaders,
-        });
+        }));
     }
 
     if (isHashedAstroAsset) {
@@ -269,5 +258,5 @@ export async function onRequest(context) {
         });
     }
 
-    return context.next();
+    return finish(await context.next());
 }

--- a/functions/_shared/crawl-analytics.js
+++ b/functions/_shared/crawl-analytics.js
@@ -1,0 +1,384 @@
+const GOOGLE_COMMON_CRAWLERS_URL = 'https://developers.google.com/static/crawling/ipranges/common-crawlers.json';
+const GOOGLE_RANGES_KV_KEY = 'seo:crawl-logs-3:google-common-crawlers:v1';
+const FLAG_PREFIX = 'seo:crawl-logs-3:enabled:';
+const FLAG_CACHE_MS = 60_000;
+const RANGE_FRESH_MS = 24 * 60 * 60 * 1000;
+const ISOLATE_RANGE_CACHE_MS = 60 * 60 * 1000;
+const SAMPLE_RATE = 0.01;
+
+export const USEFUL_CRAWL_RATIO_V1 = Object.freeze({
+  version: 1,
+  numerator: 'verified Googlebot requests with HTTP 200 whose pattern is one of: home, libro, libros, catalogo, static_page',
+  denominator: 'all verified Googlebot requests classified as content pages; excludes asset, api, sitemap and robots',
+});
+
+const USEFUL_PATTERNS = new Set(['home', 'libro', 'libros', 'catalogo', 'static_page']);
+const DENOMINATOR_EXCLUDED = new Set(['asset', 'api', 'sitemap', 'robots']);
+const STATIC_USEFUL_PATHS = new Set([
+  '/contacto',
+  '/politicas',
+  '/envios',
+  '/devoluciones',
+  '/terminos',
+  '/privacidad',
+  '/libros-maria-montessori-uruguay',
+]);
+
+let flagCache = new Map();
+let rangeCache = null;
+let schemaReadyPromise = null;
+
+function appEnv(env) {
+  return String(env?.APP_ENV || 'unknown').toLowerCase();
+}
+
+function flagKey(env) {
+  return `${FLAG_PREFIX}${appEnv(env)}`;
+}
+
+function isBotLikeUa(ua) {
+  return /(bot|crawler|spider|slurp|bingpreview|google-inspectiontool)/i.test(ua || '');
+}
+
+export function isGooglebotUa(ua) {
+  return /Googlebot/i.test(ua || '');
+}
+
+function onlyAllowedPageParam(url) {
+  const keys = [...url.searchParams.keys()];
+  if (keys.length === 0) return true;
+  return keys.every(key => key === 'page') && /^\d+$/.test(url.searchParams.get('page') || '');
+}
+
+function hasAnyQuery(url) {
+  return [...url.searchParams.keys()].length > 0;
+}
+
+export function classifyCrawlRequest(request) {
+  const url = new URL(request.url);
+  const path = url.pathname.replace(/\/+$/, '') || '/';
+
+  if (/^\/_astro\//.test(path) || /\.(?:css|js|mjs|map|png|jpe?g|gif|svg|webp|ico|woff2?|ttf|otf)$/i.test(path)) {
+    return { pattern: 'asset', legacy: false, contentPage: false, usefulCandidate: false };
+  }
+  if (path === '/robots.txt') {
+    return { pattern: 'robots', legacy: false, contentPage: false, usefulCandidate: false };
+  }
+  if (/^\/sitemap(?:[-./]|$)/.test(path) || path === '/sitemap.xml') {
+    return { pattern: 'sitemap', legacy: false, contentPage: false, usefulCandidate: false };
+  }
+  if (/^\/api(?:\/|$)/.test(path)) {
+    return { pattern: 'api', legacy: false, contentPage: false, usefulCandidate: false };
+  }
+
+  if (url.searchParams.has('book')) {
+    return { pattern: 'legacy_book', legacy: true, contentPage: true, usefulCandidate: false };
+  }
+  if (url.searchParams.has('add-to-cart')) {
+    return { pattern: 'legacy_add_to_cart', legacy: true, contentPage: true, usefulCandidate: false };
+  }
+  if (/^\/producto(?:\/|$)/.test(path)) {
+    return { pattern: 'legacy_producto', legacy: true, contentPage: true, usefulCandidate: false };
+  }
+  if (/^\/categoria-producto(?:\/|$)/.test(path)) {
+    return { pattern: 'legacy_categoria_producto', legacy: true, contentPage: true, usefulCandidate: false };
+  }
+  if (/^\/(?:page\/\d+|(?:tienda|shop)\/page\/\d+)$/.test(path)) {
+    return { pattern: 'legacy_pagination', legacy: true, contentPage: true, usefulCandidate: false };
+  }
+  if (/^\/(?:shop|tienda|mas-vendidos|my-orders)$/.test(path)) {
+    return { pattern: 'legacy_root', legacy: true, contentPage: true, usefulCandidate: false };
+  }
+
+  if (path === '/') {
+    return { pattern: hasAnyQuery(url) ? 'home_param' : 'home', legacy: false, contentPage: true, usefulCandidate: !hasAnyQuery(url) };
+  }
+  if (/^\/libro\/MLU\d+\/[^/]+$/i.test(path) && !hasAnyQuery(url)) {
+    return { pattern: 'libro', legacy: false, contentPage: true, usefulCandidate: true };
+  }
+  if (/^\/libro(?:\/|$)/i.test(path)) {
+    return { pattern: 'libro_variant', legacy: false, contentPage: true, usefulCandidate: false };
+  }
+  if (/^\/libros\/[^/]+$/i.test(path) && onlyAllowedPageParam(url)) {
+    return { pattern: 'libros', legacy: false, contentPage: true, usefulCandidate: true };
+  }
+  if (/^\/libros(?:\/|$)/i.test(path)) {
+    return { pattern: 'libros_param', legacy: false, contentPage: true, usefulCandidate: false };
+  }
+  if (path === '/catalogo') {
+    return { pattern: hasAnyQuery(url) ? 'catalogo_param' : 'catalogo', legacy: false, contentPage: true, usefulCandidate: !hasAnyQuery(url) };
+  }
+  if (STATIC_USEFUL_PATHS.has(path) && !hasAnyQuery(url)) {
+    return { pattern: 'static_page', legacy: false, contentPage: true, usefulCandidate: true };
+  }
+  return { pattern: 'other', legacy: false, contentPage: true, usefulCandidate: false };
+}
+
+export function shouldCaptureCrawlRequest(request, classification, randomFn = Math.random) {
+  const ua = request.headers.get('user-agent') || '';
+  if (classification.pattern === 'asset') return false;
+  if (classification.legacy) return true;
+  if (isBotLikeUa(ua)) return true;
+  return randomFn() < SAMPLE_RATE;
+}
+
+function ipv4ToBigInt(value) {
+  const parts = String(value || '').split('.');
+  if (parts.length !== 4) return null;
+  let out = 0n;
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) return null;
+    const n = Number(part);
+    if (!Number.isInteger(n) || n < 0 || n > 255) return null;
+    out = (out << 8n) | BigInt(n);
+  }
+  return out;
+}
+
+function normalizeIpv6WithEmbeddedIpv4(value) {
+  const input = String(value || '').toLowerCase();
+  if (!input.includes('.')) return input;
+  const lastColon = input.lastIndexOf(':');
+  if (lastColon < 0) return input;
+  const ipv4 = ipv4ToBigInt(input.slice(lastColon + 1));
+  if (ipv4 == null) return input;
+  const high = Number((ipv4 >> 16n) & 0xffffn).toString(16);
+  const low = Number(ipv4 & 0xffffn).toString(16);
+  return `${input.slice(0, lastColon)}:${high}:${low}`;
+}
+
+function ipv6ToBigInt(value) {
+  const input = normalizeIpv6WithEmbeddedIpv4(value);
+  if (!input || input.includes(':::')) return null;
+  const split = input.split('::');
+  if (split.length > 2) return null;
+  const head = split[0] ? split[0].split(':').filter(Boolean) : [];
+  const tail = split.length === 2 && split[1] ? split[1].split(':').filter(Boolean) : [];
+  let fill = 0;
+  if (split.length === 2) fill = 8 - head.length - tail.length;
+  else if (head.length !== 8) return null;
+  if (fill < 0) return null;
+  const parts = [...head, ...Array(fill).fill('0'), ...tail];
+  if (parts.length !== 8) return null;
+  let out = 0n;
+  for (const part of parts) {
+    if (!/^[0-9a-f]{1,4}$/i.test(part)) return null;
+    out = (out << 16n) | BigInt(parseInt(part, 16));
+  }
+  return out;
+}
+
+export function parseIp(value) {
+  const text = String(value || '').trim();
+  if (!text) return null;
+  if (text.includes(':')) {
+    const number = ipv6ToBigInt(text);
+    return number == null ? null : { family: 6, number, bits: 128 };
+  }
+  const number = ipv4ToBigInt(text);
+  return number == null ? null : { family: 4, number, bits: 32 };
+}
+
+export function parseCidr(cidr) {
+  const [address, prefixRaw] = String(cidr || '').split('/');
+  const ip = parseIp(address);
+  const prefix = Number(prefixRaw);
+  if (!ip || !Number.isInteger(prefix) || prefix < 0 || prefix > ip.bits) return null;
+  const shift = BigInt(ip.bits - prefix);
+  const network = shift === 0n ? ip.number : (ip.number >> shift) << shift;
+  return { family: ip.family, prefix, bits: ip.bits, network };
+}
+
+export function ipMatchesParsedRanges(ipText, ranges) {
+  const ip = parseIp(ipText);
+  if (!ip) return null;
+  for (const range of ranges || []) {
+    if (!range || range.family !== ip.family) continue;
+    const shift = BigInt(ip.bits - range.prefix);
+    if ((ip.number >> shift) === (range.network >> shift)) return true;
+  }
+  return false;
+}
+
+function parseGoogleRangesPayload(payload) {
+  const ranges = [];
+  for (const prefix of payload?.prefixes || []) {
+    const cidr = prefix.ipv4Prefix || prefix.ipv6Prefix;
+    const parsed = parseCidr(cidr);
+    if (parsed) ranges.push(parsed);
+  }
+  return ranges;
+}
+
+async function getFlag(env, nowMs) {
+  const key = flagKey(env);
+  const cached = flagCache.get(key);
+  if (cached && cached.expiresAt > nowMs) return cached.enabled;
+  if (!env?.AMADO_KV || typeof env.AMADO_KV.get !== 'function') return false;
+  const raw = await env.AMADO_KV.get(key);
+  const enabled = String(raw || '').toLowerCase() === 'true';
+  flagCache.set(key, { enabled, expiresAt: nowMs + FLAG_CACHE_MS });
+  return enabled;
+}
+
+async function loadGoogleRanges(env, nowMs, fetchFn) {
+  if (rangeCache && rangeCache.expiresAt > nowMs) return rangeCache.ranges;
+
+  let stored = null;
+  if (env?.AMADO_KV && typeof env.AMADO_KV.get === 'function') {
+    try {
+      const raw = await env.AMADO_KV.get(GOOGLE_RANGES_KV_KEY);
+      if (raw) stored = JSON.parse(raw);
+    } catch {
+      stored = null;
+    }
+  }
+
+  const storedFetchedAt = Date.parse(stored?.fetchedAt || '');
+  const storedFresh = Number.isFinite(storedFetchedAt) && (nowMs - storedFetchedAt) < RANGE_FRESH_MS;
+  if (storedFresh && stored?.payload) {
+    const ranges = parseGoogleRangesPayload(stored.payload);
+    rangeCache = { ranges, expiresAt: nowMs + ISOLATE_RANGE_CACHE_MS };
+    return ranges;
+  }
+
+  try {
+    const response = await fetchFn(GOOGLE_COMMON_CRAWLERS_URL, { headers: { accept: 'application/json' } });
+    if (!response.ok) throw new Error(`Google ranges HTTP ${response.status}`);
+    const payload = await response.json();
+    const ranges = parseGoogleRangesPayload(payload);
+    if (!ranges.length) throw new Error('Google ranges payload vacío');
+    if (env?.AMADO_KV && typeof env.AMADO_KV.put === 'function') {
+      await env.AMADO_KV.put(GOOGLE_RANGES_KV_KEY, JSON.stringify({ fetchedAt: new Date(nowMs).toISOString(), payload }));
+    }
+    rangeCache = { ranges, expiresAt: nowMs + ISOLATE_RANGE_CACHE_MS };
+    return ranges;
+  } catch (error) {
+    if (stored?.payload) {
+      const ranges = parseGoogleRangesPayload(stored.payload);
+      if (ranges.length) {
+        rangeCache = { ranges, expiresAt: nowMs + 5 * 60 * 1000 };
+        return ranges;
+      }
+    }
+    console.warn('[SEO-CRAWL-LOGS-3] No se pudieron cargar rangos Google:', error?.message || error);
+    return null;
+  }
+}
+
+async function verifyGooglebot(request, env, nowMs, fetchFn) {
+  const ua = request.headers.get('user-agent') || '';
+  if (!isGooglebotUa(ua)) return -1;
+  const ip = request.headers.get('cf-connecting-ip');
+  if (!ip) return -2;
+  const ranges = await loadGoogleRanges(env, nowMs, fetchFn);
+  if (!ranges) return -2;
+  const match = ipMatchesParsedRanges(ip, ranges);
+  return match == null ? -2 : (match ? 1 : 0);
+}
+
+async function ensureSchema(db) {
+  if (!db || typeof db.prepare !== 'function') return false;
+  if (!schemaReadyPromise) {
+    schemaReadyPromise = (async () => {
+      await db.prepare(`CREATE TABLE IF NOT EXISTS crawl_stats (
+        date TEXT NOT NULL,
+        pattern TEXT NOT NULL,
+        status INTEGER NOT NULL,
+        verified INTEGER NOT NULL,
+        ua_googlebot INTEGER NOT NULL,
+        request_count INTEGER NOT NULL DEFAULT 0,
+        bytes_sum INTEGER NOT NULL DEFAULT 0,
+        bytes_known_count INTEGER NOT NULL DEFAULT 0,
+        duration_ms_sum REAL NOT NULL DEFAULT 0,
+        PRIMARY KEY (date, pattern, status, verified, ua_googlebot)
+      )`).run();
+      return true;
+    })().catch(error => {
+      schemaReadyPromise = null;
+      throw error;
+    });
+  }
+  return schemaReadyPromise;
+}
+
+function knownContentLength(response) {
+  const raw = response.headers.get('content-length');
+  if (!raw || !/^\d+$/.test(raw)) return { bytes: 0, known: 0 };
+  const bytes = Number(raw);
+  return Number.isSafeInteger(bytes) && bytes >= 0 ? { bytes, known: 1 } : { bytes: 0, known: 0 };
+}
+
+export function isUsefulRatioNumerator({ classification, status, verified }) {
+  return verified === 1 && status === 200 && classification.usefulCandidate && USEFUL_PATTERNS.has(classification.pattern);
+}
+
+export function isUsefulRatioDenominator({ classification, verified }) {
+  return verified === 1 && classification.contentPage && !DENOMINATOR_EXCLUDED.has(classification.pattern);
+}
+
+export async function recordCrawlRequest({ request, response, env, durationMs = 0 }, deps = {}) {
+  const nowFn = deps.nowFn || Date.now;
+  const fetchFn = deps.fetchFn || fetch;
+  const randomFn = deps.randomFn || Math.random;
+  const nowMs = nowFn();
+
+  if (!(await getFlag(env, nowMs))) return { recorded: false, reason: 'disabled' };
+  if (!env?.ORDERS_DB) return { recorded: false, reason: 'db_unavailable' };
+
+  const classification = classifyCrawlRequest(request);
+  if (!shouldCaptureCrawlRequest(request, classification, randomFn)) {
+    return { recorded: false, reason: 'not_sampled' };
+  }
+
+  const ua = request.headers.get('user-agent') || '';
+  const uaGooglebot = isGooglebotUa(ua) ? 1 : 0;
+  const verified = await verifyGooglebot(request, env, nowMs, fetchFn);
+  const { bytes, known } = knownContentLength(response);
+  const date = new Date(nowMs).toISOString().slice(0, 10);
+  const safeDuration = Number.isFinite(Number(durationMs)) ? Math.max(0, Number(durationMs)) : 0;
+
+  await ensureSchema(env.ORDERS_DB);
+  await env.ORDERS_DB.prepare(`INSERT INTO crawl_stats
+    (date, pattern, status, verified, ua_googlebot, request_count, bytes_sum, bytes_known_count, duration_ms_sum)
+    VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?)
+    ON CONFLICT(date, pattern, status, verified, ua_googlebot)
+    DO UPDATE SET
+      request_count = request_count + 1,
+      bytes_sum = bytes_sum + excluded.bytes_sum,
+      bytes_known_count = bytes_known_count + excluded.bytes_known_count,
+      duration_ms_sum = duration_ms_sum + excluded.duration_ms_sum`).bind(
+        date,
+        classification.pattern,
+        response.status,
+        verified,
+        uaGooglebot,
+        bytes,
+        known,
+        safeDuration,
+      ).run();
+
+  return {
+    recorded: true,
+    pattern: classification.pattern,
+    verified,
+    uaGooglebot,
+    usefulNumerator: isUsefulRatioNumerator({ classification, status: response.status, verified }),
+    usefulDenominator: isUsefulRatioDenominator({ classification, verified }),
+  };
+}
+
+export function scheduleCrawlAnalytics(context, response, durationMs = 0) {
+  if (!context || typeof context.waitUntil !== 'function') return;
+  if (!context.request || !context.env) return;
+  context.waitUntil(
+    recordCrawlRequest({ request: context.request, response, env: context.env, durationMs })
+      .catch(error => console.warn('[SEO-CRAWL-LOGS-3] logging falló:', error?.message || error)),
+  );
+}
+
+export function resetCrawlAnalyticsCachesForTest() {
+  flagCache = new Map();
+  rangeCache = null;
+  schemaReadyPromise = null;
+}

--- a/migrations/0004_crawl_stats.sql
+++ b/migrations/0004_crawl_stats.sql
@@ -1,0 +1,18 @@
+-- SEO-CRAWL-LOGS-3
+-- Agregación diaria de observabilidad de crawl.
+-- No guarda IP, user-agent ni path/URL crudos.
+-- El middleware también ejecuta CREATE TABLE IF NOT EXISTS en background
+-- para que el rollout no dependa de aplicar esta migración antes del deploy.
+
+CREATE TABLE IF NOT EXISTS crawl_stats (
+    date TEXT NOT NULL,
+    pattern TEXT NOT NULL,
+    status INTEGER NOT NULL,
+    verified INTEGER NOT NULL,
+    ua_googlebot INTEGER NOT NULL,
+    request_count INTEGER NOT NULL DEFAULT 0,
+    bytes_sum INTEGER NOT NULL DEFAULT 0,
+    bytes_known_count INTEGER NOT NULL DEFAULT 0,
+    duration_ms_sum REAL NOT NULL DEFAULT 0,
+    PRIMARY KEY (date, pattern, status, verified, ua_googlebot)
+);

--- a/scripts/seo/crawl-report.mjs
+++ b/scripts/seo/crawl-report.mjs
@@ -1,0 +1,118 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const INPUT = process.env.CRAWL_REPORT_INPUT || 'artifacts/seo/crawl-stats-raw.json';
+const OUTPUT_DIR = process.env.CRAWL_REPORT_OUTPUT_DIR || 'artifacts/seo';
+const USEFUL_PATTERNS = new Set(['home', 'libro', 'libros', 'catalogo', 'static_page']);
+const EXCLUDED_FROM_DENOMINATOR = new Set(['asset', 'api', 'sitemap', 'robots']);
+
+function rowsFromWrangler(payload) {
+  if (Array.isArray(payload)) {
+    return payload.flatMap(entry => Array.isArray(entry?.results) ? entry.results : []);
+  }
+  return Array.isArray(payload?.results) ? payload.results : [];
+}
+
+function number(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function aggregate(rows) {
+  const byDate = new Map();
+  for (const row of rows) {
+    const date = String(row.date || 'unknown');
+    if (!byDate.has(date)) {
+      byDate.set(date, {
+        date,
+        verifiedGooglebotRequests: 0,
+        usefulNumerator: 0,
+        usefulDenominator: 0,
+        legacyRequests: 0,
+        byPattern: {},
+        byStatus: {},
+      });
+    }
+    const day = byDate.get(date);
+    const count = number(row.request_count);
+    const verified = number(row.verified);
+    const status = number(row.status);
+    const pattern = String(row.pattern || 'other');
+
+    day.byPattern[pattern] = (day.byPattern[pattern] || 0) + count;
+    day.byStatus[status] = (day.byStatus[status] || 0) + count;
+    if (pattern.startsWith('legacy_')) day.legacyRequests += count;
+
+    if (verified === 1) {
+      day.verifiedGooglebotRequests += count;
+      const inDenominator = !EXCLUDED_FROM_DENOMINATOR.has(pattern);
+      if (inDenominator) day.usefulDenominator += count;
+      if (status === 200 && USEFUL_PATTERNS.has(pattern)) day.usefulNumerator += count;
+    }
+  }
+
+  const daily = [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+  for (const day of daily) {
+    day.usefulCrawlRatioV1 = day.usefulDenominator
+      ? Number((day.usefulNumerator / day.usefulDenominator).toFixed(6))
+      : null;
+  }
+
+  const total = daily.reduce((acc, day) => {
+    acc.verifiedGooglebotRequests += day.verifiedGooglebotRequests;
+    acc.usefulNumerator += day.usefulNumerator;
+    acc.usefulDenominator += day.usefulDenominator;
+    acc.legacyRequests += day.legacyRequests;
+    return acc;
+  }, { verifiedGooglebotRequests: 0, usefulNumerator: 0, usefulDenominator: 0, legacyRequests: 0 });
+  total.usefulCrawlRatioV1 = total.usefulDenominator
+    ? Number((total.usefulNumerator / total.usefulDenominator).toFixed(6))
+    : null;
+
+  return { daily, total };
+}
+
+function csv(daily) {
+  const lines = ['date,verified_googlebot_requests,useful_numerator,useful_denominator,useful_crawl_ratio_v1,legacy_requests'];
+  for (const day of daily) {
+    lines.push([
+      day.date,
+      day.verifiedGooglebotRequests,
+      day.usefulNumerator,
+      day.usefulDenominator,
+      day.usefulCrawlRatioV1 ?? '',
+      day.legacyRequests,
+    ].join(','));
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+async function main() {
+  const payload = JSON.parse(await readFile(INPUT, 'utf8'));
+  const rows = rowsFromWrangler(payload);
+  const { daily, total } = aggregate(rows);
+  const report = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    metric: {
+      name: 'useful_crawl_ratio_v1',
+      numerator: 'verified=1 AND status=200 AND pattern IN (home, libro, libros, catalogo, static_page)',
+      denominator: 'verified=1 AND pattern NOT IN (asset, api, sitemap, robots)',
+    },
+    rowCount: rows.length,
+    total,
+    daily,
+  };
+
+  await mkdir(OUTPUT_DIR, { recursive: true });
+  await Promise.all([
+    writeFile(path.join(OUTPUT_DIR, 'crawl-summary.json'), `${JSON.stringify(report, null, 2)}\n`),
+    writeFile(path.join(OUTPUT_DIR, 'crawl-daily.csv'), csv(daily)),
+  ]);
+  console.log(JSON.stringify(total));
+}
+
+main().catch(error => {
+  console.error(error.stack || error.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Objetivo

Instrumentar observabilidad de crawl después de SEO-LEGACY-URL-CLEANUP-1 sin bloquear respuestas ni almacenar datos crudos.

## Implementación

- opción B: bots + todo legacy + muestra 1% del resto no-asset;
- verificación Googlebot = UA Googlebot + IP en rangos oficiales `common-crawlers.json`;
- CIDR IPv4/IPv6 con parseo cacheado por isolate;
- última copia válida de rangos guardada en KV con refresh lógico 24 h y fallback;
- kill switch por entorno en KV, apagado por defecto;
- todo el trabajo de flag/verificación/D1 dentro de `waitUntil()`;
- nunca clona/lee/bufferea el body para analytics;
- D1 sólo guarda agregados por fecha/patrón/status/verificación, sin IP/UA/path/MLU/query;
- schema versionado en `migrations/0004_crawl_stats.sql` y creado idempotentemente en background;
- `useful_crawl_ratio_v1` congelado y documentado;
- workflow manual para prender/apagar el flag;
- workflow + script para generar el reporte agregado de 48 h.

## Métrica v1

Numerador: Googlebot verificado + HTTP 200 + `home|libro|libros|catalogo|static_page`.

Denominador: Googlebot verificado sobre páginas de contenido; excluye `asset|api|sitemap|robots`. Legacy, parámetros, variantes y `other` permanecen en el denominador.

## Seguridad / rollback

- flag ausente o distinto de `true` = logger apagado;
- fallos de observabilidad no alteran la respuesta al usuario;
- no hay paths, IPs ni UA crudos en D1;
- no modifica lógica comercial, sitemap, contenido ni redirects de #76.

## Validación esperada

Tests para IPv4/IPv6, spoof de Googlebot, flag apagado, muestreo, clasificación y ausencia de datos crudos en binds D1. Queda draft hasta CI verde.