### PR TITLE
feat: aplicar reglas comerciales del checkout

### DIFF
--- a/astro-front/public/orders-guard.js
+++ b/astro-front/public/orders-guard.js
@@ -2,7 +2,6 @@
   'use strict';
 
   var CART_KEY = 'amado-cart';
-  var TIME_ZONE = 'America/Montevideo';
 
   function valueOf(id) {
     var element = document.getElementById(id);
@@ -23,31 +22,12 @@
 
     var required = [
       ['delivery-address', 'Por favor ingresá la dirección de entrega.'],
-      ['delivery-barrio', 'Por favor ingresá la localidad.'],
       ['delivery-departamento', 'Por favor seleccioná el departamento.'],
-      ['delivery-date', 'Por favor ingresá la fecha preferida de entrega.'],
-      ['delivery-from', 'Por favor ingresá la hora de inicio del horario.'],
-      ['delivery-to', 'Por favor ingresá la hora de fin del horario.'],
     ];
     for (var i = 0; i < required.length; i++) {
       if (!valueOf(required[i][0])) return { message: required[i][1], field: required[i][0] };
     }
-    if (valueOf('delivery-to') <= valueOf('delivery-from')) {
-      return { message: 'La hora de fin debe ser posterior a la hora de inicio.', field: 'delivery-to' };
-    }
     return null;
-  }
-
-  function localDateString() {
-    var parts = new Intl.DateTimeFormat('en-US', {
-      timeZone: TIME_ZONE,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-    }).formatToParts(new Date());
-    var values = {};
-    for (var i = 0; i < parts.length; i++) values[parts[i].type] = parts[i].value;
-    return values.year + '-' + values.month + '-' + values.day;
   }
 
   function rotateIdempotencyKey() {
@@ -66,8 +46,7 @@
 
   document.addEventListener('DOMContentLoaded', function () {
     var requiredIds = [
-      'buyer-name', 'buyer-phone', 'delivery-address', 'delivery-barrio',
-      'delivery-departamento', 'delivery-date', 'delivery-from', 'delivery-to',
+      'buyer-name', 'buyer-phone', 'delivery-address', 'delivery-departamento',
     ];
     for (var i = 0; i < requiredIds.length; i++) {
       var field = document.getElementById(requiredIds[i]);
@@ -76,8 +55,6 @@
         field.setAttribute('aria-required', 'true');
       }
     }
-    var dateField = document.getElementById('delivery-date');
-    if (dateField) dateField.min = localDateString();
   });
 
   document.addEventListener('click', function (event) {
@@ -133,7 +110,7 @@
     if (isNaN(parsed.getTime())) return;
     expiry.textContent = 'Orden válida durante 60 minutos, hasta ' +
       new Intl.DateTimeFormat('es-UY', {
-        timeZone: TIME_ZONE,
+        timeZone: 'America/Montevideo',
         hour: '2-digit',
         minute: '2-digit',
       }).format(parsed) + '.';

--- a/astro-front/src/components/BookCard.astro
+++ b/astro-front/src/components/BookCard.astro
@@ -23,8 +23,8 @@ interface Props {
 const { book } = Astro.props;
 
 // Debe coincidir con FREE_SHIPPING_THRESHOLD en functions/api/_orders_logic.js
-// (control previo HOME-COMERCIAL-1: el checkout real usa $2.000, no $1.500).
-const FREE_SHIPPING_THRESHOLD = 2000;
+// (control previo HOME-COMERCIAL-1: el checkout y la comunicación deben coincidir).
+const FREE_SHIPPING_THRESHOLD = 1500;
 
 function slugify(text: string): string {
   return (text || '')

--- a/astro-front/src/components/ShippingPayments.astro
+++ b/astro-front/src/components/ShippingPayments.astro
@@ -16,7 +16,7 @@
         <ul class="sp-list">
           <li>Entrega en 2 horas en Montevideo.*</li>
           <li>Envíos a todo Uruguay.</li>
-          <li>Envío gratis desde $2.000.</li>
+          <li>Envío gratis desde $1.500.</li>
         </ul>
         <p class="sp-disclaimer">*El plazo depende de la zona y del horario del pedido. Coordinamos la entrega con vos.</p>
       </div>
@@ -31,9 +31,9 @@
         </div>
         <h3 class="sp-col-title">Pagos</h3>
         <ul class="sp-list">
-          <li><strong class="sp-highlight">12% de descuento</strong> pagando por transferencia bancaria.</li>
+          <li><strong class="sp-highlight">12% de descuento en los libros</strong> pagando por transferencia bancaria.</li>
           <li>12 cuotas sin recargo con Mercado Pago.</li>
-          <li>Envío gratis desde $2.000.</li>
+          <li>Envío gratis desde $1.500.</li>
         </ul>
       </div>
 

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -58,9 +58,9 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
             <p class="cart-discount-line" id="cart-discount-line" hidden>Ahorro por retiro:&nbsp;<strong>−&nbsp;$150</strong></p>
             <p class="cart-total-line" id="cart-total-line" hidden>Total con retiro:&nbsp;<strong id="cart-total">$&nbsp;0</strong></p>
             <p class="cart-shipping-note" id="cart-shipping-note" hidden>Envío: a coordinar según destino</p>
-            <p class="cart-shipping-cost-line" id="cart-shipping-cost-line" hidden>Envío:&nbsp;<strong id="cart-shipping-cost">$&nbsp;250</strong></p>
+            <p class="cart-shipping-cost-line" id="cart-shipping-cost-line" hidden>Envío:&nbsp;<strong id="cart-shipping-cost">—</strong></p>
             <p class="cart-total-shipping-line" id="cart-total-shipping-line" hidden>Total con envío:&nbsp;<strong id="cart-total-shipping">$&nbsp;0</strong></p>
-            <p class="cart-transfer-note" id="cart-transfer-note" hidden>Pagando por transferencia se aplica además 12&nbsp;% de descuento.</p>
+            <p class="cart-transfer-note" id="cart-transfer-note" hidden>Transferencia (12&nbsp;% menos en los libros):&nbsp;<strong id="cart-transfer-total">$&nbsp;0</strong></p>
             <p class="cart-shipping-msg" id="cart-shipping-msg" hidden></p>
           </div>
         </div>
@@ -80,7 +80,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
               <span class="delivery-opt-content">
                 <strong class="delivery-opt-name">Pick up a pasos de Plaza Matriz</strong>
                 <span class="delivery-opt-meta">Lunes a viernes, de 8 a 17 h</span>
-                <span class="delivery-opt-badge">Ahorrás $150 retirando aquí</span>
+                <span class="delivery-opt-badge" id="pickup-saving-badge">Ahorrás $150 desde $1.000</span>
               </span>
             </label>
           </div>
@@ -119,7 +119,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
               <span class="field-error" id="err-delivery-address" role="alert" hidden></span>
             </div>
             <div class="form-field">
-              <label for="delivery-barrio" class="form-label">Barrio / Localidad</label>
+              <label for="delivery-barrio" class="form-label">Barrio / Localidad <span class="form-optional">(opcional)</span></label>
               <input type="text" id="delivery-barrio" class="form-input"
                 placeholder="Ej: Pocitos, Centro, Malvín"
                 autocomplete="shipping address-level3"
@@ -155,28 +155,10 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
               <span class="field-error" id="err-delivery-departamento" role="alert" hidden></span>
             </div>
             <div class="form-field">
-              <label for="delivery-date" class="form-label">Fecha preferida</label>
-              <input type="date" id="delivery-date" class="form-input" autocomplete="off"
-                aria-describedby="err-delivery-date">
-              <span class="field-error" id="err-delivery-date" role="alert" hidden></span>
-            </div>
-            <div class="form-row">
-              <div class="form-field">
-                <label for="delivery-from" class="form-label">Desde <span class="form-req" aria-hidden="true">*</span></label>
-                <input type="time" id="delivery-from" class="form-input" aria-describedby="err-delivery-from">
-                <span class="field-error" id="err-delivery-from" role="alert" hidden></span>
-              </div>
-              <div class="form-field">
-                <label for="delivery-to" class="form-label">Hasta <span class="form-req" aria-hidden="true">*</span></label>
-                <input type="time" id="delivery-to" class="form-input" aria-describedby="err-delivery-to">
-                <span class="field-error" id="err-delivery-to" role="alert" hidden></span>
-              </div>
-            </div>
-            <div class="form-field">
               <label for="delivery-notes" class="form-label">Notas para la entrega</label>
               <textarea id="delivery-notes" class="form-input form-textarea" rows="2" placeholder="Ej: timbre 2B, dejar con portero"></textarea>
             </div>
-            <p class="delivery-confirm-note">La fecha y la franja quedan sujetas a confirmación por WhatsApp.</p>
+            <p class="delivery-confirm-note">Después del pago coordinamos el día y el horario por WhatsApp.</p>
           </div>
         </section>
 
@@ -221,7 +203,11 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
                   <rect x="1" y="4" width="22" height="16" rx="2" ry="2"/>
                   <line x1="1" y1="10" x2="23" y2="10"/>
                 </svg>
-                <span class="btn-checkout-primary-text">Continuar a Mercado Pago</span>
+                <span class="btn-checkout-primary-text">Pagar con Mercado Pago — <strong id="mp-cta-total">$&nbsp;0</strong></span>
+              </button>
+              <button type="button" id="btn-wa-order" class="btn-transfer-order">
+                <span>Comprar por transferencia — 12% menos</span>
+                <strong id="transfer-cta-total">$&nbsp;0</strong>
               </button>
             </div>
           ) : (
@@ -229,7 +215,8 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
               <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                 <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z"/>
               </svg>
-              Enviar pedido por WhatsApp
+              <span>Comprar por transferencia — 12% menos</span>
+              <strong id="transfer-cta-total">$&nbsp;0</strong>
             </button>
           )}
 
@@ -244,12 +231,6 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
                 Consultá <a href="/envios" target="_blank">envíos</a> y
                 <a href="/devoluciones" target="_blank">devoluciones</a>.
               </p>
-              <button type="button" id="btn-wa-order" class="btn-wa-secondary">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                  <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z"/>
-                </svg>
-                O coordinar por WhatsApp
-              </button>
             </>
           )}
 
@@ -459,6 +440,11 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     color: var(--salmon);
   }
 
+  .form-optional {
+    color: var(--ink-2);
+    font-weight: 400;
+  }
+
   .buyer-note {
     font-size: 0.78rem;
     color: var(--ink-2);
@@ -595,28 +581,29 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     outline-offset: 3px;
   }
 
-  /* WhatsApp como alternativa secundaria — nunca compite visualmente con el
-     botón principal de pago. */
-  .btn-wa-secondary {
+  /* Transferencia es una alternativa comercial explícita, con su total final,
+     pero Mercado Pago conserva la jerarquía primaria del checkout online. */
+  .btn-transfer-order {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 0.4rem;
-    padding: 0.6rem 1rem;
-    background: transparent;
-    color: var(--ink-2);
-    border: none;
+    gap: 0.45rem;
+    flex-wrap: wrap;
+    padding: 0.75rem 1rem;
+    background: var(--surface);
+    color: var(--ink);
+    border: 1px solid var(--salmon);
+    border-radius: var(--r);
     font-family: var(--font-ui);
-    font-size: 0.82rem;
-    font-weight: 600;
-    text-decoration: underline;
-    text-underline-offset: 2px;
+    font-size: 0.88rem;
+    font-weight: 700;
     cursor: pointer;
     min-height: 44px;
-    align-self: center;
+    width: 100%;
   }
-  .btn-wa-secondary:hover { color: var(--ink); }
-  .btn-wa-secondary:focus-visible {
+  .btn-transfer-order strong { color: #267a42; }
+  .btn-transfer-order:hover { background: #fff7f4; }
+  .btn-transfer-order:focus-visible {
     outline: 2px solid var(--ink);
     outline-offset: 2px;
   }
@@ -856,7 +843,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
      o cuando el footer entra en pantalla. */
   @media (max-width: 640px) {
     .cart-page[data-online-checkout="enabled"] {
-      padding-bottom: calc(8rem + env(safe-area-inset-bottom, 0px));
+      padding-bottom: calc(12rem + env(safe-area-inset-bottom, 0px));
     }
 
     .cart-page[data-online-checkout="enabled"] .checkout-mobile-bar {
@@ -995,9 +982,12 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
   document.addEventListener('DOMContentLoaded', function () {
 
     // ── Constantes ──────────────────────────────────────────────────────
-    var RETIRO_DISCOUNT             = 150;
-    var SHIPPING_COST               = 250;
-    var FREE_SHIPPING_THRESHOLD_UYU = 2000;
+    var RETIRO_DISCOUNT               = 150;
+    var RETIRO_DISCOUNT_THRESHOLD_UYU = 1000;
+    var SHIPPING_COST_MONTEVIDEO      = 250;
+    var SHIPPING_COST_INTERIOR        = 300;
+    var FREE_SHIPPING_THRESHOLD_UYU   = 1500;
+    var TRANSFER_FACTOR               = 0.88;
 
     // ── Elementos ───────────────────────────────────────────────────────
     var loadingEl        = document.getElementById('cart-loading');
@@ -1018,6 +1008,10 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     var totalShippingLineEl  = document.getElementById('cart-total-shipping-line');
     var totalShippingEl      = document.getElementById('cart-total-shipping');
     var stickyTotalEl        = document.getElementById('checkout-sticky-total-value');
+    var mpCtaTotalEl         = document.getElementById('mp-cta-total');
+    var transferCtaTotalEl   = document.getElementById('transfer-cta-total');
+    var transferTotalEl      = document.getElementById('cart-transfer-total');
+    var pickupSavingBadgeEl  = document.getElementById('pickup-saving-badge');
     var checkoutErrorEl      = document.getElementById('checkout-error');
     var cartPageEl           = document.querySelector('.cart-page');
 
@@ -1077,6 +1071,36 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       return checked ? checked.value : 'pickup';
     }
 
+    function getShippingDepartment() {
+      return ((document.getElementById('delivery-departamento') || {}).value || '').trim();
+    }
+
+    function calculateDisplayedTotals(subtotal) {
+      var isPickup = getDeliveryType() === 'pickup';
+      var pickupDiscount = isPickup && subtotal >= RETIRO_DISCOUNT_THRESHOLD_UYU
+        ? RETIRO_DISCOUNT
+        : 0;
+      var shippingCost = 0;
+      var shippingDepartment = getShippingDepartment();
+      var shippingPending = !isPickup && !shippingDepartment;
+      if (!isPickup && !shippingPending && subtotal < FREE_SHIPPING_THRESHOLD_UYU) {
+        shippingCost = shippingDepartment === 'Montevideo'
+          ? SHIPPING_COST_MONTEVIDEO
+          : SHIPPING_COST_INTERIOR;
+      }
+      var listTotal = subtotal - pickupDiscount + shippingCost;
+      var transferProductsTotal = Math.round(subtotal * TRANSFER_FACTOR);
+      var transferTotal = Math.max(0, transferProductsTotal - pickupDiscount + shippingCost);
+      return {
+        pickupDiscount: pickupDiscount,
+        shippingCost: shippingCost,
+        listTotal: listTotal,
+        transferTotal: transferTotal,
+        transferDiscount: subtotal - transferProductsTotal,
+        shippingPending: shippingPending,
+      };
+    }
+
     // ── PICKUP-CX-1 ──────────────────────────────────────────────────────
     var pickupAckBox = document.getElementById('pickup-ack-box');
     var pickupAck    = document.getElementById('pickup-ack');
@@ -1117,38 +1141,46 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       var subtotal     = window.AmadoCart.subtotal();
       var deliveryType = getDeliveryType();
       var isPickup     = deliveryType === 'pickup';
+      var totals       = calculateDisplayedTotals(subtotal);
 
       if (subtotalEl) subtotalEl.textContent = fmt.format(subtotal);
 
       if (isPickup) {
-        var total = Math.max(0, subtotal - RETIRO_DISCOUNT);
-        if (discountLineEl)      discountLineEl.hidden      = false;
+        if (discountLineEl)      discountLineEl.hidden      = totals.pickupDiscount === 0;
         if (totalLineEl)         totalLineEl.hidden         = false;
-        if (totalEl)             totalEl.textContent        = fmt.format(total);
+        if (totalEl)             totalEl.textContent        = fmt.format(totals.listTotal);
         if (shippingNoteEl)      shippingNoteEl.hidden      = true;
         if (transferNoteEl)      transferNoteEl.hidden      = false;
         if (shippingCostLineEl)  shippingCostLineEl.hidden  = true;
         if (totalShippingLineEl) totalShippingLineEl.hidden = true;
         if (shippingMsgEl)       shippingMsgEl.hidden       = true;
-        if (stickyTotalEl)       stickyTotalEl.textContent  = fmt.format(total);
+        if (stickyTotalEl)       stickyTotalEl.textContent  = fmt.format(totals.listTotal);
+        if (pickupSavingBadgeEl) {
+          pickupSavingBadgeEl.textContent = totals.pickupDiscount
+            ? 'Ahorrás $150 retirando aquí'
+            : 'Ahorrás $150 desde $1.000';
+        }
       } else {
-        var shippingCost      = subtotal < FREE_SHIPPING_THRESHOLD_UYU ? SHIPPING_COST : 0;
-        var totalWithShipping = subtotal + shippingCost;
         if (discountLineEl)     discountLineEl.hidden     = true;
         if (totalLineEl)        totalLineEl.hidden        = true;
         if (shippingNoteEl)     shippingNoteEl.hidden     = true;
-        if (transferNoteEl)     transferNoteEl.hidden     = true;
         if (shippingCostLineEl) {
           shippingCostLineEl.hidden = false;
-          if (shippingCostEl) shippingCostEl.textContent = shippingCost === 0 ? 'Gratis' : fmt.format(shippingCost);
+          if (shippingCostEl) shippingCostEl.textContent = totals.shippingPending
+            ? 'Seleccioná el departamento'
+            : (totals.shippingCost === 0 ? 'Gratis' : fmt.format(totals.shippingCost));
         }
         if (totalShippingLineEl) {
           totalShippingLineEl.hidden = false;
-          if (totalShippingEl) totalShippingEl.textContent = fmt.format(totalWithShipping);
+          if (totalShippingEl) totalShippingEl.textContent = totals.shippingPending ? '—' : fmt.format(totals.listTotal);
         }
         if (shippingMsgEl) shippingMsgEl.hidden = true;
-        if (stickyTotalEl) stickyTotalEl.textContent = fmt.format(totalWithShipping);
+        if (stickyTotalEl) stickyTotalEl.textContent = totals.shippingPending ? '—' : fmt.format(totals.listTotal);
       }
+      if (transferNoteEl)     transferNoteEl.hidden = false;
+      if (transferTotalEl)    transferTotalEl.textContent = totals.shippingPending ? '—' : fmt.format(totals.transferTotal);
+      if (mpCtaTotalEl)       mpCtaTotalEl.textContent = totals.shippingPending ? '—' : fmt.format(totals.listTotal);
+      if (transferCtaTotalEl) transferCtaTotalEl.textContent = totals.shippingPending ? '—' : fmt.format(totals.transferTotal);
     }
 
     // ── Construir fila de item ───────────────────────────────────────────
@@ -1323,6 +1355,8 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         updateTotals();
       });
     });
+    var departmentSelect = document.getElementById('delivery-departamento');
+    if (departmentSelect) departmentSelect.addEventListener('change', updateTotals);
     syncShippingFields();
 
     // ── Barra mobile: no tapar teclado ni footer ─────────────────────────
@@ -1380,24 +1414,23 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         var name         = ((document.getElementById('buyer-name')            || {}).value || '').trim();
         var phone        = ((document.getElementById('buyer-phone')           || {}).value || '').trim();
 
+        clearFieldErrors();
+        if (!name)  { showFieldError('buyer-name', 'Por favor ingresá tu nombre.'); return; }
+        if (!phone) { showFieldError('buyer-phone', 'Por favor ingresá tu teléfono o WhatsApp.'); return; }
+
         if (deliveryType === 'shipping') {
           if (!address) {
-            alert('Por favor ingresá la dirección de entrega.');
-            var addrEl = document.getElementById('delivery-address');
-            if (addrEl) addrEl.focus();
-            return;
+            showFieldError('delivery-address', 'Por favor ingresá la dirección de entrega.'); return;
           }
           if (!departamento) {
-            alert('Por favor seleccioná el departamento.');
-            var deptEl = document.getElementById('delivery-departamento');
-            if (deptEl) deptEl.focus();
-            return;
+            showFieldError('delivery-departamento', 'Por favor seleccioná el departamento.'); return;
           }
         }
 
         var subtotal = window.AmadoCart.subtotal();
+        var totals = calculateDisplayedTotals(subtotal);
 
-        var lines = ['PEDIDO WEB', '', 'Hola Amado Libros! Quiero hacer este pedido:'];
+        var lines = ['COMPRA POR TRANSFERENCIA — 12% MENOS', '', 'Hola Amado Libros! Quiero hacer este pedido:'];
         lines.push('');
         for (var i = 0; i < cart.items.length; i++) {
           var it = cart.items[i];
@@ -1405,30 +1438,21 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         }
         lines.push('');
         lines.push('Total de productos: ' + fmt.format(subtotal) + ' UYU');
+        lines.push('Descuento por transferencia (12% en libros): −' + fmt.format(totals.transferDiscount) + ' UYU');
         if (deliveryType === 'pickup') {
-          var total = Math.max(0, subtotal - RETIRO_DISCOUNT);
-          lines.push('Ahorro por retiro: −$' + RETIRO_DISCOUNT);
-          lines.push('Total con retiro: ' + fmt.format(total) + ' UYU');
-          lines.push('Nota: pagando por transferencia bancaria se aplica además 12 % de descuento.');
+          if (totals.pickupDiscount) lines.push('Ahorro por retiro: −$' + RETIRO_DISCOUNT);
           lines.push('Entrega: Pick up a pasos de Plaza Matriz');
         } else {
-          var shippingCostWa = subtotal < FREE_SHIPPING_THRESHOLD_UYU ? SHIPPING_COST : 0;
-          if (shippingCostWa === 0) {
+          if (totals.shippingCost === 0) {
             lines.push('Envío: Gratis (compra desde $' + FREE_SHIPPING_THRESHOLD_UYU + ')');
           } else {
-            lines.push('Envío: $' + SHIPPING_COST);
+            lines.push('Envío: ' + fmt.format(totals.shippingCost) + ' UYU');
           }
-          lines.push('Total con envío: ' + fmt.format(subtotal + shippingCostWa) + ' UYU');
           var lugar = [address, barrio, departamento].filter(Boolean).join(', ');
           lines.push('Entrega: Envío a domicilio — ' + lugar);
-          var waDate = ((document.getElementById('delivery-date') || {}).value || '').trim();
-          var waFrom = ((document.getElementById('delivery-from') || {}).value || '').trim();
-          var waTo   = ((document.getElementById('delivery-to')   || {}).value || '').trim();
-          if (waDate) lines.push('Fecha solicitada: ' + waDate);
-          if (waFrom || waTo) {
-            lines.push('Horario solicitado: ' + [waFrom, waTo].filter(Boolean).join(' – '));
-          }
+          lines.push('Día y horario: a coordinar por WhatsApp después del pago.');
         }
+        lines.push('TOTAL FINAL POR TRANSFERENCIA: ' + fmt.format(totals.transferTotal) + ' UYU');
         if (name)  lines.push('Nombre: ' + name);
         if (phone) lines.push('WhatsApp/Tel: ' + phone);
 
@@ -1437,7 +1461,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       });
     }
 
-    // ── Continuar a Mercado Pago — pantalla única ────────────────────────
+    // ── Pagar con Mercado Pago — pantalla única ──────────────────────────
     // Un solo clic encadena: crear/recuperar la orden (POST /api/orders) →
     // crear/recuperar la preferencia (POST /api/preferences) → redirect.
     // Ambos endpoints ya son idempotentes por diseño (idempotency_key /
@@ -1470,9 +1494,6 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         var prepAddress  = ((document.getElementById('delivery-address')     || {}).value || '').trim();
         var prepBarrio   = ((document.getElementById('delivery-barrio')       || {}).value || '').trim();
         var prepDepto    = ((document.getElementById('delivery-departamento') || {}).value || '').trim();
-        var prepDate     = ((document.getElementById('delivery-date')         || {}).value || '').trim();
-        var prepFrom     = ((document.getElementById('delivery-from')         || {}).value || '').trim();
-        var prepTo       = ((document.getElementById('delivery-to')           || {}).value || '').trim();
         var prepNotes    = ((document.getElementById('delivery-notes')        || {}).value || '').trim();
         var prepName     = ((document.getElementById('buyer-name')            || {}).value || '').trim();
         var prepPhone    = ((document.getElementById('buyer-phone')           || {}).value || '').trim();
@@ -1489,11 +1510,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         }
         if (deliveryType === 'shipping') {
           if (!prepAddress) { showFieldError('delivery-address', 'Por favor ingresá la dirección de entrega.'); return; }
-          if (!prepBarrio)  { showFieldError('delivery-barrio', 'Por favor ingresá la localidad.'); return; }
           if (!prepDepto)   { showFieldError('delivery-departamento', 'Por favor seleccioná el departamento.'); return; }
-          if (!prepDate)    { showFieldError('delivery-date', 'Por favor ingresá la fecha preferida de entrega.'); return; }
-          if (!prepFrom)    { showFieldError('delivery-from', 'Por favor ingresá la hora de inicio del horario.'); return; }
-          if (!prepTo)      { showFieldError('delivery-to', 'Por favor ingresá la hora de fin del horario.'); return; }
         }
 
         btnPrepare.disabled = true;
@@ -1558,12 +1575,9 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         if (deliveryType === 'shipping') {
           payload.shipping = {
             address:        prepAddress,
-            locality:       prepBarrio,
             department:     prepDepto,
-            requested_date: prepDate,
-            requested_from: prepFrom,
-            requested_to:   prepTo,
           };
+          if (prepBarrio) payload.shipping.locality = prepBarrio;
           if (prepNotes) payload.shipping.notes = prepNotes;
         }
 

--- a/astro-front/src/pages/envios.astro
+++ b/astro-front/src/pages/envios.astro
@@ -10,19 +10,19 @@ import TrustPageLayout from '../layouts/TrustPageLayout.astro';
   <h2>Cobertura y costo</h2>
   <ul>
     <li>Realizamos envíos a los 19 departamentos de Uruguay.</li>
-    <li>El envío cuesta <strong>$250 UYU</strong> en compras inferiores a $2.000 UYU.</li>
-    <li>El envío es <strong>gratis desde $2.000 UYU</strong>.</li>
+    <li>En compras inferiores a $1.500 UYU, el envío cuesta <strong>$250 UYU en Montevideo</strong> y <strong>$300 UYU al resto del país</strong>.</li>
+    <li>El envío es <strong>gratis desde $1.500 UYU</strong>.</li>
     <li>El costo definitivo se muestra en el carrito antes de continuar a Mercado Pago.</li>
   </ul>
 
   <h2>Montevideo</h2>
-  <p>Los productos disponibles pueden entregarse en el día mediante cadetería. La entrega en aproximadamente 2 horas está sujeta a disponibilidad, zona, horario y confirmación por WhatsApp. La fecha y la franja elegidas en el checkout quedan sujetas a confirmación.</p>
+  <p>Los productos disponibles pueden entregarse en el día mediante cadetería. La entrega en aproximadamente 2 horas está sujeta a disponibilidad, zona y horario. Después del pago coordinamos el día y la franja por WhatsApp.</p>
 
   <h2>Interior del país</h2>
   <p>Despachamos por DAC u otra agencia coordinada con el cliente dentro de 1 a 2 días hábiles desde la confirmación del pago. La entrega suele demorar de 1 a 3 días hábiles adicionales, según la localidad y el operador. Cuando el envío dispone de seguimiento, enviamos el dato al comprador.</p>
 
   <h2>Retiro</h2>
-  <p>Podés retirar tu pedido en nuestro <strong>pick up a pasos de Plaza Matriz</strong>, de lunes a viernes, de 8 a 17 h. El checkout descuenta $150 por retiro. <strong>Esperá nuestra confirmación por WhatsApp antes de venir:</strong> te avisamos apenas tu pedido esté pronto para retirar, y ahí te pasamos la dirección exacta.</p>
+  <p>Podés retirar tu pedido en nuestro <strong>pick up a pasos de Plaza Matriz</strong>, de lunes a viernes, de 8 a 17 h. Desde $1.000 en libros, el checkout descuenta $150 por retiro. <strong>Esperá nuestra confirmación por WhatsApp antes de venir:</strong> te avisamos apenas tu pedido esté pronto para retirar, y ahí te pasamos la dirección exacta.</p>
 
   <h2>Demoras o incidencias</h2>
   <p>Los plazos son estimados. Si un envío presenta una demora o daño visible, contactanos por <a href="https://wa.me/59899841325">WhatsApp al 099 841 325</a> o por <a href="mailto:adm@amadolibros.com">adm@amadolibros.com</a> indicando el número de pedido.</p>

--- a/astro-front/src/pages/pedido.astro
+++ b/astro-front/src/pages/pedido.astro
@@ -96,7 +96,7 @@ const WA_HREF =
           // confirmación real de pago aprobado, leída de D1 vía
           // /api/orders/status (nunca del simple regreso del navegador ni
           // del parámetro ?result= de la URL). Nunca se vacía al hacer clic
-          // en "Continuar a Mercado Pago" ni por un retorno pending/rejected/
+          // en "Pagar con Mercado Pago" ni por un retorno pending/rejected/
           // abandonado — ver el polling más abajo.
           if (window.AmadoCart && typeof window.AmadoCart.clear === 'function') {
             window.AmadoCart.clear();

--- a/functions/__tests__/catalog-display.test.js
+++ b/functions/__tests__/catalog-display.test.js
@@ -290,8 +290,8 @@ test('el catálogo indexable comunica el umbral real de envío gratis', async ()
   const html = await response.text();
   const description = html.match(/<meta name="description" content="([^"]+)">/)?.[1] || '';
 
-  assert.match(description, /envío gratis desde \$2\.000/);
-  assert.doesNotMatch(description, /envío gratis desde \$1\.500/);
+  assert.match(description, /envío gratis desde \$1\.500/);
+  assert.doesNotMatch(description, /envío gratis desde \$2\.000/);
 });
 
 test('la ficha pausada queda noindex, sin precio ni compra directa', async () => {

--- a/functions/__tests__/checkout-single-step.test.js
+++ b/functions/__tests__/checkout-single-step.test.js
@@ -35,11 +35,7 @@ const REQUIRED_FIELD_IDS = [
   'buyer-name',
   'buyer-phone',
   'delivery-address',
-  'delivery-barrio',
   'delivery-departamento',
-  'delivery-date',
-  'delivery-from',
-  'delivery-to',
 ];
 
 // ── Una sola pantalla, un solo botón principal ──────────────────────────────
@@ -55,8 +51,9 @@ test('carrito.astro: exactamente un botón principal id="btn-prepare-order" en e
   assert.equal(matches.length, 1);
 });
 
-test('carrito.astro: el CTA principal dice "Continuar a Mercado Pago"', () => {
-  assert.match(carritoAstro, /Continuar a Mercado Pago/);
+test('carrito.astro: Mercado Pago muestra el total sin descuento por transferencia', () => {
+  assert.match(carritoAstro, /Pagar con Mercado Pago/);
+  assert.match(carritoAstro, /id="mp-cta-total"/);
 });
 
 test('carrito.astro: un solo listener de click maneja todo el pago (no hay un segundo botón/handler de "pagar")', () => {
@@ -81,12 +78,31 @@ test('carrito.astro: el mismo click crea la orden y la preferencia, sin un segun
 
 // ── WhatsApp subordinado, no competidor ─────────────────────────────────────
 
-test('carrito.astro: con checkout ON, WhatsApp usa estilo secundario (no compite con el CTA principal)', () => {
-  assert.match(carritoAstro, /class="btn-wa-secondary"/);
+test('carrito.astro: con checkout ON, transferencia tiene CTA y total final explícitos', () => {
+  assert.match(carritoAstro, /Comprar por transferencia — 12% menos/);
+  assert.match(carritoAstro, /class="btn-transfer-order"/);
+  assert.match(carritoAstro, /id="transfer-cta-total"/);
 });
 
 test('carrito.astro: con checkout OFF, WhatsApp sigue siendo la única acción disponible', () => {
   assert.match(carritoAstro, /class="btn-wa-order"/);
+});
+
+test('carrito.astro: localidad no bloquea y día/horario se coordinan después del pago', () => {
+  assert.match(carritoAstro, /Barrio \/ Localidad[\s\S]*\(opcional\)/);
+  assert.doesNotMatch(carritoAstro, /if \(!prepBarrio\)/);
+  assert.doesNotMatch(carritoAstro, /id="delivery-date"/);
+  assert.doesNotMatch(carritoAstro, /id="delivery-from"/);
+  assert.doesNotMatch(carritoAstro, /id="delivery-to"/);
+  assert.match(carritoAstro, /Después del pago coordinamos el día y el horario por WhatsApp/);
+});
+
+test('carrito.astro: refleja las reglas comerciales aprobadas', () => {
+  assert.match(carritoAstro, /RETIRO_DISCOUNT_THRESHOLD_UYU\s*=\s*1000/);
+  assert.match(carritoAstro, /SHIPPING_COST_MONTEVIDEO\s*=\s*250/);
+  assert.match(carritoAstro, /SHIPPING_COST_INTERIOR\s*=\s*300/);
+  assert.match(carritoAstro, /FREE_SHIPPING_THRESHOLD_UYU\s*=\s*1500/);
+  assert.match(carritoAstro, /Math\.round\(subtotal \* TRANSFER_FACTOR\)/);
 });
 
 // ── Validación inline y accesibilidad ───────────────────────────────────────

--- a/functions/__tests__/merchant-trust-pages.test.js
+++ b/functions/__tests__/merchant-trust-pages.test.js
@@ -24,9 +24,11 @@ test('shipping policy matches checkout cost and free-shipping threshold', () => 
   const page = read('astro-front/src/pages/envios.astro');
   const logic = read('functions/api/_orders_logic.js');
   assert.match(page, /\$250 UYU/);
-  assert.match(page, /gratis desde \$2\.000 UYU/);
-  assert.match(logic, /FREE_SHIPPING_THRESHOLD = 2000/);
-  assert.match(logic, /SHIPPING_COST\s+= 250/);
+  assert.match(page, /\$300 UYU/);
+  assert.match(page, /gratis desde \$1\.500 UYU/);
+  assert.match(logic, /FREE_SHIPPING_THRESHOLD\s+= 1500/);
+  assert.match(logic, /SHIPPING_COST_MONTEVIDEO\s+= 250/);
+  assert.match(logic, /SHIPPING_COST_INTERIOR\s+= 300/);
 });
 
 test('footer and checkout expose trust links before purchase', () => {

--- a/functions/api/__tests__/orders.test.js
+++ b/functions/api/__tests__/orders.test.js
@@ -16,6 +16,7 @@ const CATALOG = { items: [
   { id:'A', title:'Alpha', price:1000, available_quantity:5, status:'active', thumbnail:null },
   { id:'B', title:'Beta', price:1250, available_quantity:3, status:'active', thumbnail:null },
   { id:'G', title:'Gamma', price:800, available_quantity:5, status:'active', thumbnail:null },
+  { id:'C', title:'Centro', price:500, available_quantity:5, status:'active', thumbnail:null },
   { id:'P', title:'Pausado', price:300, available_quantity:10, status:'paused', thumbnail:null },
   { id:'X', title:'Precio roto', price:'NaN', available_quantity:2, status:'active', thumbnail:null },
 ] };
@@ -50,16 +51,24 @@ function ctx(body, db, opts={}) {
   return { request:new Request('https://x/api/orders',{method,headers,body:method==='POST'?(typeof body==='string'?body:JSON.stringify(body)):undefined}), env, waitUntil(){} };
 }
 function pickup(key='k'){ return { idempotency_key:key, cf_turnstile_response:'ok-token', items:[{product_id:'A',quantity:2},{product_id:'B',quantity:1}], delivery_type:'pickup', pickup_ack:true, buyer:{name:'Ana',phone:'099'} }; }
-function shipping(key='s', patch={}) { const base={ idempotency_key:key, cf_turnstile_response:'ok-token', items:[{product_id:'G',quantity:1},{product_id:'A',quantity:1}], delivery_type:'shipping', buyer:{name:'Carlos',phone:'098'}, shipping:{address:'Calle 1',locality:'Centro',department:'Montevideo',requested_date:'2026-07-20',requested_from:'09:00',requested_to:'12:00',notes:'2B'} }; return {...base,...patch,shipping:{...base.shipping,...(patch.shipping||{})}}; }
+function shipping(key='s', patch={}) { const base={ idempotency_key:key, cf_turnstile_response:'ok-token', items:[{product_id:'A',quantity:1}], delivery_type:'shipping', buyer:{name:'Carlos',phone:'098'}, shipping:{address:'Calle 1',department:'Montevideo',notes:'2B'} }; return {...base,...patch,shipping:{...base.shipping,...(patch.shipping||{})}}; }
 function stored(body, patch={}) { return { id:'uuid', idempotency_key:body.idempotency_key, request_fingerprint:generateFingerprint(body,consolidateItems(body.items)), public_code:'AL-TEST', status:'open', payment_status:'not_started', delivery_type:body.delivery_type, products_total_uyu:3250, pickup_discount_uyu:150, shipping_cost_uyu:0, payable_total_uyu:3100, currency:'UYU', expires_at:'2026-07-19T17:00:00.000Z', ...patch }; }
 function handler(fetchCatalog=async()=>CATALOG, now=NOW, verifyTurnstileToken=TS_OK){ return createOrdersHandler({fetchCatalog,getNow:()=>new Date(now),verifyTurnstileToken}); }
 
 async function call(body, db=dbMock(), opts={}, h=handler()){ const response=await h(ctx(body,db,opts)); return {response,data:await response.json(),db}; }
 
-test('reglas comerciales: retiro, envío pago y umbral inclusivo', async()=>{
+test('reglas comerciales: retiro desde $1.000, envío por departamento y gratis desde $1.500', async()=>{
   let r=await call(pickup()); assert.equal(r.data.order.payable_total_uyu,3100);
-  r=await call(shipping()); assert.equal(r.data.order.payable_total_uyu,2050);
-  r=await call(shipping('t',{items:[{product_id:'A',quantity:2}]})); assert.equal(r.data.order.shipping_cost_uyu,0); assert.equal(r.data.order.payable_total_uyu,2000);
+  r=await call({...pickup('pickup-low'),items:[{product_id:'G',quantity:1}]}); assert.equal(r.data.order.pickup_discount_uyu,0); assert.equal(r.data.order.payable_total_uyu,800);
+  r=await call({...pickup('pickup-threshold'),items:[{product_id:'A',quantity:1}]}); assert.equal(r.data.order.pickup_discount_uyu,150); assert.equal(r.data.order.payable_total_uyu,850);
+  r=await call(shipping()); assert.equal(r.data.order.shipping_cost_uyu,250); assert.equal(r.data.order.payable_total_uyu,1250);
+  r=await call(shipping('interior',{shipping:{department:'Canelones'}})); assert.equal(r.data.order.shipping_cost_uyu,300); assert.equal(r.data.order.payable_total_uyu,1300);
+  r=await call(shipping('free',{items:[{product_id:'A',quantity:1},{product_id:'C',quantity:1}],shipping:{department:'Canelones'}})); assert.equal(r.data.order.shipping_cost_uyu,0); assert.equal(r.data.order.payable_total_uyu,1500);
+});
+
+test('localidad, fecha y horario son opcionales para crear la orden', async()=>{
+  const r=await call(shipping('optional'));
+  assert.equal(r.response.status,201);
 });
 
 test('expira exactamente en 60 minutos y no expone UUID', async()=>{

--- a/functions/api/_orders_handler.js
+++ b/functions/api/_orders_handler.js
@@ -124,7 +124,7 @@ export function createOrdersHandler({ fetchCatalog, getNow = () => new Date(), v
     }
 
     const { productsTotal, pickupDiscount, shippingCost, payableTotal } =
-      calculateTotals(snapshot, body.delivery_type);
+      calculateTotals(snapshot, body.delivery_type, body.shipping?.department || '');
 
     let publicCode = null;
     try {

--- a/functions/api/_orders_logic.js
+++ b/functions/api/_orders_logic.js
@@ -1,6 +1,8 @@
 export const RETIRO_DISCOUNT         = 150;
-export const SHIPPING_COST           = 250;
-export const FREE_SHIPPING_THRESHOLD = 2000;
+export const RETIRO_DISCOUNT_THRESHOLD = 1000;
+export const SHIPPING_COST_MONTEVIDEO  = 250;
+export const SHIPPING_COST_INTERIOR    = 300;
+export const FREE_SHIPPING_THRESHOLD   = 1500;
 export const EXPIRY_MINUTES          = 60;
 export const MAX_BODY_BYTES          = 32 * 1024;
 export const MAX_ITEMS               = 20;
@@ -82,15 +84,23 @@ export function validateBody(body) {
     if (!isNonEmptyString(shipping.address)) return 'Dirección requerida.';
     if (shipping.address.trim().length > MAX_ADDRESS_LEN) return 'Dirección demasiado larga.';
 
-    if (!isNonEmptyString(shipping.locality)) return 'Localidad requerida.';
-    if (shipping.locality.trim().length > MAX_LOCALITY_LEN) return 'Localidad demasiado larga.';
+    if (shipping.locality !== undefined && shipping.locality !== null) {
+      if (typeof shipping.locality !== 'string') return 'Localidad inválida.';
+      if (shipping.locality.trim().length > MAX_LOCALITY_LEN) return 'Localidad demasiado larga.';
+    }
 
     if (!isNonEmptyString(shipping.department)) return 'Departamento requerido.';
     if (shipping.department.trim().length > MAX_DEPARTMENT_LEN) return 'Departamento demasiado largo.';
 
-    if (!isValidDateString(shipping.requested_date)) return 'Fecha inválida (formato YYYY-MM-DD).';
-    if (!isValidTimeString(shipping.requested_from)) return 'Hora desde inválida (formato HH:MM).';
-    if (!isValidTimeString(shipping.requested_to)) return 'Hora hasta inválida (formato HH:MM).';
+    if (shipping.requested_date && !isValidDateString(shipping.requested_date)) {
+      return 'Fecha inválida (formato YYYY-MM-DD).';
+    }
+    if (shipping.requested_from && !isValidTimeString(shipping.requested_from)) {
+      return 'Hora desde inválida (formato HH:MM).';
+    }
+    if (shipping.requested_to && !isValidTimeString(shipping.requested_to)) {
+      return 'Hora hasta inválida (formato HH:MM).';
+    }
 
     if (shipping.notes !== undefined && shipping.notes !== null) {
       if (typeof shipping.notes !== 'string') return 'Notas inválidas.';
@@ -114,8 +124,10 @@ export function dateInTimeZone(now, timeZone = BUSINESS_TIME_ZONE) {
 
 export function validateShippingDate(requestedDate, requestedFrom, requestedTo, now) {
   const today = dateInTimeZone(now);
-  if (requestedDate < today) return 'La fecha solicitada ya pasó.';
-  if (requestedTo <= requestedFrom) return 'La hora de fin debe ser posterior a la hora de inicio.';
+  if (requestedDate && requestedDate < today) return 'La fecha solicitada ya pasó.';
+  if (requestedFrom && requestedTo && requestedTo <= requestedFrom) {
+    return 'La hora de fin debe ser posterior a la hora de inicio.';
+  }
   return null;
 }
 
@@ -193,15 +205,18 @@ export function buildSnapshot(consolidatedItems, catalogItems) {
   return { errors, snapshot };
 }
 
-export function calculateTotals(snapshotItems, deliveryType) {
+export function calculateTotals(snapshotItems, deliveryType, department = '') {
   const productsTotal = snapshotItems.reduce((sum, item) => sum + item.line_total_uyu, 0);
   let pickupDiscount = 0;
   let shippingCost = 0;
 
   if (deliveryType === 'pickup') {
-    pickupDiscount = Math.min(RETIRO_DISCOUNT, productsTotal);
+    pickupDiscount = productsTotal >= RETIRO_DISCOUNT_THRESHOLD ? RETIRO_DISCOUNT : 0;
   } else {
-    shippingCost = productsTotal < FREE_SHIPPING_THRESHOLD ? SHIPPING_COST : 0;
+    const isMontevideo = department.trim().toLocaleLowerCase('es-UY') === 'montevideo';
+    shippingCost = productsTotal < FREE_SHIPPING_THRESHOLD
+      ? (isMontevideo ? SHIPPING_COST_MONTEVIDEO : SHIPPING_COST_INTERIOR)
+      : 0;
   }
 
   const payableTotal = Math.max(0, productsTotal - pickupDiscount + shippingCost);
@@ -222,7 +237,7 @@ export function generateFingerprint(body, consolidatedItems) {
   if (body.delivery_type === 'shipping') {
     fingerprint.shipping = {
       address: body.shipping.address.trim(),
-      locality: body.shipping.locality.trim(),
+      locality: typeof body.shipping.locality === 'string' ? body.shipping.locality.trim() : '',
       department: body.shipping.department.trim(),
       requested_date: body.shipping.requested_date,
       requested_from: body.shipping.requested_from,

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -671,7 +671,7 @@ export async function onRequest(ctx) {
     // contenido delgado/duplicado en resultados de búsqueda/categoría.
     const isIndex = !hasFilter;
     const metaDescription = isIndex
-        ? `${activeItems.length} libros para comprar online en Uruguay. 12% de descuento por transferencia y envío gratis desde $2.000. Envíos a todo el país.`
+        ? `${activeItems.length} libros para comprar online en Uruguay. 12% de descuento por transferencia y envío gratis desde $1.500. Envíos a todo el país.`
         : 'Resultados en Amado Libros.';
     // Las búsquedas internas no se indexan, pero sí se siguen: `follow` deja
     // que el crawler descubra las fichas enlazadas desde los resultados.

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -595,7 +595,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     </div>
     ${!inStock && detailRows ? `<dl class="details">${detailRows}</dl>` : ''}
     <p class="shipping">${inStock
-      ? '🚚 Entrega en 2 horas en Montevideo · Envíos a todo Uruguay · Envío gratis desde $2.000.'
+      ? '🚚 Entrega en 2 horas en Montevideo · Envíos a todo Uruguay · Envío gratis desde $1.500.'
       : '🌎 Si preferís no esperar, también podemos buscarlo por encargo en el exterior.'
     } <a href="/politicas#envios">Ver política de envíos</a>.</p>
   </div>


### PR DESCRIPTION
## Resultado

Aplica el lote de checkout definido hoy sin mezclarlo con R2.

## Reglas

- Envío: $250 Montevideo, $300 interior, gratis desde $1.500.
- Retiro: ahorro de $150 sólo desde $1.000.
- Localidad opcional; día y horario dejan de bloquear y se coordinan por WhatsApp después del pago.
- Mercado Pago conserva precio de lista (más envío/retiro aplicable), sin 12%.
- Transferencia muestra el CTA `Comprar por transferencia — 12% menos` y el total final; el 12% se aplica sólo a los libros, no al envío.
- Copy comercial alineado en carrito, home, catálogo, ficha y política de envíos.

## Validación

- Suite focalizada: 92/92.
- Suite completa: OK (224 tests en el bloque principal y resto de suites verdes).
- Build Astro checkout OFF: OK.
- Build Astro checkout ON con configuración pública de Producción: OK.
- HTML generado verificado: CTAs y copy presentes; campos de fecha/hora ausentes.