### PR TITLE
COVER-R2-PRODUCTION-1: promover 20 portadas validadas

### DIFF
--- a/.github/workflows/deploy-cover-r2-preview-ui.yml
+++ b/.github/workflows/deploy-cover-r2-preview-ui.yml
@@ -23,13 +23,13 @@ concurrency:
 
 jobs:
   guard:
+    # Workflow de aceptación de un solo uso. En ramas posteriores queda
+    # omitido en vez de producir un check rojo falso por compartir paths.
+    if: github.head_ref == 'agent/cover-r2-preview-ui-20' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - name: Block every source except the isolated in-repo Preview
-        if: github.head_ref != 'agent/cover-r2-preview-ui-20' || github.event.pull_request.head.repo.full_name != github.repository
-        run: |
-          echo "Deploy bloqueado: sólo se permite agent/cover-r2-preview-ui-20 -> main."
-          exit 1
+      - name: Confirm isolated in-repo Preview source
+        run: echo "Rama Preview aislada confirmada."
 
   validate:
     needs: guard

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -269,8 +269,20 @@ jobs:
             if (!(s.with_valid_copy >= 20) || !/^MLU\d+$/.test(s.sample_product_id || "")) process.exit(1);
             process.stdout.write(s.sample_product_id);
           ')"
-          curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 --max-time 60 \
-            "https://www.amadolibros.com/libro/$SAMPLE_ID" > /tmp/cover-r2-book.html
+          BOOK_CODE=""
+          for attempt in 1 2 3 4 5 6 7 8; do
+            BOOK_CODE="$(curl -sSL --max-time 60 -o /tmp/cover-r2-book.html -w '%{http_code}' \
+              "https://www.amadolibros.com/libro/$SAMPLE_ID")"
+            if [ "$BOOK_CODE" = "200" ] && grep -Fq "/preview-cover/$SAMPLE_ID/0/" /tmp/cover-r2-book.html; then
+              break
+            fi
+            echo "Ficha R2 productiva todavía propagándose (intento $attempt/8; HTTP $BOOK_CODE)."
+            sleep 10
+          done
+          if [ "$BOOK_CODE" != "200" ]; then
+            echo "La ficha productiva no respondió 200."
+            exit 1
+          fi
           IMAGE_PATH="$(grep -Eo "/preview-cover/$SAMPLE_ID/0/[a-f0-9]{64}\.(jpg|png|webp)" \
             /tmp/cover-r2-book.html | head -1)"
           if [ -z "$IMAGE_PATH" ]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -219,6 +219,14 @@ jobs:
           printf '%s' "$RESEND_API_KEY" |
             npx wrangler@3.114.17 pages secret put RESEND_API_KEY --project-name amadolibros-web
 
+      - name: Promote 20 validated covers to production R2
+        run: bash scripts/promote-cover-r2-production.sh
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          SOURCE_BUCKET: amadolibros-images-preview
+          TARGET_BUCKET: amadolibros-images-production
+
       - name: Deploy via Wrangler
         run: npx wrangler@3.114.17 pages deploy ./astro-front/dist --project-name amadolibros-web --branch main
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -239,6 +239,43 @@ jobs:
           SMOKE_EXPECT_CHECKOUT: 'enabled'
         run: node scripts/smoke-production.js
 
+      - name: Verify production R2 covers
+        id: cover_r2_smoke
+        run: |
+          STATUS_CODE=""
+          for attempt in 1 2 3 4 5 6 7 8; do
+            STATUS_CODE="$(curl -sS --max-time 30 -o /tmp/cover-r2-status.json -w '%{http_code}' \
+              'https://www.amadolibros.com/preview-cover/status')"
+            [ "$STATUS_CODE" = "200" ] && break
+            echo "Portadas R2 todavía propagándose (intento $attempt/8; HTTP $STATUS_CODE)."
+            sleep 10
+          done
+          cat /tmp/cover-r2-status.json
+          if [ "$STATUS_CODE" != "200" ]; then
+            echo "Status R2 productivo no respondió 200."
+            exit 1
+          fi
+
+          SAMPLE_ID="$(node -e '
+            const s=require("/tmp/cover-r2-status.json");
+            if (!(s.with_valid_copy >= 20) || !/^MLU\d+$/.test(s.sample_product_id || "")) process.exit(1);
+            process.stdout.write(s.sample_product_id);
+          ')"
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 --max-time 60 \
+            "https://www.amadolibros.com/libro/$SAMPLE_ID" > /tmp/cover-r2-book.html
+          IMAGE_PATH="$(grep -Eo "/preview-cover/$SAMPLE_ID/0/[a-f0-9]{64}\.(jpg|png|webp)" \
+            /tmp/cover-r2-book.html | head -1)"
+          if [ -z "$IMAGE_PATH" ]; then
+            echo "La ficha productiva no contiene una URL R2 inmutable."
+            exit 1
+          fi
+          curl -fsS --max-time 60 -D /tmp/cover-r2-image.headers \
+            "https://www.amadolibros.com$IMAGE_PATH" -o /tmp/cover-r2-image.bin
+          tr -d '\r' < /tmp/cover-r2-image.headers | grep -Eqi '^content-type: image/(jpeg|png|webp)$'
+          tr -d '\r' < /tmp/cover-r2-image.headers | grep -Fqi 'x-amado-cover-source: r2-production'
+          test -s /tmp/cover-r2-image.bin
+          echo "Portadas R2 productivas: manifest, ficha y bytes OK."
+
       - name: Deployment summary
         if: always()
         run: |
@@ -250,5 +287,6 @@ jobs:
           echo "| **Trigger** | \`${{ github.event_name }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **home.json** | ${{ steps.home_json.outcome == 'success' && '✅ fresh' || '⚠️ fallback (committed copy)' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **Smoke test** | ${{ steps.smoke.outcome == 'success' && '✅ passed' || steps.smoke.outcome == 'skipped' && '— not run' || '❌ failed' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **R2 covers** | ${{ steps.cover_r2_smoke.outcome == 'success' && '✅ passed' || steps.cover_r2_smoke.outcome == 'skipped' && '— not run' || '❌ failed' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **Attempts** | ${{ steps.smoke.outputs.attempts_used || '—' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **URL** | https://www.amadolibros.com |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-cover-r2-production.yml
+++ b/.github/workflows/promote-cover-r2-production.yml
@@ -14,6 +14,7 @@ on:
       - '.github/workflows/deploy.yml'
       - '.github/workflows/deploy-cover-r2-preview-ui.yml'
       - '.github/workflows/promote-cover-r2-production.yml'
+      - 'scripts/promote-cover-r2-production.sh'
 
 permissions:
   contents: read
@@ -42,98 +43,8 @@ jobs:
           cache-dependency-path: astro-front/package-lock.json
       - run: bash scripts/validate-ci.sh
 
-  seed-production-bucket:
-    needs: validate
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    environment:
-      name: production
-    env:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      SOURCE_BUCKET: amadolibros-images-preview
-      TARGET_BUCKET: amadolibros-images-production
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22.12.0'
-
-      - name: Create isolated production bucket if missing
-        run: |
-          if npx wrangler@4.107.0 r2 bucket info "$TARGET_BUCKET" --json >/tmp/cover-r2-bucket.json 2>/tmp/cover-r2-bucket.err; then
-            echo "Bucket productivo ya existe."
-          else
-            npx wrangler@4.107.0 r2 bucket create "$TARGET_BUCKET"
-          fi
-
-      - name: Validate source manifest and copy 20 objects by hash
-        run: |
-          npx wrangler@4.107.0 r2 object get \
-            "$SOURCE_BUCKET/covers/v1/manifest.json" \
-            --remote --file /tmp/cover-r2-manifest.json
-
-          node <<'NODE'
-          const fs = require('node:fs');
-          const manifest = JSON.parse(fs.readFileSync('/tmp/cover-r2-manifest.json', 'utf8'));
-          const entries = Object.values(manifest.entries || {});
-          if (manifest.schema_version !== 1 || entries.length !== 20) {
-            throw new Error(`Manifest fuente inválido: ${entries.length} entradas`);
-          }
-          const rows = entries.map(entry => {
-            const current = entry?.current || {};
-            const match = /^covers\/v1\/objects\/([a-f0-9]{64})\.(jpg|png|webp)$/.exec(current.object_key || '');
-            if (!match || current.sha256 !== match[1]) throw new Error(`Objeto inválido: ${current.object_key}`);
-            const expectedMime = `image/${match[2] === 'jpg' ? 'jpeg' : match[2]}`;
-            if (current.mime !== expectedMime) throw new Error(`MIME inválido: ${current.object_key}`);
-            return [current.object_key, current.mime, current.sha256].join('\t');
-          });
-          if (new Set(rows.map(row => row.split('\t')[0])).size !== 20) {
-            throw new Error('El manifest contiene objetos duplicados.');
-          }
-          fs.writeFileSync('/tmp/cover-r2-objects.tsv', `${rows.join('\n')}\n`);
-          NODE
-
-          while IFS=$'\t' read -r OBJECT_KEY MIME SHA; do
-            EXT="${OBJECT_KEY##*.}"
-            SOURCE_FILE="/tmp/cover-r2-source-$SHA.$EXT"
-            VERIFY_FILE="/tmp/cover-r2-verify-$SHA.$EXT"
-
-            npx wrangler@4.107.0 r2 object get \
-              "$SOURCE_BUCKET/$OBJECT_KEY" --remote --file "$SOURCE_FILE"
-            ACTUAL_SHA="$(sha256sum "$SOURCE_FILE" | cut -d' ' -f1)"
-            if [ "$ACTUAL_SHA" != "$SHA" ]; then
-              echo "SHA fuente inválido para $OBJECT_KEY"
-              exit 1
-            fi
-
-            npx wrangler@4.107.0 r2 object put \
-              "$TARGET_BUCKET/$OBJECT_KEY" --remote --file "$SOURCE_FILE" \
-              --content-type "$MIME" --cache-control 'public, max-age=31536000, immutable'
-            npx wrangler@4.107.0 r2 object get \
-              "$TARGET_BUCKET/$OBJECT_KEY" --remote --file "$VERIFY_FILE"
-            PROMOTED_SHA="$(sha256sum "$VERIFY_FILE" | cut -d' ' -f1)"
-            if [ "$PROMOTED_SHA" != "$SHA" ]; then
-              echo "SHA productivo inválido para $OBJECT_KEY"
-              exit 1
-            fi
-            rm -f "$SOURCE_FILE" "$VERIFY_FILE"
-          done < /tmp/cover-r2-objects.tsv
-
-      - name: Publish manifest last and verify exact copy
-        run: |
-          npx wrangler@4.107.0 r2 object put \
-            "$TARGET_BUCKET/covers/v1/manifest.json" --remote \
-            --file /tmp/cover-r2-manifest.json \
-            --content-type application/json --cache-control no-store
-          npx wrangler@4.107.0 r2 object get \
-            "$TARGET_BUCKET/covers/v1/manifest.json" --remote \
-            --file /tmp/cover-r2-production-manifest.json
-          cmp /tmp/cover-r2-manifest.json /tmp/cover-r2-production-manifest.json
-          echo "Promoción R2: 20 objetos verificados y manifest publicado último."
-
   deploy-preview:
-    needs: seed-production-bucket
+    needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment:

--- a/.github/workflows/promote-cover-r2-production.yml
+++ b/.github/workflows/promote-cover-r2-production.yml
@@ -92,8 +92,17 @@ jobs:
             if (s.with_valid_copy !== 20 || !/^MLU\d+$/.test(s.sample_product_id || "")) process.exit(1);
             process.stdout.write(s.sample_product_id);
           ')"
-          curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
-            "$PREVIEW_URL/libro/$SAMPLE_ID" > /tmp/cover-book.html
+          BOOK_CODE=""
+          for attempt in 1 2 3 4 5 6 7 8; do
+            BOOK_CODE="$(curl -sSL --max-time 60 -o /tmp/cover-book.html -w '%{http_code}' \
+              "$PREVIEW_URL/libro/$SAMPLE_ID")"
+            if [ "$BOOK_CODE" = "200" ] && grep -Fq "/preview-cover/$SAMPLE_ID/0/" /tmp/cover-book.html; then
+              break
+            fi
+            echo "Ficha Preview todavía propagándose (intento $attempt/8; HTTP $BOOK_CODE)."
+            sleep 10
+          done
+          [ "$BOOK_CODE" = "200" ]
           IMAGE_PATH="$(grep -Eo "/preview-cover/$SAMPLE_ID/0/[a-f0-9]{64}\.(jpg|png|webp)" \
             /tmp/cover-book.html | head -1)"
           [ -n "$IMAGE_PATH" ]

--- a/.github/workflows/promote-cover-r2-production.yml
+++ b/.github/workflows/promote-cover-r2-production.yml
@@ -1,0 +1,192 @@
+name: Promote Cover R2 Production
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - 'functions/_shared/preview-cover.js'
+      - 'functions/preview-cover/**'
+      - 'functions/catalogo.js'
+      - 'functions/libro/**'
+      - 'functions/__tests__/**'
+      - 'wrangler.toml'
+      - '.github/workflows/deploy.yml'
+      - '.github/workflows/deploy-cover-r2-preview-ui.yml'
+      - '.github/workflows/promote-cover-r2-production.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: promote-cover-r2-production-20
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    if: github.head_ref == 'agent/cover-r2-production-20' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Promoción R2 productiva autorizada para la rama aislada."
+
+  validate:
+    needs: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: astro-front/package-lock.json
+      - run: bash scripts/validate-ci.sh
+
+  seed-production-bucket:
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: production
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      SOURCE_BUCKET: amadolibros-images-preview
+      TARGET_BUCKET: amadolibros-images-production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Create isolated production bucket if missing
+        run: |
+          if npx wrangler@4.107.0 r2 bucket info "$TARGET_BUCKET" --json >/tmp/cover-r2-bucket.json 2>/tmp/cover-r2-bucket.err; then
+            echo "Bucket productivo ya existe."
+          else
+            npx wrangler@4.107.0 r2 bucket create "$TARGET_BUCKET"
+          fi
+
+      - name: Validate source manifest and copy 20 objects by hash
+        run: |
+          npx wrangler@4.107.0 r2 object get \
+            "$SOURCE_BUCKET/covers/v1/manifest.json" \
+            --remote --file /tmp/cover-r2-manifest.json
+
+          node <<'NODE'
+          const fs = require('node:fs');
+          const manifest = JSON.parse(fs.readFileSync('/tmp/cover-r2-manifest.json', 'utf8'));
+          const entries = Object.values(manifest.entries || {});
+          if (manifest.schema_version !== 1 || entries.length !== 20) {
+            throw new Error(`Manifest fuente inválido: ${entries.length} entradas`);
+          }
+          const rows = entries.map(entry => {
+            const current = entry?.current || {};
+            const match = /^covers\/v1\/objects\/([a-f0-9]{64})\.(jpg|png|webp)$/.exec(current.object_key || '');
+            if (!match || current.sha256 !== match[1]) throw new Error(`Objeto inválido: ${current.object_key}`);
+            const expectedMime = `image/${match[2] === 'jpg' ? 'jpeg' : match[2]}`;
+            if (current.mime !== expectedMime) throw new Error(`MIME inválido: ${current.object_key}`);
+            return [current.object_key, current.mime, current.sha256].join('\t');
+          });
+          if (new Set(rows.map(row => row.split('\t')[0])).size !== 20) {
+            throw new Error('El manifest contiene objetos duplicados.');
+          }
+          fs.writeFileSync('/tmp/cover-r2-objects.tsv', `${rows.join('\n')}\n`);
+          NODE
+
+          while IFS=$'\t' read -r OBJECT_KEY MIME SHA; do
+            EXT="${OBJECT_KEY##*.}"
+            SOURCE_FILE="/tmp/cover-r2-source-$SHA.$EXT"
+            VERIFY_FILE="/tmp/cover-r2-verify-$SHA.$EXT"
+
+            npx wrangler@4.107.0 r2 object get \
+              "$SOURCE_BUCKET/$OBJECT_KEY" --remote --file "$SOURCE_FILE"
+            ACTUAL_SHA="$(sha256sum "$SOURCE_FILE" | cut -d' ' -f1)"
+            if [ "$ACTUAL_SHA" != "$SHA" ]; then
+              echo "SHA fuente inválido para $OBJECT_KEY"
+              exit 1
+            fi
+
+            npx wrangler@4.107.0 r2 object put \
+              "$TARGET_BUCKET/$OBJECT_KEY" --remote --file "$SOURCE_FILE" \
+              --content-type "$MIME" --cache-control 'public, max-age=31536000, immutable'
+            npx wrangler@4.107.0 r2 object get \
+              "$TARGET_BUCKET/$OBJECT_KEY" --remote --file "$VERIFY_FILE"
+            PROMOTED_SHA="$(sha256sum "$VERIFY_FILE" | cut -d' ' -f1)"
+            if [ "$PROMOTED_SHA" != "$SHA" ]; then
+              echo "SHA productivo inválido para $OBJECT_KEY"
+              exit 1
+            fi
+            rm -f "$SOURCE_FILE" "$VERIFY_FILE"
+          done < /tmp/cover-r2-objects.tsv
+
+      - name: Publish manifest last and verify exact copy
+        run: |
+          npx wrangler@4.107.0 r2 object put \
+            "$TARGET_BUCKET/covers/v1/manifest.json" --remote \
+            --file /tmp/cover-r2-manifest.json \
+            --content-type application/json --cache-control no-store
+          npx wrangler@4.107.0 r2 object get \
+            "$TARGET_BUCKET/covers/v1/manifest.json" --remote \
+            --file /tmp/cover-r2-production-manifest.json
+          cmp /tmp/cover-r2-manifest.json /tmp/cover-r2-production-manifest.json
+          echo "Promoción R2: 20 objetos verificados y manifest publicado último."
+
+  deploy-preview:
+    needs: seed-production-bucket
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: preview
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: astro-front/package-lock.json
+      - name: Install and build protected Preview
+        working-directory: astro-front
+        env:
+          PUBLIC_INDEXABLE: 'false'
+          PUBLIC_GA_ID: ''
+          PUBLIC_CHECKOUT_ENABLED: 'false'
+          PUBLIC_TURNSTILE_SITE_KEY: '0x4AAAAAAD6E9kz8K3comwjj'
+          PUBLIC_TURNSTILE_ALLOWED_HOSTS: '.amadolibros-web.pages.dev'
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+      - name: Deploy isolated Preview
+        run: >
+          npx wrangler@3.114.17 pages deploy ./astro-front/dist
+          --project-name amadolibros-web
+          --branch agent/cover-r2-production-20
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Verify Preview fallback and image bytes
+        env:
+          PREVIEW_URL: https://agent-cover-r2-production-20.amadolibros-web.pages.dev
+        run: |
+          STATUS_CODE=""
+          for attempt in 1 2 3 4 5 6 7 8; do
+            STATUS_CODE="$(curl -sS --max-time 30 -o /tmp/cover-status.json -w '%{http_code}' \
+              "$PREVIEW_URL/preview-cover/status")"
+            [ "$STATUS_CODE" = "200" ] && break
+            sleep 10
+          done
+          [ "$STATUS_CODE" = "200" ]
+          SAMPLE_ID="$(node -e '
+            const s=require("/tmp/cover-status.json");
+            if (s.with_valid_copy !== 20 || !/^MLU\d+$/.test(s.sample_product_id || "")) process.exit(1);
+            process.stdout.write(s.sample_product_id);
+          ')"
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
+            "$PREVIEW_URL/libro/$SAMPLE_ID" > /tmp/cover-book.html
+          IMAGE_PATH="$(grep -Eo "/preview-cover/$SAMPLE_ID/0/[a-f0-9]{64}\.(jpg|png|webp)" \
+            /tmp/cover-book.html | head -1)"
+          [ -n "$IMAGE_PATH" ]
+          curl -fsS -D /tmp/cover-image.headers \
+            "$PREVIEW_URL$IMAGE_PATH" -o /tmp/cover-image.bin
+          tr -d '\r' < /tmp/cover-image.headers | grep -Fqi 'x-amado-cover-source: r2-preview'
+          test -s /tmp/cover-image.bin

--- a/functions/__tests__/catalog-display.test.js
+++ b/functions/__tests__/catalog-display.test.js
@@ -164,6 +164,30 @@ test('COVER-R2 Preview: card y ficha usan la copia validada del mismo origen', a
   );
 });
 
+test('COVER-R2 Producción: card y ficha usan el binding productivo', async () => {
+  const env = { COVER_R2: previewCoverBucket() };
+  const catalogResponse = await catalogRequest(
+    context('https://www.amadolibros.com/catalogo', {}, 'production', env)
+  );
+  const catalogHtml = await catalogResponse.text();
+  assert.match(
+    catalogHtml,
+    new RegExp(`/preview-cover/MLU1/0/${PREVIEW_COVER_HASH}\\.jpg`),
+  );
+
+  const bookResponse = await bookRequest(context(
+    'https://www.amadolibros.com/libro/MLU1/alpha-disponible',
+    { path: ['MLU1', 'alpha-disponible'] },
+    'production',
+    env,
+  ));
+  const bookHtml = await bookResponse.text();
+  assert.match(
+    bookHtml,
+    new RegExp(`/preview-cover/MLU1/0/${PREVIEW_COVER_HASH}\\.jpg`),
+  );
+});
+
 test('COVER-R2 Preview: URL origen distinta mantiene mlstatic como fallback', async () => {
   const staleManifest = structuredClone(PREVIEW_COVER_MANIFEST);
   staleManifest.entries['MLU1:0'].current.source_url =

--- a/functions/__tests__/cover-preview-ui-config.test.js
+++ b/functions/__tests__/cover-preview-ui-config.test.js
@@ -22,8 +22,8 @@ function runtimeJsFiles(dir) {
 }
 
 test('workflow R2 UI sólo acepta la rama Preview in-repo y despliega checkout apagado', () => {
-  assert.match(workflow, /github\.head_ref != 'agent\/cover-r2-preview-ui-20'/);
-  assert.match(workflow, /head\.repo\.full_name != github\.repository/);
+  assert.match(workflow, /github\.head_ref == 'agent\/cover-r2-preview-ui-20'/);
+  assert.match(workflow, /head\.repo\.full_name == github\.repository/);
   assert.match(workflow, /--branch agent\/cover-r2-preview-ui-20/);
   assert.match(workflow, /PUBLIC_INDEXABLE:\s*'false'/);
   assert.match(workflow, /PUBLIC_CHECKOUT_ENABLED:\s*'false'/);

--- a/functions/__tests__/cover-production-config.test.js
+++ b/functions/__tests__/cover-production-config.test.js
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const promotion = readFileSync(
+  path.join(ROOT, '.github', 'workflows', 'promote-cover-r2-production.yml'),
+  'utf8',
+);
+const deploy = readFileSync(path.join(ROOT, '.github', 'workflows', 'deploy.yml'), 'utf8');
+const resolver = readFileSync(
+  path.join(ROOT, 'functions', '_shared', 'preview-cover.js'),
+  'utf8',
+);
+const route = readFileSync(
+  path.join(ROOT, 'functions', 'preview-cover', '[[path]].js'),
+  'utf8',
+);
+
+test('promoción R2 sólo corre para la rama productiva in-repo autorizada', () => {
+  assert.match(promotion, /github\.head_ref == 'agent\/cover-r2-production-20'/);
+  assert.match(promotion, /head\.repo\.full_name == github\.repository/);
+  assert.match(promotion, /environment:\s*\n\s+name: production/);
+  assert.doesNotMatch(promotion, /push:\s*\n\s+branches:\s*\[main\]/);
+});
+
+test('promoción usa buckets separados, verifica SHA y publica el manifest último', () => {
+  assert.match(promotion, /SOURCE_BUCKET: amadolibros-images-preview/);
+  assert.match(promotion, /TARGET_BUCKET: amadolibros-images-production/);
+  assert.match(promotion, /entries\.length !== 20/);
+  assert.match(promotion, /sha256sum "\$SOURCE_FILE"/);
+  assert.match(promotion, /sha256sum "\$VERIFY_FILE"/);
+  assert.match(promotion, /cmp \/tmp\/cover-r2-manifest\.json \/tmp\/cover-r2-production-manifest\.json/);
+  const objectLoop = promotion.indexOf("done < /tmp/cover-r2-objects.tsv");
+  const manifestPut = promotion.indexOf('$TARGET_BUCKET/covers/v1/manifest.json');
+  assert.ok(objectLoop > -1 && manifestPut > objectLoop, 'el manifest debe escribirse después de los objetos');
+});
+
+test('runtime R2 admite sólo Preview/Producción y mantiene acceso de lectura', () => {
+  assert.match(resolver, /\['preview', 'production'\]\.includes\(ctx\?\.env\?\.APP_ENV\)/);
+  assert.match(route, /\['preview', 'production'\]\.includes\(context\.env\?\.APP_ENV\)/);
+  assert.match(route, /context\.env\.COVER_R2\.get\(/);
+  assert.doesNotMatch(
+    `${resolver}\n${route}`,
+    /COVER_R2\.(?:put|delete|list|head|createMultipartUpload|resumeMultipartUpload)\s*\(/,
+  );
+});
+
+test('deploy productivo exige manifest, ficha y bytes R2 antes de quedar verde', () => {
+  assert.match(deploy, /name: Verify production R2 covers/);
+  assert.match(deploy, /s\.with_valid_copy >= 20/);
+  assert.match(deploy, /www\.amadolibros\.com\/libro\/\$SAMPLE_ID/);
+  assert.match(deploy, /x-amado-cover-source: r2-production/i);
+  assert.match(deploy, /steps\.cover_r2_smoke\.outcome/);
+});

--- a/functions/__tests__/cover-production-config.test.js
+++ b/functions/__tests__/cover-production-config.test.js
@@ -10,6 +10,10 @@ const promotion = readFileSync(
   'utf8',
 );
 const deploy = readFileSync(path.join(ROOT, '.github', 'workflows', 'deploy.yml'), 'utf8');
+const promotionScript = readFileSync(
+  path.join(ROOT, 'scripts', 'promote-cover-r2-production.sh'),
+  'utf8',
+);
 const resolver = readFileSync(
   path.join(ROOT, 'functions', '_shared', 'preview-cover.js'),
   'utf8',
@@ -19,23 +23,37 @@ const route = readFileSync(
   'utf8',
 );
 
-test('promoción R2 sólo corre para la rama productiva in-repo autorizada', () => {
+test('PR R2 sólo prueba la rama in-repo autorizada y no abre Producción', () => {
   assert.match(promotion, /github\.head_ref == 'agent\/cover-r2-production-20'/);
   assert.match(promotion, /head\.repo\.full_name == github\.repository/);
-  assert.match(promotion, /environment:\s*\n\s+name: production/);
+  assert.match(promotion, /environment:\s*\n\s+name: preview/);
+  assert.doesNotMatch(promotion, /name: production/);
+  assert.doesNotMatch(promotion, /seed-production-bucket/);
   assert.doesNotMatch(promotion, /push:\s*\n\s+branches:\s*\[main\]/);
 });
 
 test('promoción usa buckets separados, verifica SHA y publica el manifest último', () => {
-  assert.match(promotion, /SOURCE_BUCKET: amadolibros-images-preview/);
-  assert.match(promotion, /TARGET_BUCKET: amadolibros-images-production/);
-  assert.match(promotion, /entries\.length !== 20/);
-  assert.match(promotion, /sha256sum "\$SOURCE_FILE"/);
-  assert.match(promotion, /sha256sum "\$VERIFY_FILE"/);
-  assert.match(promotion, /cmp \/tmp\/cover-r2-manifest\.json \/tmp\/cover-r2-production-manifest\.json/);
-  const objectLoop = promotion.indexOf("done < /tmp/cover-r2-objects.tsv");
-  const manifestPut = promotion.indexOf('$TARGET_BUCKET/covers/v1/manifest.json');
+  assert.match(promotionScript, /SOURCE_BUCKET:-amadolibros-images-preview/);
+  assert.match(promotionScript, /TARGET_BUCKET:-amadolibros-images-production/);
+  assert.match(promotionScript, /entries\.length !== 20/);
+  assert.match(promotionScript, /sha256sum "\$SOURCE_FILE"/);
+  assert.match(promotionScript, /sha256sum "\$VERIFY_FILE"/);
+  assert.match(promotionScript, /cmp \/tmp\/cover-r2-manifest\.json \/tmp\/cover-r2-production-manifest\.json/);
+  const objectLoop = promotionScript.indexOf("done < /tmp/cover-r2-objects.tsv");
+  const manifestPut = promotionScript.indexOf('$TARGET_BUCKET/covers/v1/manifest.json');
   assert.ok(objectLoop > -1 && manifestPut > objectLoop, 'el manifest debe escribirse después de los objetos');
+});
+
+test('main promueve el bucket antes de desplegar Pages', () => {
+  assert.match(deploy, /name: Promote 20 validated covers to production R2/);
+  assert.match(deploy, /bash scripts\/promote-cover-r2-production\.sh/);
+  assert.match(deploy, /SOURCE_BUCKET: amadolibros-images-preview/);
+  assert.match(deploy, /TARGET_BUCKET: amadolibros-images-production/);
+  assert.ok(
+    deploy.indexOf('name: Promote 20 validated covers to production R2') <
+      deploy.indexOf('name: Deploy via Wrangler'),
+    'la promoción debe terminar antes del deploy productivo',
+  );
 });
 
 test('runtime R2 admite sólo Preview/Producción y mantiene acceso de lectura', () => {

--- a/functions/__tests__/cover-production-config.test.js
+++ b/functions/__tests__/cover-production-config.test.js
@@ -30,6 +30,8 @@ test('PR R2 sólo prueba la rama in-repo autorizada y no abre Producción', () =
   assert.doesNotMatch(promotion, /name: production/);
   assert.doesNotMatch(promotion, /seed-production-bucket/);
   assert.doesNotMatch(promotion, /push:\s*\n\s+branches:\s*\[main\]/);
+  assert.match(promotion, /Ficha Preview todavía propagándose/);
+  assert.match(promotion, /grep -Fq "\/preview-cover\/\$SAMPLE_ID\/0\/"/);
 });
 
 test('promoción usa buckets separados, verifica SHA y publica el manifest último', () => {
@@ -70,6 +72,8 @@ test('deploy productivo exige manifest, ficha y bytes R2 antes de quedar verde',
   assert.match(deploy, /name: Verify production R2 covers/);
   assert.match(deploy, /s\.with_valid_copy >= 20/);
   assert.match(deploy, /www\.amadolibros\.com\/libro\/\$SAMPLE_ID/);
+  assert.match(deploy, /Ficha R2 productiva todavía propagándose/);
+  assert.match(deploy, /grep -Fq "\/preview-cover\/\$SAMPLE_ID\/0\/"/);
   assert.match(deploy, /x-amado-cover-source: r2-production/i);
   assert.match(deploy, /steps\.cover_r2_smoke\.outcome/);
 });

--- a/functions/__tests__/preview-cover.test.js
+++ b/functions/__tests__/preview-cover.test.js
@@ -68,9 +68,16 @@ test('Preview resuelve una URL inmutable del mismo origen y memoiza el manifest'
   assert.deepEqual(coverBucket.reads, [PREVIEW_COVER_MANIFEST_KEY]);
 });
 
-test('Producción no consulta el bucket ni expone una portada Preview', async () => {
+test('Producción resuelve la misma URL inmutable desde su binding separado', async () => {
   const coverBucket = bucket();
   const result = await previewCoverUrl(ctx({ appEnv: 'production', coverBucket }), ID, 0, SOURCE);
+  assert.equal(result, `https://cover-ui.example/preview-cover/${ID}/0/${HASH}.jpg`);
+  assert.deepEqual(coverBucket.reads, [PREVIEW_COVER_MANIFEST_KEY]);
+});
+
+test('Entorno desconocido no consulta el bucket', async () => {
+  const coverBucket = bucket();
+  const result = await previewCoverUrl(ctx({ appEnv: 'test', coverBucket }), ID, 0, SOURCE);
   assert.equal(result, null);
   assert.deepEqual(coverBucket.reads, []);
 });
@@ -109,24 +116,32 @@ test('HEAD valida la misma portada y devuelve headers sin cuerpo', async () => {
   assert.equal(await response.text(), '');
 });
 
-test('Ruta rechaza hash ajeno, métodos de escritura y cualquier acceso en Producción', async () => {
+test('Ruta rechaza hash ajeno, métodos de escritura y entornos desconocidos', async () => {
   const wrongHash = await coverRequest(ctx({ path: [ID, '0', `${'b'.repeat(64)}.jpg`] }));
   assert.equal(wrongHash.status, 404);
   const post = await coverRequest(ctx({ path: [ID, '0', `${HASH}.jpg`], method: 'POST' }));
   assert.equal(post.status, 405);
-  const production = await coverRequest(ctx({
-    appEnv: 'production', path: [ID, '0', `${HASH}.jpg`],
+  const unknown = await coverRequest(ctx({
+    appEnv: 'test', path: [ID, '0', `${HASH}.jpg`],
   }));
-  assert.equal(production.status, 404);
+  assert.equal(unknown.status, 404);
 });
 
-test('Status Preview expone sólo conteo y un ID de muestra; Producción devuelve 404', async () => {
+test('Status expone sólo conteo y un ID de muestra en Preview y Producción', async () => {
   const summary = await previewCoverSummary(ctx());
   assert.deepEqual(summary, { entries: 1, with_valid_copy: 1, sample_product_id: ID });
   const response = await coverRequest(ctx({ path: ['status'] }));
   assert.deepEqual(await response.json(), summary);
   const production = await coverRequest(ctx({ appEnv: 'production', path: ['status'] }));
-  assert.equal(production.status, 404);
+  assert.deepEqual(await production.json(), summary);
+});
+
+test('Producción etiqueta los bytes como R2 productivo', async () => {
+  const response = await coverRequest(ctx({
+    appEnv: 'production', path: [ID, '0', `${HASH}.jpg`],
+  }));
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('x-amado-cover-source'), 'r2-production');
 });
 
 test('Ficha usa la portada R2 sólo como primera imagen y conserva las secundarias', () => {

--- a/functions/__tests__/wrangler-config.test.js
+++ b/functions/__tests__/wrangler-config.test.js
@@ -104,15 +104,19 @@ test('wrangler.toml: Preview declara destinatarios internos sin declarar RESEND_
   assert.doesNotMatch(previewVars, /RESEND_API_KEY/);
 });
 
-test('COVER-R2: binding de portadas existe sólo en Preview', () => {
+test('COVER-R2: Preview y Producción usan buckets separados', () => {
   assert.match(
     wranglerToml,
     /\[\[env\.preview\.r2_buckets\]\][\s\S]*?binding\s*=\s*"COVER_R2"[\s\S]*?bucket_name\s*=\s*"amadolibros-images-preview"/,
   );
   const productionStart = wranglerToml.indexOf('[[env.production.kv_namespaces]]');
   assert.ok(productionStart > -1);
-  assert.doesNotMatch(wranglerToml.slice(productionStart), /binding\s*=\s*"COVER_R2"/);
-  assert.doesNotMatch(wranglerToml.slice(productionStart), /amadolibros-images-preview/);
+  const productionConfig = wranglerToml.slice(productionStart);
+  assert.match(
+    productionConfig,
+    /\[\[env\.production\.r2_buckets\]\][\s\S]*?binding\s*=\s*"COVER_R2"[\s\S]*?bucket_name\s*=\s*"amadolibros-images-production"/,
+  );
+  assert.doesNotMatch(productionConfig, /amadolibros-images-preview/);
 });
 
 test('STOCK-1 Preview queda limitado a su rama y checkout apagado', () => {
@@ -249,13 +253,15 @@ test('carrito.astro: la site key se lee de PUBLIC_TURNSTILE_SITE_KEY, no de un l
   assert.match(carritoAstro, /import\.meta\.env\.PUBLIC_TURNSTILE_SITE_KEY/);
 });
 
-// ── CF-R2-1: binding R2 exclusivo de Preview ────────────────────────────────
+// ── CF-R2-1: el catálogo R2 sigue siendo exclusivo de Preview ──────────────
 
-test('wrangler.toml: el binding R2 de CF-R2-1 existe solo en env.preview, nunca en env.production', () => {
+test('wrangler.toml: CATALOG_BUCKET existe solo en Preview, nunca en Producción', () => {
   assert.match(wranglerToml, /\[\[env\.preview\.r2_buckets\]\]/);
   assert.match(wranglerToml, /binding\s*=\s*"CATALOG_BUCKET"/);
   assert.match(wranglerToml, /bucket_name\s*=\s*"amadolibros-catalog"/);
-  assert.doesNotMatch(wranglerToml, /\[\[env\.production\.r2_buckets\]\]/);
+  const productionStart = wranglerToml.indexOf('[[env.production.kv_namespaces]]');
+  assert.ok(productionStart > -1);
+  assert.doesNotMatch(wranglerToml.slice(productionStart), /binding\s*=\s*"CATALOG_BUCKET"/);
 });
 
 test('wrangler.toml: CATALOG_BUCKET usa el mismo bucket real que worker-sync (amadolibros-catalog)', () => {

--- a/functions/_shared/preview-cover.js
+++ b/functions/_shared/preview-cover.js
@@ -23,12 +23,12 @@ function validManifest(value) {
 }
 
 async function readPreviewManifest(ctx) {
-    if (ctx?.env?.APP_ENV !== 'preview') return null;
+    if (!['preview', 'production'].includes(ctx?.env?.APP_ENV)) return null;
     const bucket = ctx?.env?.COVER_R2;
     if (!bucket || typeof bucket.get !== 'function') return null;
     if (!ctx.data || typeof ctx.data !== 'object') ctx.data = {};
-    if (!ctx.data.__previewCoverManifestPromise) {
-        ctx.data.__previewCoverManifestPromise = (async () => {
+    if (!ctx.data.__coverManifestPromise) {
+        ctx.data.__coverManifestPromise = (async () => {
             try {
                 const object = await bucket.get(MANIFEST_KEY);
                 if (!object || typeof object.text !== 'function') return null;
@@ -39,7 +39,7 @@ async function readPreviewManifest(ctx) {
             }
         })();
     }
-    return ctx.data.__previewCoverManifestPromise;
+    return ctx.data.__coverManifestPromise;
 }
 
 function validCurrent(entry) {

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -556,10 +556,10 @@ export async function onRequest(ctx) {
     const rangeFrom = totalResults === 0 ? 0 : offset + 1;
     const rangeTo   = offset + limited.length;
 
-    // COVER-R2-PREVIEW-UI-1: una sola lectura memoizada del manifest por
+    // COVER-R2-PRODUCTION-1: una sola lectura memoizada del manifest por
     // request. Con catálogo completo exigimos coincidencia de la URL origen;
     // el índice compacto no conserva pictures[] y pasa null explícitamente.
-    const previewCovers = ctx.env?.APP_ENV === 'preview'
+    const r2Covers = ['preview', 'production'].includes(ctx.env?.APP_ENV)
         ? await Promise.all(limited.map(b => {
             const hasFullPictures = Array.isArray(b.pictures);
             const source = hasFullPictures
@@ -573,7 +573,7 @@ export async function onRequest(ctx) {
         const slug  = slugify(b.title);
         const href  = escapeHtml(`${previewBase}/libro/${b.id}/${slug}`);
         const img   = escapeHtml(
-            previewCovers[idx] || httpsImg(b.pictures?.[0] || b.thumbnail || '')
+            r2Covers[idx] || httpsImg(b.pictures?.[0] || b.thumbnail || '')
         );
         const title = escapeHtml(b.title);
         const author = b.author

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -762,7 +762,8 @@ export async function onRequest(context) {
         : '';
 
     const originalImages = normalizeImages(item);
-    const previewCoverSrc = isPreview && originalImages[0]
+    const coversEnabled = ['preview', 'production'].includes(context.env?.APP_ENV);
+    const previewCoverSrc = coversEnabled && originalImages[0]
         ? await resolvePreviewCoverUrl(context, item.id, 0, originalImages[0])
         : null;
 

--- a/functions/preview-cover/[[path]].js
+++ b/functions/preview-cover/[[path]].js
@@ -17,7 +17,7 @@ function pathParts(context) {
 }
 
 export async function onRequest(context) {
-    if (context.env?.APP_ENV !== 'preview') return notFound();
+    if (!['preview', 'production'].includes(context.env?.APP_ENV)) return notFound();
     if (context.request.method !== 'GET' && context.request.method !== 'HEAD') {
         return new Response('Method not allowed', {
             status: 405,
@@ -52,7 +52,9 @@ export async function onRequest(context) {
             'Cache-Control': 'public, max-age=31536000, immutable',
             'ETag': `"${cover.sha256}"`,
             'X-Content-Type-Options': 'nosniff',
-            'X-Amado-Cover-Source': 'r2-preview',
+            'X-Amado-Cover-Source': context.env.APP_ENV === 'production'
+                ? 'r2-production'
+                : 'r2-preview',
         });
         if (Number.isFinite(Number(object.size))) {
             headers.set('Content-Length', String(object.size));

--- a/scripts/promote-cover-r2-production.sh
+++ b/scripts/promote-cover-r2-production.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_BUCKET="${SOURCE_BUCKET:-amadolibros-images-preview}"
+TARGET_BUCKET="${TARGET_BUCKET:-amadolibros-images-production}"
+WRANGLER_VERSION="${WRANGLER_VERSION:-4.107.0}"
+
+if npx "wrangler@$WRANGLER_VERSION" r2 bucket info "$TARGET_BUCKET" --json \
+  >/tmp/cover-r2-bucket.json 2>/tmp/cover-r2-bucket.err; then
+  echo "Bucket productivo ya existe."
+else
+  npx "wrangler@$WRANGLER_VERSION" r2 bucket create "$TARGET_BUCKET"
+fi
+
+npx "wrangler@$WRANGLER_VERSION" r2 object get \
+  "$SOURCE_BUCKET/covers/v1/manifest.json" \
+  --remote --file /tmp/cover-r2-manifest.json
+
+node <<'NODE'
+const fs = require('node:fs');
+const manifest = JSON.parse(fs.readFileSync('/tmp/cover-r2-manifest.json', 'utf8'));
+const entries = Object.values(manifest.entries || {});
+if (manifest.schema_version !== 1 || entries.length !== 20) {
+  throw new Error(`Manifest fuente inválido: ${entries.length} entradas`);
+}
+const rows = entries.map(entry => {
+  const current = entry?.current || {};
+  const match = /^covers\/v1\/objects\/([a-f0-9]{64})\.(jpg|png|webp)$/.exec(current.object_key || '');
+  if (!match || current.sha256 !== match[1]) throw new Error(`Objeto inválido: ${current.object_key}`);
+  const expectedMime = `image/${match[2] === 'jpg' ? 'jpeg' : match[2]}`;
+  if (current.mime !== expectedMime) throw new Error(`MIME inválido: ${current.object_key}`);
+  return [current.object_key, current.mime, current.sha256].join('\t');
+});
+if (new Set(rows.map(row => row.split('\t')[0])).size !== 20) {
+  throw new Error('El manifest contiene objetos duplicados.');
+}
+fs.writeFileSync('/tmp/cover-r2-objects.tsv', `${rows.join('\n')}\n`);
+NODE
+
+while IFS=$'\t' read -r OBJECT_KEY MIME SHA; do
+  EXT="${OBJECT_KEY##*.}"
+  SOURCE_FILE="/tmp/cover-r2-source-$SHA.$EXT"
+  VERIFY_FILE="/tmp/cover-r2-verify-$SHA.$EXT"
+
+  npx "wrangler@$WRANGLER_VERSION" r2 object get \
+    "$SOURCE_BUCKET/$OBJECT_KEY" --remote --file "$SOURCE_FILE"
+  ACTUAL_SHA="$(sha256sum "$SOURCE_FILE" | cut -d' ' -f1)"
+  if [ "$ACTUAL_SHA" != "$SHA" ]; then
+    echo "SHA fuente inválido para $OBJECT_KEY"
+    exit 1
+  fi
+
+  npx "wrangler@$WRANGLER_VERSION" r2 object put \
+    "$TARGET_BUCKET/$OBJECT_KEY" --remote --file "$SOURCE_FILE" \
+    --content-type "$MIME" --cache-control 'public, max-age=31536000, immutable'
+  npx "wrangler@$WRANGLER_VERSION" r2 object get \
+    "$TARGET_BUCKET/$OBJECT_KEY" --remote --file "$VERIFY_FILE"
+  PROMOTED_SHA="$(sha256sum "$VERIFY_FILE" | cut -d' ' -f1)"
+  if [ "$PROMOTED_SHA" != "$SHA" ]; then
+    echo "SHA productivo inválido para $OBJECT_KEY"
+    exit 1
+  fi
+  rm -f "$SOURCE_FILE" "$VERIFY_FILE"
+done < /tmp/cover-r2-objects.tsv
+
+# R2 no ofrece una transacción conjunta entre objetos y manifest. El manifest
+# se publica último: un corte puede dejar un objeto huérfano, nunca una portada
+# declarada como válida sin que su objeto haya sido verificado antes.
+npx "wrangler@$WRANGLER_VERSION" r2 object put \
+  "$TARGET_BUCKET/covers/v1/manifest.json" --remote \
+  --file /tmp/cover-r2-manifest.json \
+  --content-type application/json --cache-control no-store
+npx "wrangler@$WRANGLER_VERSION" r2 object get \
+  "$TARGET_BUCKET/covers/v1/manifest.json" --remote \
+  --file /tmp/cover-r2-production-manifest.json
+cmp /tmp/cover-r2-manifest.json /tmp/cover-r2-production-manifest.json
+echo "Promoción R2: 20 objetos verificados y manifest publicado último."

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -73,6 +73,12 @@ binding = "ORDERS_DB"
 database_name = "amadolibros-orders-production"
 database_id = "6dc8dc3a-2d4f-4045-b428-14323c7b0bcd"
 
+# COVER-R2-PRODUCTION-1: bucket productivo separado, promovido desde el piloto
+# sólo después de validar SHA-256 de las 20 copias. Pages únicamente lo lee.
+[[env.production.r2_buckets]]
+binding     = "COVER_R2"
+bucket_name = "amadolibros-images-production"
+
 # CHECKOUT_ENABLED en "true" (2-N-H1): el kill switch queda encendido, así que
 # POST /api/orders y POST /api/preferences aceptan pedidos reales. Para apagar
 # los cobros de forma inmediata, cambiar esta variable a "false" en el


### PR DESCRIPTION
## Objetivo

Promover las 20 portadas R2 ya aprobadas visualmente a Producción, sin reutilizar el bucket Preview como dependencia productiva.

Parte directamente de `main` en `059c419a6e58d695ae12f630af4a0cea3b6300fb`.

## Cambios

- prepara un bucket aislado `amadolibros-images-production`;
- valida el manifest fuente con exactamente 20 entradas;
- copia cada objeto desde Preview y verifica SHA-256 antes y después;
- publica `covers/v1/manifest.json` únicamente al final;
- agrega `COVER_R2` a `env.production` apuntando al bucket productivo;
- habilita el resolvedor same-origin en Preview y Producción;
- conserva `mlstatic` como fallback cuando falta o no coincide una copia;
- mantiene la ruta en sólo lectura (`GET/HEAD`, únicamente `COVER_R2.get`);
- agrega smoke productivo de manifest, ficha, MIME, bytes y header `r2-production`;
- vuelve inerte el workflow Preview de un solo uso para ramas posteriores.

## Barrera de Producción

El PR no abre ni escribe el environment `production`. El primer run confirmó que GitHub impide correctamente usarlo desde la rama.

Después del merge autorizado, el workflow de `main` ejecuta este orden dentro del job productivo:

1. valida otra vez el repositorio;
2. crea/verifica el bucket productivo;
3. copia y verifica las 20 imágenes;
4. publica el manifest último;
5. recién entonces ejecuta `pages deploy`;
6. prueba manifest, ficha y bytes en Producción.

Si los pasos 2–4 fallan, `pages deploy` no se ejecuta y la versión productiva anterior permanece activa.

## Seguridad y radio de impacto

- Preview y Producción usan buckets distintos.
- Los objetos se identifican por SHA-256 y tienen URL inmutable.
- Un fallo de R2 conserva la portada actual de Mercado Libre.
- No toca checkout, Mercado Pago, tarifas, feed, Merchant Center ni sync.

## Validación local

- sintaxis JS y Bash: OK;
- YAML: OK;
- pruebas específicas R2/config: verdes;
- integración card/ficha en Preview y Producción: OK;
- suite completa del repositorio: verde;
- `npm ci`: OK;
- build checkout OFF: OK;
- build checkout ON: OK;
- `git diff --check`: OK.

## Aceptación remota antes del merge

1. CI general verde.
2. Preview de esta rama con manifest 20/20, ficha y bytes R2.
3. PR mergeable.

El usuario autorizó expresamente el merge y despliegue productivo una vez cumplidas estas barreras. El PR permanece Draft durante la aceptación remota.