### PR TITLE
COVER-R2-PILOT-1: copiar 20 portadas en R2 Preview

### DIFF
--- a/.github/workflows/deploy-cover-r2-pilot-preview.yml
+++ b/.github/workflows/deploy-cover-r2-pilot-preview.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   group: deploy-cover-r2-pilot-preview
@@ -96,20 +95,36 @@ jobs:
         run: |
           echo "Esperando propagación del Worker Preview..."
           sleep 10
-          STATUS_CODE="$(curl -sS --max-time 30 -o /tmp/cover-pilot-before.json -w '%{http_code}' \
-            "$PILOT_URL/status" \
-            -H "Authorization: Bearer $COVER_PILOT_SECRET")"
+          STATUS_CODE=""
+          for attempt in 1 2 3 4 5 6; do
+            STATUS_CODE="$(curl -sS --max-time 30 -o /tmp/cover-pilot-before.json -w '%{http_code}' \
+              "$PILOT_URL/status" \
+              -H "Authorization: Bearer $COVER_PILOT_SECRET")"
+            if [ "$STATUS_CODE" != "401" ]; then
+              break
+            fi
+            echo "Secret todavía propagándose para status inicial (intento $attempt/6); espero 10 s."
+            sleep 10
+          done
           if [ "$STATUS_CODE" != "200" ]; then
             echo "Status inicial respondió HTTP $STATUS_CODE."
             cat /tmp/cover-pilot-before.json
             exit 1
           fi
 
-          IMPORT_CODE="$(curl -sS --max-time 300 -o /tmp/cover-pilot-import.json -w '%{http_code}' \
-            -X POST "$PILOT_URL/import" \
-            -H "Authorization: Bearer $COVER_PILOT_SECRET" \
-            -H 'Content-Type: application/json' \
-            --data-binary @/tmp/cover-pilot-payload.json)"
+          IMPORT_CODE=""
+          for attempt in 1 2 3 4 5 6; do
+            IMPORT_CODE="$(curl -sS --max-time 300 -o /tmp/cover-pilot-import.json -w '%{http_code}' \
+              -X POST "$PILOT_URL/import" \
+              -H "Authorization: Bearer $COVER_PILOT_SECRET" \
+              -H 'Content-Type: application/json' \
+              --data-binary @/tmp/cover-pilot-payload.json)"
+            if [ "$IMPORT_CODE" != "401" ]; then
+              break
+            fi
+            echo "Secret todavía propagándose (intento $attempt/6); espero 10 s."
+            sleep 10
+          done
           cat /tmp/cover-pilot-import.json
           if [ "$IMPORT_CODE" != "200" ]; then
             echo "Import respondió HTTP $IMPORT_CODE."
@@ -117,39 +132,20 @@ jobs:
           fi
           node -e "const r=require('/tmp/cover-pilot-import.json'); if(r.attempted!==20||r.failed!==0) process.exit(1); console.log('Import real: 20/20 sin fallos.');"
 
-          curl -fsS --max-time 30 "$PILOT_URL/status" \
-            -H "Authorization: Bearer $COVER_PILOT_SECRET" \
-            -o /tmp/cover-pilot-after.json
+          AFTER_CODE=""
+          for attempt in 1 2 3 4 5 6; do
+            AFTER_CODE="$(curl -sS --max-time 30 -o /tmp/cover-pilot-after.json -w '%{http_code}' \
+              "$PILOT_URL/status" \
+              -H "Authorization: Bearer $COVER_PILOT_SECRET")"
+            if [ "$AFTER_CODE" != "401" ]; then
+              break
+            fi
+            echo "Secret todavía propagándose para status (intento $attempt/6); espero 10 s."
+            sleep 10
+          done
           cat /tmp/cover-pilot-after.json
+          if [ "$AFTER_CODE" != "200" ]; then
+            echo "Status final respondió HTTP $AFTER_CODE."
+            exit 1
+          fi
           node -e "const s=require('/tmp/cover-pilot-after.json'); if(s.manifest.with_valid_copy!==20) process.exit(1); console.log('Manifest verificado: 20 copias válidas.');"
-
-  report:
-    if: always()
-    needs: [guard, validate, deploy]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Publish durable pilot result on PR 99
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const result = '${{ needs.deploy.result }}';
-            const succeeded = result === 'success';
-            const headSha = context.payload.pull_request.head.sha;
-            const body = [
-              `### COVER-R2-PILOT — ${succeeded ? '20/20 CONFIRMADO' : 'NO CONFIRMADO'}`,
-              '',
-              `- Commit: \`${headSha}\``,
-              `- Deploy/aceptación: **${result}**`,
-              `- Run: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              succeeded
-                ? '- El workflow desplegó el Worker Preview y verificó 20 copias válidas en el manifest.'
-                : '- Revisar el paso fallido del run. No reintentar hasta identificar la causa.',
-              '',
-              'Producción y `amadolibros-catalog` no fueron modificados.',
-            ].join('\n');
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: 99,
-              body,
-            });

--- a/.github/workflows/deploy-cover-r2-pilot-preview.yml
+++ b/.github/workflows/deploy-cover-r2-pilot-preview.yml
@@ -1,0 +1,65 @@
+name: Deploy Cover R2 Pilot Preview
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-cover-r2-pilot-preview
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block every branch except the isolated pilot
+        if: github.ref != 'refs/heads/agent/cover-r2-pilot-20'
+        run: |
+          echo "Deploy bloqueado: este Worker sólo existe en agent/cover-r2-pilot-20."
+          exit 1
+
+  validate:
+    needs: guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+      - name: Validate isolated pilot
+        run: |
+          find cover-r2-pilot -type f -name '*.js' -print0 | xargs -0 -r -n1 node --check
+          node --test cover-r2-pilot/__tests__/*.test.js
+
+  deploy:
+    needs: validate
+    runs-on: ubuntu-latest
+    environment:
+      name: preview
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+      - name: Require isolated secret
+        run: |
+          if [ -z "$COVER_PILOT_SECRET" ]; then
+            echo "COVER_PILOT_SECRET no está configurado en el environment preview."
+            exit 1
+          fi
+        env:
+          COVER_PILOT_SECRET: ${{ secrets.COVER_PILOT_SECRET }}
+      - name: Configure pilot secret
+        run: |
+          printf '%s' "$COVER_PILOT_SECRET" | npx wrangler@3.114.17 secret put COVER_PILOT_SECRET --config cover-r2-pilot/wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          COVER_PILOT_SECRET: ${{ secrets.COVER_PILOT_SECRET }}
+      - name: Deploy isolated pilot Worker
+        run: npx wrangler@3.114.17 deploy --config cover-r2-pilot/wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-cover-r2-pilot-preview.yml
+++ b/.github/workflows/deploy-cover-r2-pilot-preview.yml
@@ -1,6 +1,12 @@
 name: Deploy Cover R2 Pilot Preview
 
 on:
+  push:
+    branches:
+      - agent/cover-r2-pilot-20
+    paths:
+      - 'cover-r2-pilot/**'
+      - '.github/workflows/deploy-cover-r2-pilot-preview.yml'
   workflow_dispatch:
 
 permissions:
@@ -43,23 +49,75 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22.12.0'
-      - name: Require isolated secret
+      - name: Create one-run pilot secret
         run: |
-          if [ -z "$COVER_PILOT_SECRET" ]; then
-            echo "COVER_PILOT_SECRET no está configurado en el environment preview."
-            exit 1
+          PILOT_SECRET="$(openssl rand -hex 32)"
+          echo "::add-mask::$PILOT_SECRET"
+          echo "COVER_PILOT_SECRET=$PILOT_SECRET" >> "$GITHUB_ENV"
+      - name: Ensure isolated Preview bucket exists
+        run: |
+          BUCKETS="$(npx wrangler@3.114.17 r2 bucket list)"
+          if echo "$BUCKETS" | grep -Fq 'amadolibros-images-preview'; then
+            echo "Bucket Preview ya existe."
+          else
+            echo "Bucket Preview ausente; se crea una sola vez."
+            npx wrangler@3.114.17 r2 bucket create amadolibros-images-preview
           fi
         env:
-          COVER_PILOT_SECRET: ${{ secrets.COVER_PILOT_SECRET }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Configure pilot secret
         run: |
           printf '%s' "$COVER_PILOT_SECRET" | npx wrangler@3.114.17 secret put COVER_PILOT_SECRET --config cover-r2-pilot/wrangler.toml
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          COVER_PILOT_SECRET: ${{ secrets.COVER_PILOT_SECRET }}
       - name: Deploy isolated pilot Worker
-        run: npx wrangler@3.114.17 deploy --config cover-r2-pilot/wrangler.toml
+        run: |
+          npx wrangler@3.114.17 deploy --config cover-r2-pilot/wrangler.toml 2>&1 | tee /tmp/cover-pilot-deploy.txt
+          PILOT_URL="$(grep -Eo 'https://[^[:space:]]+\.workers\.dev' /tmp/cover-pilot-deploy.txt | tail -1)"
+          if [ -z "$PILOT_URL" ]; then
+            echo "No se pudo resolver la URL workers.dev del deploy."
+            exit 1
+          fi
+          echo "PILOT_URL=$PILOT_URL" >> "$GITHUB_ENV"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Build payload from 20 real catalog covers
+        run: |
+          curl -fsS --max-time 180 \
+            'https://pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev/catalog.json' \
+            | node cover-r2-pilot/scripts/select-real-covers.js \
+            > /tmp/cover-pilot-payload.json
+          node -e "const p=require('/tmp/cover-pilot-payload.json'); if(p.items.length!==20) process.exit(1); console.log('Payload real: 20 portadas.');"
+      - name: Import and verify 20 real covers
+        run: |
+          echo "Esperando propagación del Worker Preview..."
+          sleep 10
+          STATUS_CODE="$(curl -sS --max-time 30 -o /tmp/cover-pilot-before.json -w '%{http_code}' \
+            "$PILOT_URL/status" \
+            -H "Authorization: Bearer $COVER_PILOT_SECRET")"
+          if [ "$STATUS_CODE" != "200" ]; then
+            echo "Status inicial respondió HTTP $STATUS_CODE."
+            cat /tmp/cover-pilot-before.json
+            exit 1
+          fi
+
+          IMPORT_CODE="$(curl -sS --max-time 300 -o /tmp/cover-pilot-import.json -w '%{http_code}' \
+            -X POST "$PILOT_URL/import" \
+            -H "Authorization: Bearer $COVER_PILOT_SECRET" \
+            -H 'Content-Type: application/json' \
+            --data-binary @/tmp/cover-pilot-payload.json)"
+          cat /tmp/cover-pilot-import.json
+          if [ "$IMPORT_CODE" != "200" ]; then
+            echo "Import respondió HTTP $IMPORT_CODE."
+            exit 1
+          fi
+          node -e "const r=require('/tmp/cover-pilot-import.json'); if(r.attempted!==20||r.failed!==0) process.exit(1); console.log('Import real: 20/20 sin fallos.');"
+
+          curl -fsS --max-time 30 "$PILOT_URL/status" \
+            -H "Authorization: Bearer $COVER_PILOT_SECRET" \
+            -o /tmp/cover-pilot-after.json
+          cat /tmp/cover-pilot-after.json
+          node -e "const s=require('/tmp/cover-pilot-after.json'); if(s.manifest.with_valid_copy!==20) process.exit(1); console.log('Manifest verificado: 20 copias válidas.');"

--- a/.github/workflows/deploy-cover-r2-pilot-preview.yml
+++ b/.github/workflows/deploy-cover-r2-pilot-preview.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: deploy-cover-r2-pilot-preview
@@ -121,3 +122,33 @@ jobs:
             -o /tmp/cover-pilot-after.json
           cat /tmp/cover-pilot-after.json
           node -e "const s=require('/tmp/cover-pilot-after.json'); if(s.manifest.with_valid_copy!==20) process.exit(1); console.log('Manifest verificado: 20 copias válidas.');"
+
+  report:
+    if: always()
+    needs: [guard, validate, deploy]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish durable pilot result on PR 99
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const result = '${{ needs.deploy.result }}';
+            const succeeded = result === 'success';
+            const body = [
+              `### COVER-R2-PILOT — ${succeeded ? '20/20 CONFIRMADO' : 'NO CONFIRMADO'}`,
+              '',
+              `- Commit: \`${context.sha}\``,
+              `- Deploy/aceptación: **${result}**`,
+              `- Run: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              succeeded
+                ? '- El workflow desplegó el Worker Preview y verificó 20 copias válidas en el manifest.'
+                : '- Revisar el paso fallido del run. No reintentar hasta identificar la causa.',
+              '',
+              'Producción y `amadolibros-catalog` no fueron modificados.',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 99,
+              body,
+            });

--- a/.github/workflows/deploy-cover-r2-pilot-preview.yml
+++ b/.github/workflows/deploy-cover-r2-pilot-preview.yml
@@ -1,13 +1,13 @@
 name: Deploy Cover R2 Pilot Preview
 
 on:
-  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
     branches:
-      - agent/cover-r2-pilot-20
+      - main
     paths:
       - 'cover-r2-pilot/**'
       - '.github/workflows/deploy-cover-r2-pilot-preview.yml'
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -21,10 +21,10 @@ jobs:
   guard:
     runs-on: ubuntu-latest
     steps:
-      - name: Block every branch except the isolated pilot
-        if: github.ref != 'refs/heads/agent/cover-r2-pilot-20'
+      - name: Block every source except the isolated in-repo pilot
+        if: github.head_ref != 'agent/cover-r2-pilot-20' || github.event.pull_request.head.repo.full_name != github.repository
         run: |
-          echo "Deploy bloqueado: este Worker sólo existe en agent/cover-r2-pilot-20."
+          echo "Deploy bloqueado: sólo se permite el PR in-repo agent/cover-r2-pilot-20 -> main."
           exit 1
 
   validate:
@@ -134,10 +134,11 @@ jobs:
           script: |
             const result = '${{ needs.deploy.result }}';
             const succeeded = result === 'success';
+            const headSha = context.payload.pull_request.head.sha;
             const body = [
               `### COVER-R2-PILOT — ${succeeded ? '20/20 CONFIRMADO' : 'NO CONFIRMADO'}`,
               '',
-              `- Commit: \`${context.sha}\``,
+              `- Commit: \`${headSha}\``,
               `- Deploy/aceptación: **${result}**`,
               `- Run: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               succeeded

--- a/cover-r2-pilot/README.md
+++ b/cover-r2-pilot/README.md
@@ -1,0 +1,74 @@
+# Piloto de portadas en R2 (20 imágenes)
+
+Worker aislado para comprobar la descarga, validación y conservación de
+portadas de Mercado Libre antes de diseñar una migración de catálogo completa.
+
+## Límites de seguridad
+
+- Bucket único: `amadolibros-images-preview` mediante `COVER_R2`.
+- No importa ni comparte rutas con `worker-sync`.
+- Sin cron y sin rutas de dominio; sólo `workers.dev` de Preview.
+- `POST /import` y `GET /status` requieren `Authorization: Bearer ...` con el
+  secret exclusivo `COVER_PILOT_SECRET`.
+- Máximo duro de 20 entradas por request.
+- Sólo URLs HTTPS de `http2.mlstatic.com`; no sigue redirecciones.
+- Máximo 8 MiB por imagen; acepta JPEG, PNG o WebP con MIME, firma, estructura
+  y dimensiones coherentes (100–12.000 px).
+- No modifica `catalog.json`, `home.json`, Pages, fichas, catálogo ni checkout.
+- No elimina objetos durante el piloto.
+
+## Escritura segura y refresco
+
+La imagen se guarda como objeto inmutable por hash:
+
+`covers/v1/objects/{sha256}.{ext}`
+
+El puntero mutable es `covers/v1/manifest.json` y se escribe último. Si una
+descarga, validación o escritura falla, el manifiesto conserva `current` y la
+última copia válida. Si el manifest falla después de escribir la imagen, queda
+un objeto huérfano recuperable, no una portada rota.
+
+Una URL nueva se valida en la siguiente ejecución. La misma URL se considera
+vigente durante 30 días y luego se revalida con `If-None-Match` y/o
+`If-Modified-Since` cuando Mercado Libre entrega validadores. Si el contenido
+cambia con la misma URL, cambia el SHA-256 y el manifiesto apunta al objeto
+nuevo sólo después del readback de R2.
+
+Para una migración completa, el barrido debe escalonarse: imágenes nuevas o
+con URL distinta primero; después `1/30` del catálogo por día. Los objetos sin
+referencias se conservarán 90 días y se eliminarán sólo mediante un lote
+separado, después de confirmar que ningún producto activo o pausado los usa.
+
+## Costo orientativo del catálogo completo
+
+Con 17.478 imágenes:
+
+- 250 KiB promedio: ~4,37 GB.
+- 500 KiB promedio: ~8,74 GB.
+- 1 MiB promedio: ~17,48 GB.
+- Importación inicial: 17.478 escrituras de objetos más escrituras pequeñas de
+  manifiesto (menos del 1,8% del millón de operaciones Class A incluidas).
+
+El costo incremental esperado es USD 0 mientras la cuenta completa permanezca
+dentro de la franquicia mensual vigente de R2. Si las imágenes promediaran
+1 MiB y el resto de la cuenta no consumiera espacio incluido, el excedente
+orientativo sería ~8 GB, unos USD 0,12/mes a USD 0,015 por GB-mes. Debe
+recalcularse con el consumo real de toda la cuenta antes de ampliar el piloto.
+
+## Request de importación
+
+```json
+{
+  "items": [
+    {
+      "product_id": "MLU123456789",
+      "position": 0,
+      "url": "https://http2.mlstatic.com/D_NQ_NP_...-O.webp"
+    }
+  ]
+}
+```
+
+El HTTP 200 indica que todas las entradas terminaron sin error; HTTP 207
+indica resultado mixto. Cada resultado informa `imported`, `revalidated`,
+`not-modified`, `fresh-skip` o `failed`.

--- a/cover-r2-pilot/README.md
+++ b/cover-r2-pilot/README.md
@@ -75,8 +75,10 @@ indica resultado mixto. Cada resultado informa `imported`, `revalidated`,
 
 ## Despliegue del piloto
 
-El workflow se dispara únicamente al actualizar `agent/cover-r2-pilot-20` o
-manualmente desde esa misma rama. Comprueba el bucket Preview, genera un secret
-aleatorio de una sola ejecución, lo enmascara, despliega el Worker, selecciona
-20 portadas reales del catálogo público y exige `20/20` importaciones válidas.
-No declara ningún trigger sobre `main`.
+El workflow se dispara únicamente al actualizar el PR in-repo de
+`agent/cover-r2-pilot-20` hacia `main`. Comprueba el bucket Preview, genera un
+secret aleatorio de una sola ejecución, lo enmascara, despliega el Worker,
+selecciona 20 portadas reales del catálogo público y exige `20/20`
+importaciones válidas. Si una ubicación edge todavía no recibió el secret
+nuevo, reintenta únicamente la respuesta 401 hasta seis veces. No declara
+ningún trigger de despliegue sobre `main`.

--- a/cover-r2-pilot/README.md
+++ b/cover-r2-pilot/README.md
@@ -72,3 +72,11 @@ recalcularse con el consumo real de toda la cuenta antes de ampliar el piloto.
 El HTTP 200 indica que todas las entradas terminaron sin error; HTTP 207
 indica resultado mixto. Cada resultado informa `imported`, `revalidated`,
 `not-modified`, `fresh-skip` o `failed`.
+
+## Despliegue del piloto
+
+El workflow se dispara únicamente al actualizar `agent/cover-r2-pilot-20` o
+manualmente desde esa misma rama. Comprueba el bucket Preview, genera un secret
+aleatorio de una sola ejecución, lo enmascara, despliega el Worker, selecciona
+20 portadas reales del catálogo público y exige `20/20` importaciones válidas.
+No declara ningún trigger sobre `main`.

--- a/cover-r2-pilot/__tests__/config.test.js
+++ b/cover-r2-pilot/__tests__/config.test.js
@@ -13,13 +13,16 @@ test('wrangler usa sólo el bucket Preview y no declara cron ni routes', () => {
   assert.doesNotMatch(wrangler, /\[triggers\]|crons\s*=|routes?\s*=/);
 });
 
-test('deploy es manual y queda bloqueado a la rama exacta del piloto', () => {
+test('deploy automático y manual queda bloqueado a la rama exacta del piloto', () => {
   assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /push:\n\s+branches:\n\s+- agent\/cover-r2-pilot-20/);
   assert.match(workflow, /refs\/heads\/agent\/cover-r2-pilot-20/);
-  assert.doesNotMatch(workflow, /^\s*push:/m);
   assert.doesNotMatch(workflow, /refs\/heads\/main|branches:\s*\[?main/);
   assert.match(workflow, /COVER_PILOT_SECRET/);
   assert.match(workflow, /environment:\n\s+name: preview/);
+  assert.match(workflow, /r2 bucket create amadolibros-images-preview/);
+  assert.match(workflow, /openssl rand -hex 32/);
+  assert.match(workflow, /attempted!==20\|\|r\.failed!==0/);
 });
 
 test('CI compartido incluye sintaxis y tests del piloto', () => {

--- a/cover-r2-pilot/__tests__/config.test.js
+++ b/cover-r2-pilot/__tests__/config.test.js
@@ -13,11 +13,12 @@ test('wrangler usa sólo el bucket Preview y no declara cron ni routes', () => {
   assert.doesNotMatch(wrangler, /\[triggers\]|crons\s*=|routes?\s*=/);
 });
 
-test('deploy automático y manual queda bloqueado a la rama exacta del piloto', () => {
-  assert.match(workflow, /workflow_dispatch:/);
-  assert.match(workflow, /push:\n\s+branches:\n\s+- agent\/cover-r2-pilot-20/);
-  assert.match(workflow, /refs\/heads\/agent\/cover-r2-pilot-20/);
-  assert.doesNotMatch(workflow, /refs\/heads\/main|branches:\s*\[?main/);
+test('deploy del PR queda bloqueado a la rama y repo exactos del piloto', () => {
+  assert.match(workflow, /pull_request:\n\s+types: \[opened, synchronize, reopened\]/);
+  assert.match(workflow, /branches:\n\s+- main/);
+  assert.match(workflow, /github\.head_ref != 'agent\/cover-r2-pilot-20'/);
+  assert.match(workflow, /github\.event\.pull_request\.head\.repo\.full_name != github\.repository/);
+  assert.doesNotMatch(workflow, /workflow_dispatch:|\npush:/);
   assert.match(workflow, /COVER_PILOT_SECRET/);
   assert.match(workflow, /environment:\n\s+name: preview/);
   assert.match(workflow, /r2 bucket create amadolibros-images-preview/);

--- a/cover-r2-pilot/__tests__/config.test.js
+++ b/cover-r2-pilot/__tests__/config.test.js
@@ -23,6 +23,9 @@ test('deploy automático y manual queda bloqueado a la rama exacta del piloto', 
   assert.match(workflow, /r2 bucket create amadolibros-images-preview/);
   assert.match(workflow, /openssl rand -hex 32/);
   assert.match(workflow, /attempted!==20\|\|r\.failed!==0/);
+  assert.match(workflow, /issues: write/);
+  assert.match(workflow, /COVER-R2-PILOT —.*20\/20 CONFIRMADO/);
+  assert.match(workflow, /issue_number: 99/);
 });
 
 test('CI compartido incluye sintaxis y tests del piloto', () => {

--- a/cover-r2-pilot/__tests__/config.test.js
+++ b/cover-r2-pilot/__tests__/config.test.js
@@ -24,9 +24,9 @@ test('deploy del PR queda bloqueado a la rama y repo exactos del piloto', () => 
   assert.match(workflow, /r2 bucket create amadolibros-images-preview/);
   assert.match(workflow, /openssl rand -hex 32/);
   assert.match(workflow, /attempted!==20\|\|r\.failed!==0/);
-  assert.match(workflow, /issues: write/);
-  assert.match(workflow, /COVER-R2-PILOT —.*20\/20 CONFIRMADO/);
-  assert.match(workflow, /issue_number: 99/);
+  assert.match(workflow, /for attempt in 1 2 3 4 5 6/);
+  assert.match(workflow, /if \[ "\$IMPORT_CODE" != "401" \]/);
+  assert.doesNotMatch(workflow, /issues: write|createComment/);
 });
 
 test('CI compartido incluye sintaxis y tests del piloto', () => {

--- a/cover-r2-pilot/__tests__/config.test.js
+++ b/cover-r2-pilot/__tests__/config.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const wrangler = readFileSync('cover-r2-pilot/wrangler.toml', 'utf8');
+const workflow = readFileSync('.github/workflows/deploy-cover-r2-pilot-preview.yml', 'utf8');
+const validate = readFileSync('scripts/validate-ci.sh', 'utf8');
+
+test('wrangler usa sólo el bucket Preview y no declara cron ni routes', () => {
+  assert.match(wrangler, /binding\s*=\s*"COVER_R2"/);
+  assert.match(wrangler, /bucket_name\s*=\s*"amadolibros-images-preview"/);
+  assert.doesNotMatch(wrangler, /amadolibros-catalog/);
+  assert.doesNotMatch(wrangler, /\[triggers\]|crons\s*=|routes?\s*=/);
+});
+
+test('deploy es manual y queda bloqueado a la rama exacta del piloto', () => {
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /refs\/heads\/agent\/cover-r2-pilot-20/);
+  assert.doesNotMatch(workflow, /^\s*push:/m);
+  assert.doesNotMatch(workflow, /refs\/heads\/main|branches:\s*\[?main/);
+  assert.match(workflow, /COVER_PILOT_SECRET/);
+  assert.match(workflow, /environment:\n\s+name: preview/);
+});
+
+test('CI compartido incluye sintaxis y tests del piloto', () => {
+  assert.match(validate, /find functions scripts worker-sync cover-r2-pilot/);
+  assert.match(validate, /node --test cover-r2-pilot\/__tests__\/\*\.test\.js/);
+});

--- a/cover-r2-pilot/__tests__/cover-pilot.test.js
+++ b/cover-r2-pilot/__tests__/cover-pilot.test.js
@@ -1,0 +1,235 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  MANIFEST_KEY,
+  importCovers,
+} from '../lib/cover-pilot.js';
+
+const SOURCE_A = 'https://http2.mlstatic.com/D_NQ_NP_123456-MLU12345678901_012026-O.webp';
+const SOURCE_B = 'https://http2.mlstatic.com/D_NQ_NP_987654-MLU12345678901_022026-O.webp';
+
+function pngBytes(width = 300, height = 450, salt = 0) {
+  const bytes = new Uint8Array(45);
+  bytes.set([137, 80, 78, 71, 13, 10, 26, 10], 0);
+  bytes.set([0, 0, 0, 13], 8);
+  bytes.set([73, 72, 68, 82], 12); // IHDR
+  const view = new DataView(bytes.buffer);
+  view.setUint32(16, width);
+  view.setUint32(20, height);
+  bytes.set([8, 2, 0, 0, 0], 24);
+  bytes[32] = salt;
+  bytes.set([0, 0, 0, 0], 33);
+  bytes.set([73, 69, 78, 68], 37); // IEND
+  bytes[44] = salt;
+  return bytes;
+}
+
+function imageResponse(bytes = pngBytes(), headers = {}) {
+  return new Response(bytes, {
+    status: 200,
+    headers: {
+      'Content-Type': 'image/png',
+      'Content-Length': String(bytes.byteLength),
+      ...headers,
+    },
+  });
+}
+
+class MockR2 {
+  constructor() {
+    this.objects = new Map();
+    this.operations = [];
+  }
+
+  async get(key) {
+    this.operations.push(`get:${key}`);
+    const object = this.objects.get(key);
+    if (!object) return null;
+    return {
+      text: async () => new TextDecoder().decode(object.bytes),
+      arrayBuffer: async () => object.bytes.buffer.slice(
+        object.bytes.byteOffset,
+        object.bytes.byteOffset + object.bytes.byteLength,
+      ),
+    };
+  }
+
+  async head(key) {
+    this.operations.push(`head:${key}`);
+    const object = this.objects.get(key);
+    return object ? { size: object.bytes.byteLength } : null;
+  }
+
+  async put(key, body, options = {}) {
+    this.operations.push(`put:${key}`);
+    const bytes = typeof body === 'string'
+      ? new TextEncoder().encode(body)
+      : new Uint8Array(body);
+    this.objects.set(key, { bytes: bytes.slice(), options });
+  }
+
+  manifest() {
+    const object = this.objects.get(MANIFEST_KEY);
+    return object ? JSON.parse(new TextDecoder().decode(object.bytes)) : null;
+  }
+}
+
+function payload(url = SOURCE_A) {
+  return {
+    items: [{ product_id: 'MLU123456789', position: 0, url }],
+  };
+}
+
+test('rechaza más de 20 imágenes antes de tocar R2 o la red', async () => {
+  const bucket = new MockR2();
+  const items = Array.from({ length: 21 }, (_, index) => ({
+    product_id: `MLU${String(100000000 + index)}`,
+    position: 0,
+    url: SOURCE_A,
+  }));
+  let fetched = false;
+  await assert.rejects(
+    importCovers({ COVER_R2: bucket }, { items }, {
+      fetchFn: async () => { fetched = true; return imageResponse(); },
+    }),
+    error => error.code === 'ITEM_LIMIT_EXCEEDED',
+  );
+  assert.equal(fetched, false);
+  assert.deepEqual(bucket.operations, []);
+});
+
+test('rechaza hosts que no sean el origen HTTPS exacto de Mercado Libre', async () => {
+  const bucket = new MockR2();
+  await assert.rejects(
+    importCovers({ COVER_R2: bucket }, payload('https://example.com/cover.png')),
+    error => error.code === 'SOURCE_HOST_NOT_ALLOWED',
+  );
+  await assert.rejects(
+    importCovers({ COVER_R2: bucket }, payload('http://http2.mlstatic.com/cover.png')),
+    error => error.code === 'SOURCE_HOST_NOT_ALLOWED',
+  );
+});
+
+test('guarda por SHA-256, verifica R2 y publica el manifest último', async () => {
+  const bucket = new MockR2();
+  const result = await importCovers({ COVER_R2: bucket }, payload(), {
+    fetchFn: async () => imageResponse(pngBytes(), { ETag: '"cover-v1"' }),
+    now: () => new Date('2026-08-09T20:00:00Z'),
+  });
+
+  assert.equal(result.failed, 0);
+  assert.equal(result.imported, 1);
+  assert.match(result.results[0].object_key, /^covers\/v1\/objects\/[a-f0-9]{64}\.png$/);
+  const puts = bucket.operations.filter(operation => operation.startsWith('put:'));
+  assert.equal(puts.at(-1), `put:${MANIFEST_KEY}`);
+  assert.equal(puts.length, 2);
+
+  const manifest = bucket.manifest();
+  const entry = manifest.entries['MLU123456789:0'];
+  assert.equal(entry.current.width, 300);
+  assert.equal(entry.current.height, 450);
+  assert.equal(entry.current.source_url, SOURCE_A);
+  assert.equal(entry.source_validators.etag, '"cover-v1"');
+  assert.equal(entry.last_error, null);
+});
+
+test('no vuelve a descargar una URL validada hace menos de 30 días', async () => {
+  const bucket = new MockR2();
+  let fetches = 0;
+  const fetchFn = async () => { fetches += 1; return imageResponse(); };
+  await importCovers({ COVER_R2: bucket }, payload(), {
+    fetchFn,
+    now: () => new Date('2026-08-01T00:00:00Z'),
+  });
+  const second = await importCovers({ COVER_R2: bucket }, payload(), {
+    fetchFn,
+    now: () => new Date('2026-08-20T00:00:00Z'),
+  });
+  assert.equal(fetches, 1);
+  assert.equal(second.results[0].status, 'fresh-skip');
+});
+
+test('a los 30 días revalida con ETag y conserva el objeto ante 304', async () => {
+  const bucket = new MockR2();
+  await importCovers({ COVER_R2: bucket }, payload(), {
+    fetchFn: async () => imageResponse(pngBytes(), {
+      ETag: '"cover-v1"',
+      'Last-Modified': 'Sat, 01 Aug 2026 00:00:00 GMT',
+    }),
+    now: () => new Date('2026-08-01T00:00:00Z'),
+  });
+  const oldKey = bucket.manifest().entries['MLU123456789:0'].current.object_key;
+  let conditionalHeaders;
+  const second = await importCovers({ COVER_R2: bucket }, payload(), {
+    fetchFn: async (_url, options) => {
+      conditionalHeaders = options.headers;
+      return new Response(null, { status: 304 });
+    },
+    now: () => new Date('2026-09-01T00:00:00Z'),
+  });
+  assert.equal(conditionalHeaders['If-None-Match'], '"cover-v1"');
+  assert.equal(conditionalHeaders['If-Modified-Since'], 'Sat, 01 Aug 2026 00:00:00 GMT');
+  assert.equal(second.results[0].status, 'not-modified');
+  assert.equal(bucket.manifest().entries['MLU123456789:0'].current.object_key, oldKey);
+});
+
+test('una portada cambiada reemplaza el puntero y conserva la clave anterior', async () => {
+  const bucket = new MockR2();
+  await importCovers({ COVER_R2: bucket }, payload(), {
+    fetchFn: async () => imageResponse(pngBytes(300, 450, 1)),
+    now: () => new Date('2026-08-01T00:00:00Z'),
+  });
+  const oldKey = bucket.manifest().entries['MLU123456789:0'].current.object_key;
+  const second = await importCovers({ COVER_R2: bucket }, payload(), {
+    fetchFn: async () => imageResponse(pngBytes(301, 450, 2)),
+    now: () => new Date('2026-09-01T00:00:00Z'),
+  });
+  const entry = bucket.manifest().entries['MLU123456789:0'];
+  assert.equal(second.results[0].status, 'imported');
+  assert.equal(second.results[0].replaced_previous, true);
+  assert.notEqual(entry.current.object_key, oldKey);
+  assert.equal(entry.previous_object_key, oldKey);
+  assert.equal(bucket.objects.has(oldKey), true, 'el piloto no borra la copia anterior');
+});
+
+test('si la URL nueva falla mantiene visible la última copia válida', async () => {
+  const bucket = new MockR2();
+  await importCovers({ COVER_R2: bucket }, payload(), {
+    fetchFn: async () => imageResponse(),
+    now: () => new Date('2026-08-01T00:00:00Z'),
+  });
+  const oldEntry = structuredClone(bucket.manifest().entries['MLU123456789:0']);
+  const second = await importCovers({ COVER_R2: bucket }, payload(SOURCE_B), {
+    fetchFn: async () => new Response('fallo', { status: 503 }),
+    now: () => new Date('2026-08-02T00:00:00Z'),
+  });
+  const entry = bucket.manifest().entries['MLU123456789:0'];
+  assert.equal(second.failed, 1);
+  assert.equal(second.results[0].retained_previous, true);
+  assert.equal(entry.current.object_key, oldEntry.current.object_key);
+  assert.equal(entry.current.source_url, SOURCE_A);
+  assert.equal(entry.last_attempted_source_url, SOURCE_B);
+  assert.equal(entry.last_error.code, 'SOURCE_HTTP_ERROR');
+});
+
+test('rechaza redirecciones y no escribe un objeto de imagen', async () => {
+  const bucket = new MockR2();
+  const result = await importCovers({ COVER_R2: bucket }, payload(), {
+    fetchFn: async () => new Response(null, { status: 302, headers: { Location: 'https://example.com/x' } }),
+  });
+  assert.equal(result.failed, 1);
+  assert.equal(result.results[0].code, 'SOURCE_REDIRECT_REJECTED');
+  assert.deepEqual(
+    bucket.operations.filter(operation => operation.startsWith('put:covers/v1/objects/')),
+    [],
+  );
+});
+
+test('rechaza MIME que no coincide con la firma del archivo', async () => {
+  const bucket = new MockR2();
+  const result = await importCovers({ COVER_R2: bucket }, payload(), {
+    fetchFn: async () => imageResponse(pngBytes(), { 'Content-Type': 'image/jpeg' }),
+  });
+  assert.equal(result.failed, 1);
+  assert.equal(result.results[0].code, 'IMAGE_MIME_MISMATCH');
+});

--- a/cover-r2-pilot/__tests__/index.test.js
+++ b/cover-r2-pilot/__tests__/index.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import worker from '../index.js';
+
+class EmptyR2 {
+  async get() { return null; }
+  async put() {}
+  async head() { return null; }
+}
+
+const URL = 'https://amadolibros-cover-r2-pilot.example.workers.dev/status';
+
+test('sin secret configurado responde 404', async () => {
+  const response = await worker.fetch(new Request(URL), { COVER_R2: new EmptyR2() });
+  assert.equal(response.status, 404);
+});
+
+test('con bearer incorrecto responde 401 sin revelar el secret', async () => {
+  const response = await worker.fetch(new Request(URL, {
+    headers: { Authorization: 'Bearer incorrecto' },
+  }), { COVER_R2: new EmptyR2(), COVER_PILOT_SECRET: 'secreto-real' });
+  assert.equal(response.status, 401);
+  assert.equal((await response.text()).includes('secreto-real'), false);
+});
+
+test('status autenticado confirma el límite duro y manifest vacío', async () => {
+  const response = await worker.fetch(new Request(URL, {
+    headers: { Authorization: 'Bearer test-secret' },
+  }), {
+    COVER_R2: new EmptyR2(),
+    COVER_PILOT_SECRET: 'test-secret',
+    PILOT_SCOPE: 'preview-20',
+  });
+  assert.equal(response.status, 200);
+  const data = await response.json();
+  assert.equal(data.max_items_per_run, 20);
+  assert.equal(data.scope, 'preview-20');
+  assert.equal(data.manifest.entries, 0);
+});
+
+test('import exige application/json', async () => {
+  const response = await worker.fetch(new Request(URL.replace('/status', '/import'), {
+    method: 'POST',
+    headers: { Authorization: 'Bearer test-secret', 'Content-Type': 'text/plain' },
+    body: '{}',
+  }), { COVER_R2: new EmptyR2(), COVER_PILOT_SECRET: 'test-secret' });
+  assert.equal(response.status, 415);
+  assert.equal((await response.json()).code, 'CONTENT_TYPE_INVALID');
+});

--- a/cover-r2-pilot/__tests__/select-real-covers.test.js
+++ b/cover-r2-pilot/__tests__/select-real-covers.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { selectRealCovers } from '../scripts/select-real-covers.js';
+
+function item(index, overrides = {}) {
+  return {
+    id: `MLU${String(100000000 + index)}`,
+    status: 'active',
+    available_quantity: 1,
+    pictures: [{ url: `http://http2.mlstatic.com/D_NQ_NP_${index}-O.jpg` }],
+    ...overrides,
+  };
+}
+
+test('selecciona exactamente 20 activos con stock y normaliza HTTPS', () => {
+  const catalog = { items: Array.from({ length: 25 }, (_, index) => item(index)) };
+  const payload = selectRealCovers(catalog);
+  assert.equal(payload.items.length, 20);
+  assert.ok(payload.items.every(entry => entry.url.startsWith('https://http2.mlstatic.com/')));
+  assert.ok(payload.items.every(entry => entry.position === 0));
+});
+
+test('descarta pausados, sin stock, hosts ajenos y URLs duplicadas', () => {
+  const valid = Array.from({ length: 20 }, (_, index) => item(index + 10));
+  const catalog = {
+    items: [
+      item(1, { status: 'paused' }),
+      item(2, { available_quantity: 0 }),
+      item(3, { pictures: [{ url: 'https://example.com/cover.jpg' }] }),
+      item(4),
+      item(5, { pictures: [{ url: 'http://http2.mlstatic.com/D_NQ_NP_4-O.jpg' }] }),
+      ...valid,
+    ],
+  };
+  const payload = selectRealCovers(catalog);
+  assert.equal(payload.items.length, 20);
+  assert.equal(payload.items.some(entry => entry.product_id === 'MLU100000001'), false);
+  assert.equal(new Set(payload.items.map(entry => entry.url)).size, 20);
+});
+
+test('falla cerrado si no puede reunir 20 portadas válidas', () => {
+  assert.throws(
+    () => selectRealCovers({ items: [item(1)] }),
+    /Sólo se encontraron 1 portadas válidas/,
+  );
+});

--- a/cover-r2-pilot/index.js
+++ b/cover-r2-pilot/index.js
@@ -1,0 +1,116 @@
+import {
+  MAX_IMPORT_ITEMS,
+  importCovers,
+  manifestSummary,
+  readManifest,
+} from './lib/cover-pilot.js';
+
+const SECRET_HEADER = 'Authorization';
+const MAX_REQUEST_BYTES = 64 * 1024;
+
+function json(data, status = 200, extraHeaders = {}) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+      'Cache-Control': 'no-store',
+      ...extraHeaders,
+    },
+  });
+}
+
+function timingSafeEqual(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  if (a.length === 0 || a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let index = 0; index < a.length; index += 1) {
+    mismatch |= a.charCodeAt(index) ^ b.charCodeAt(index);
+  }
+  return mismatch === 0;
+}
+
+async function readJsonBody(request) {
+  const contentType = request.headers.get('Content-Type') || '';
+  if (!contentType.toLowerCase().startsWith('application/json')) {
+    throw Object.assign(new Error('Content-Type debe ser application/json.'), {
+      status: 415,
+      code: 'CONTENT_TYPE_INVALID',
+    });
+  }
+
+  const declaredLength = Number(request.headers.get('Content-Length'));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_REQUEST_BYTES) {
+    throw Object.assign(new Error('El cuerpo excede 64 KiB.'), {
+      status: 413,
+      code: 'REQUEST_TOO_LARGE',
+    });
+  }
+
+  const text = await request.text();
+  if (new TextEncoder().encode(text).byteLength > MAX_REQUEST_BYTES) {
+    throw Object.assign(new Error('El cuerpo excede 64 KiB.'), {
+      status: 413,
+      code: 'REQUEST_TOO_LARGE',
+    });
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw Object.assign(new Error('JSON inválido.'), {
+      status: 400,
+      code: 'JSON_INVALID',
+    });
+  }
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const expectedSecret = typeof env?.COVER_PILOT_SECRET === 'string'
+      ? env.COVER_PILOT_SECRET.trim()
+      : '';
+
+    // El Worker no revela si el secreto todavía no fue configurado.
+    if (!expectedSecret) return new Response('Not found', { status: 404 });
+
+    const supplied = request.headers.get(SECRET_HEADER) || '';
+    if (!timingSafeEqual(supplied, `Bearer ${expectedSecret}`)) {
+      return json({ error: 'No autorizado.' }, 401);
+    }
+
+    if (!env?.COVER_R2 || typeof env.COVER_R2.get !== 'function' ||
+        typeof env.COVER_R2.put !== 'function') {
+      return json({ error: 'Binding COVER_R2 no disponible.' }, 503);
+    }
+
+    if (request.method === 'GET' && url.pathname === '/status') {
+      try {
+        const manifest = await readManifest(env.COVER_R2);
+        return json({
+          status: 'ready',
+          scope: env.PILOT_SCOPE || 'preview-20',
+          max_items_per_run: MAX_IMPORT_ITEMS,
+          manifest: manifestSummary(manifest),
+        });
+      } catch (error) {
+        return json({ error: 'Manifest inválido.', code: error.code || 'MANIFEST_INVALID' }, 503);
+      }
+    }
+
+    if (request.method === 'POST' && url.pathname === '/import') {
+      try {
+        const payload = await readJsonBody(request);
+        const result = await importCovers(env, payload);
+        return json(result, result.failed > 0 ? 207 : 200);
+      } catch (error) {
+        return json({
+          error: error.message || 'Error de importación.',
+          code: error.code || 'IMPORT_FAILED',
+        }, error.status || 500);
+      }
+    }
+
+    return json({ error: 'Not found.' }, 404);
+  },
+};

--- a/cover-r2-pilot/lib/cover-pilot.js
+++ b/cover-r2-pilot/lib/cover-pilot.js
@@ -1,0 +1,425 @@
+export const MAX_IMPORT_ITEMS = 20;
+export const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+export const REFRESH_AFTER_MS = 30 * 24 * 60 * 60 * 1000;
+export const MANIFEST_KEY = 'covers/v1/manifest.json';
+
+const ALLOWED_HOST = 'http2.mlstatic.com';
+const MIN_DIMENSION = 100;
+const MAX_DIMENSION = 12_000;
+const FETCH_TIMEOUT_MS = 12_000;
+
+class PilotError extends Error {
+  constructor(status, code, message) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function emptyManifest(nowIso) {
+  return {
+    schema_version: 1,
+    updated_at: nowIso,
+    entries: {},
+  };
+}
+
+function isManifest(value) {
+  return value && value.schema_version === 1 &&
+    typeof value.updated_at === 'string' &&
+    value.entries && typeof value.entries === 'object' &&
+    !Array.isArray(value.entries);
+}
+
+export async function readManifest(bucket, nowIso = new Date().toISOString()) {
+  const object = await bucket.get(MANIFEST_KEY);
+  if (!object) return emptyManifest(nowIso);
+  let parsed;
+  try {
+    parsed = JSON.parse(await object.text());
+  } catch {
+    throw new PilotError(503, 'MANIFEST_INVALID', 'El manifest no es JSON válido.');
+  }
+  if (!isManifest(parsed)) {
+    throw new PilotError(503, 'MANIFEST_INVALID', 'El manifest no tiene el esquema esperado.');
+  }
+  return parsed;
+}
+
+export function manifestSummary(manifest) {
+  const entries = Object.values(manifest.entries || {});
+  return {
+    updated_at: manifest.updated_at,
+    entries: entries.length,
+    with_valid_copy: entries.filter(entry => entry?.current?.object_key).length,
+    with_last_error: entries.filter(entry => entry?.last_error).length,
+  };
+}
+
+function validateSourceUrl(raw) {
+  let url;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new PilotError(400, 'SOURCE_URL_INVALID', 'URL de imagen inválida.');
+  }
+  if (url.protocol !== 'https:' || url.hostname !== ALLOWED_HOST || url.username || url.password) {
+    throw new PilotError(
+      400,
+      'SOURCE_HOST_NOT_ALLOWED',
+      `Sólo se acepta https://${ALLOWED_HOST}/.`,
+    );
+  }
+  url.hash = '';
+  return url.toString();
+}
+
+function normalizeItems(payload) {
+  if (!payload || !Array.isArray(payload.items)) {
+    throw new PilotError(400, 'ITEMS_REQUIRED', 'items debe ser un array.');
+  }
+  if (payload.items.length === 0) {
+    throw new PilotError(400, 'ITEMS_EMPTY', 'items no puede estar vacío.');
+  }
+  if (payload.items.length > MAX_IMPORT_ITEMS) {
+    throw new PilotError(
+      400,
+      'ITEM_LIMIT_EXCEEDED',
+      `Máximo ${MAX_IMPORT_ITEMS} imágenes por ejecución.`,
+    );
+  }
+
+  const seen = new Set();
+  return payload.items.map((item, index) => {
+    const productId = typeof item?.product_id === 'string' ? item.product_id.trim() : '';
+    const position = Number(item?.position);
+    if (!/^MLU\d{6,20}$/.test(productId)) {
+      throw new PilotError(400, 'PRODUCT_ID_INVALID', `product_id inválido en items[${index}].`);
+    }
+    if (!Number.isInteger(position) || position < 0 || position > 15) {
+      throw new PilotError(400, 'POSITION_INVALID', `position inválida en items[${index}].`);
+    }
+    const key = `${productId}:${position}`;
+    if (seen.has(key)) {
+      throw new PilotError(400, 'ITEM_DUPLICATED', `Entrada duplicada: ${key}.`);
+    }
+    seen.add(key);
+    return {
+      key,
+      product_id: productId,
+      position,
+      source_url: validateSourceUrl(item.url),
+    };
+  });
+}
+
+function readUint24LE(bytes, offset) {
+  return bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16);
+}
+
+function pngInfo(bytes) {
+  const signature = [137, 80, 78, 71, 13, 10, 26, 10];
+  if (bytes.length < 33 || !signature.every((value, index) => bytes[index] === value)) return null;
+  if (String.fromCharCode(...bytes.slice(12, 16)) !== 'IHDR') return null;
+  const end = bytes.length - 12;
+  if (end < 33 || String.fromCharCode(...bytes.slice(end + 4, end + 8)) !== 'IEND') return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return { mime: 'image/png', ext: 'png', width: view.getUint32(16), height: view.getUint32(20) };
+}
+
+function jpegInfo(bytes) {
+  if (bytes.length < 16 || bytes[0] !== 0xff || bytes[1] !== 0xd8 ||
+      bytes[bytes.length - 2] !== 0xff || bytes[bytes.length - 1] !== 0xd9) return null;
+  const sofMarkers = new Set([0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf]);
+  let offset = 2;
+  while (offset + 8 < bytes.length) {
+    if (bytes[offset] !== 0xff) { offset += 1; continue; }
+    while (bytes[offset] === 0xff) offset += 1;
+    const marker = bytes[offset];
+    offset += 1;
+    if (marker === 0xd9 || marker === 0xda) break;
+    if (marker >= 0xd0 && marker <= 0xd7) continue;
+    if (offset + 1 >= bytes.length) break;
+    const length = (bytes[offset] << 8) | bytes[offset + 1];
+    if (length < 2 || offset + length > bytes.length) break;
+    if (sofMarkers.has(marker) && length >= 7) {
+      const height = (bytes[offset + 3] << 8) | bytes[offset + 4];
+      const width = (bytes[offset + 5] << 8) | bytes[offset + 6];
+      return { mime: 'image/jpeg', ext: 'jpg', width, height };
+    }
+    offset += length;
+  }
+  return null;
+}
+
+function webpInfo(bytes) {
+  if (bytes.length < 30 || String.fromCharCode(...bytes.slice(0, 4)) !== 'RIFF' ||
+      String.fromCharCode(...bytes.slice(8, 12)) !== 'WEBP') return null;
+  const declaredSize = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(4, true) + 8;
+  if (declaredSize !== bytes.length) return null;
+  const chunk = String.fromCharCode(...bytes.slice(12, 16));
+  if (chunk === 'VP8X') {
+    return {
+      mime: 'image/webp', ext: 'webp',
+      width: readUint24LE(bytes, 24) + 1,
+      height: readUint24LE(bytes, 27) + 1,
+    };
+  }
+  if (chunk === 'VP8L' && bytes[20] === 0x2f) {
+    return {
+      mime: 'image/webp', ext: 'webp',
+      width: 1 + (bytes[21] | ((bytes[22] & 0x3f) << 8)),
+      height: 1 + (((bytes[22] & 0xc0) >> 6) | (bytes[23] << 2) | ((bytes[24] & 0x0f) << 10)),
+    };
+  }
+  if (chunk === 'VP8 ' && bytes[23] === 0x9d && bytes[24] === 0x01 && bytes[25] === 0x2a) {
+    return {
+      mime: 'image/webp', ext: 'webp',
+      width: (bytes[26] | (bytes[27] << 8)) & 0x3fff,
+      height: (bytes[28] | (bytes[29] << 8)) & 0x3fff,
+    };
+  }
+  return null;
+}
+
+function inspectImage(bytes, responseMime) {
+  const info = pngInfo(bytes) || jpegInfo(bytes) || webpInfo(bytes);
+  if (!info) {
+    throw new PilotError(422, 'IMAGE_SIGNATURE_INVALID', 'Firma o estructura de imagen inválida.');
+  }
+  const normalizedMime = String(responseMime || '').split(';')[0].trim().toLowerCase();
+  if (normalizedMime !== info.mime) {
+    throw new PilotError(422, 'IMAGE_MIME_MISMATCH', 'Content-Type no coincide con el archivo.');
+  }
+  if (info.width < MIN_DIMENSION || info.height < MIN_DIMENSION ||
+      info.width > MAX_DIMENSION || info.height > MAX_DIMENSION) {
+    throw new PilotError(422, 'IMAGE_DIMENSIONS_INVALID', 'Dimensiones fuera del rango permitido.');
+  }
+  return info;
+}
+
+async function readLimitedBody(response) {
+  const declared = Number(response.headers.get('Content-Length'));
+  if (Number.isFinite(declared) && declared > MAX_IMAGE_BYTES) {
+    throw new PilotError(413, 'IMAGE_TOO_LARGE', 'La imagen excede 8 MiB.');
+  }
+  if (!response.body) throw new PilotError(502, 'IMAGE_BODY_MISSING', 'Respuesta sin cuerpo.');
+
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_IMAGE_BYTES) {
+      await reader.cancel();
+      throw new PilotError(413, 'IMAGE_TOO_LARGE', 'La imagen excede 8 MiB.');
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+async function sha256Hex(bytes) {
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes));
+  return [...digest].map(value => value.toString(16).padStart(2, '0')).join('');
+}
+
+function dueForRefresh(entry, sourceUrl, nowMs) {
+  if (!entry?.current) return true;
+  if (entry.current.source_url !== sourceUrl) return true;
+  const lastValidated = Date.parse(entry.last_validated_at || '');
+  return !Number.isFinite(lastValidated) || nowMs - lastValidated >= REFRESH_AFTER_MS;
+}
+
+async function fetchSource(item, entry, fetchFn) {
+  const headers = { Accept: 'image/webp,image/png,image/jpeg' };
+  const sameSource = entry?.current?.source_url === item.source_url;
+  if (sameSource && entry.source_validators?.etag) {
+    headers['If-None-Match'] = entry.source_validators.etag;
+  }
+  if (sameSource && entry.source_validators?.last_modified) {
+    headers['If-Modified-Since'] = entry.source_validators.last_modified;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetchFn(item.source_url, {
+      method: 'GET',
+      headers,
+      redirect: 'manual',
+      signal: controller.signal,
+    });
+    if (response.status !== 304 && response.status >= 300 && response.status < 400) {
+      throw new PilotError(502, 'SOURCE_REDIRECT_REJECTED', 'Mercado Libre respondió con una redirección.');
+    }
+    return response;
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      throw new PilotError(504, 'SOURCE_TIMEOUT', 'La descarga excedió 12 segundos.');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function safeError(error, nowIso) {
+  return {
+    at: nowIso,
+    code: String(error?.code || 'SOURCE_IMPORT_FAILED').slice(0, 80),
+    message: String(error?.message || 'Error de importación.').slice(0, 240),
+  };
+}
+
+async function processItem(bucket, item, entry, nowIso, nowMs, fetchFn) {
+  if (!dueForRefresh(entry, item.source_url, nowMs)) {
+    return { entry, result: { key: item.key, status: 'fresh-skip', object_key: entry.current.object_key } };
+  }
+
+  const response = await fetchSource(item, entry, fetchFn);
+  if (response.status === 304 && entry?.current) {
+    return {
+      entry: { ...entry, last_validated_at: nowIso, last_error: null },
+      result: { key: item.key, status: 'not-modified', object_key: entry.current.object_key },
+    };
+  }
+  if (!response.ok) {
+    throw new PilotError(502, 'SOURCE_HTTP_ERROR', `Mercado Libre respondió HTTP ${response.status}.`);
+  }
+
+  const bytes = await readLimitedBody(response);
+  const image = inspectImage(bytes, response.headers.get('Content-Type'));
+  const hash = await sha256Hex(bytes);
+  const objectKey = `covers/v1/objects/${hash}.${image.ext}`;
+  const existing = typeof bucket.head === 'function' ? await bucket.head(objectKey) : null;
+
+  if (existing && Number(existing.size) !== bytes.byteLength) {
+    throw new PilotError(
+      503,
+      'R2_EXISTING_OBJECT_INVALID',
+      'Ya existe un objeto con el mismo hash pero tamaño incoherente.',
+    );
+  }
+
+  if (!existing) {
+    await bucket.put(objectKey, bytes, {
+      httpMetadata: {
+        contentType: image.mime,
+        cacheControl: 'public, max-age=31536000, immutable',
+      },
+      customMetadata: {
+        sha256: hash,
+        importedAt: nowIso,
+        sourceHost: ALLOWED_HOST,
+      },
+    });
+    if (typeof bucket.head !== 'function') {
+      throw new PilotError(503, 'R2_HEAD_UNAVAILABLE', 'R2 no permite verificar la escritura.');
+    }
+    const stored = await bucket.head(objectKey);
+    if (!stored || Number(stored.size) !== bytes.byteLength) {
+      throw new PilotError(503, 'R2_READBACK_FAILED', 'La verificación de la copia en R2 falló.');
+    }
+  }
+
+  const previousObjectKey = entry?.current?.object_key || null;
+  const nextEntry = {
+    product_id: item.product_id,
+    position: item.position,
+    current: {
+      object_key: objectKey,
+      sha256: hash,
+      bytes: bytes.byteLength,
+      mime: image.mime,
+      width: image.width,
+      height: image.height,
+      source_url: item.source_url,
+      imported_at: nowIso,
+    },
+    previous_object_key: previousObjectKey !== objectKey ? previousObjectKey : entry?.previous_object_key || null,
+    source_validators: {
+      etag: response.headers.get('ETag') || null,
+      last_modified: response.headers.get('Last-Modified') || null,
+    },
+    last_validated_at: nowIso,
+    last_error: null,
+  };
+  return {
+    entry: nextEntry,
+    result: {
+      key: item.key,
+      status: previousObjectKey === objectKey ? 'revalidated' : 'imported',
+      object_key: objectKey,
+      replaced_previous: Boolean(previousObjectKey && previousObjectKey !== objectKey),
+    },
+  };
+}
+
+export async function importCovers(env, payload, {
+  fetchFn = fetch,
+  now = () => new Date(),
+} = {}) {
+  const items = normalizeItems(payload);
+  const bucket = env?.COVER_R2;
+  if (!bucket || typeof bucket.get !== 'function' || typeof bucket.put !== 'function') {
+    throw new PilotError(503, 'R2_BINDING_MISSING', 'Binding COVER_R2 no disponible.');
+  }
+  const nowDate = now();
+  const nowIso = nowDate.toISOString();
+  const nowMs = nowDate.getTime();
+  const manifest = await readManifest(bucket, nowIso);
+  const nextManifest = {
+    ...manifest,
+    updated_at: nowIso,
+    entries: { ...manifest.entries },
+  };
+  const results = [];
+
+  // Secuencial a propósito: el piloto reduce presión sobre mlstatic y evita
+  // que una sola ejecución dispare 20 descargas simultáneas.
+  for (const item of items) {
+    const previous = nextManifest.entries[item.key] || null;
+    try {
+      const processed = await processItem(bucket, item, previous, nowIso, nowMs, fetchFn);
+      nextManifest.entries[item.key] = processed.entry;
+      results.push(processed.result);
+    } catch (error) {
+      nextManifest.entries[item.key] = {
+        ...(previous || { product_id: item.product_id, position: item.position, current: null }),
+        last_attempted_source_url: item.source_url,
+        last_error: safeError(error, nowIso),
+      };
+      results.push({
+        key: item.key,
+        status: 'failed',
+        code: error.code || 'SOURCE_IMPORT_FAILED',
+        retained_previous: Boolean(previous?.current?.object_key),
+      });
+    }
+  }
+
+  // Único puntero mutable, escrito al final. Una falla previa conserva el
+  // manifest anterior; una falla acá puede dejar sólo un objeto huérfano.
+  await bucket.put(MANIFEST_KEY, JSON.stringify(nextManifest), {
+    httpMetadata: { contentType: 'application/json', cacheControl: 'no-store' },
+  });
+
+  return {
+    status: 'completed',
+    attempted: results.length,
+    imported: results.filter(result => ['imported', 'revalidated'].includes(result.status)).length,
+    unchanged: results.filter(result => ['fresh-skip', 'not-modified'].includes(result.status)).length,
+    failed: results.filter(result => result.status === 'failed').length,
+    manifest_key: MANIFEST_KEY,
+    results,
+  };
+}

--- a/cover-r2-pilot/scripts/select-real-covers.js
+++ b/cover-r2-pilot/scripts/select-real-covers.js
@@ -1,0 +1,63 @@
+import { pathToFileURL } from 'node:url';
+
+const ALLOWED_HOST = 'http2.mlstatic.com';
+const TARGET_COUNT = 20;
+
+function normalizedUrl(raw) {
+  if (typeof raw !== 'string' || raw.trim() === '') return null;
+  let url;
+  try {
+    url = new URL(raw.trim());
+  } catch {
+    return null;
+  }
+  if (url.hostname !== ALLOWED_HOST || !['http:', 'https:'].includes(url.protocol)) return null;
+  url.protocol = 'https:';
+  url.hash = '';
+  return url.toString();
+}
+
+function candidateUrls(item) {
+  const pictures = Array.isArray(item?.pictures) ? item.pictures : [];
+  return [
+    ...pictures.map(picture => typeof picture === 'string'
+      ? picture
+      : picture?.secure_url || picture?.url),
+    item?.thumbnail,
+  ];
+}
+
+export function selectRealCovers(catalog, targetCount = TARGET_COUNT) {
+  const items = Array.isArray(catalog?.items) ? catalog.items : [];
+  const selected = [];
+  const seenUrls = new Set();
+
+  for (const item of items) {
+    if (selected.length >= targetCount) break;
+    if (item?.status !== 'active' || Number(item.available_quantity) <= 0 ||
+        !/^MLU\d{6,20}$/.test(String(item.id || ''))) continue;
+    const url = candidateUrls(item).map(normalizedUrl).find(Boolean);
+    if (!url || seenUrls.has(url)) continue;
+    seenUrls.add(url);
+    selected.push({ product_id: item.id, position: 0, url });
+  }
+
+  if (selected.length !== targetCount) {
+    throw new Error(`Sólo se encontraron ${selected.length} portadas válidas; se esperaban ${targetCount}.`);
+  }
+  return { items: selected };
+}
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) input += chunk;
+  const catalog = JSON.parse(input);
+  process.stdout.write(`${JSON.stringify(selectRealCovers(catalog))}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/cover-r2-pilot/wrangler.toml
+++ b/cover-r2-pilot/wrangler.toml
@@ -1,0 +1,15 @@
+name = "amadolibros-cover-r2-pilot"
+main = "index.js"
+compatibility_date = "2024-09-23"
+workers_dev = true
+
+# Piloto aislado: sin cron, sin routes y sin acceso al bucket productivo.
+[[r2_buckets]]
+binding = "COVER_R2"
+bucket_name = "amadolibros-images-preview"
+
+[vars]
+PILOT_SCOPE = "preview-20"
+
+# Secret requerido (se configura en Cloudflare, nunca en el repo):
+# COVER_PILOT_SECRET

--- a/scripts/validate-ci.sh
+++ b/scripts/validate-ci.sh
@@ -69,13 +69,14 @@ assert_404_page() {
 }
 
 # ── 1. Sintaxis ───────────────────────────────────────────────────────────
-step "Sintaxis JS (functions, scripts, worker-sync)"
-find functions scripts worker-sync -type f -name '*.js' -print0 |
+step "Sintaxis JS (functions, scripts, worker-sync, cover-r2-pilot)"
+find functions scripts worker-sync cover-r2-pilot -type f -name '*.js' -print0 |
   xargs -0 -r -n1 node --check
 
 # ── 2. Suite completa ─────────────────────────────────────────────────────
 step "Suite completa de tests"
 node --test worker-sync/__tests__/*.test.js
+node --test cover-r2-pilot/__tests__/*.test.js
 node --test functions/__tests__/*.test.js
 node --test astro-front/src/lib/__tests__/*.test.js
 node --test functions/api/__tests__/*.test.js


### PR DESCRIPTION
## Objetivo

Probar con exactamente 20 portadas reales si podemos cortar la dependencia de `mlstatic` mediante copias permanentes y verificadas en un bucket R2 exclusivo de Preview.

## Resultado de aceptación

**20/20 CONFIRMADO en Preview.**

- Commit aceptado: `51e337f2fcc3a6a244c3244f63b3dc5e73ecb7a7`
- [CI completo — success](https://github.com/trexxeseba/amadolibros-web/actions/runs/31336476345)
- [Deploy y aceptación Preview — success](https://github.com/trexxeseba/amadolibros-web/actions/runs/31336476353)
- Importación real: `attempted: 20`, `imported: 20`, `failed: 0`
- Manifest: `entries: 20`, `with_valid_copy: 20`, `with_last_error: 0`
- Bucket aislado confirmado: `amadolibros-images-preview`
- Worker aislado confirmado: `amadolibros-cover-r2-pilot`

El primer intento observable detectó propagación eventual del secret entre ubicaciones edge: `/status` respondió con el secret nuevo y `/import` recibió 401 desde una ubicación todavía atrasada. El workflow ahora reintenta únicamente 401, hasta seis veces, y la aceptación posterior terminó verde.

## Qué cambia

- agrega un Worker independiente en `cover-r2-pilot/`;
- usa únicamente el binding `COVER_R2` hacia `amadolibros-images-preview`;
- no comparte cron, rutas ni código con `worker-sync`;
- protege `POST /import` y `GET /status` con el secret exclusivo `COVER_PILOT_SECRET`;
- impone un máximo duro de 20 imágenes por request;
- acepta sólo URLs HTTPS exactas de `http2.mlstatic.com` y no sigue redirecciones;
- valida tamaño, MIME, firma, estructura y dimensiones de JPEG/PNG/WebP;
- guarda objetos inmutables por SHA-256 y actualiza el manifest al final;
- conserva la última copia válida si una descarga o validación nueva falla;
- revalida la misma URL a los 30 días con ETag/Last-Modified cuando existen;
- selecciona 20 portadas activas con stock desde el catálogo público;
- dispara el deploy sólo para el PR in-repo `agent/cover-r2-pilot-20` hacia `main`;
- incorpora 19 tests del piloto al validador compartido de CI.

## Política operativa

Una URL modificada se revisa en la siguiente ejecución. Una URL estable se revalida cada 30 días. Si cambia el contenido con la misma URL, se crea un objeto con hash nuevo y el manifest cambia sólo después de verificar R2. El piloto no elimina objetos; la retención propuesta para una fase posterior es 90 días sin referencias activas ni pausadas.

## Costos documentados

Para 17.478 posiciones de imagen:

- 250 KB promedio: 4,37 GB
- 500 KB promedio: 8,74 GB
- 1 MB promedio: 17,48 GB

Las ~17.478 escrituras iniciales consumen menos de 1,8% del millón de operaciones Class A incluido. Si el total de la cuenta agotara la franquicia y quedaran 8 GB facturables, el orden de magnitud documentado es ~USD 0,12/mes. No se compra Cloudflare Images ni otro add-on.

## Fuera de alcance

- no modifica `catalog.json`, `home.json`, fichas, cards, catálogo ni checkout;
- no usa el bucket `amadolibros-catalog`;
- no crea cron;
- no despliega a producción;
- no integra todavía las portadas copiadas con la web visible;
- no borra objetos viejos.

## Validación

- tests específicos del piloto: 19/19;
- sintaxis JS completa: OK;
- suites existentes del repositorio: OK;
- build checkout OFF: OK;
- build checkout ON: OK;
- `git diff --check`: OK;
- CI remoto: success;
- deploy/aceptación Preview: success.

## Estado

**Draft. No mergear.** El piloto quedó aceptado en infraestructura separada y producción no fue modificada.