### PR TITLE
Destacar transferencia y 12% en fichas

### DIFF
--- a/functions/__tests__/ficha-pricing-cta-order.test.js
+++ b/functions/__tests__/ficha-pricing-cta-order.test.js
@@ -1,7 +1,6 @@
 // AL-WEB: jerarquía de precios y orden de acciones en la ficha individual
 // (functions/libro/[[path]].js). Cubre las dos correcciones comerciales:
-// 1. Precio web/tarjeta primero, cuotas debajo, transferencia como
-//    beneficio secundario.
+// 1. Transferencia y ahorro primero, precio web/tarjeta y cuotas debajo.
 // 2. Agregar al carrito → WhatsApp → Mercado Libre, con Mercado Libre
 //    visualmente subordinado (sin el relleno amarillo dominante que tenía).
 import test from 'node:test';
@@ -35,34 +34,37 @@ function extractBlock(html, className) {
     return match[0];
 }
 
-test('1. Precio web/tarjeta aparece antes que transferencia, con el texto exacto aprobado (dentro del price-box, no en meta description)', () => {
+test('1. Transferencia aparece primero y muestra el 12% y el ahorro exacto', () => {
     const html = renderPage(book({ price: 1200 }), 'un-libro-de-prueba', false, '');
     assert.match(html, /Precio web\/tarjeta:<\/span> \$1\.200 UYU/);
-    assert.match(html, /Transferencia: \$1\.056 UYU/); // 1200 * 0.88 = 1056
+    assert.match(html, /12% menos por transferencia/);
+    assert.match(html, /<strong>\$1\.056 UYU<\/strong>/); // 1200 * 0.88 = 1056
+    assert.match(html, /Ahorrás \$144 UYU/);
     const priceBox = extractBlock(html, 'price-box');
     const priceIdx = priceBox.indexOf('Precio web/tarjeta:');
-    const transferIdx = priceBox.indexOf('Transferencia:');
+    const transferIdx = priceBox.indexOf('12% menos por transferencia');
     assert.ok(priceIdx > -1 && transferIdx > -1);
-    assert.ok(priceIdx < transferIdx, 'el precio principal debe aparecer antes que la transferencia');
+    assert.ok(transferIdx < priceIdx, 'la transferencia debe aparecer antes que tarjeta');
 });
 
-test('2. Cuotas visibles, con el texto aprobado, entre precio y transferencia', () => {
+test('2. Tarjeta y cuotas quedan visibles debajo de transferencia', () => {
     const html = renderPage(book({ price: 1200 }), 'un-libro-de-prueba', false, '');
     assert.match(html, /Hasta 12 cuotas de aprox\. \$100 UYU/); // 1200 / 12 = 100
     const priceBox = extractBlock(html, 'price-box');
     const priceIdx = priceBox.indexOf('Precio web/tarjeta:');
     const installmentIdx = priceBox.indexOf('Hasta 12 cuotas');
-    const transferIdx = priceBox.indexOf('Transferencia:');
-    assert.ok(priceIdx < installmentIdx, 'el precio principal debe ir antes que las cuotas');
-    assert.ok(installmentIdx < transferIdx, 'las cuotas deben ir antes que la transferencia');
+    const transferIdx = priceBox.indexOf('12% menos por transferencia');
+    assert.ok(transferIdx < priceIdx, 'transferencia debe ir antes que tarjeta');
+    assert.ok(priceIdx < installmentIdx, 'tarjeta debe ir antes que las cuotas');
 });
 
-test('3. Precio principal usa una clase visualmente más fuerte que transferencia', () => {
+test('3. Transferencia usa la jerarquía visual principal y tarjeta la secundaria', () => {
     const html = renderPage(book({ price: 1200 }), 'un-libro-de-prueba', false, '');
-    assert.match(html, /class="price-main"/);
     assert.match(html, /class="price-transfer"/);
-    assert.match(html, /\.price-main\{font-size:1\.35rem;font-weight:800/);
-    assert.match(html, /\.price-transfer\{font-size:\.85rem;font-weight:600/);
+    assert.match(html, /class="price-card"/);
+    assert.match(html, /\.price-transfer strong\{font-size:1\.55rem;font-weight:850/);
+    assert.match(html, /\.price-card\{font-size:\.9rem;font-weight:600/);
+    assert.match(html, /\.price-transfer-kicker\{display:inline-flex;background:#166534;color:#fff/);
 });
 
 test('4. Orden de botones: Agregar al carrito → WhatsApp → Mercado Libre (dentro del bloque .cta, no de la hoja de estilos)', () => {
@@ -118,6 +120,7 @@ test('10. No cambia el cálculo de precio, cuotas ni transferencia (solo texto/o
     const html = renderPage(book({ price: 999 }), 'un-libro', false, '');
     assert.match(html, /\$999 UYU/); // precio base sin redondeo especial
     assert.match(html, /\$879 UYU/); // 999 * 0.88 = 879.12 -> Math.round = 879 (transferencia)
+    assert.match(html, /Ahorrás \$120 UYU/); // ahorro = 999 - 879, consistente con el total final
     assert.match(html, /\$83 UYU/);  // Math.round(999/12) = 83 (cuotas)
 });
 

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -248,7 +248,9 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     const img          = images[0] || '';
     const price         = Number(item.price) || 0;
     const priceUY       = price.toLocaleString('es-UY');
-    const transferPrice = Math.round(price * 0.88).toLocaleString('es-UY');
+    const transferAmount = Math.round(price * 0.88);
+    const transferPrice = transferAmount.toLocaleString('es-UY');
+    const transferSaving = (price - transferAmount).toLocaleString('es-UY');
     const installment   = Math.round(price / 12).toLocaleString('es-UY');
     const stockQty      = Number(item.available_quantity) || 0;
     const inStock       = item.status === 'active' && stockQty > 0;
@@ -322,9 +324,13 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
 
     const priceHtml = inStock
         ? `<div class="price-box">
-      <div class="price-main"><span class="price-label">Precio web/tarjeta:</span> $${priceUY} UYU</div>
+      <div class="price-transfer">
+        <span class="price-transfer-kicker">12% menos por transferencia</span>
+        <strong>$${transferPrice} UYU</strong>
+        <span class="price-saving">Ahorrás $${transferSaving} UYU</span>
+      </div>
+      <div class="price-card"><span class="price-label">Precio web/tarjeta:</span> $${priceUY} UYU</div>
       <div class="price-installment">Hasta 12 cuotas de aprox. $${installment} UYU</div>
-      <div class="price-transfer">Transferencia: $${transferPrice} UYU</div>
     </div>`
         : `<div class="order-box">
       <strong>¿Buscás este libro?</strong>
@@ -500,12 +506,19 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     .detail-row:last-child{border-bottom:0}
     .detail-row dt{font-weight:700;color:#334155}
     .detail-row dd{color:#475569}
-    .price-box{background:#f5f3ff;border:1px solid #ddd6fe;border-radius:.5rem;
+    .price-box{background:#f0fdf4;border:1px solid #86efac;border-radius:.65rem;
                padding:1rem 1.25rem;margin:.875rem 0}
-    .price-main{font-size:1.35rem;font-weight:800;color:#0f172a;line-height:1.3}
-    .price-label{font-weight:800}
-    .price-installment{font-size:1rem;font-weight:600;color:#374151;margin-top:.35rem}
-    .price-transfer{font-size:.85rem;font-weight:600;color:#a94e3d;margin-top:.35rem}
+    .price-transfer{display:flex;flex-direction:column;align-items:flex-start;gap:.1rem}
+    .price-transfer-kicker{display:inline-flex;background:#166534;color:#fff;border-radius:999px;
+                           padding:.2rem .65rem;font-size:.74rem;font-weight:800;
+                           letter-spacing:.035em;text-transform:uppercase;line-height:1.35}
+    .price-transfer strong{font-size:1.55rem;font-weight:850;color:#14532d;line-height:1.25;
+                           margin-top:.2rem}
+    .price-saving{font-size:.88rem;font-weight:700;color:#166534}
+    .price-card{font-size:.9rem;font-weight:600;color:#334155;margin-top:.8rem;
+                padding-top:.7rem;border-top:1px solid #bbf7d0}
+    .price-label{font-weight:700}
+    .price-installment{font-size:.88rem;font-weight:600;color:#475569;margin-top:.2rem}
     .order-box{display:flex;flex-direction:column;gap:.25rem;background:#fff7e8;
                border:1px solid #efd2a6;border-radius:.5rem;padding:1rem 1.25rem;
                margin:.875rem 0;color:#6b4218}


### PR DESCRIPTION
## Qué cambia

- Muestra primero el precio por transferencia con el badge **12% menos por transferencia**.
- Muestra el ahorro exacto, consistente con el total redondeado.
- Deja precio web/tarjeta y cuotas visibles, pero con jerarquía secundaria.
- Usa un bloque verde suave y mayor contraste para el beneficio principal.

## Alcance

Cambio aislado a la ficha individual. No modifica catálogo, checkout, Mercado Pago, feed ni JSON-LD.

## Causa

La ficha daba más tamaño y contraste al precio con tarjeta, mientras el beneficio por transferencia quedaba reducido a una nota de 0,85 rem.

## Validación

- 684 pruebas verdes.
- Build Astro con checkout OFF: verde.
- Build Astro con checkout ON: verde.
- Diff remoto: 2 archivos; base exacta `5bc2db896e7c8a1b07315d009e81983e7c98d538`.