### PR TITLE
Validar stock vigente en el carrito

### DIFF
--- a/astro-front/public/cart.js
+++ b/astro-front/public/cart.js
@@ -193,6 +193,46 @@
       return cart.idempotency_key;
     },
 
+    // Actualiza solamente datos comerciales confirmados por /api/cart/validate.
+    // Los agotados permanecen en el carrito para poder ofrecer el encargo;
+    // esta función nunca confía en título, precio o stock del navegador.
+    syncValidated: function (validatedItems) {
+      if (!Array.isArray(validatedItems)) return false;
+      var byId = {};
+      for (var i = 0; i < validatedItems.length; i++) {
+        var validated = validatedItems[i];
+        if (validated && typeof validated.product_id === 'string') {
+          byId[validated.product_id] = validated;
+        }
+      }
+      var cart = load();
+      var changed = false;
+      for (var j = 0; j < cart.items.length; j++) {
+        var item = cart.items[j];
+        var current = byId[item.id];
+        if (!current || current.status === 'sin_stock' || current.status === 'no_existe') continue;
+        var price = Math.round(Number(current.price_uyu));
+        var available = Math.floor(Number(current.available_quantity));
+        if (isFinite(price) && price > 0 && item.price !== price) {
+          item.price = price;
+          changed = true;
+        }
+        if (isFinite(available) && available > 0 && item.max_qty !== available) {
+          item.max_qty = available;
+          changed = true;
+        }
+        if (isFinite(available) && available > 0 && item.quantity > available) {
+          item.quantity = available;
+          changed = true;
+        }
+      }
+      if (changed) {
+        cart.idempotency_key = uuid();
+        save(cart);
+      }
+      return changed;
+    },
+
     count: function () {
       return load().items.reduce(function (s, i) { return s + (i.quantity || 0); }, 0);
     },

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -896,6 +896,62 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     margin-top: 0.1rem;
   }
 
+  :global(.cart-item-unavailable) {
+    background: #fff8f5;
+    border: 1px solid #efc7ba;
+    border-radius: 8px;
+    margin: 0.5rem 0;
+    padding: 0.875rem;
+  }
+
+  :global(.cart-item-unavailable .cart-item-img),
+  :global(.cart-item-unavailable .cart-item-img-placeholder) {
+    opacity: 0.58;
+  }
+
+  :global(.cart-unavailable-box) {
+    grid-column: 2 / 4;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 0.75rem;
+    color: #7f2f20;
+    font-size: 0.8rem;
+    line-height: 1.4;
+  }
+
+  :global(.cart-unavailable-box strong) {
+    flex-basis: 100%;
+  }
+
+  :global(.cart-unavailable-wa) {
+    display: inline-flex;
+    align-items: center;
+    min-height: 40px;
+    padding: 0.45rem 0.75rem;
+    border-radius: 6px;
+    background: #267a42;
+    color: #fff;
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  :global(.cart-unavailable-remove) {
+    min-height: 40px;
+    border: 0;
+    background: transparent;
+    color: #7f2f20;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  :global(.cart-item-update-msg) {
+    grid-column: 2 / 4;
+    color: #267a42;
+    font-size: 0.75rem;
+    font-weight: 600;
+  }
+
   /* ── Totales ───────────────────────────────────────── */
   .cart-totals {
     display: flex;
@@ -1168,6 +1224,12 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     var transferData         = null;
     var transferIdempotencyKey = '';
     var selectedAccountId    = 'brou';
+    var cartValidationById   = {};
+    var cartValidationReady  = false;
+    var cartValidationFailed = false;
+    var cartValidationChanged = false;
+    var validationRequest    = null;
+    var applyingValidation   = false;
 
     // ── Formato moneda ───────────────────────────────────────────────────
     var fmt = new Intl.NumberFormat('es-UY', {
@@ -1342,10 +1404,135 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     var restoredDraft = restoreDraft();
     syncPickupAck();
 
+    // ── STOCK-CARRITO-1: disponibilidad vigente ────────────────────────
+    function isUnavailableStatus(status) {
+      return status === 'sin_stock' || status === 'no_existe';
+    }
+
+    function validationFor(item) {
+      return cartValidationById[item.id] || null;
+    }
+
+    function getSellableItems(cart) {
+      if (!cartValidationReady || cartValidationFailed) return [];
+      return cart.items.filter(function (item) {
+        var validation = validationFor(item);
+        return validation && !isUnavailableStatus(validation.status);
+      });
+    }
+
+    function getSellableSubtotal() {
+      if (!window.AmadoCart) return 0;
+      return getSellableItems(window.AmadoCart.get()).reduce(function (sum, item) {
+        return sum + item.price * item.quantity;
+      }, 0);
+    }
+
+    function paymentItemsPayload(cart) {
+      return getSellableItems(cart).map(function (item) {
+        return { product_id: item.id, quantity: item.quantity };
+      });
+    }
+
+    function syncPaymentAvailability() {
+      var cart = window.AmadoCart ? window.AmadoCart.get() : { items: [] };
+      var canPay = cartValidationReady && !cartValidationFailed &&
+        !validationRequest && getSellableItems(cart).length > 0;
+      var transferButton = document.getElementById('btn-transfer-order');
+      var mercadoPagoButton = document.getElementById('btn-prepare-order');
+      if (transferButton && !transferButton.hasAttribute('aria-busy')) transferButton.disabled = !canPay;
+      if (mercadoPagoButton && !mercadoPagoButton.hasAttribute('aria-busy')) mercadoPagoButton.disabled = !canPay;
+    }
+
+    function buildCartValidationPayload(cart) {
+      return {
+        items: cart.items.map(function (item) {
+          return {
+            product_id: item.id,
+            quantity: item.quantity,
+            unit_price_uyu: item.price,
+          };
+        }),
+      };
+    }
+
+    async function runCartValidation(options) {
+      var cart = window.AmadoCart.get();
+      if (cart.items.length === 0) {
+        cartValidationById = {};
+        cartValidationReady = true;
+        cartValidationFailed = false;
+        cartValidationChanged = false;
+        renderCart();
+        return false;
+      }
+
+      if (options && options.initial && loadingEl) {
+        loadingEl.hidden = false;
+        loadingEl.textContent = 'Verificando disponibilidad…';
+      }
+
+      var response = await fetch('/api/cart/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildCartValidationPayload(cart)),
+      });
+      var data = await response.json();
+      if (!response.ok || !Array.isArray(data.items)) {
+        var validationError = new Error(
+          data.error || 'No pudimos verificar la disponibilidad. Probá de nuevo en unos minutos.'
+        );
+        validationError.code = data.code || '';
+        throw validationError;
+      }
+
+      var nextById = {};
+      for (var i = 0; i < data.items.length; i++) {
+        nextById[data.items[i].product_id] = data.items[i];
+      }
+      cartValidationById = nextById;
+      cartValidationReady = true;
+      cartValidationFailed = false;
+      cartValidationChanged = data.has_changes === true;
+
+      applyingValidation = true;
+      try { window.AmadoCart.syncValidated(data.items); }
+      finally { applyingValidation = false; }
+
+      renderCart();
+      var remaining = getSellableItems(window.AmadoCart.get()).length;
+      if (data.has_changes) {
+        announce(remaining > 0
+          ? 'Actualizamos la disponibilidad del carrito. Podés continuar con los libros disponibles.'
+          : 'Los libros del carrito ya no están disponibles. Podés pedir que los busquemos por encargo.');
+      }
+      return remaining > 0;
+    }
+
+    async function refreshCartAvailability(options) {
+      if (validationRequest) return validationRequest;
+      cartValidationReady = false;
+      cartValidationFailed = false;
+      syncPaymentAvailability();
+      validationRequest = runCartValidation(options).catch(function (error) {
+        cartValidationReady = false;
+        cartValidationFailed = true;
+        renderCart();
+        showCheckoutError(
+          error.message || 'No pudimos verificar la disponibilidad. Probá de nuevo en unos minutos.'
+        );
+        return false;
+      }).finally(function () {
+        validationRequest = null;
+        syncPaymentAvailability();
+      });
+      return validationRequest;
+    }
+
     // ── Calcular y mostrar totales ───────────────────────────────────────
     function updateTotals() {
       if (!window.AmadoCart) return;
-      var subtotal     = window.AmadoCart.subtotal();
+      var subtotal     = getSellableSubtotal();
       var deliveryType = getDeliveryType();
       var isPickup     = deliveryType === 'pickup';
 
@@ -1383,7 +1570,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     }
 
     // ── Construir fila de item ───────────────────────────────────────────
-    function buildItemRow(item) {
+    function buildItemRow(item, validation) {
       var art = document.createElement('article');
       art.className = 'cart-item';
       art.setAttribute('role', 'listitem');
@@ -1408,10 +1595,58 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       titleEl.textContent = item.title;
       art.appendChild(titleEl);
 
+      if (validation && isUnavailableStatus(validation.status)) {
+        art.classList.add('cart-item-unavailable');
+        var unavailableBox = document.createElement('div');
+        unavailableBox.className = 'cart-unavailable-box';
+
+        var unavailableText = document.createElement('strong');
+        unavailableText.textContent = 'Vendimos todos los ejemplares de “' + item.title + '”. Si querés, lo buscamos para vos.';
+        unavailableBox.appendChild(unavailableText);
+
+        var waText = 'Hola, vi que “' + item.title + '”';
+        var currentAuthor = validation.author || '';
+        if (currentAuthor) waText += ' de ' + currentAuthor;
+        waText += ' ya no está disponible. ¿Pueden buscarlo por encargo?';
+        var waLink = document.createElement('a');
+        waLink.className = 'cart-unavailable-wa';
+        waLink.href = 'https://wa.me/' + WHATSAPP_NUMBER + '?text=' + encodeURIComponent(waText);
+        waLink.target = '_blank';
+        waLink.rel = 'noopener noreferrer';
+        waLink.textContent = 'Buscarlo por encargo';
+        unavailableBox.appendChild(waLink);
+
+        var unavailableRemove = document.createElement('button');
+        unavailableRemove.type = 'button';
+        unavailableRemove.className = 'cart-unavailable-remove';
+        unavailableRemove.textContent = 'Quitar del carrito';
+        unavailableRemove.addEventListener('click', function () {
+          announce('Se eliminó "' + item.title + '" del carrito.');
+          window.AmadoCart.remove(item.id);
+        });
+        unavailableBox.appendChild(unavailableRemove);
+        art.appendChild(unavailableBox);
+        return art;
+      }
+
       var unitEl = document.createElement('p');
       unitEl.className = 'cart-item-unit-price';
       unitEl.textContent = fmt.format(item.price) + ' c/u';
       art.appendChild(unitEl);
+
+      if (validation && validation.status === 'precio_cambiado') {
+        var priceUpdate = document.createElement('span');
+        priceUpdate.className = 'cart-item-update-msg';
+        priceUpdate.textContent = 'El precio se actualizó a ' + fmt.format(item.price) + ' según el catálogo vigente.';
+        art.appendChild(priceUpdate);
+      }
+
+      if (validation && validation.status === 'cantidad_ajustada') {
+        var quantityUpdate = document.createElement('span');
+        quantityUpdate.className = 'cart-item-update-msg';
+        quantityUpdate.textContent = 'Quedaba menos stock: ajustamos la cantidad a ' + item.quantity + '.';
+        art.appendChild(quantityUpdate);
+      }
 
       var controls = document.createElement('div');
       controls.className = 'cart-item-controls';
@@ -1510,10 +1745,11 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
 
       while (itemsList.firstChild) itemsList.removeChild(itemsList.firstChild);
       for (var i = 0; i < cart.items.length; i++) {
-        itemsList.appendChild(buildItemRow(cart.items[i]));
+        itemsList.appendChild(buildItemRow(cart.items[i], validationFor(cart.items[i])));
       }
 
       updateTotals();
+      syncPaymentAvailability();
     }
 
     // ── Guardia ──────────────────────────────────────────────────────────
@@ -1532,7 +1768,13 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         if (checkoutEditStepEl) checkoutEditStepEl.hidden = false;
         try { sessionStorage.removeItem(CHECKOUT_DRAFT_KEY); } catch (_) {}
       }
-      renderCart();
+      if (applyingValidation) {
+        renderCart();
+      } else {
+        cartValidationReady = false;
+        cartValidationFailed = false;
+        refreshCartAvailability();
+      }
     });
 
     // ── Toggle entrega ───────────────────────────────────────────────────
@@ -1621,9 +1863,13 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     // ── WhatsApp ──────────────────────────────────────────────────────────
     var btnWa = document.getElementById('btn-wa-order');
     if (btnWa) {
-      btnWa.addEventListener('click', function () {
+      btnWa.addEventListener('click', async function () {
         var cart = window.AmadoCart.get();
         if (cart.items.length === 0) return;
+        if (!await refreshCartAvailability({ beforePayment: true })) return;
+        cart = window.AmadoCart.get();
+        var sellableItems = getSellableItems(cart);
+        if (sellableItems.length === 0) return;
 
         var deliveryType = getDeliveryType();
         var address      = ((document.getElementById('delivery-address')     || {}).value || '').trim();
@@ -1647,12 +1893,12 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
           }
         }
 
-        var subtotal = window.AmadoCart.subtotal();
+        var subtotal = getSellableSubtotal();
 
         var lines = ['PEDIDO WEB', '', 'Hola Amado Libros! Quiero hacer este pedido:'];
         lines.push('');
-        for (var i = 0; i < cart.items.length; i++) {
-          var it = cart.items[i];
+        for (var i = 0; i < sellableItems.length; i++) {
+          var it = sellableItems[i];
           lines.push('• ' + it.title + ' (x' + it.quantity + ') — ' + fmt.format(it.price) + ' c/u');
         }
         lines.push('');
@@ -1691,6 +1937,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       btnTransfer.disabled = false;
       btnTransfer.removeAttribute('aria-busy');
       btnTransfer.innerHTML = btnTransferOriginalHtml;
+      syncPaymentAvailability();
     }
 
     function selectedTransferAccount() {
@@ -1810,14 +2057,15 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       var payment = transferData.payment;
       var account = selectedTransferAccount();
       var cart = window.AmadoCart.get();
+      var sellableItems = getSellableItems(cart);
       var lines = [
         'COMPROBANTE DE TRANSFERENCIA',
         '',
         'Hola Amado Libros. Ya realicé la transferencia de mi pedido ' + payment.public_code + '.',
         '',
       ];
-      for (var i = 0; i < cart.items.length; i++) {
-        lines.push('• ' + cart.items[i].title + ' (x' + cart.items[i].quantity + ')');
+      for (var i = 0; i < sellableItems.length; i++) {
+        lines.push('• ' + sellableItems[i].title + ' (x' + sellableItems[i].quantity + ')');
       }
       lines.push('');
       lines.push('Total transferido: ' + fmt.format(payment.transfer_total_uyu) + ' UYU');
@@ -1926,11 +2174,15 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       btnTransfer.setAttribute('aria-busy', 'true');
       btnTransfer.textContent = 'Verificando precio y stock…';
 
+      var availabilityOk = await refreshCartAvailability({ beforePayment: true });
+      if (!availabilityOk) return null;
+      cart = window.AmadoCart.get();
+
       var token = await getTurnstileTokenForOrder();
       var payload = {
         idempotency_key: cart.idempotency_key,
         cf_turnstile_response: token,
-        items: cart.items.map(function (item) { return { product_id: item.id, quantity: item.quantity }; }),
+        items: paymentItemsPayload(cart),
         delivery_type: deliveryType,
         buyer: { name: name, phone: phone },
       };
@@ -1946,6 +2198,10 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         body: JSON.stringify(payload),
       });
       var orderData = await response.json();
+      if (!response.ok && orderData.code === 'CART_CHANGED') {
+        await refreshCartAvailability({ beforePayment: true });
+        return null;
+      }
       if (!response.ok) throw new Error(orderData.error || 'No pudimos preparar el pedido.');
       transferIdempotencyKey = cart.idempotency_key;
       return orderData.order;
@@ -2053,6 +2309,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       btnPrepare.disabled = false;
       btnPrepare.removeAttribute('aria-busy');
       btnPrepare.innerHTML = origBtnHTML;
+      syncPaymentAvailability();
     }
 
     if (btnPrepare) {
@@ -2093,6 +2350,13 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
 
         btnPrepare.disabled = true;
         btnPrepare.setAttribute('aria-busy', 'true');
+
+        var availabilityOk = await refreshCartAvailability({ beforePayment: true });
+        if (!availabilityOk) {
+          resetPrepareButton();
+          return;
+        }
+        cart = window.AmadoCart.get();
 
         // Fail closed: si el checkout está habilitado pero Turnstile no
         // pudo configurarse (site key ausente, o este host no está
@@ -2143,9 +2407,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         var payload = {
           idempotency_key: cart.idempotency_key,
           cf_turnstile_response: cfTsResponse,
-          items: cart.items.map(function (it) {
-            return { product_id: it.id, quantity: it.quantity };
-          }),
+          items: paymentItemsPayload(cart),
           delivery_type: deliveryType,
           buyer: { name: prepName, phone: prepPhone },
         };
@@ -2168,6 +2430,11 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
           });
           orderData = await resp.json();
           if (!resp.ok) {
+            if (orderData.code === 'CART_CHANGED') {
+              await refreshCartAvailability({ beforePayment: true });
+              resetPrepareButton();
+              return;
+            }
             showCheckoutError('Error: ' + (orderData.error || 'Intentá de nuevo.'));
             resetPrepareButton();
             return;
@@ -2216,24 +2483,26 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       });
     }
 
-    renderCart();
-    if (transferStepEl && restoredDraft && restoredDraft.step === 'transfer' && restoredDraft.transfer_auth &&
-        restoredDraft.transfer_auth.idempotency_key === window.AmadoCart.get().idempotency_key) {
-      transferIdempotencyKey = restoredDraft.transfer_auth.idempotency_key;
-      fetchTransferOptions(restoredDraft.transfer_auth.public_code, transferIdempotencyKey)
-        .then(function (data) {
-          transferData = data;
-          showTransferStep(restoredDraft.payer_channel_id, restoredDraft.scroll_y);
-        })
-        .catch(function (error) {
-          transferData = null;
-          transferIdempotencyKey = '';
-          try { sessionStorage.removeItem(CHECKOUT_DRAFT_KEY); } catch (_) {}
-          showEditStep();
-          showCheckoutError(error.message || 'No pudimos recuperar la transferencia. Prepará el pedido nuevamente.');
-        });
-    } else if (restoredDraft && Number.isFinite(restoredDraft.scroll_y)) {
-      requestAnimationFrame(function () { window.scrollTo(0, restoredDraft.scroll_y); });
-    }
+    refreshCartAvailability({ initial: true }).then(function () {
+      if (transferStepEl && restoredDraft && restoredDraft.step === 'transfer' &&
+          restoredDraft.transfer_auth && !cartValidationChanged &&
+          restoredDraft.transfer_auth.idempotency_key === window.AmadoCart.get().idempotency_key) {
+        transferIdempotencyKey = restoredDraft.transfer_auth.idempotency_key;
+        fetchTransferOptions(restoredDraft.transfer_auth.public_code, transferIdempotencyKey)
+          .then(function (data) {
+            transferData = data;
+            showTransferStep(restoredDraft.payer_channel_id, restoredDraft.scroll_y);
+          })
+          .catch(function (error) {
+            transferData = null;
+            transferIdempotencyKey = '';
+            try { sessionStorage.removeItem(CHECKOUT_DRAFT_KEY); } catch (_) {}
+            showEditStep();
+            showCheckoutError(error.message || 'No pudimos recuperar la transferencia. Prepará el pedido nuevamente.');
+          });
+      } else if (restoredDraft && Number.isFinite(restoredDraft.scroll_y)) {
+        requestAnimationFrame(function () { window.scrollTo(0, restoredDraft.scroll_y); });
+      }
+    });
   });
 </script>

--- a/functions/__tests__/cart-stock-validation.test.js
+++ b/functions/__tests__/cart-stock-validation.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const carrito = readFileSync(path.join(ROOT, 'astro-front/src/pages/carrito.astro'), 'utf8');
+const cartJs = readFileSync(path.join(ROOT, 'astro-front/public/cart.js'), 'utf8');
+const ordersHandler = readFileSync(path.join(ROOT, 'functions/api/_orders_handler.js'), 'utf8');
+const ordersRoute = readFileSync(path.join(ROOT, 'functions/api/orders.js'), 'utf8');
+
+test('el carrito revalida al abrir y antes de transferencia, Mercado Pago y WhatsApp', () => {
+  assert.match(carrito, /refreshCartAvailability\(\{ initial: true \}\)/);
+  assert.ok((carrito.match(/refreshCartAvailability\(\{ beforePayment: true \}\)/g) || []).length >= 3);
+  assert.match(carrito, /fetch\('\/api\/cart\/validate'/);
+});
+
+test('agotados quedan visibles, no suman y ofrecen encargo por WhatsApp', () => {
+  assert.match(carrito, /Vendimos todos los ejemplares de/);
+  assert.match(carrito, /Buscarlo por encargo/);
+  assert.match(carrito, /cart-item-unavailable/);
+  assert.match(carrito, /getSellableSubtotal/);
+  assert.match(carrito, /paymentItemsPayload\(cart\)/);
+});
+
+test('precio y stock del navegador se reemplazan sólo con respuesta validada', () => {
+  assert.match(cartJs, /syncValidated: function/);
+  assert.match(cartJs, /current\.price_uyu/);
+  assert.match(cartJs, /current\.available_quantity/);
+  const syncStart = cartJs.indexOf('syncValidated: function');
+  const syncBlock = cartJs.slice(syncStart, syncStart + 2200);
+  assert.doesNotMatch(syncBlock, /item\.title\s*=/);
+  assert.match(syncBlock, /status === 'sin_stock'/);
+});
+
+test('la validación final ya no responde el error genérico y usa el índice vigente', () => {
+  assert.doesNotMatch(ordersHandler, /Productos con problemas\./);
+  assert.match(ordersHandler, /code: 'CART_CHANGED'/);
+  assert.match(ordersRoute, /fetchCheckoutCatalog/);
+  assert.doesNotMatch(ordersRoute, /fetchCatalog\s*}/);
+});
+
+test('una caída técnica nunca se comunica como agotado', () => {
+  assert.match(carrito, /No pudimos verificar la disponibilidad/);
+  assert.match(carrito, /cartValidationFailed = true/);
+  assert.match(carrito, /syncPaymentAvailability/);
+});

--- a/functions/_shared/catalog.js
+++ b/functions/_shared/catalog.js
@@ -289,6 +289,14 @@ export async function fetchActiveIndex(ctx) {
     return null;
 }
 
+// Stock y precios de checkout deben seguir el manifiesto vigente (60 s), no
+// catalog.json cacheado durante una hora. El índice activo es versionado y es
+// la misma fuente que publica el sincronizador para Producción y Preview.
+export async function fetchCheckoutCatalog(ctx) {
+    const activeIndex = await fetchActiveIndex(ctx);
+    return activeIndex && Array.isArray(activeIndex.items) ? activeIndex : null;
+}
+
 export function pausedBlockNumberForId(id, blockCount) {
     const digits = String(id || '').replace(/\D/g, '');
     if (!digits || !Number.isInteger(blockCount) || blockCount < 1) return 0;

--- a/functions/api/__tests__/cart_validate.test.js
+++ b/functions/api/__tests__/cart_validate.test.js
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createCartValidationHandler } from '../_cart_validation_handler.js';
+
+const CATALOG = { items: [
+  { id: 'MLU1', title: 'Disponible', author: 'Autora', price: 1000, available_quantity: 2, status: 'active' },
+  { id: 'MLU2', title: 'Agotado', author: 'Autor', price: 900, available_quantity: 0, status: 'paused' },
+  { id: 'MLU3', title: 'Una unidad', author: '', price: 750, available_quantity: 1, status: 'active' },
+] };
+
+function context(body, { method = 'POST', type = 'application/json', length } = {}) {
+  const headers = { 'Content-Type': type };
+  if (length !== undefined) headers['Content-Length'] = String(length);
+  return {
+    request: new Request('https://www.amadolibros.com/api/cart/validate', {
+      method,
+      headers,
+      body: method === 'POST' ? (typeof body === 'string' ? body : JSON.stringify(body)) : undefined,
+    }),
+    env: { APP_ENV: 'production' },
+    waitUntil() {},
+  };
+}
+
+async function call(body, fetchCatalog = async () => CATALOG, options) {
+  const handler = createCartValidationHandler({ fetchCatalog });
+  const response = await handler(context(body, options));
+  return { response, data: await response.json() };
+}
+
+test('devuelve estado individual y no bloquea los productos que siguen vendibles', async () => {
+  const { response, data } = await call({ items: [
+    { product_id: 'MLU1', quantity: 1, unit_price_uyu: 1000 },
+    { product_id: 'MLU2', quantity: 1, unit_price_uyu: 900 },
+    { product_id: 'MLU404', quantity: 1, unit_price_uyu: 800 },
+  ] });
+  assert.equal(response.status, 200);
+  assert.deepEqual(data.items.map(item => item.status), ['ok', 'sin_stock', 'no_existe']);
+  assert.equal(data.items[1].title, 'Agotado');
+  assert.equal(data.has_blocking_items, true);
+  assert.equal(response.headers.get('Cache-Control'), 'no-store');
+  assert.equal(response.headers.get('X-Robots-Tag'), 'noindex, nofollow');
+});
+
+test('actualiza precio y reduce cantidad al stock vigente sin perder la venta', async () => {
+  const { data } = await call({ items: [
+    { product_id: 'MLU1', quantity: 1, unit_price_uyu: 850 },
+    { product_id: 'MLU3', quantity: 2, unit_price_uyu: 750 },
+  ] });
+  assert.equal(data.items[0].status, 'precio_cambiado');
+  assert.equal(data.items[0].price_uyu, 1000);
+  assert.equal(data.items[1].status, 'cantidad_ajustada');
+  assert.equal(data.items[1].suggested_quantity, 1);
+});
+
+test('catálogo caído es 503 y nunca se interpreta como agotado', async () => {
+  for (const fetchCatalog of [async () => null, async () => { throw new Error('R2'); }]) {
+    const { response, data } = await call({
+      items: [{ product_id: 'MLU1', quantity: 1, unit_price_uyu: 1000 }],
+    }, fetchCatalog);
+    assert.equal(response.status, 503);
+    assert.equal(data.code, 'CATALOG_UNAVAILABLE');
+  }
+});
+
+test('contrato HTTP limita método, tipo, tamaño, duplicados y cantidades', async () => {
+  assert.equal((await call(null, async () => CATALOG, { method: 'GET' })).response.status, 405);
+  assert.equal((await call('{}', async () => CATALOG, { type: 'text/plain' })).response.status, 415);
+  assert.equal((await call('{}', async () => CATALOG, { length: 33 * 1024 })).response.status, 413);
+  assert.equal((await call({ items: [
+    { product_id: 'MLU1', quantity: 1 },
+    { product_id: 'MLU1', quantity: 1 },
+  ] })).response.status, 400);
+  assert.equal((await call({ items: [{ product_id: 'MLU1', quantity: 100 }] })).response.status, 400);
+});

--- a/functions/api/__tests__/orders.test.js
+++ b/functions/api/__tests__/orders.test.js
@@ -89,7 +89,14 @@ test('precio del navegador se ignora y manda catálogo', async()=>{
 });
 
 test('stock, producto, estado y precio inválidos devuelven 422', async()=>{
-  for(const id of ['NOPE','P','X']) { const b=pickup(id); b.items=[{product_id:id,quantity:1}]; assert.equal((await call(b)).response.status,422); }
+  for(const id of ['NOPE','P','X']) {
+    const b=pickup(id); b.items=[{product_id:id,quantity:1}];
+    const result=await call(b);
+    assert.equal(result.response.status,422);
+    assert.equal(result.data.code,'CART_CHANGED');
+    assert.notEqual(result.data.error,'Productos con problemas.');
+    assert.equal(Array.isArray(result.data.issues),true);
+  }
   const b=pickup('stock'); b.items=[{product_id:'A',quantity:6}]; assert.equal((await call(b)).response.status,422);
 });
 

--- a/functions/api/_cart_validation_handler.js
+++ b/functions/api/_cart_validation_handler.js
@@ -1,0 +1,70 @@
+import {
+  MAX_BODY_BYTES,
+  validateCartAgainstCatalog,
+  validateCartBody,
+} from './_orders_logic.js';
+
+function json(body, status = 200, extraHeaders = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+      'X-Robots-Tag': 'noindex, nofollow',
+      ...extraHeaders,
+    },
+  });
+}
+
+export function createCartValidationHandler({ fetchCatalog }) {
+  return async function onRequest(context) {
+    const { request } = context;
+    if (request.method !== 'POST') {
+      return json({ error: 'Método no permitido.' }, 405, { Allow: 'POST' });
+    }
+
+    const contentType = request.headers.get('Content-Type') || '';
+    if (!contentType.toLowerCase().includes('application/json')) {
+      return json({ error: 'Content-Type debe ser application/json.' }, 415);
+    }
+
+    const contentLength = Number.parseInt(request.headers.get('Content-Length') || '0', 10);
+    if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+      return json({ error: 'Body demasiado grande (máx. 32 KB).' }, 413);
+    }
+
+    let body;
+    try {
+      const text = await request.text();
+      if (new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) {
+        return json({ error: 'Body demasiado grande (máx. 32 KB).' }, 413);
+      }
+      body = JSON.parse(text);
+    } catch {
+      return json({ error: 'JSON inválido.' }, 400);
+    }
+
+    const validationError = validateCartBody(body);
+    if (validationError) return json({ error: validationError }, 400);
+
+    let catalog;
+    try {
+      catalog = await fetchCatalog(context);
+    } catch {
+      catalog = null;
+    }
+    if (!catalog || !Array.isArray(catalog.items)) {
+      return json({
+        error: 'No pudimos verificar la disponibilidad. Probá de nuevo en unos minutos.',
+        code: 'CATALOG_UNAVAILABLE',
+      }, 503);
+    }
+
+    const items = validateCartAgainstCatalog(body.items, catalog.items);
+    return json({
+      items,
+      has_blocking_items: items.some(item => item.status === 'sin_stock' || item.status === 'no_existe'),
+      has_changes: items.some(item => item.status !== 'ok'),
+    });
+  };
+}

--- a/functions/api/_orders_handler.js
+++ b/functions/api/_orders_handler.js
@@ -118,9 +118,13 @@ export function createOrdersHandler({ fetchCatalog, getNow = () => new Date(), v
       return json({ error: 'Catálogo no disponible. Intentá de nuevo en unos segundos.' }, 503);
     }
 
-    const { errors, snapshot } = buildSnapshot(consolidatedItems, catalog.items);
+    const { errors, issues, snapshot } = buildSnapshot(consolidatedItems, catalog.items);
     if (errors.length > 0) {
-      return json({ error: 'Productos con problemas.', details: errors }, 422);
+      return json({
+        error: 'Actualizamos la disponibilidad de tu carrito.',
+        code: 'CART_CHANGED',
+        issues,
+      }, 422);
     }
 
     const { productsTotal, pickupDiscount, shippingCost, payableTotal } =

--- a/functions/api/_orders_logic.js
+++ b/functions/api/_orders_logic.js
@@ -150,22 +150,42 @@ export function buildSnapshot(consolidatedItems, catalogItems) {
   }
 
   const errors = [];
+  const issues = [];
   const snapshot = [];
 
   for (const item of consolidatedItems) {
     const catalogItem = byId.get(item.product_id);
     if (!catalogItem) {
       errors.push('Producto no encontrado: ' + item.product_id);
+      issues.push({
+        product_id: item.product_id,
+        status: 'no_existe',
+        available_quantity: 0,
+      });
       continue;
     }
     if (catalogItem.status && catalogItem.status !== 'active') {
       errors.push('Producto no disponible: ' + item.product_id);
+      issues.push({
+        product_id: item.product_id,
+        status: 'sin_stock',
+        title: typeof catalogItem.title === 'string' ? catalogItem.title : '',
+        author: typeof catalogItem.author === 'string' ? catalogItem.author : '',
+        available_quantity: 0,
+      });
       continue;
     }
 
     const available = Number(catalogItem.available_quantity);
     if (!Number.isInteger(available) || available < 0) {
       errors.push('Stock inválido para: ' + item.product_id);
+      issues.push({
+        product_id: item.product_id,
+        status: 'sin_stock',
+        title: typeof catalogItem.title === 'string' ? catalogItem.title : '',
+        author: typeof catalogItem.author === 'string' ? catalogItem.author : '',
+        available_quantity: 0,
+      });
       continue;
     }
     if (item.quantity > available) {
@@ -173,12 +193,25 @@ export function buildSnapshot(consolidatedItems, catalogItems) {
         'Stock insuficiente para: ' + item.product_id +
         ' (disponible: ' + available + ')'
       );
+      issues.push({
+        product_id: item.product_id,
+        status: available === 0 ? 'sin_stock' : 'cantidad_ajustada',
+        title: typeof catalogItem.title === 'string' ? catalogItem.title : '',
+        author: typeof catalogItem.author === 'string' ? catalogItem.author : '',
+        available_quantity: available,
+        suggested_quantity: available,
+      });
       continue;
     }
 
     const rawPrice = Number(catalogItem.price);
     if (!Number.isFinite(rawPrice) || rawPrice <= 0) {
       errors.push('Precio inválido para: ' + item.product_id);
+      issues.push({
+        product_id: item.product_id,
+        status: 'no_existe',
+        available_quantity: 0,
+      });
       continue;
     }
 
@@ -199,7 +232,92 @@ export function buildSnapshot(consolidatedItems, catalogItems) {
     });
   }
 
-  return { errors, snapshot };
+  return { errors, issues, snapshot };
+}
+
+export function validateCartBody(body) {
+  if (!isRecord(body)) return 'Body inválido.';
+  if (!Array.isArray(body.items) || body.items.length === 0) return 'El carrito está vacío.';
+  if (body.items.length > MAX_ITEMS) return 'Demasiados productos (máx. ' + MAX_ITEMS + ').';
+
+  const ids = new Set();
+  for (const item of body.items) {
+    if (!isRecord(item)) return 'Item inválido.';
+    if (!isNonEmptyString(item.product_id)) return 'product_id inválido.';
+    const productId = item.product_id.trim();
+    if (productId.length > MAX_PRODUCT_ID_LEN) return 'product_id demasiado largo.';
+    if (ids.has(productId)) return 'Producto duplicado.';
+    ids.add(productId);
+    if (!Number.isInteger(item.quantity) || item.quantity < 1 || item.quantity > MAX_QUANTITY_PER_ITEM) {
+      return 'Cantidad inválida.';
+    }
+    if (item.unit_price_uyu !== undefined) {
+      const clientPrice = Number(item.unit_price_uyu);
+      if (!Number.isFinite(clientPrice) || clientPrice <= 0) return 'Precio inválido.';
+    }
+  }
+  return null;
+}
+
+export function validateCartAgainstCatalog(requestItems, catalogItems) {
+  const byId = new Map();
+  for (const catalogItem of catalogItems) {
+    if (isRecord(catalogItem) && typeof catalogItem.id === 'string') {
+      byId.set(catalogItem.id, catalogItem);
+    }
+  }
+
+  return requestItems.map(requestItem => {
+    const productId = requestItem.product_id.trim();
+    const catalogItem = byId.get(productId);
+    if (!catalogItem) {
+      return { product_id: productId, status: 'no_existe', available_quantity: 0 };
+    }
+
+    const title = typeof catalogItem.title === 'string' ? catalogItem.title : '';
+    const author = typeof catalogItem.author === 'string' ? catalogItem.author : '';
+    const available = Number(catalogItem.available_quantity);
+    const active = (!catalogItem.status || catalogItem.status === 'active') &&
+      Number.isInteger(available) && available > 0;
+    if (!active) {
+      return {
+        product_id: productId,
+        status: 'sin_stock',
+        title,
+        author,
+        available_quantity: 0,
+      };
+    }
+
+    const price = Math.round(Number(catalogItem.price));
+    if (!Number.isFinite(price) || price <= 0) {
+      return { product_id: productId, status: 'no_existe', available_quantity: 0 };
+    }
+
+    if (requestItem.quantity > available) {
+      return {
+        product_id: productId,
+        status: 'cantidad_ajustada',
+        title,
+        author,
+        price_uyu: price,
+        available_quantity: available,
+        suggested_quantity: available,
+      };
+    }
+
+    const clientPrice = Number(requestItem.unit_price_uyu);
+    return {
+      product_id: productId,
+      status: Number.isFinite(clientPrice) && Math.round(clientPrice) !== price
+        ? 'precio_cambiado'
+        : 'ok',
+      title,
+      author,
+      price_uyu: price,
+      available_quantity: available,
+    };
+  });
 }
 
 export function calculateTotals(snapshotItems, deliveryType) {

--- a/functions/api/cart/validate.js
+++ b/functions/api/cart/validate.js
@@ -1,0 +1,4 @@
+import { fetchCheckoutCatalog } from '../../_shared/catalog.js';
+import { createCartValidationHandler } from '../_cart_validation_handler.js';
+
+export const onRequest = createCartValidationHandler({ fetchCatalog: fetchCheckoutCatalog });

--- a/functions/api/orders.js
+++ b/functions/api/orders.js
@@ -1,4 +1,4 @@
-import { fetchCatalog } from '../_shared/catalog.js';
+import { fetchCheckoutCatalog } from '../_shared/catalog.js';
 import { createOrdersHandler } from './_orders_handler.js';
 
-export const onRequest = createOrdersHandler({ fetchCatalog });
+export const onRequest = createOrdersHandler({ fetchCatalog: fetchCheckoutCatalog });


### PR DESCRIPTION
## Qué cambia

- Revalida precio y disponibilidad al abrir el carrito.
- Revalida nuevamente antes de transferencia, Mercado Pago y pedido por WhatsApp.
- Mantiene visibles los libros agotados, pero los excluye del total y del pedido.
- Nombra el título afectado y ofrece **Buscarlo por encargo** por WhatsApp.
- Permite continuar con los demás libros disponibles.
- Actualiza precios y ajusta cantidades cuando cambió el catálogo.
- Si el catálogo no responde, informa un error técnico y no inventa que el libro está agotado.
- Sustituye el mensaje genérico "Productos con problemas" por estados accionables.

## Causa raíz

El carrito se guarda en el navegador con el stock disponible al momento de agregar el libro. Si la última unidad se vendía después, el navegador conservaba ese dato viejo. El servidor impedía cobrar el agotado, pero recién al final y con un mensaje genérico.

## Impacto

Reduce compras imposibles sin perder el resto del pedido y transforma el agotado en una consulta comercial por encargo. No modifica precios, descuento por transferencia, entrega/retiro, cuentas bancarias ni integración con Mercado Pago.

## Validación

- 693 pruebas verdes.
- Build con checkout OFF: verde.
- Build con checkout ON: verde.
- Casos cubiertos: mezcla de disponible/agotado, todos agotados, precio cambiado, cantidad ajustada, catálogo caído, transferencia, Mercado Pago y WhatsApp.

## Barrera de publicación

PR en borrador. **No mergear ni desplegar a producción hasta validación humana y autorización explícita de Seba.**