### PR TITLE
Corregir entorno D1 del deploy de checkout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -195,7 +195,7 @@ jobs:
         # continúa enviando fecha/franja hasta que Pages publique el build nuevo.
         run: >
           npx wrangler@3.114.17 d1 migrations apply
-          amadolibros-orders-production --remote
+          ORDERS_DB --env production --remote
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/functions/__tests__/checkout-transfer-schema.test.js
+++ b/functions/__tests__/checkout-transfer-schema.test.js
@@ -90,5 +90,8 @@ test('deploy productivo aplica migraciones D1 antes de publicar Pages', () => {
   assert.notEqual(migrationStep, -1, 'el deploy debe aplicar migraciones D1');
   assert.notEqual(pagesDeployStep, -1, 'el deploy debe publicar Pages');
   assert.ok(migrationStep < pagesDeployStep, 'D1 debe migrarse antes de publicar el frontend');
-  assert.match(productionDeploy, /amadolibros-orders-production --remote/);
+  assert.match(
+    productionDeploy,
+    /d1 migrations apply\s+ORDERS_DB --env production --remote/,
+  );
 });


### PR DESCRIPTION
## Causa

El deploy de #104 se detuvo antes de ejecutar SQL: Wrangler no encuentra el nombre físico dentro del `wrangler.toml` sin seleccionar el entorno.

## Corrección

- Usa el binding `ORDERS_DB`.
- Declara `--env production --remote`.
- Actualiza el test para exigir el comando productivo exacto.

## Seguridad

- El deploy fallido no ejecutó la migración ni publicó Pages.
- Producción conserva el checkout anterior.
- El hotfix modifica sólo el comando del workflow y su test.
- Test de migración/preservación: 2/2 verde.
