### PR TITLE
Avisar por email cuando un libro vuelve a tener stock

### DIFF
--- a/.github/workflows/deploy-worker-sync.yml
+++ b/.github/workflows/deploy-worker-sync.yml
@@ -37,6 +37,19 @@ jobs:
         with:
           node-version: '22.12.0'
 
+      - name: Sync Resend secret to Worker
+        run: |
+          if [ -z "$RESEND_API_KEY" ]; then
+            echo "ERROR: RESEND_API_KEY no está configurada."
+            exit 1
+          fi
+          cd worker-sync
+          printf '%s' "$RESEND_API_KEY" | npx wrangler@3 secret put RESEND_API_KEY
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+
       - name: Deploy amadolibros-sync Worker
         run: |
           cd worker-sync

--- a/functions/__tests__/stock-aviso-2-migration.test.js
+++ b/functions/__tests__/stock-aviso-2-migration.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const migration = readFileSync(path.join(ROOT, 'migrations/0007_stock_waitlist_customer_notification.sql'), 'utf8');
+
+test('stock-aviso-2: migración agrega outbox sin tocar pedidos', () => {
+  assert.match(migration, /customer_notification_status/);
+  assert.match(migration, /customer_notification_id/);
+  assert.match(migration, /last_notification_attempt_at/);
+  assert.doesNotMatch(migration, /ALTER TABLE\s+(orders|order_items|order_events)/i);
+  assert.doesNotMatch(migration, /DROP TABLE/i);
+});

--- a/migrations/0007_stock_waitlist_customer_notification.sql
+++ b/migrations/0007_stock_waitlist_customer_notification.sql
@@ -1,0 +1,10 @@
+-- STOCK-AVISO-2: estado durable del correo automático al cliente.
+ALTER TABLE stock_waitlist ADD COLUMN customer_notification_status TEXT NOT NULL DEFAULT 'pending'
+  CHECK (customer_notification_status IN ('pending','sending','sent','failed','skipped'));
+ALTER TABLE stock_waitlist ADD COLUMN customer_notification_id TEXT;
+ALTER TABLE stock_waitlist ADD COLUMN customer_notification_error TEXT;
+ALTER TABLE stock_waitlist ADD COLUMN customer_notification_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE stock_waitlist ADD COLUMN last_notification_attempt_at TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_stock_waitlist_customer_pending
+  ON stock_waitlist (status, customer_notification_status, created_at);

--- a/worker-sync/__tests__/run-sync-no-partial-publish.test.js
+++ b/worker-sync/__tests__/run-sync-no-partial-publish.test.js
@@ -126,6 +126,26 @@ test('un sync exitoso publica una vez y registra sync:last_ok', async () => {
   assert.deepEqual(deletes, ['sync:last_error']);
 });
 
+test('aviso de reposición corre después de publicar y su fallo no revierte el sync', async () => {
+  const { env } = fakeEnv();
+  const order = [];
+  const result = await runSync(env, { source: 'cron' }, {
+    getAccessTokenFn: async () => 'token',
+    buildCatalogFn: async () => ({
+      total: 1,
+      updated_at: '2026-08-10T12:00:00.000Z',
+      items: [{ id: 'MLU1', status: 'active', available_quantity: 1, price: 1000 }],
+    }),
+    publishToR2Fn: async () => { order.push('publish'); },
+    processStockWaitlistFn: async () => { order.push('notify'); throw new Error('Resend caído'); },
+    notifyHealthcheckFn: noHealthcheck,
+  });
+  assert.deepEqual(order, ['publish', 'notify']);
+  assert.equal(result.status, 'ok');
+  assert.equal(result.stock_notifications.status, 'error');
+  assert.match(result.stock_notifications.error, /Resend caído/);
+});
+
 test('si falla autenticación tampoco intenta publicar', async () => {
   const { env } = fakeEnv();
   let buildCalls = 0;

--- a/worker-sync/__tests__/stock-waitlist-notifier.test.js
+++ b/worker-sync/__tests__/stock-waitlist-notifier.test.js
@@ -1,0 +1,140 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildRestockEmail,
+  createStockWaitlistProcessor,
+} from '../stock-waitlist-notifier.js';
+
+const NOW = new Date('2026-08-10T15:00:00.000Z');
+const ENV_BASE = {
+  RESEND_API_KEY: 're_test',
+  SALES_NOTIFICATION_FROM: 'Amado Libros <web@notificaciones.amadolibros.com>',
+  CANONICAL_ORIGIN: 'https://www.amadolibros.com',
+};
+
+function row(patch = {}) {
+  return {
+    id: 'wait-1', product_id: 'MLU1', product_title: 'Libro esperado',
+    email: 'cliente@example.com', status: 'waiting',
+    source_url: 'https://www.amadolibros.com/libro/MLU1/libro-esperado',
+    customer_notification_status: 'pending', customer_notification_attempts: 0,
+    last_notification_attempt_at: null, restocked_at: null, notified_at: null,
+    ...patch,
+  };
+}
+
+function dbMock(initialRows) {
+  const rows = initialRows.map(value => ({ ...value }));
+  return {
+    rows,
+    prepare(sql) {
+      return {
+        bind(...args) {
+          return {
+            async all() {
+              if (!sql.startsWith('SELECT id,product_id')) throw new Error(`SQL all inesperado: ${sql}`);
+              return { results: rows.filter(item => item.status === 'waiting' && ['pending', 'failed', 'sending'].includes(item.customer_notification_status)) };
+            },
+            async run() {
+              if (sql.startsWith("UPDATE stock_waitlist SET customer_notification_status='sending'")) {
+                const [attemptAt, restockedAt, updatedAt, id, staleBefore] = args;
+                const item = rows.find(value => value.id === id);
+                const reclaimable = item && item.status === 'waiting' && (
+                  ['pending', 'failed'].includes(item.customer_notification_status) ||
+                  (item.customer_notification_status === 'sending' && (!item.last_notification_attempt_at || item.last_notification_attempt_at < staleBefore))
+                );
+                if (!reclaimable) return { meta: { changes: 0 } };
+                item.customer_notification_status = 'sending';
+                item.customer_notification_attempts++;
+                item.last_notification_attempt_at = attemptAt;
+                item.restocked_at ||= restockedAt;
+                item.updated_at = updatedAt;
+                return { meta: { changes: 1 } };
+              }
+              if (sql.startsWith("UPDATE stock_waitlist SET status='notified'")) {
+                const [providerId, notifiedAt, updatedAt, id] = args;
+                const item = rows.find(value => value.id === id && value.customer_notification_status === 'sending');
+                if (!item) return { meta: { changes: 0 } };
+                item.status = 'notified'; item.customer_notification_status = 'sent';
+                item.customer_notification_id = providerId; item.notified_at = notifiedAt; item.updated_at = updatedAt;
+                return { meta: { changes: 1 } };
+              }
+              if (sql.startsWith("UPDATE stock_waitlist SET customer_notification_status='failed'")) {
+                const [error, updatedAt, id] = args;
+                const item = rows.find(value => value.id === id && value.customer_notification_status === 'sending');
+                if (!item) return { meta: { changes: 0 } };
+                item.customer_notification_status = 'failed'; item.customer_notification_error = error; item.updated_at = updatedAt;
+                return { meta: { changes: 1 } };
+              }
+              throw new Error(`SQL run inesperado: ${sql}`);
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+const CATALOG = { items: [
+  { id: 'MLU1', title: 'Libro esperado', status: 'active', available_quantity: 1, price: 2000 },
+  { id: 'MLU2', title: 'Sigue agotado', status: 'active', available_quantity: 0, price: 1500 },
+] };
+
+test('restock-email: usa stock y precio reales con urgencia honesta', () => {
+  const email = buildRestockEmail({
+    row: row(), product: CATALOG.items[0],
+    url: 'https://www.amadolibros.com/libro/MLU1/libro-esperado',
+  });
+  assert.match(email.subject, /compralo antes de que se agote/);
+  assert.match(email.text, /Hay 1 ejemplar disponible/);
+  assert.match(email.text, /Precio vigente: \$2\.000/);
+  assert.match(email.text, /Por transferencia: \$1\.760 \(12% menos\)/);
+  assert.match(email.html, />Comprar ahora</);
+});
+
+test('restock: sólo avisa títulos realmente activos y marca notified', async () => {
+  const db = dbMock([row(), row({ id: 'wait-2', product_id: 'MLU2' })]);
+  const requests = [];
+  const processor = createStockWaitlistProcessor({
+    getNow: () => NOW,
+    sleep: async () => {},
+    fetchFn: async (_url, init) => {
+      requests.push({ headers: init.headers, body: JSON.parse(init.body) });
+      return Response.json({ id: 'resend-1' });
+    },
+  });
+  const result = await processor({ ...ENV_BASE, ORDERS_DB: db }, CATALOG);
+  assert.deepEqual(result, { status: 'ok', examined: 2, matched: 1, sent: 1, failed: 0, truncated: false });
+  assert.equal(requests.length, 1);
+  assert.deepEqual(requests[0].body.to, ['cliente@example.com']);
+  assert.equal(requests[0].headers['Idempotency-Key'], 'stock-restocked/wait-1');
+  assert.equal(db.rows[0].status, 'notified');
+  assert.equal(db.rows[0].customer_notification_status, 'sent');
+  assert.equal(db.rows[1].status, 'waiting');
+
+  await processor({ ...ENV_BASE, ORDERS_DB: db }, CATALOG);
+  assert.equal(requests.length, 1, 'una solicitud notificada no se vuelve a enviar');
+});
+
+test('restock: fallo de Resend queda reintentable y no marca notified', async () => {
+  const db = dbMock([row()]);
+  let calls = 0;
+  const processor = createStockWaitlistProcessor({
+    getNow: () => NOW,
+    sleep: async () => {},
+    fetchFn: async () => { calls++; return new Response('{}', { status: 503 }); },
+  });
+  const result = await processor({ ...ENV_BASE, ORDERS_DB: db }, CATALOG);
+  assert.equal(calls, 3);
+  assert.equal(result.status, 'partial');
+  assert.equal(result.failed, 1);
+  assert.equal(db.rows[0].status, 'waiting');
+  assert.equal(db.rows[0].customer_notification_status, 'failed');
+  assert.equal(db.rows[0].customer_notification_error, 'RESEND_HTTP_503');
+});
+
+test('restock: sin D1 o configuración no inventa éxito', async () => {
+  const processor = createStockWaitlistProcessor();
+  assert.equal((await processor(ENV_BASE, CATALOG)).reason, 'orders_db_missing');
+  assert.equal((await processor({ ORDERS_DB: dbMock([]) }, CATALOG)).reason, 'email_config_missing');
+});

--- a/worker-sync/index.js
+++ b/worker-sync/index.js
@@ -46,6 +46,7 @@ import { getAccessToken } from './meli-auth.js';
 import { buildCatalog   } from './meli-catalog.js';
 import { publishToR2    } from './r2-publish.js';
 import { notifyHealthcheck } from './healthcheck.js';
+import { processStockWaitlist } from './stock-waitlist-notifier.js';
 import {
   addCompressedIndexes,
   buildManifest,
@@ -396,6 +397,7 @@ export async function runSync(env, options = {}, {
   buildCatalogFn = buildCatalog,
   publishToR2Fn = publishToR2,
   notifyHealthcheckFn = notifyHealthcheck,
+  processStockWaitlistFn = processStockWaitlist,
 } = {}) {
   const startedAt = new Date().toISOString();
   const source = options.source || 'unknown';
@@ -429,6 +431,17 @@ export async function runSync(env, options = {}, {
     };
     await publishToR2Fn(env, catalog, syncMeta);
 
+    // STOCK-AVISO-2: sólo después de que R2 confirmó la publicación. Un fallo
+    // de correo queda registrado y reintentable, pero no convierte un catálogo
+    // ya publicado correctamente en un sync fallido.
+    let stockNotifications;
+    try {
+      stockNotifications = await processStockWaitlistFn(env, catalog);
+    } catch (error) {
+      console.error(`[Stock waitlist] Error: ${error?.message || 'Error'}`);
+      stockNotifications = { status: 'error', error: String(error?.message || 'Error').slice(0, 200) };
+    }
+
     // 4. Estado: éxito
     await kvPut(env, 'sync:last_ok', finishedAt);
     await kvDelete(env, 'sync:last_error');
@@ -443,6 +456,7 @@ export async function runSync(env, options = {}, {
       started_at:     startedAt,
       finished_at:    finishedAt,
       duration_ms:    durationMs,
+      stock_notifications: stockNotifications,
     };
 
   } catch (err) {

--- a/worker-sync/stock-waitlist-notifier.js
+++ b/worker-sync/stock-waitlist-notifier.js
@@ -1,0 +1,218 @@
+const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+const EMAIL_TIMEOUT_MS = 7000;
+const MAX_SEND_ATTEMPTS = 3;
+const CLAIM_STALE_MS = 30 * 60 * 1000;
+const QUERY_LIMIT = 500;
+
+function cleanString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function formatMoney(value) {
+  return `$${new Intl.NumberFormat('es-UY', { maximumFractionDigits: 0 }).format(Number(value) || 0)}`;
+}
+
+function emailConfig(env) {
+  const apiKey = cleanString(env?.RESEND_API_KEY);
+  const from = cleanString(env?.SALES_NOTIFICATION_FROM);
+  const canonicalOrigin = cleanString(env?.CANONICAL_ORIGIN).replace(/\/$/, '');
+  if (!apiKey || !from || canonicalOrigin !== 'https://www.amadolibros.com') return null;
+  return { apiKey, from, canonicalOrigin };
+}
+
+function productUrl(config, row, product) {
+  const fallback = `${config.canonicalOrigin}/libro/${encodeURIComponent(product.id)}`;
+  const stored = cleanString(row.source_url);
+  if (!stored) return fallback;
+  try {
+    const url = new URL(stored);
+    const expectedPath = `/libro/${encodeURIComponent(product.id)}`;
+    if (url.origin !== config.canonicalOrigin || (url.pathname !== expectedPath && !url.pathname.startsWith(`${expectedPath}/`))) {
+      return fallback;
+    }
+    return url.toString();
+  } catch {
+    return fallback;
+  }
+}
+
+export function buildRestockEmail({ row, product, url }) {
+  const stock = Number(product.available_quantity);
+  const price = Math.round(Number(product.price));
+  const transferPrice = Math.round(price * 0.88);
+  const oneLeft = stock === 1;
+  const stockLine = oneLeft
+    ? 'Hay 1 ejemplar disponible.'
+    : `Hay ${stock} ejemplares disponibles.`;
+  const subject = `Volvió “${product.title}” — compralo antes de que se agote`;
+  const text = [
+    `Volvió “${product.title}”`,
+    '',
+    'El libro que estabas esperando ya está disponible en Amado Libros.',
+    stockLine,
+    `Precio vigente: ${formatMoney(price)}`,
+    `Por transferencia: ${formatMoney(transferPrice)} (12% menos)`,
+    'También podés pagar con tarjeta o Mercado Pago.',
+    '',
+    `Comprar ahora: ${url}`,
+    '',
+    'La disponibilidad se confirma al momento de completar el pedido.',
+  ].join('\n');
+  const html = `<!doctype html><html lang="es"><body style="font-family:Arial,sans-serif;color:#222;line-height:1.5">
+    <h1 style="font-size:22px">Volvió “${escapeHtml(product.title)}”</h1>
+    <p>El libro que estabas esperando ya está disponible en Amado Libros.</p>
+    <p><strong>${escapeHtml(stockLine)}</strong><br>
+       Precio vigente: ${escapeHtml(formatMoney(price))}<br>
+       <strong>Por transferencia: ${escapeHtml(formatMoney(transferPrice))} (12% menos)</strong><br>
+       También podés pagar con tarjeta o Mercado Pago.</p>
+    <p><a href="${escapeHtml(url)}" style="display:inline-block;padding:12px 18px;background:#a94e3d;color:#fff;text-decoration:none;border-radius:6px;font-weight:bold">Comprar ahora</a></p>
+    <p style="font-size:13px;color:#666">La disponibilidad se confirma al momento de completar el pedido.</p>
+  </body></html>`;
+  return { subject, text, html };
+}
+
+async function claimRow(db, row, now) {
+  const staleBefore = new Date(now.getTime() - CLAIM_STALE_MS).toISOString();
+  const result = await db.prepare(
+    "UPDATE stock_waitlist SET customer_notification_status='sending', " +
+    'customer_notification_attempts=customer_notification_attempts+1, ' +
+    'last_notification_attempt_at=?, restocked_at=COALESCE(restocked_at,?), updated_at=? ' +
+    "WHERE id=? AND status='waiting' AND (" +
+    "customer_notification_status IN ('pending','failed') OR " +
+    "(customer_notification_status='sending' AND (last_notification_attempt_at IS NULL OR last_notification_attempt_at<?)))"
+  ).bind(now.toISOString(), now.toISOString(), now.toISOString(), row.id, staleBefore).run();
+  return Number(result?.meta?.changes) > 0;
+}
+
+async function sendEmail({ config, row, email, fetchFn, timeoutMs }) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchFn(RESEND_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        'Content-Type': 'application/json',
+        'Idempotency-Key': `stock-restocked/${row.id}`,
+      },
+      body: JSON.stringify({ from: config.from, to: [row.email], ...email }),
+      signal: controller.signal,
+    });
+    let data = null;
+    try { data = await response.json(); } catch { /* opcional */ }
+    if (response.ok && cleanString(data?.id)) return { ok: true, providerId: data.id };
+    return {
+      ok: false,
+      retryable: response.status === 429 || response.status >= 500,
+      code: `RESEND_HTTP_${response.status}`,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      retryable: true,
+      code: error?.name === 'AbortError' ? 'RESEND_TIMEOUT' : 'RESEND_NETWORK_ERROR',
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function finishRow(db, row, result, now) {
+  if (result.ok) {
+    await db.prepare(
+      "UPDATE stock_waitlist SET status='notified', customer_notification_status='sent', " +
+      'customer_notification_id=?, customer_notification_error=NULL, notified_at=?, updated_at=? ' +
+      "WHERE id=? AND customer_notification_status='sending'"
+    ).bind(result.providerId, now.toISOString(), now.toISOString(), row.id).run();
+    return;
+  }
+  await db.prepare(
+    "UPDATE stock_waitlist SET customer_notification_status='failed', " +
+    'customer_notification_error=?, updated_at=? ' +
+    "WHERE id=? AND status='waiting' AND customer_notification_status='sending'"
+  ).bind(cleanString(result.code).slice(0, 80) || 'RESEND_ERROR', now.toISOString(), row.id).run();
+}
+
+export function createStockWaitlistProcessor({
+  fetchFn = globalThis.fetch,
+  sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
+  getNow = () => new Date(),
+  timeoutMs = EMAIL_TIMEOUT_MS,
+} = {}) {
+  return async function processStockWaitlist(env, catalog) {
+    const config = emailConfig(env);
+    if (!config) return { status: 'skipped', reason: 'email_config_missing', examined: 0, matched: 0, sent: 0, failed: 0 };
+    const db = env?.ORDERS_DB;
+    if (!db) return { status: 'skipped', reason: 'orders_db_missing', examined: 0, matched: 0, sent: 0, failed: 0 };
+
+    const items = Array.isArray(catalog?.items) ? catalog.items : [];
+    const available = new Map(items
+      .filter(item => item?.status === 'active' && Number(item.available_quantity) > 0 && Number(item.price) > 0)
+      .map(item => [item.id, item]));
+
+    const queryNow = getNow();
+    if (!(queryNow instanceof Date) || Number.isNaN(queryNow.getTime())) {
+      return { status: 'error', reason: 'invalid_clock', examined: 0, matched: 0, sent: 0, failed: 0 };
+    }
+    const staleBefore = new Date(queryNow.getTime() - CLAIM_STALE_MS).toISOString();
+    const result = await db.prepare(
+      "SELECT id,product_id,product_title,email,source_url,customer_notification_status,last_notification_attempt_at " +
+      "FROM stock_waitlist WHERE status='waiting' AND (" +
+      "customer_notification_status IN ('pending','failed') OR " +
+      "(customer_notification_status='sending' AND (last_notification_attempt_at IS NULL OR last_notification_attempt_at<?))) " +
+      'ORDER BY created_at LIMIT ?'
+    ).bind(staleBefore, QUERY_LIMIT).all();
+    const rows = Array.isArray(result?.results) ? result.results : [];
+    const matched = rows.filter(row => available.has(row.product_id));
+    let sent = 0;
+    let failed = 0;
+
+    for (const row of matched) {
+      let claimed = false;
+      try {
+        const now = getNow();
+        if (!(now instanceof Date) || Number.isNaN(now.getTime())) throw new Error('INVALID_CLOCK');
+        claimed = await claimRow(db, row, now);
+        if (!claimed) continue;
+        const product = available.get(row.product_id);
+        const url = productUrl(config, row, product);
+        const email = buildRestockEmail({ row, product, url });
+        let sendResult;
+        for (let attempt = 1; attempt <= MAX_SEND_ATTEMPTS; attempt++) {
+          sendResult = await sendEmail({ config, row, email, fetchFn, timeoutMs });
+          if (sendResult.ok || !sendResult.retryable || attempt === MAX_SEND_ATTEMPTS) break;
+          await sleep(250 * (2 ** (attempt - 1)));
+        }
+        await finishRow(db, row, sendResult, getNow());
+        if (sendResult.ok) sent++;
+        else failed++;
+      } catch (error) {
+        failed++;
+        console.error(`[Stock waitlist] Fila ${row.id}: ${error?.message || 'Error'}`);
+        if (claimed) {
+          await finishRow(db, row, { ok: false, code: 'PROCESSING_ERROR' }, getNow()).catch(() => {});
+        }
+      }
+    }
+
+    return {
+      status: failed > 0 ? 'partial' : 'ok',
+      examined: rows.length,
+      matched: matched.length,
+      sent,
+      failed,
+      truncated: rows.length === QUERY_LIMIT,
+    };
+  };
+}
+
+export const processStockWaitlist = createStockWaitlistProcessor();

--- a/worker-sync/wrangler.toml
+++ b/worker-sync/wrangler.toml
@@ -17,6 +17,8 @@ APP_ID          = "4741021817925208"
 USER_ID         = "440298103"
 # Mínimo de items activos aceptables — aborta si R2 se quedaría con menos.
 MIN_ACTIVE_ITEMS = "500"
+CANONICAL_ORIGIN = "https://www.amadolibros.com"
+SALES_NOTIFICATION_FROM = "Amado Libros <web@notificaciones.amadolibros.com>"
 
 # ── R2: destino del catálogo ──────────────────────────────────────────────────
 # Binding name: CATALOG_R2
@@ -32,7 +34,14 @@ bucket_name = "amadolibros-catalog"
 binding = "AMADO_KV"
 id      = "6ea0ff4682d647118442a24fe384abc4"
 
+# D1 productiva: únicamente lee y actualiza solicitudes de aviso de stock.
+[[d1_databases]]
+binding = "ORDERS_DB"
+database_name = "amadolibros-orders-production"
+database_id = "6dc8dc3a-2d4f-4045-b428-14323c7b0bcd"
+
 # ── Secrets a configurar via `wrangler secret put` ───────────────────────────
 # CLIENT_SECRET  — secreto OAuth de la app MercadoLibre
 # SYNC_SECRET    — token para el trigger manual POST /trigger
+# RESEND_API_KEY — envío automático al cliente cuando vuelve el stock
 # (No hay env REFRESH_TOKEN — el token rotativo vive en KV: auth:refresh_token)


### PR DESCRIPTION
## Qué cambia

- Detecta reposiciones reales después de una sincronización publicada con éxito.
- Envía al cliente un email con el título, precio y enlace directo de compra.
- Usa datos vigentes de catálogo y urgencia basada en stock real.
- Registra estado, intentos y resultado del envío para evitar duplicados y permitir reintentos.
- Mantiene el catálogo publicado aunque falle el proveedor de email.

## Por qué

La solicitud de disponibilidad ya se guardaba y avisaba internamente a Amado, pero no existía el proceso que notificara al cliente cuando el libro volvía.

## Validación

- Suite completa aprobada.
- Migración D1 validada.
- Builds con checkout ON y OFF aprobados.
- Rama aislada de EMAIL-COMPRA-2 y PICKUP-CX-2.

## Despliegue

PR en borrador. No mergear ni desplegar hasta completar revisión y prueba de Preview.