### PR TITLE
COVER-R2-PREVIEW-UI-1: mostrar 20 portadas R2 en Preview

### DIFF
--- a/.github/workflows/deploy-cover-r2-preview-ui.yml
+++ b/.github/workflows/deploy-cover-r2-preview-ui.yml
@@ -109,7 +109,7 @@ jobs:
           )"
           export SAMPLE_ID
 
-          curl -fsS --max-time 180 \
+          curl -fsS --retry 5 --retry-all-errors --retry-delay 3 --max-time 180 \
             'https://pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev/catalog.json' \
             > /tmp/cover-ui-catalog.json
           SAMPLE_QUERY="$(node <<'NODE'

--- a/.github/workflows/deploy-cover-r2-preview-ui.yml
+++ b/.github/workflows/deploy-cover-r2-preview-ui.yml
@@ -1,0 +1,150 @@
+name: Deploy Cover R2 UI Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+    paths:
+      - 'functions/_shared/preview-cover.js'
+      - 'functions/preview-cover/**'
+      - 'functions/catalogo.js'
+      - 'functions/libro/**'
+      - 'functions/__tests__/**'
+      - 'wrangler.toml'
+      - '.github/workflows/deploy-cover-r2-preview-ui.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-cover-r2-preview-ui
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block every source except the isolated in-repo Preview
+        if: github.head_ref != 'agent/cover-r2-preview-ui-20' || github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "Deploy bloqueado: sólo se permite agent/cover-r2-preview-ui-20 -> main."
+          exit 1
+
+  validate:
+    needs: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: astro-front/package-lock.json
+      - name: Validate shared suite
+        run: bash scripts/validate-ci.sh
+
+  deploy-preview:
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: preview
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: astro-front/package-lock.json
+      - name: Install Astro dependencies
+        working-directory: astro-front
+        run: npm ci --no-audit --no-fund
+      - name: Build protected Preview
+        working-directory: astro-front
+        env:
+          PUBLIC_INDEXABLE: 'false'
+          PUBLIC_GA_ID: ''
+          PUBLIC_CHECKOUT_ENABLED: 'false'
+          PUBLIC_TURNSTILE_SITE_KEY: '0x4AAAAAAD6E9kz8K3comwjj'
+          PUBLIC_TURNSTILE_ALLOWED_HOSTS: '.amadolibros-web.pages.dev'
+        run: npm run build
+      - name: Deploy isolated Pages Preview
+        run: >
+          npx wrangler@3.114.17 pages deploy ./astro-front/dist
+          --project-name amadolibros-web
+          --branch agent/cover-r2-preview-ui-20
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Verify manifest, catalog card, product page and image bytes
+        env:
+          PREVIEW_URL: https://agent-cover-r2-preview-ui-20.amadolibros-web.pages.dev
+        run: |
+          STATUS_CODE=""
+          for attempt in 1 2 3 4 5 6 7 8; do
+            STATUS_CODE="$(curl -sS --max-time 30 -o /tmp/cover-ui-status.json -w '%{http_code}' \
+              "$PREVIEW_URL/preview-cover/status")"
+            if [ "$STATUS_CODE" = "200" ]; then
+              break
+            fi
+            echo "Preview todavía propagándose (intento $attempt/8; HTTP $STATUS_CODE)."
+            sleep 10
+          done
+          cat /tmp/cover-ui-status.json
+          if [ "$STATUS_CODE" != "200" ]; then
+            echo "Status Preview no respondió 200."
+            exit 1
+          fi
+
+          SAMPLE_ID="$(node <<'NODE'
+          const fs = require('node:fs');
+          const status = JSON.parse(fs.readFileSync('/tmp/cover-ui-status.json', 'utf8'));
+          if (status.with_valid_copy !== 20 || !/^MLU\d+$/.test(status.sample_product_id || '')) {
+            throw new Error(`Manifest inesperado: ${JSON.stringify(status)}`);
+          }
+          process.stdout.write(status.sample_product_id);
+          NODE
+          )"
+          export SAMPLE_ID
+
+          curl -fsS --max-time 180 \
+            'https://pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev/catalog.json' \
+            > /tmp/cover-ui-catalog.json
+          SAMPLE_QUERY="$(node <<'NODE'
+          const fs = require('node:fs');
+          const catalog = JSON.parse(fs.readFileSync('/tmp/cover-ui-catalog.json', 'utf8'));
+          const item = catalog.items.find(row => row.id === process.env.SAMPLE_ID);
+          if (!item) throw new Error(`No se encontró ${process.env.SAMPLE_ID} en catalog.json.`);
+          process.stdout.write(encodeURIComponent(item.title));
+          NODE
+          )"
+
+          curl -fsS --retry 5 --retry-all-errors --retry-delay 3 --max-time 60 \
+            "$PREVIEW_URL/catalogo?q=$SAMPLE_QUERY" > /tmp/cover-ui-card.html
+          grep -Fq "/preview-cover/$SAMPLE_ID/0/" /tmp/cover-ui-card.html
+
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 --max-time 60 \
+            "$PREVIEW_URL/libro/$SAMPLE_ID" > /tmp/cover-ui-book.html
+          grep -Fq "/preview-cover/$SAMPLE_ID/0/" /tmp/cover-ui-book.html
+
+          IMAGE_PATH="$(grep -Eo "/preview-cover/$SAMPLE_ID/0/[a-f0-9]{64}\.(jpg|png|webp)" \
+            /tmp/cover-ui-book.html | head -1)"
+          if [ -z "$IMAGE_PATH" ]; then
+            echo "La ficha no contiene una URL R2 inmutable."
+            exit 1
+          fi
+          curl -fsS --max-time 60 -D /tmp/cover-ui-image.headers \
+            "$PREVIEW_URL$IMAGE_PATH" -o /tmp/cover-ui-image.bin
+          tr -d '\r' < /tmp/cover-ui-image.headers | grep -Eqi '^content-type: image/(jpeg|png|webp)$'
+          tr -d '\r' < /tmp/cover-ui-image.headers | grep -Fqi 'x-amado-cover-source: r2-preview'
+          test -s /tmp/cover-ui-image.bin
+
+          PROD_CODE="$(curl -sS --max-time 30 -o /dev/null -w '%{http_code}' \
+            'https://www.amadolibros.com/preview-cover/status')"
+          if [ "$PROD_CODE" != "404" ]; then
+            echo "Producción respondió $PROD_CODE en /preview-cover/status; se esperaba 404."
+            exit 1
+          fi
+          echo "Aceptación R2 UI: manifest 20/20, card, ficha, imagen y aislamiento productivo OK."

--- a/functions/__tests__/catalog-display.test.js
+++ b/functions/__tests__/catalog-display.test.js
@@ -17,7 +17,8 @@ const CATALOG = {
       id: 'MLU1', title: 'Alpha disponible', author: 'Autora Uno',
       isbn: '9789991234567',
       price: 1000, status: 'active', available_quantity: 2,
-      thumbnail: '', pictures: [], permalink: 'https://articulo.mercadolibre.com.uy/MLU1',
+      thumbnail: '', pictures: ['https://http2.mlstatic.com/D_TEST-O.jpg'],
+      permalink: 'https://articulo.mercadolibre.com.uy/MLU1',
     },
   ],
 };
@@ -30,15 +31,45 @@ const VERSION = '20260730120000000';
 const BLOCK = pausedBlockNumberForId(PAUSED.id, 128);
 const PREFIX = `stock1-preview/versions/${VERSION}`;
 
-function context(url, params = {}, appEnv = 'preview') {
+function context(url, params = {}, appEnv = 'preview', envOverrides = {}) {
   return {
     request: new Request(url),
     params,
     env: {
       APP_ENV: appEnv,
       STOCK_WAITLIST_TURNSTILE_SITE_KEY: '0xpreview-test-sitekey',
+      ...envOverrides,
     },
     waitUntil() {},
+  };
+}
+
+const PREVIEW_COVER_HASH = 'a'.repeat(64);
+const PREVIEW_COVER_MANIFEST = {
+  schema_version: 1,
+  updated_at: '2026-08-09T21:00:00.000Z',
+  entries: {
+    'MLU1:0': {
+      product_id: 'MLU1',
+      position: 0,
+      current: {
+        object_key: `covers/v1/objects/${PREVIEW_COVER_HASH}.jpg`,
+        sha256: PREVIEW_COVER_HASH,
+        mime: 'image/jpeg',
+        source_url: 'https://http2.mlstatic.com/D_TEST-O.jpg',
+      },
+    },
+  },
+};
+
+function previewCoverBucket() {
+  return {
+    async get(key) {
+      if (key === 'covers/v1/manifest.json') {
+        return { async text() { return JSON.stringify(PREVIEW_COVER_MANIFEST); } };
+      }
+      return null;
+    },
   };
 }
 
@@ -107,6 +138,50 @@ test.beforeEach(() => {
       async put() {},
     },
   };
+});
+
+test('COVER-R2 Preview: card y ficha usan la copia validada del mismo origen', async () => {
+  const env = { COVER_R2: previewCoverBucket() };
+  const catalogResponse = await catalogRequest(
+    context('https://preview.example/catalogo', {}, 'preview', env)
+  );
+  const catalogHtml = await catalogResponse.text();
+  assert.match(
+    catalogHtml,
+    new RegExp(`/preview-cover/MLU1/0/${PREVIEW_COVER_HASH}\\.jpg`),
+  );
+
+  const bookResponse = await bookRequest(context(
+    'https://preview.example/libro/MLU1/alpha-disponible',
+    { path: ['MLU1', 'alpha-disponible'] },
+    'preview',
+    env,
+  ));
+  const bookHtml = await bookResponse.text();
+  assert.match(
+    bookHtml,
+    new RegExp(`/preview-cover/MLU1/0/${PREVIEW_COVER_HASH}\\.jpg`),
+  );
+});
+
+test('COVER-R2 Preview: URL origen distinta mantiene mlstatic como fallback', async () => {
+  const staleManifest = structuredClone(PREVIEW_COVER_MANIFEST);
+  staleManifest.entries['MLU1:0'].current.source_url =
+    'https://http2.mlstatic.com/D_OLD-O.jpg';
+  const staleBucket = {
+    async get(key) {
+      if (key === 'covers/v1/manifest.json') {
+        return { async text() { return JSON.stringify(staleManifest); } };
+      }
+      return null;
+    },
+  };
+  const response = await catalogRequest(
+    context('https://preview.example/catalogo', {}, 'preview', { COVER_R2: staleBucket })
+  );
+  const html = await response.text();
+  assert.doesNotMatch(html, /\/preview-cover\/MLU1\/0\//);
+  assert.match(html, /https:\/\/http2\.mlstatic\.com\/D_TEST-O\.jpg/);
 });
 
 // CF-CATEGORÍAS-2D: en Preview, un pausado ya no se muestra como "No

--- a/functions/__tests__/cover-preview-ui-config.test.js
+++ b/functions/__tests__/cover-preview-ui-config.test.js
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const workflow = readFileSync(
+  path.join(ROOT, '.github', 'workflows', 'deploy-cover-r2-preview-ui.yml'),
+  'utf8',
+);
+
+function runtimeJsFiles(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const absolute = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__') return [];
+      return runtimeJsFiles(absolute);
+    }
+    return entry.isFile() && entry.name.endsWith('.js') ? [absolute] : [];
+  });
+}
+
+test('workflow R2 UI sólo acepta la rama Preview in-repo y despliega checkout apagado', () => {
+  assert.match(workflow, /github\.head_ref != 'agent\/cover-r2-preview-ui-20'/);
+  assert.match(workflow, /head\.repo\.full_name != github\.repository/);
+  assert.match(workflow, /--branch agent\/cover-r2-preview-ui-20/);
+  assert.match(workflow, /PUBLIC_INDEXABLE:\s*'false'/);
+  assert.match(workflow, /PUBLIC_CHECKOUT_ENABLED:\s*'false'/);
+  assert.doesNotMatch(workflow, /--branch main/);
+  assert.doesNotMatch(workflow, /env\.production/);
+});
+
+test('workflow prueba 20 copias, card, ficha, bytes y 404 productivo sin secret de portada', () => {
+  assert.match(workflow, /status\.with_valid_copy !== 20/);
+  assert.match(workflow, /\/catalogo\?q=\$SAMPLE_QUERY/);
+  assert.match(workflow, /\/libro\/\$SAMPLE_ID/);
+  assert.match(workflow, /x-amado-cover-source: r2-preview/i);
+  assert.match(workflow, /www\.amadolibros\.com\/preview-cover\/status/);
+  assert.doesNotMatch(workflow, /COVER_PILOT_SECRET|SYNC_SECRET/);
+});
+
+test('COVER_R2 sólo es referenciado por los dos módulos runtime de portadas', () => {
+  const references = runtimeJsFiles(path.join(ROOT, 'functions'))
+    .filter(file => readFileSync(file, 'utf8').includes('COVER_R2'))
+    .map(file => path.relative(ROOT, file).replaceAll(path.sep, '/'))
+    .sort();
+
+  assert.deepEqual(references, [
+    'functions/_shared/preview-cover.js',
+    'functions/preview-cover/[[path]].js',
+  ]);
+});
+
+test('módulos COVER_R2 sólo leen con get; no escriben, borran ni enumeran', () => {
+  const sources = [
+    'functions/_shared/preview-cover.js',
+    'functions/preview-cover/[[path]].js',
+  ].map(file => readFileSync(path.join(ROOT, file), 'utf8')).join('\n');
+
+  assert.match(sources, /COVER_R2\.get\(|bucket\.get\(/);
+  assert.doesNotMatch(
+    sources,
+    /COVER_R2\.(?:put|delete|list|head|createMultipartUpload|resumeMultipartUpload)\s*\(|bucket\.(?:put|delete|list|head|createMultipartUpload|resumeMultipartUpload)\s*\(/,
+  );
+});

--- a/functions/__tests__/cover-preview-ui-config.test.js
+++ b/functions/__tests__/cover-preview-ui-config.test.js
@@ -33,6 +33,10 @@ test('workflow R2 UI sólo acepta la rama Preview in-repo y despliega checkout a
 
 test('workflow prueba 20 copias, card, ficha, bytes y 404 productivo sin secret de portada', () => {
   assert.match(workflow, /status\.with_valid_copy !== 20/);
+  assert.match(
+    workflow,
+    /curl -fsS --retry 5 --retry-all-errors --retry-delay 3 --max-time 180/,
+  );
   assert.match(workflow, /\/catalogo\?q=\$SAMPLE_QUERY/);
   assert.match(workflow, /\/libro\/\$SAMPLE_ID/);
   assert.match(workflow, /x-amado-cover-source: r2-preview/i);

--- a/functions/__tests__/preview-cover.test.js
+++ b/functions/__tests__/preview-cover.test.js
@@ -1,0 +1,149 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PREVIEW_COVER_MANIFEST_KEY,
+  findPreviewCover,
+  previewCoverSummary,
+  previewCoverUrl,
+} from '../_shared/preview-cover.js';
+import { onRequest as coverRequest } from '../preview-cover/[[path]].js';
+import { renderPage } from '../libro/[[path]].js';
+
+const ID = 'MLU123456789';
+const HASH = 'a'.repeat(64);
+const SOURCE = 'https://http2.mlstatic.com/D_TEST-O.jpg';
+const OBJECT_KEY = `covers/v1/objects/${HASH}.jpg`;
+
+function manifest(overrides = {}) {
+  return {
+    schema_version: 1,
+    updated_at: '2026-08-09T21:00:00.000Z',
+    entries: {
+      [`${ID}:0`]: {
+        product_id: ID,
+        position: 0,
+        current: {
+          object_key: OBJECT_KEY,
+          sha256: HASH,
+          mime: 'image/jpeg',
+          source_url: SOURCE,
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+function bucket({ manifestValue = manifest(), image = new Uint8Array([1, 2, 3]) } = {}) {
+  const reads = [];
+  return {
+    reads,
+    async get(key) {
+      reads.push(key);
+      if (key === PREVIEW_COVER_MANIFEST_KEY) {
+        return { async text() { return JSON.stringify(manifestValue); } };
+      }
+      if (key === OBJECT_KEY) return { body: image, size: image.byteLength };
+      return null;
+    },
+  };
+}
+
+function ctx({ appEnv = 'preview', coverBucket = bucket(), path = [], method = 'GET' } = {}) {
+  return {
+    request: new Request('https://cover-ui.example/preview-cover/test', { method }),
+    params: { path },
+    env: { APP_ENV: appEnv, COVER_R2: coverBucket },
+    data: {},
+  };
+}
+
+test('Preview resuelve una URL inmutable del mismo origen y memoiza el manifest', async () => {
+  const coverBucket = bucket();
+  const context = ctx({ coverBucket });
+  const first = await previewCoverUrl(context, ID, 0, SOURCE);
+  const second = await previewCoverUrl(context, ID, 0, SOURCE);
+  assert.equal(first, `https://cover-ui.example/preview-cover/${ID}/0/${HASH}.jpg`);
+  assert.equal(second, first);
+  assert.deepEqual(coverBucket.reads, [PREVIEW_COVER_MANIFEST_KEY]);
+});
+
+test('Producción no consulta el bucket ni expone una portada Preview', async () => {
+  const coverBucket = bucket();
+  const result = await previewCoverUrl(ctx({ appEnv: 'production', coverBucket }), ID, 0, SOURCE);
+  assert.equal(result, null);
+  assert.deepEqual(coverBucket.reads, []);
+});
+
+test('URL origen modificada conserva el fallback de Mercado Libre', async () => {
+  const result = await previewCoverUrl(
+    ctx(), ID, 0, 'https://http2.mlstatic.com/D_CHANGED-O.jpg'
+  );
+  assert.equal(result, null);
+});
+
+test('Manifest u objeto actual incoherente se rechazan sin lanzar error', async () => {
+  const broken = manifest();
+  broken.entries[`${ID}:0`].current.sha256 = 'b'.repeat(64);
+  assert.equal(await findPreviewCover(ctx({ coverBucket: bucket({ manifestValue: broken }) }), ID), null);
+});
+
+test('Ruta pública sirve sólo el objeto exacto referenciado, con caché inmutable', async () => {
+  const response = await coverRequest(ctx({ path: [ID, '0', `${HASH}.jpg`] }));
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('content-type'), 'image/jpeg');
+  assert.equal(response.headers.get('cache-control'), 'public, max-age=31536000, immutable');
+  assert.equal(response.headers.get('etag'), `"${HASH}"`);
+  assert.equal(response.headers.get('x-amado-cover-source'), 'r2-preview');
+  assert.deepEqual([...new Uint8Array(await response.arrayBuffer())], [1, 2, 3]);
+});
+
+test('HEAD valida la misma portada y devuelve headers sin cuerpo', async () => {
+  const response = await coverRequest(ctx({
+    path: [ID, '0', `${HASH}.jpg`],
+    method: 'HEAD',
+  }));
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('content-type'), 'image/jpeg');
+  assert.equal(response.headers.get('cache-control'), 'public, max-age=31536000, immutable');
+  assert.equal(await response.text(), '');
+});
+
+test('Ruta rechaza hash ajeno, métodos de escritura y cualquier acceso en Producción', async () => {
+  const wrongHash = await coverRequest(ctx({ path: [ID, '0', `${'b'.repeat(64)}.jpg`] }));
+  assert.equal(wrongHash.status, 404);
+  const post = await coverRequest(ctx({ path: [ID, '0', `${HASH}.jpg`], method: 'POST' }));
+  assert.equal(post.status, 405);
+  const production = await coverRequest(ctx({
+    appEnv: 'production', path: [ID, '0', `${HASH}.jpg`],
+  }));
+  assert.equal(production.status, 404);
+});
+
+test('Status Preview expone sólo conteo y un ID de muestra; Producción devuelve 404', async () => {
+  const summary = await previewCoverSummary(ctx());
+  assert.deepEqual(summary, { entries: 1, with_valid_copy: 1, sample_product_id: ID });
+  const response = await coverRequest(ctx({ path: ['status'] }));
+  assert.deepEqual(await response.json(), summary);
+  const production = await coverRequest(ctx({ appEnv: 'production', path: ['status'] }));
+  assert.equal(production.status, 404);
+});
+
+test('Ficha usa la portada R2 sólo como primera imagen y conserva las secundarias', () => {
+  const previewSrc = `https://cover-ui.example/preview-cover/${ID}/0/${HASH}.jpg`;
+  const html = renderPage({
+    id: ID,
+    title: 'Libro de prueba',
+    author: 'Autora',
+    price: 1200,
+    status: 'active',
+    available_quantity: 1,
+    condition: 'new',
+    pictures: [SOURCE, 'https://http2.mlstatic.com/D_SECOND-O.jpg'],
+    thumbnail: '',
+    permalink: 'https://articulo.mercadolibre.com.uy/test',
+  }, 'libro-de-prueba', true, '', previewSrc);
+  assert.match(html, new RegExp(`class="cover-main"[^>]+src="${previewSrc.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
+  assert.match(html, /https:\/\/http2\.mlstatic\.com\/D_SECOND-O\.jpg/);
+  assert.match(html, new RegExp(`data-thumbnail="${previewSrc.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
+});

--- a/functions/__tests__/wrangler-config.test.js
+++ b/functions/__tests__/wrangler-config.test.js
@@ -104,6 +104,17 @@ test('wrangler.toml: Preview declara destinatarios internos sin declarar RESEND_
   assert.doesNotMatch(previewVars, /RESEND_API_KEY/);
 });
 
+test('COVER-R2: binding de portadas existe sólo en Preview', () => {
+  assert.match(
+    wranglerToml,
+    /\[\[env\.preview\.r2_buckets\]\][\s\S]*?binding\s*=\s*"COVER_R2"[\s\S]*?bucket_name\s*=\s*"amadolibros-images-preview"/,
+  );
+  const productionStart = wranglerToml.indexOf('[[env.production.kv_namespaces]]');
+  assert.ok(productionStart > -1);
+  assert.doesNotMatch(wranglerToml.slice(productionStart), /binding\s*=\s*"COVER_R2"/);
+  assert.doesNotMatch(wranglerToml.slice(productionStart), /amadolibros-images-preview/);
+});
+
 test('STOCK-1 Preview queda limitado a su rama y checkout apagado', () => {
   assert.match(stockPreviewYml, /refs\/heads\/agent\/stock-1-preview/);
   assert.match(stockPreviewYml, /--branch agent\/stock-1-preview/);

--- a/functions/_shared/preview-cover.js
+++ b/functions/_shared/preview-cover.js
@@ -1,0 +1,96 @@
+const MANIFEST_KEY = 'covers/v1/manifest.json';
+const OBJECT_KEY_RE = /^covers\/v1\/objects\/([a-f0-9]{64})\.(jpg|png|webp)$/;
+const PRODUCT_ID_RE = /^MLU\d+$/;
+
+function normalizeSourceUrl(raw) {
+    if (typeof raw !== 'string' || raw.trim() === '') return null;
+    try {
+        const url = new URL(raw.trim());
+        if (url.hostname !== 'http2.mlstatic.com' ||
+            !['http:', 'https:'].includes(url.protocol)) return null;
+        url.protocol = 'https:';
+        url.hash = '';
+        return url.toString();
+    } catch {
+        return null;
+    }
+}
+
+function validManifest(value) {
+    return value && value.schema_version === 1 &&
+        value.entries && typeof value.entries === 'object' &&
+        !Array.isArray(value.entries);
+}
+
+async function readPreviewManifest(ctx) {
+    if (ctx?.env?.APP_ENV !== 'preview') return null;
+    const bucket = ctx?.env?.COVER_R2;
+    if (!bucket || typeof bucket.get !== 'function') return null;
+    if (!ctx.data || typeof ctx.data !== 'object') ctx.data = {};
+    if (!ctx.data.__previewCoverManifestPromise) {
+        ctx.data.__previewCoverManifestPromise = (async () => {
+            try {
+                const object = await bucket.get(MANIFEST_KEY);
+                if (!object || typeof object.text !== 'function') return null;
+                const parsed = JSON.parse(await object.text());
+                return validManifest(parsed) ? parsed : null;
+            } catch {
+                return null;
+            }
+        })();
+    }
+    return ctx.data.__previewCoverManifestPromise;
+}
+
+function validCurrent(entry) {
+    const match = OBJECT_KEY_RE.exec(String(entry?.current?.object_key || ''));
+    if (!match || entry.current.sha256 !== match[1]) return null;
+    if (entry.current.mime !== `image/${match[2] === 'jpg' ? 'jpeg' : match[2]}`) return null;
+    return {
+        entry,
+        objectKey: entry.current.object_key,
+        sha256: match[1],
+        extension: match[2],
+        mime: entry.current.mime,
+    };
+}
+
+export async function findPreviewCover(ctx, productId, position = 0, sourceUrl = null) {
+    if (!PRODUCT_ID_RE.test(String(productId || '')) ||
+        !Number.isInteger(position) || position < 0 || position > 15) return null;
+    const manifest = await readPreviewManifest(ctx);
+    const current = validCurrent(manifest?.entries?.[`${productId}:${position}`]);
+    if (!current) return null;
+
+    // Cuando el catálogo completo está disponible, exigimos que la copia
+    // corresponda a la URL vigente de Mercado Libre. Los índices compactos
+    // no conservan pictures[]; en ese caso sourceUrl=null y confiamos en el
+    // manifest validado/refrescado por el piloto.
+    if (sourceUrl !== null) {
+        const normalized = normalizeSourceUrl(sourceUrl);
+        if (!normalized || normalized !== current.entry.current.source_url) return null;
+    }
+    return current;
+}
+
+export async function previewCoverUrl(ctx, productId, position = 0, sourceUrl = null) {
+    const cover = await findPreviewCover(ctx, productId, position, sourceUrl);
+    if (!cover) return null;
+    const origin = new URL(ctx.request.url).origin;
+    return `${origin}/preview-cover/${productId}/${position}/${cover.sha256}.${cover.extension}`;
+}
+
+export async function previewCoverSummary(ctx) {
+    const manifest = await readPreviewManifest(ctx);
+    if (!manifest) return null;
+    const covers = Object.values(manifest.entries)
+        .map(validCurrent)
+        .filter(Boolean);
+    return {
+        entries: Object.keys(manifest.entries).length,
+        with_valid_copy: covers.length,
+        sample_product_id: covers[0]?.entry?.product_id || null,
+    };
+}
+
+export const PREVIEW_COVER_MANIFEST_KEY = MANIFEST_KEY;

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -52,6 +52,7 @@ import {
     recordPerf,
     serverTimingValue,
 } from './_shared/perf.js';
+import { previewCoverUrl } from './_shared/preview-cover.js';
 
 const MAX_RESULTS = 48;
 const WA = 'https://wa.me/59899841325';
@@ -555,10 +556,25 @@ export async function onRequest(ctx) {
     const rangeFrom = totalResults === 0 ? 0 : offset + 1;
     const rangeTo   = offset + limited.length;
 
+    // COVER-R2-PREVIEW-UI-1: una sola lectura memoizada del manifest por
+    // request. Con catálogo completo exigimos coincidencia de la URL origen;
+    // el índice compacto no conserva pictures[] y pasa null explícitamente.
+    const previewCovers = ctx.env?.APP_ENV === 'preview'
+        ? await Promise.all(limited.map(b => {
+            const hasFullPictures = Array.isArray(b.pictures);
+            const source = hasFullPictures
+                ? httpsImg(b.pictures[0] || b.thumbnail || '')
+                : null;
+            return previewCoverUrl(ctx, b.id, 0, source);
+        }))
+        : Array(limited.length).fill(null);
+
     const cards = limited.map((b, idx) => {
         const slug  = slugify(b.title);
         const href  = escapeHtml(`${previewBase}/libro/${b.id}/${slug}`);
-        const img   = escapeHtml(httpsImg(b.pictures?.[0] || b.thumbnail || ''));
+        const img   = escapeHtml(
+            previewCovers[idx] || httpsImg(b.pictures?.[0] || b.thumbnail || '')
+        );
         const title = escapeHtml(b.title);
         const author = b.author
             ? `<p class="rc-author">${escapeHtml(b.author)}</p>`

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -15,6 +15,7 @@
 
 import { slugify } from '../_shared/slug.js';
 import { BASE, fetchCatalog, fetchPausedItem } from '../_shared/catalog.js';
+import { previewCoverUrl as resolvePreviewCoverUrl } from '../_shared/preview-cover.js';
 // GLOBAL-SHELL-1: shell global compartido con Astro (marca, favicon, footer
 // y burbuja de WhatsApp). Ver functions/_shared/brand.js.
 import {
@@ -46,7 +47,7 @@ function httpsImg(url) {
     return (url || '').replace('http://', 'https://');
 }
 
-function normalizeImages(item) {
+function normalizeImages(item, previewCoverSrc = '') {
     const urls = [];
 
     if (Array.isArray(item.pictures)) {
@@ -57,7 +58,9 @@ function normalizeImages(item) {
 
     if (item.thumbnail) urls.push(item.thumbnail);
 
-    return [...new Set(urls.map(httpsImg).filter(Boolean))].slice(0, 6);
+    const normalized = [...new Set(urls.map(httpsImg).filter(Boolean))].slice(0, 6);
+    if (previewCoverSrc && normalized.length > 0) normalized[0] = previewCoverSrc;
+    return normalized;
 }
 
 function formatCondition(condition) {
@@ -237,11 +240,11 @@ function notFound() {
 // Render HTML completo de la ficha
 // ---------------------------------------------------------------------------
 
-export function renderPage(item, slug, isPreview, waitlistSiteKey) {
+export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverSrc = '') {
     const canonicalUrl = `${BASE}/libro/${item.id}/${slug}`;
     const safeTitle    = escapeHtml(item.title);
     const safeAuthor   = item.author ? escapeHtml(item.author) : null;
-    const images       = normalizeImages(item);
+    const images       = normalizeImages(item, previewCoverSrc);
     const img          = images[0] || '';
     const price         = Number(item.price) || 0;
     const priceUY       = price.toLocaleString('es-UY');
@@ -758,7 +761,12 @@ export async function onRequest(context) {
         ? context.env.STOCK_WAITLIST_TURNSTILE_SITE_KEY.trim()
         : '';
 
-    return new Response(renderPage(item, slug, isPreview, waitlistSiteKey), {
+    const originalImages = normalizeImages(item);
+    const previewCoverSrc = isPreview && originalImages[0]
+        ? await resolvePreviewCoverUrl(context, item.id, 0, originalImages[0])
+        : null;
+
+    return new Response(renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverSrc || ''), {
         headers: {
             'content-type':  'text/html;charset=UTF-8',
             'cache-control': 'public, max-age=3600',

--- a/functions/preview-cover/[[path]].js
+++ b/functions/preview-cover/[[path]].js
@@ -1,0 +1,67 @@
+import {
+    findPreviewCover,
+    previewCoverSummary,
+} from '../_shared/preview-cover.js';
+
+function notFound() {
+    return new Response('Not found', {
+        status: 404,
+        headers: { 'Cache-Control': 'no-store' },
+    });
+}
+
+function pathParts(context) {
+    return Array.isArray(context.params.path)
+        ? context.params.path
+        : [context.params.path].filter(Boolean);
+}
+
+export async function onRequest(context) {
+    if (context.env?.APP_ENV !== 'preview') return notFound();
+    if (context.request.method !== 'GET' && context.request.method !== 'HEAD') {
+        return new Response('Method not allowed', {
+            status: 405,
+            headers: { Allow: 'GET, HEAD', 'Cache-Control': 'no-store' },
+        });
+    }
+
+    const parts = pathParts(context);
+    if (parts.length === 1 && parts[0] === 'status') {
+        const summary = await previewCoverSummary(context);
+        return summary
+            ? Response.json(summary, { headers: { 'Cache-Control': 'no-store' } })
+            : notFound();
+    }
+
+    if (parts.length !== 3) return notFound();
+    const [productId, rawPosition, filename] = parts;
+    const position = Number(rawPosition);
+    const fileMatch = /^([a-f0-9]{64})\.(jpg|png|webp)$/.exec(filename || '');
+    if (!fileMatch) return notFound();
+
+    const cover = await findPreviewCover(context, productId, position);
+    if (!cover || cover.sha256 !== fileMatch[1] || cover.extension !== fileMatch[2]) {
+        return notFound();
+    }
+
+    try {
+        const object = await context.env.COVER_R2.get(cover.objectKey);
+        if (!object?.body) return notFound();
+        const headers = new Headers({
+            'Content-Type': cover.mime,
+            'Cache-Control': 'public, max-age=31536000, immutable',
+            'ETag': `"${cover.sha256}"`,
+            'X-Content-Type-Options': 'nosniff',
+            'X-Amado-Cover-Source': 'r2-preview',
+        });
+        if (Number.isFinite(Number(object.size))) {
+            headers.set('Content-Length', String(object.size));
+        }
+        return new Response(context.request.method === 'HEAD' ? null : object.body, {
+            status: 200,
+            headers,
+        });
+    } catch {
+        return notFound();
+    }
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -39,6 +39,12 @@ database_id = "6fa387af-f29e-46dc-97e5-30298568b4a6"
 binding     = "CATALOG_BUCKET"
 bucket_name = "amadolibros-catalog"
 
+# COVER-R2-PREVIEW-UI-1: lectura exclusiva de las 20 portadas validadas del
+# piloto. Pages nunca escribe en este bucket y Producción no recibe el binding.
+[[env.preview.r2_buckets]]
+binding     = "COVER_R2"
+bucket_name = "amadolibros-images-preview"
+
 # Vars no secretas de Preview — env.preview.vars aplica a TODOS los
 # preview deployments del proyecto, no solo a esta rama. CANONICAL_ORIGIN
 # queda fijado al alias de esta rama porque Cloudflare Pages no permite


### PR DESCRIPTION
## Objetivo

Mostrar las 20 portadas ya copiadas y validadas por el piloto R2 en cards de `/catalogo` y en la portada principal de `/libro/...`, exclusivamente en Cloudflare Pages Preview.

Este lote parte directamente de `main`; no apila commits ni código sobre el PR #99. La única dependencia externa es el bucket Preview descartable `amadolibros-images-preview`, ya creado y aceptado 20/20 por ese piloto.

## Arquitectura elegida

Se usa binding R2 directo en Pages Preview (Opción A):

- `COVER_R2` existe sólo bajo `[[env.preview.r2_buckets]]`;
- la imagen se sirve same-origin desde `/preview-cover/{MLU}/{posición}/{sha256}.{ext}`;
- no hay URL `workers.dev`, CORS ni secret en el navegador;
- la URL es inmutable por hash y usa caché de un año;
- la ruta admite sólo `GET` y `HEAD`;
- valida ID MLU, posición, hash, extensión, MIME y referencia exacta en el manifest;
- objeto o manifest ausente/incoherente devuelve 404;
- el frontend decide server-side: usa R2 sólo si el manifest confirma la copia; de lo contrario conserva `mlstatic`.

## Aislamiento

- Producción no recibe `COVER_R2`.
- En producción, `/preview-cover/*` responde 404 sin tocar R2.
- Sólo dos módulos runtime pueden referenciar `COVER_R2`.
- Esos módulos sólo pueden ejecutar `get`; los tests prohíben `put`, `delete`, `list`, `head` y multipart.
- El workflow sólo acepta el PR in-repo `agent/cover-r2-preview-ui-20 -> main`.
- Preview se construye con indexación y checkout apagados.
- No se usa `COVER_PILOT_SECRET`, `SYNC_SECRET` ni ningún secreto de portada.

## Cambios visibles en Preview

- Cards del catálogo: reemplazan la portada principal sólo para las copias confirmadas.
- Fichas: reemplazan únicamente la primera imagen; las secundarias siguen iguales.
- Si la URL vigente de Mercado Libre no coincide con la guardada, se conserva `mlstatic`.
- No se modifica el checkout, feed, Merchant Center, catálogo productivo ni worker de sync.

## Validación local completa

- pruebas específicas y guardas R2 UI: 54/54;
- sintaxis JS completa: OK;
- todas las suites del repositorio: OK;
- `npm ci`: OK con caché local escribible;
- build checkout OFF: OK;
- build checkout ON: OK;
- 404 y Turnstile: OK;
- `git diff --check`: OK.

El entorno local requería `NPM_CONFIG_CACHE=/tmp/...` y `ASTRO_TELEMETRY_DISABLED=1` porque no puede escribir `/root/.npm` ni `/root/.config/astro`; no se cambió código ni configuración del repo para esa limitación.

## Aceptación remota esperada

El workflow del PR exige:

1. manifest con 20 copias válidas;
2. una card renderizada con URL R2 same-origin;
3. una ficha renderizada con URL R2 same-origin;
4. bytes de imagen con MIME y header de origen correctos;
5. 404 real en `https://www.amadolibros.com/preview-cover/status`.

## Estado

**Draft. No mergear. No desplegar a producción.**

## Resultado de aceptación remota

**APROBADO en Preview.**

- Commit aceptado: `7c21b96363473e62a89d599c17539b9f0b0d1697`
- [CI general — success](https://github.com/trexxeseba/amadolibros-web/actions/runs/31338080007)
- [Deploy y aceptación R2 UI — success](https://github.com/trexxeseba/amadolibros-web/actions/runs/31338080000)
- Manifest: `entries: 20`, `with_valid_copy: 20`
- Muestra verificada: `MLU478189961`
- Card: URL R2 same-origin confirmada
- Ficha: URL R2 same-origin confirmada
- Imagen: bytes, MIME y header `x-amado-cover-source: r2-preview` confirmados
- Producción: `/preview-cover/status` respondió 404

El primer run detectó un 404 puntual en la consulta auxiliar directa a `r2.dev/catalog.json`. El runtime ya había respondido 20/20. Se agregó reintento acotado sólo a esa consulta del workflow; el segundo run completó toda la aceptación.

**El PR permanece Draft. No mergear ni desplegar a producción.**