### PR TITLE
test: align production robots smoke

### DIFF
--- a/functions/__tests__/smoke-robots-meta.test.js
+++ b/functions/__tests__/smoke-robots-meta.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import smoke from '../../scripts/smoke-production.js';
+
+test('smoke SEO espera el robots real de las búsquedas: noindex, follow', () => {
+  const route = smoke.SMOKE_ROUTES.find(
+    item => item.path === '/catalogo?q=zzzinexistente999'
+  );
+  assert.ok(route);
+  assert.equal(route.robots, 'noindex, follow');
+});
+
+test('hasHtmlMeta reconoce noindex, follow sin rebajarlo a noindex literal', () => {
+  const html = '<meta name="robots" content="noindex, follow">';
+  assert.equal(smoke.hasHtmlMeta(html, 'robots', 'noindex, follow'), true);
+  assert.equal(smoke.hasHtmlMeta(html, 'robots', 'noindex'), false);
+});

--- a/scripts/smoke-production.js
+++ b/scripts/smoke-production.js
@@ -60,7 +60,7 @@ const INTERNAL_FIELDS = [
 const ROUTES = [
   { path: '/', kind: 'html', canonical: `${BASE_URL}/`, robots: 'index, follow' },
   { path: '/catalogo', kind: 'html', canonical: `${BASE_URL}/catalogo`, robots: 'index, follow' },
-  { path: '/catalogo?q=zzzinexistente999', kind: 'html', canonical: `${BASE_URL}/catalogo`, robots: 'noindex' },
+  { path: '/catalogo?q=zzzinexistente999', kind: 'html', canonical: `${BASE_URL}/catalogo`, robots: 'noindex, follow' },
   { path: '/carrito/', kind: 'cart' },
   { path: '/robots.txt', kind: 'robots' },
   { path: '/sitemap.xml', kind: 'sitemap-index' },
@@ -513,6 +513,8 @@ module.exports = {
   analyzeSitemapBody,
   resolveCheckoutExpectation,
   hasRenderedElementWithId,
+  hasHtmlMeta,
+  SMOKE_ROUTES: ROUTES,
   VALID_CHECKOUT_EXPECTATIONS,
   TURNSTILE_SITE_KEY_PRODUCTION,
   TURNSTILE_SITE_KEY_PREVIEW,


### PR DESCRIPTION
## Qué corrige

Alinea el smoke de producción con el meta robots real y correcto de las búsquedas sin resultados: `noindex, follow`.

## Alcance

- Cambia únicamente la expectativa del smoke.
- Exporta los helpers necesarios para probarla.
- Agrega una regresión específica.
- No modifica HTML, SEO runtime, checkout ni la promoción R2.

## Validación

- `bash scripts/validate-ci.sh`: OK (223 tests, builds checkout OFF/ON).
- Smoke real contra producción: OK en todas las rutas.