### PR TITLE
CATALOG-IDENTITY-1: preserve Mercado Libre catalog signals

### DIFF
--- a/worker-sync/__tests__/meli-catalog.test.js
+++ b/worker-sync/__tests__/meli-catalog.test.js
@@ -43,6 +43,7 @@ test('sincroniza activos y pausados, y conserva la guarda sobre disponibles', as
         body: {
           id: 'MLU1', title: 'Disponible', price: 1000, status: 'active',
           available_quantity: 2, attributes: [], pictures: [],
+          catalog_listing: false, catalog_product_id: 'MLU-P1',
         },
       },
       {
@@ -62,8 +63,12 @@ test('sincroniza activos y pausados, y conserva la guarda sobre disponibles', as
     assert.equal(catalog.active_total, 1);
     assert.equal(catalog.order_total, 1);
     assert.deepEqual(catalog.items.map(item => item.status), ['active', 'paused']);
+    assert.equal(catalog.items[0].catalog_listing, false);
+    assert.equal(catalog.items[0].catalog_product_id, 'MLU-P1');
     assert.ok(urls.some(url => url.includes('status=active')));
     assert.ok(urls.some(url => url.includes('status=paused')));
+    assert.ok(urls.some(url => url.includes('catalog_listing')));
+    assert.ok(urls.some(url => url.includes('catalog_product_id')));
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -367,6 +372,24 @@ test('slimItem conserva la publicación cuando descarta sus medidas inválidas',
   assert.equal(item.dimensions, null);
   assert.equal(quality.omitted_dimension_fields, 1);
   assert.equal(quality.omitted_weight_fields, 1);
+});
+
+test('slimItem conserva identidad de catálogo ML sin inventar señales ausentes', () => {
+  const catalogListing = slimItem({
+    id: 'MLU10',
+    catalog_listing: true,
+    catalog_product_id: '  MLU-P123  ',
+  });
+  assert.equal(catalogListing.catalog_listing, true);
+  assert.equal(catalogListing.catalog_product_id, 'MLU-P123');
+
+  const traditional = slimItem({ id: 'MLU11', catalog_listing: false });
+  assert.equal(traditional.catalog_listing, false);
+  assert.equal(traditional.catalog_product_id, null);
+
+  const unknown = slimItem({ id: 'MLU12', catalog_listing: 'false', catalog_product_id: '' });
+  assert.equal(unknown.catalog_listing, null);
+  assert.equal(unknown.catalog_product_id, null);
 });
 
 // ── CF-R2-2-BRIDGE: publicación productiva del catálogo pausado ─────────────

--- a/worker-sync/meli-catalog.js
+++ b/worker-sync/meli-catalog.js
@@ -15,7 +15,8 @@
  *     updated_at: ISO string,
  *     items: [{
  *       id, title, author, price, status, available_quantity,
- *       thumbnail, pictures, permalink, start_time
+ *       thumbnail, pictures, permalink, start_time,
+ *       catalog_listing, catalog_product_id
  *     }]
  *   }
  *
@@ -30,7 +31,7 @@ const SCROLL_SLEEP_MS  = 350;  // delay entre páginas de scroll (cortesía ML)
 const DETAIL_SLEEP_MS  = 250;  // delay entre batches de detalles
 const DETAIL_BATCH     = 20;   // ML multi-get soporta hasta 20 ids por request
 const ML_ATTRIBUTES    =       // campos que necesita slim_item + AUTHOR + enriched fields
-  'id,title,price,status,available_quantity,thumbnail,pictures,permalink,start_time,attributes,condition';
+  'id,title,price,status,available_quantity,thumbnail,pictures,permalink,start_time,attributes,condition,catalog_listing,catalog_product_id';
 
 export const ML_MAX_RETRIES = 6;
 export const ML_BASE_BACKOFF_MS = 1000;
@@ -202,7 +203,7 @@ async function fetchDetails(ids, accessToken, retryBudget, mlGetDeps = {}) {
 /**
  * Devuelve solo los campos que consumen los SSR de Pages (catalogo.js,
  * libro/[[path]].js, sitemap.xml.js, feed.xml.js, /api/catalog).
- * Versión enriquecida: incluye pictures[], isbn, publisher, pages, dimensions, condition.
+ * Versión enriquecida: incluye pictures[], ISBN, datos bibliográficos e identidad de catálogo ML.
  */
 export function slimItem(raw, dataQuality = createDataQualitySummary()) {
   const attrs = raw.attributes || [];
@@ -218,6 +219,10 @@ export function slimItem(raw, dataQuality = createDataQualitySummary()) {
     pictures:           normalizePictures(raw.pictures),
     permalink:          raw.permalink    || null,
     start_time:         raw.start_time   || null,
+    catalog_listing:    typeof raw.catalog_listing === 'boolean' ? raw.catalog_listing : null,
+    catalog_product_id: typeof raw.catalog_product_id === 'string' && raw.catalog_product_id.trim()
+      ? raw.catalog_product_id.trim()
+      : null,
     isbn:               extractIsbn(attrs),
     publisher:          extractPublisher(attrs),
     pages:              extractPages(attrs),


### PR DESCRIPTION
## Objetivo
Conservar en el catálogo sincronizado las dos señales oficiales de identidad de Mercado Libre necesarias para medir publicaciones tradicionales vs catálogo.

## Cambio
- solicita `catalog_listing` y `catalog_product_id` en el multi-get de items;
- conserva `catalog_listing` sólo cuando Mercado Libre devuelve un booleano real;
- conserva `catalog_product_id` sólo cuando devuelve una cadena no vacía;
- usa `null` ante señal ausente o inválida, sin inferir;
- no oculta, agrupa ni modifica ningún producto.

## Evidencia previa
El auditor #89 midió 211 grupos ISBN estrictos y encontró 211/211 con identidad de catálogo incompleta porque el sync actual descartaba estos campos.

## Validación
- bloque afectado: 16/16;
- suite completa: todos los bloques verdes, incluido 223/223 en el bloque final;
- sintaxis y `git diff --check`: OK;
- build Astro checkout OFF: OK;
- build Astro checkout ON: OK.

## Alcance operativo
Este PR no ejecuta un sync, no escribe R2, no cambia HTML/SEO/checkout y no toca Producción. Tras aprobación futura, el dato aparecerá en el siguiente sync y recién entonces se repetirá el auditor #89.