### PR TITLE
Enviar confirmaciones de compra por email

### DIFF
--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -186,6 +186,18 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
                 aria-describedby="err-buyer-phone">
               <span class="field-error" id="err-buyer-phone" role="alert" hidden></span>
             </div>
+            <div class="form-field">
+              <label for="buyer-email" class="form-label">Correo electrónico <span class="form-req" aria-hidden="true">*</span></label>
+              <input type="email" id="buyer-email" class="form-input"
+                placeholder="tu@email.com"
+                autocomplete="email"
+                inputmode="email"
+                maxlength="254"
+                required
+                aria-describedby="buyer-email-help err-buyer-email">
+              <span class="field-help" id="buyer-email-help">Ahí te enviamos la confirmación y el número de pedido.</span>
+              <span class="field-error" id="err-buyer-email" role="alert" hidden></span>
+            </div>
           </div>
         </section>
 
@@ -568,6 +580,12 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     display: block;
     font-size: 0.78rem;
     color: #b42318;
+    line-height: 1.4;
+  }
+
+  .field-help {
+    font-size: 0.75rem;
+    color: var(--ink-2);
     line-height: 1.4;
   }
 
@@ -1291,7 +1309,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     // sessionStorage sobrevive a recargas y al salto a una app bancaria, pero
     // se elimina al cerrar la pestaña. Así no guardamos PII indefinidamente.
     var draftFieldIds = [
-      'buyer-name', 'buyer-phone', 'delivery-address', 'delivery-barrio',
+      'buyer-name', 'buyer-phone', 'buyer-email', 'delivery-address', 'delivery-barrio',
       'delivery-departamento', 'delivery-notes',
     ];
 
@@ -1877,6 +1895,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         var departamento = ((document.getElementById('delivery-departamento') || {}).value || '').trim();
         var name         = ((document.getElementById('buyer-name')            || {}).value || '').trim();
         var phone        = ((document.getElementById('buyer-phone')           || {}).value || '').trim();
+        var email        = ((document.getElementById('buyer-email')           || {}).value || '').trim();
 
         if (deliveryType === 'shipping') {
           if (!address) {
@@ -1923,6 +1942,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         }
         if (name)  lines.push('Nombre: ' + name);
         if (phone) lines.push('WhatsApp/Tel: ' + phone);
+        if (email) lines.push('Correo: ' + email);
 
         var msg = encodeURIComponent(lines.join('\n'));
         window.open('https://wa.me/59899841325?text=' + msg, '_blank', 'noopener,noreferrer');
@@ -2147,11 +2167,16 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       var notes = ((document.getElementById('delivery-notes') || {}).value || '').trim();
       var name = ((document.getElementById('buyer-name') || {}).value || '').trim();
       var phone = ((document.getElementById('buyer-phone') || {}).value || '').trim();
+      var email = ((document.getElementById('buyer-email') || {}).value || '').trim();
 
       clearCheckoutError();
       clearFieldErrors();
       if (!name) { showFieldError('buyer-name', 'Por favor ingresá tu nombre.'); return null; }
       if (!phone) { showFieldError('buyer-phone', 'Por favor ingresá tu teléfono o WhatsApp.'); return null; }
+      if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+        showFieldError('buyer-email', 'Ingresá un correo válido para recibir la confirmación.');
+        return null;
+      }
       if (deliveryType === 'shipping') {
         if (!address) { showFieldError('delivery-address', 'Por favor ingresá la dirección de entrega.'); return null; }
         if (!locality) { showFieldError('delivery-barrio', 'Por favor ingresá la localidad.'); return null; }
@@ -2184,7 +2209,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         cf_turnstile_response: token,
         items: paymentItemsPayload(cart),
         delivery_type: deliveryType,
-        buyer: { name: name, phone: phone },
+        buyer: { name: name, phone: phone, email: email },
       };
       if (deliveryType === 'pickup') payload.pickup_ack = true;
       if (deliveryType === 'shipping') {
@@ -2331,6 +2356,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         var prepNotes    = ((document.getElementById('delivery-notes')        || {}).value || '').trim();
         var prepName     = ((document.getElementById('buyer-name')            || {}).value || '').trim();
         var prepPhone    = ((document.getElementById('buyer-phone')           || {}).value || '').trim();
+        var prepEmail    = ((document.getElementById('buyer-email')           || {}).value || '').trim();
 
         // Primer campo inválido gana — mismo orden que antes, ahora con
         // error inline debajo del campo en vez de un alert() bloqueante.
@@ -2340,6 +2366,10 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         }
         if (!prepPhone) {
           showFieldError('buyer-phone', 'Por favor ingresá tu teléfono o WhatsApp.');
+          return;
+        }
+        if (!prepEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(prepEmail)) {
+          showFieldError('buyer-email', 'Ingresá un correo válido para recibir la confirmación.');
           return;
         }
         if (deliveryType === 'shipping') {
@@ -2409,7 +2439,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
           cf_turnstile_response: cfTsResponse,
           items: paymentItemsPayload(cart),
           delivery_type: deliveryType,
-          buyer: { name: prepName, phone: prepPhone },
+          buyer: { name: prepName, phone: prepPhone, email: prepEmail },
         };
         if (deliveryType === 'pickup') payload.pickup_ack = true;
         if (deliveryType === 'shipping') {

--- a/functions/__tests__/checkout-single-step.test.js
+++ b/functions/__tests__/checkout-single-step.test.js
@@ -38,6 +38,7 @@ const cartJs = readFileSync(
 const REQUIRED_FIELD_IDS = [
   'buyer-name',
   'buyer-phone',
+  'buyer-email',
   'delivery-address',
   'delivery-barrio',
   'delivery-departamento',
@@ -144,7 +145,10 @@ test('carrito.astro: con checkout OFF, WhatsApp sigue siendo la única acción d
 for (const fieldId of REQUIRED_FIELD_IDS) {
   test(`carrito.astro: el campo #${fieldId} tiene su span de error inline asociado`, () => {
     assert.match(carritoAstro, new RegExp(`id="err-${fieldId}"`));
-    assert.match(carritoAstro, new RegExp(`id="${fieldId}"[^>]*aria-describedby="err-${fieldId}"`));
+    assert.match(
+      carritoAstro,
+      new RegExp(`id="${fieldId}"[^>]*aria-describedby="[^"]*\\berr-${fieldId}\\b[^"]*"`),
+    );
   });
 }
 

--- a/functions/__tests__/email-compra-2.test.js
+++ b/functions/__tests__/email-compra-2.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const carrito = readFileSync(path.join(ROOT, 'astro-front/src/pages/carrito.astro'), 'utf8');
+const migration = readFileSync(path.join(ROOT, 'migrations/0006_orders_buyer_email.sql'), 'utf8');
+
+test('email-compra-2: checkout pide correo con ayuda y error accesible', () => {
+  assert.match(carrito, /id="buyer-email"[^>]*type="email"|type="email"[^>]*id="buyer-email"/);
+  assert.match(carrito, /id="buyer-email"[^>]*\brequired\b/);
+  assert.match(carrito, /id="buyer-email-help"/);
+  assert.match(carrito, /aria-describedby="buyer-email-help err-buyer-email"/);
+  assert.match(carrito, /id="err-buyer-email"[^>]*role="alert"/);
+  assert.match(carrito, /buyer:\s*\{ name: name, phone: phone, email: email \}/);
+  assert.match(carrito, /buyer:\s*\{ name: prepName, phone: prepPhone, email: prepEmail \}/);
+});
+
+test('email-compra-2: correo permanece sólo en el borrador de esta pestaña', () => {
+  assert.match(carrito, /'buyer-name', 'buyer-phone', 'buyer-email'/);
+  assert.match(carrito, /sessionStorage\.setItem\(CHECKOUT_DRAFT_KEY/);
+  assert.doesNotMatch(carrito, /localStorage[^\n]*buyer-email/);
+});
+
+test('email-compra-2: migración agrega buyer_email sin alterar órdenes históricas', () => {
+  assert.match(migration, /ALTER TABLE orders ADD COLUMN buyer_email TEXT/);
+  assert.doesNotMatch(migration, /NOT NULL/);
+});

--- a/functions/__tests__/pickup-cx-1.test.js
+++ b/functions/__tests__/pickup-cx-1.test.js
@@ -72,7 +72,7 @@ const itemsOk = [{ product_id: 'MLU1', quantity: 1 }];
 const base = {
     idempotency_key: 'k'.repeat(20),
     items: itemsOk,
-    buyer: { name: 'Ada Lovelace', phone: '099111222' },
+    buyer: { name: 'Ada Lovelace', phone: '099111222', email: 'ada@example.com' },
     cf_turnstile_response: 'x',
 };
 const envio = {

--- a/functions/api/__tests__/mp_webhook.test.js
+++ b/functions/api/__tests__/mp_webhook.test.js
@@ -104,6 +104,7 @@ function baseOrder(patch = {}) {
     payment_status:         'not_started',
     buyer_name:             'Ana Pérez',
     buyer_phone:            '099123456',
+    buyer_email:            'ana@example.com',
     delivery_type:'pickup', pickup_ack:true,
     address:                null,
     locality:               null,
@@ -161,11 +162,13 @@ function handler({
   getPayment = async () => basePayment(),
   getMerchantOrder = async () => ({ ok: false, code: 'NOT_FOUND' }),
   saleNotifier = async () => ({ ok: true }),
+  orderEmails = { sendPaidCustomer: async () => ({ ok: true }) },
 } = {}) {
   return createMpWebhookHandler({
     mpClient: { getPayment, getMerchantOrder },
     getNow: () => NOW,
     saleNotifier,
+    orderEmails,
   });
 }
 
@@ -731,6 +734,29 @@ test('email-1: pago aprobado en producción agenda una notificación con la orde
   assert.equal(calls[0].order.buyer_name, 'Ana Pérez');
   assert.equal(calls[0].payment.id, 123);
   assert.equal(calls[0].now.toISOString(), NOW.toISOString());
+});
+
+test('email-1b: pago aprobado en producción confirma al correo del cliente', async () => {
+  const calls = [];
+  const h = handler({
+    getPayment: async () => basePayment({ collector_id: PROD_COLLECTOR_ID, live_mode: true }),
+    orderEmails: {
+      sendPaidCustomer: async args => { calls.push(args); return { ok: true }; },
+    },
+  });
+  const res = await h({
+    request: makeReq({ host: 'www.amadolibros.com' }),
+    env: {
+      ...PRODUCTION_ENV_CONFIG,
+      MP_WEBHOOK_SECRET: TEST_SECRET,
+      MP_ACCESS_TOKEN: TEST_TOKEN,
+      ORDERS_DB: dbMock({ order: baseOrder() }),
+    },
+  });
+  assert.equal(res.status, 200);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].order.buyer_email, 'ana@example.com');
+  assert.equal(calls[0].payment.method, 'mercado_pago');
 });
 
 test('email-2: pago aprobado en preview no envía notificación interna', async () => {

--- a/functions/api/__tests__/order_email.test.js
+++ b/functions/api/__tests__/order_email.test.js
@@ -1,0 +1,127 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildCustomerOrderEmail,
+  buildInternalTransferEmail,
+  createOrderEmailService,
+} from '../_order_email.js';
+
+const NOW = new Date('2026-08-10T15:00:00.000Z');
+const ORDER = {
+  id: 'order-1', public_code: 'AL-260810-TEST', buyer_name: 'Ana <Pérez>',
+  buyer_phone: '099123456', buyer_email: 'ana@example.com', delivery_type: 'pickup',
+  address: null, locality: null, department: null,
+  products_total_uyu: 2000, pickup_discount_uyu: 150, shipping_cost_uyu: 0,
+  payable_total_uyu: 1850,
+};
+const ITEMS = [{ title: 'Libro <especial>', quantity: 1, unit_price_uyu: 2000, line_total_uyu: 2000 }];
+const ENV = {
+  RESEND_API_KEY: 're_test',
+  SALES_NOTIFICATION_FROM: 'Amado Libros <web@notificaciones.amadolibros.com>',
+  SALES_NOTIFICATION_TO: 'ventas@example.com,admin@example.com',
+};
+
+function dbMock() {
+  const events = new Map();
+  return {
+    events,
+    prepare(sql) {
+      return {
+        bind(...args) {
+          return {
+            async run() {
+              if (sql.startsWith('INSERT OR IGNORE INTO order_events')) {
+                const [id, orderId, eventType, payload, createdAt] = args;
+                if (events.has(id)) return { meta: { changes: 0 } };
+                events.set(id, { id, orderId, eventType, payload_json: payload, createdAt });
+                return { meta: { changes: 1 } };
+              }
+              if (sql.startsWith('UPDATE order_events SET payload_json')) {
+                const [next, id, previous] = args;
+                const row = events.get(id);
+                if (!row || row.payload_json !== previous) return { meta: { changes: 0 } };
+                row.payload_json = next;
+                return { meta: { changes: 1 } };
+              }
+              throw new Error(`SQL run no esperado: ${sql}`);
+            },
+            async first() {
+              if (sql.startsWith('SELECT payload_json FROM order_events')) {
+                const row = events.get(args[0]);
+                return row ? { payload_json: row.payload_json } : null;
+              }
+              throw new Error(`SQL first no esperado: ${sql}`);
+            },
+            async all() {
+              if (sql.startsWith('SELECT title,quantity')) return { results: ITEMS };
+              throw new Error(`SQL all no esperado: ${sql}`);
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+test('order-email: cliente distingue transferencia pendiente de pago aprobado', () => {
+  const transfer = buildCustomerOrderEmail({
+    order: ORDER, items: ITEMS,
+    payment: { method: 'bank_transfer', transfer_discount_uyu: 240, total_uyu: 1610 },
+  });
+  assert.match(transfer.subject, /pendiente de transferencia/);
+  assert.match(transfer.text, /Total a transferir: \$1\.610 UYU/);
+  assert.match(transfer.text, /pendiente hasta que Amado Libros confirme/);
+  assert.doesNotMatch(transfer.text, /pago fue aprobado/);
+
+  const paid = buildCustomerOrderEmail({
+    order: ORDER, items: ITEMS,
+    payment: { method: 'mercado_pago', total_uyu: 1850 },
+  });
+  assert.match(paid.subject, /Pago confirmado/);
+  assert.match(paid.text, /Total pagado: \$1\.850 UYU/);
+  assert.match(paid.text, /pago con Mercado Pago fue aprobado/);
+});
+
+test('order-email: HTML escapa datos del cliente y del libro', () => {
+  const email = buildCustomerOrderEmail({
+    order: ORDER, items: ITEMS,
+    payment: { method: 'mercado_pago', total_uyu: 1850 },
+  });
+  assert.match(email.html, /Ana &lt;Pérez&gt;/);
+  assert.match(email.html, /Libro &lt;especial&gt;/);
+  assert.doesNotMatch(email.html, /Ana <Pérez>/);
+});
+
+test('order-email: transferencia manda al cliente y a Amado una sola vez', async () => {
+  const db = dbMock();
+  const requests = [];
+  const service = createOrderEmailService({
+    sleep: async () => {},
+    fetchFn: async (_url, init) => {
+      requests.push(JSON.parse(init.body));
+      return Response.json({ id: `resend-${requests.length}` });
+    },
+  });
+  const args = {
+    db, env: ENV, order: ORDER,
+    payment: { method: 'bank_transfer', transfer_discount_uyu: 240, total_uyu: 1610 },
+    now: NOW,
+  };
+  await service.sendTransferNotifications(args);
+  await service.sendTransferNotifications(args);
+  assert.equal(requests.length, 2);
+  assert.deepEqual(requests[0].to, ['ana@example.com']);
+  assert.deepEqual(requests[1].to, ['ventas@example.com', 'admin@example.com']);
+  assert.equal(db.events.size, 2);
+  for (const row of db.events.values()) assert.equal(JSON.parse(row.payload_json).status, 'sent');
+});
+
+test('order-email: aviso interno deja claro que la transferencia está pendiente', () => {
+  const email = buildInternalTransferEmail({
+    order: ORDER, items: ITEMS,
+    payment: { method: 'bank_transfer', transfer_discount_uyu: 240, total_uyu: 1610 },
+  });
+  assert.match(email.subject, /pendiente/);
+  assert.match(email.text, /ESTADO: pendiente de comprobante/);
+  assert.match(email.text, /Correo: ana@example\.com/);
+});

--- a/functions/api/__tests__/orders.test.js
+++ b/functions/api/__tests__/orders.test.js
@@ -49,8 +49,8 @@ function ctx(body, db, opts={}) {
   const env = opts.env !== undefined ? opts.env : (db ? { ...PREVIEW_CONFIG, ORDERS_DB:db, TURNSTILE_SECRET_KEY:'ts-test-secret' } : { ...PREVIEW_CONFIG });
   return { request:new Request('https://x/api/orders',{method,headers,body:method==='POST'?(typeof body==='string'?body:JSON.stringify(body)):undefined}), env, waitUntil(){} };
 }
-function pickup(key='k'){ return { idempotency_key:key, cf_turnstile_response:'ok-token', items:[{product_id:'A',quantity:2},{product_id:'B',quantity:1}], delivery_type:'pickup', pickup_ack:true, buyer:{name:'Ana',phone:'099'} }; }
-function shipping(key='s', patch={}) { const base={ idempotency_key:key, cf_turnstile_response:'ok-token', items:[{product_id:'G',quantity:1},{product_id:'A',quantity:1}], delivery_type:'shipping', buyer:{name:'Carlos',phone:'098'}, shipping:{address:'Calle 1',locality:'Centro',department:'Montevideo',requested_date:'2026-07-20',requested_from:'09:00',requested_to:'12:00',notes:'2B'} }; return {...base,...patch,shipping:{...base.shipping,...(patch.shipping||{})}}; }
+function pickup(key='k'){ return { idempotency_key:key, cf_turnstile_response:'ok-token', items:[{product_id:'A',quantity:2},{product_id:'B',quantity:1}], delivery_type:'pickup', pickup_ack:true, buyer:{name:'Ana',phone:'099',email:'ana@example.com'} }; }
+function shipping(key='s', patch={}) { const base={ idempotency_key:key, cf_turnstile_response:'ok-token', items:[{product_id:'G',quantity:1},{product_id:'A',quantity:1}], delivery_type:'shipping', buyer:{name:'Carlos',phone:'098',email:'carlos@example.com'}, shipping:{address:'Calle 1',locality:'Centro',department:'Montevideo',requested_date:'2026-07-20',requested_from:'09:00',requested_to:'12:00',notes:'2B'} }; return {...base,...patch,buyer:{...base.buyer,...(patch.buyer||{})},shipping:{...base.shipping,...(patch.shipping||{})}}; }
 function stored(body, patch={}) { return { id:'uuid', idempotency_key:body.idempotency_key, request_fingerprint:generateFingerprint(body,consolidateItems(body.items)), public_code:'AL-TEST', status:'open', payment_status:'not_started', delivery_type:body.delivery_type, products_total_uyu:3250, pickup_discount_uyu:150, shipping_cost_uyu:0, payable_total_uyu:3100, currency:'UYU', expires_at:'2026-07-19T17:00:00.000Z', ...patch }; }
 function handler(fetchCatalog=async()=>CATALOG, now=NOW, verifyTurnstileToken=TS_OK){ return createOrdersHandler({fetchCatalog,getNow:()=>new Date(now),verifyTurnstileToken}); }
 
@@ -85,7 +85,7 @@ test('notas integran fingerprint', async()=>{
 });
 
 test('precio del navegador se ignora y manda catálogo', async()=>{
-  const body={idempotency_key:'price',cf_turnstile_response:'ok-token',items:[{product_id:'A',quantity:1,price:99999,title:'falso'}],delivery_type:'pickup', pickup_ack:true,buyer:{name:'T',phone:'099'}}; const r=await call(body); assert.equal(r.data.order.products_total_uyu,1000); assert.equal(r.data.order.payable_total_uyu,850);
+  const body={idempotency_key:'price',cf_turnstile_response:'ok-token',items:[{product_id:'A',quantity:1,price:99999,title:'falso'}],delivery_type:'pickup', pickup_ack:true,buyer:{name:'T',phone:'099',email:'t@example.com'}}; const r=await call(body); assert.equal(r.data.order.products_total_uyu,1000); assert.equal(r.data.order.payable_total_uyu,850);
 });
 
 test('stock, producto, estado y precio inválidos devuelven 422', async()=>{
@@ -101,7 +101,8 @@ test('stock, producto, estado y precio inválidos devuelven 422', async()=>{
 });
 
 test('tipos JSON incorrectos devuelven 400 sin excepción', async()=>{
-  const bodies=[{...pickup('null'),items:[null]},{...pickup('name'),buyer:{name:123,phone:'099'}},shipping('address',{shipping:{address:123}}),shipping('notes',{shipping:{notes:123}})];
+  const bodies=[{...pickup('null'),items:[null]},{...pickup('name'),buyer:{name:123,phone:'099',email:'ana@example.com'}},shipping('address',{shipping:{address:123}}),shipping('notes',{shipping:{notes:123}}),pickup('email')];
+  bodies[bodies.length - 1].buyer.email = 'correo-invalido';
   for(const b of bodies) assert.equal((await call(b)).response.status,400);
 });
 

--- a/functions/api/__tests__/transfer_options.test.js
+++ b/functions/api/__tests__/transfer_options.test.js
@@ -16,6 +16,7 @@ const CONFIG = {
 
 function openOrder(patch = {}) {
   return {
+    id: 'order-uuid',
     public_code: 'AL-260809-TEST',
     status: 'open',
     payment_status: 'not_started',
@@ -25,6 +26,13 @@ function openOrder(patch = {}) {
     shipping_cost_uyu: 0,
     payable_total_uyu: 1850,
     currency: 'UYU',
+    buyer_name: 'Ana Pérez',
+    buyer_phone: '099123456',
+    buyer_email: 'ana@example.com',
+    delivery_type: 'pickup',
+    address: null,
+    locality: null,
+    department: null,
     ...patch,
   };
 }
@@ -55,8 +63,11 @@ function request(body = { public_code: 'AL-260809-TEST', idempotency_key: 'idem-
   });
 }
 
-async function call({ body, order, requestPatch, envPatch, dbOptions } = {}) {
-  const handler = createTransferOptionsHandler({ getNow: () => NOW });
+async function call({ body, order, requestPatch, envPatch, dbOptions, orderEmails } = {}) {
+  const handler = createTransferOptionsHandler({
+    getNow: () => NOW,
+    orderEmails: orderEmails || { sendTransferNotifications: async () => ({}) },
+  });
   const response = await handler({
     request: request(body, requestPatch),
     env: { ...CONFIG, ORDERS_DB: dbMock(order === undefined ? openOrder() : order, dbOptions), ...envPatch },
@@ -94,6 +105,21 @@ test('transfer: 12% se aplica a libros, no al ahorro de retiro', async () => {
   assert.equal(data.payment.transfer_discount_uyu, 240);
   assert.equal(data.payment.transfer_total_uyu, 1610);
   assert.equal(data.payment.list_total_uyu, 1850);
+});
+
+test('transfer: agenda confirmación al cliente y aviso interno con el total exacto', async () => {
+  const calls = [];
+  const { response } = await call({
+    orderEmails: {
+      sendTransferNotifications: async args => { calls.push(args); return {}; },
+    },
+  });
+  assert.equal(response.status, 200);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].order.buyer_email, 'ana@example.com');
+  assert.equal(calls[0].payment.method, 'bank_transfer');
+  assert.equal(calls[0].payment.transfer_discount_uyu, 240);
+  assert.equal(calls[0].payment.total_uyu, 1610);
 });
 
 test('transfer: costo de envío no recibe 12% de descuento', async () => {

--- a/functions/api/_mp_webhook_handler.js
+++ b/functions/api/_mp_webhook_handler.js
@@ -4,6 +4,7 @@ import {
 } from './_mp_client.js';
 import { resolveConfig } from './_env_config.js';
 import { sendSaleNotification as defaultSendSaleNotification } from './_sale_notification.js';
+import { orderEmailService as defaultOrderEmailService } from './_order_email.js';
 
 const MAX_BODY_BYTES = 32768;
 
@@ -122,6 +123,7 @@ export function createMpWebhookHandler({
   mpClient = { getPayment: defaultGetPayment, getMerchantOrder: defaultGetMerchantOrder },
   getNow       = () => new Date(),
   saleNotifier = defaultSendSaleNotification,
+  orderEmails  = defaultOrderEmailService,
 } = {}) {
   return async function onRequest(context) {
     const { request, env } = context;
@@ -218,7 +220,7 @@ export function createMpWebhookHandler({
 
     const order = await db
       .prepare(
-        'SELECT id,public_code,status,payment_status,buyer_name,buyer_phone,delivery_type,' +
+        'SELECT id,public_code,status,payment_status,buyer_name,buyer_phone,buyer_email,delivery_type,' +
         'address,locality,department,requested_delivery_date,requested_delivery_from,' +
         'requested_delivery_to,delivery_notes,products_total_uyu,pickup_discount_uyu,' +
         'shipping_cost_uyu,payable_total_uyu,currency,payment_preference_id ' +
@@ -280,9 +282,16 @@ export function createMpWebhookHandler({
     // Un fallo de Resend se registra en order_events, pero Mercado Pago recibe
     // 200 para no degradar una venta ya validada.
     if (normalized === 'approved' && config.isProduction) {
-      const notification = Promise.resolve(
-        saleNotifier({ db, env, order, payment, now })
-      ).catch(error => {
+      const notification = Promise.all([
+        Promise.resolve(saleNotifier({ db, env, order, payment, now })),
+        Promise.resolve(orderEmails.sendPaidCustomer({
+          db,
+          env,
+          order,
+          payment: { method: 'mercado_pago', total_uyu: order.payable_total_uyu },
+          now,
+        })),
+      ]).catch(error => {
         console.error('[mp_webhook] falló la tarea de notificación', {
           order_id: order.id,
           error: error?.name || 'Error',

--- a/functions/api/_order_email.js
+++ b/functions/api/_order_email.js
@@ -1,0 +1,259 @@
+const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+const REQUEST_TIMEOUT_MS = 7000;
+const MAX_SEND_ATTEMPTS = 3;
+const CLAIM_STALE_MS = 5 * 60 * 1000;
+
+function cleanString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function formatMoney(value) {
+  return `$${new Intl.NumberFormat('es-UY', { maximumFractionDigits: 0 }).format(Number(value) || 0)}`;
+}
+
+function emailConfig(env) {
+  const apiKey = cleanString(env?.RESEND_API_KEY);
+  const from = cleanString(env?.SALES_NOTIFICATION_FROM);
+  const internalTo = cleanString(env?.SALES_NOTIFICATION_TO)
+    .split(',').map(value => value.trim()).filter(Boolean);
+  if (!apiKey || !from) return null;
+  return { apiKey, from, internalTo };
+}
+
+function deliveryText(order) {
+  if (order.delivery_type === 'pickup') {
+    return 'Retiro a pasos de Plaza Matriz. Esperá nuestra confirmación por WhatsApp antes de venir.';
+  }
+  return [order.address, order.locality, order.department].map(cleanString).filter(Boolean).join(', ');
+}
+
+function itemText(items) {
+  return items.map(item => `${item.quantity} × ${item.title} — ${formatMoney(item.line_total_uyu)}`);
+}
+
+function itemRows(items) {
+  return items.map(item => `<tr>
+    <td style="padding:8px;border-bottom:1px solid #ddd">${escapeHtml(item.title)}</td>
+    <td style="padding:8px;border-bottom:1px solid #ddd;text-align:center">${escapeHtml(item.quantity)}</td>
+    <td style="padding:8px;border-bottom:1px solid #ddd;text-align:right">${escapeHtml(formatMoney(item.line_total_uyu))}</td>
+  </tr>`).join('');
+}
+
+function totalsText(order, payment) {
+  const lines = [`Productos: ${formatMoney(order.products_total_uyu)}`];
+  if (Number(order.pickup_discount_uyu) > 0) {
+    lines.push(`Descuento por retiro: −${formatMoney(order.pickup_discount_uyu)}`);
+  }
+  if (Number(order.shipping_cost_uyu) > 0) {
+    lines.push(`Envío: ${formatMoney(order.shipping_cost_uyu)}`);
+  } else if (order.delivery_type === 'shipping') {
+    lines.push('Envío: Gratis');
+  }
+  if (payment.method === 'bank_transfer') {
+    lines.push(`Descuento por transferencia: −${formatMoney(payment.transfer_discount_uyu)}`);
+    lines.push(`Total a transferir: ${formatMoney(payment.total_uyu)} UYU`);
+  } else {
+    lines.push(`Total pagado: ${formatMoney(order.payable_total_uyu)} UYU`);
+  }
+  return lines;
+}
+
+export function buildCustomerOrderEmail({ order, items, payment }) {
+  const transfer = payment.method === 'bank_transfer';
+  const subject = transfer
+    ? `Recibimos tu pedido ${order.public_code} — pendiente de transferencia`
+    : `Pago confirmado — pedido ${order.public_code}`;
+  const heading = transfer ? 'Recibimos tu pedido' : 'Tu pago fue confirmado';
+  const state = transfer
+    ? 'El pedido queda pendiente hasta que Amado Libros confirme el comprobante por WhatsApp.'
+    : 'El pago con Mercado Pago fue aprobado. Vamos a coordinar la entrega contigo.';
+  const totals = totalsText(order, payment);
+  const delivery = deliveryText(order);
+
+  const text = [
+    heading,
+    '',
+    `Pedido: ${order.public_code}`,
+    `Cliente: ${order.buyer_name}`,
+    '',
+    'Libros:',
+    ...itemText(items).map(line => `- ${line}`),
+    '',
+    ...totals,
+    '',
+    `Entrega: ${delivery}`,
+    '',
+    state,
+    'Si necesitás ayuda, respondé este correo o escribinos por WhatsApp.',
+  ].join('\n');
+
+  const html = `<!doctype html><html lang="es"><body style="font-family:Arial,sans-serif;color:#222;line-height:1.5">
+    <h1 style="font-size:22px">${escapeHtml(heading)}</h1>
+    <p><strong>Pedido:</strong> ${escapeHtml(order.public_code)}<br>
+       <strong>Cliente:</strong> ${escapeHtml(order.buyer_name)}</p>
+    <table style="border-collapse:collapse;width:100%;max-width:700px">
+      <thead><tr><th style="padding:8px;text-align:left;border-bottom:2px solid #999">Libro</th><th style="padding:8px;border-bottom:2px solid #999">Cant.</th><th style="padding:8px;text-align:right;border-bottom:2px solid #999">Total</th></tr></thead>
+      <tbody>${itemRows(items)}</tbody>
+    </table>
+    <p>${totals.map(line => escapeHtml(line)).join('<br>')}</p>
+    <p><strong>Entrega:</strong> ${escapeHtml(delivery)}</p>
+    <p>${escapeHtml(state)}</p>
+    <p>Si necesitás ayuda, respondé este correo o escribinos por WhatsApp.</p>
+  </body></html>`;
+  return { subject, text, html };
+}
+
+export function buildInternalTransferEmail({ order, items, payment }) {
+  const subject = `Pedido por transferencia pendiente — ${order.public_code}`;
+  const totals = totalsText(order, payment);
+  const text = [
+    `Nuevo pedido por transferencia: ${order.public_code}`,
+    'ESTADO: pendiente de comprobante y confirmación.',
+    '',
+    `Cliente: ${order.buyer_name}`,
+    `Teléfono: ${order.buyer_phone}`,
+    `Correo: ${order.buyer_email}`,
+    '',
+    ...itemText(items).map(line => `- ${line}`),
+    '',
+    ...totals,
+    `Entrega: ${deliveryText(order)}`,
+  ].join('\n');
+  const html = `<!doctype html><html lang="es"><body style="font-family:Arial,sans-serif;color:#222;line-height:1.5">
+    <h1 style="font-size:22px">Pedido por transferencia pendiente</h1>
+    <p><strong>${escapeHtml(order.public_code)}</strong> — pendiente de comprobante y confirmación.</p>
+    <p><strong>Cliente:</strong> ${escapeHtml(order.buyer_name)}<br><strong>Teléfono:</strong> ${escapeHtml(order.buyer_phone)}<br><strong>Correo:</strong> ${escapeHtml(order.buyer_email)}</p>
+    <ul>${itemText(items).map(line => `<li>${escapeHtml(line)}</li>`).join('')}</ul>
+    <p>${totals.map(line => escapeHtml(line)).join('<br>')}</p>
+    <p><strong>Entrega:</strong> ${escapeHtml(deliveryText(order))}</p>
+  </body></html>`;
+  return { subject, text, html };
+}
+
+function parseState(value) {
+  try { return JSON.parse(value); } catch { return null; }
+}
+
+async function claim(db, eventId, orderId, eventType, now) {
+  const payload = JSON.stringify({ status: 'sending', attempt: 1, attempted_at: now.toISOString() });
+  const inserted = await db.prepare(
+    'INSERT OR IGNORE INTO order_events (id,order_id,event_type,payload_json,created_at) VALUES (?,?,?,?,?)'
+  ).bind(eventId, orderId, eventType, payload, now.toISOString()).run();
+  if (Number(inserted?.meta?.changes) > 0) return { ok: true, payload, attempt: 1 };
+
+  const row = await db.prepare('SELECT payload_json FROM order_events WHERE id=?').bind(eventId).first();
+  const state = parseState(row?.payload_json);
+  if (state?.status === 'sent') return { ok: false, reason: 'already_sent' };
+  const attemptedAt = Date.parse(state?.attempted_at || '');
+  if (state?.status === 'sending' && Number.isFinite(attemptedAt) && now.getTime() - attemptedAt < CLAIM_STALE_MS) {
+    return { ok: false, reason: 'in_progress' };
+  }
+  const attempt = Number.isInteger(state?.attempt) ? state.attempt + 1 : 1;
+  const next = JSON.stringify({ status: 'sending', attempt, attempted_at: now.toISOString() });
+  const updated = await db.prepare('UPDATE order_events SET payload_json=? WHERE id=? AND payload_json=?')
+    .bind(next, eventId, row?.payload_json || '').run();
+  return Number(updated?.meta?.changes) > 0
+    ? { ok: true, payload: next, attempt }
+    : { ok: false, reason: 'claim_lost' };
+}
+
+async function updateClaim(db, eventId, previous, state) {
+  await db.prepare('UPDATE order_events SET payload_json=? WHERE id=? AND payload_json=?')
+    .bind(JSON.stringify(state), eventId, previous).run();
+}
+
+async function postEmail({ config, to, email, idempotencyKey, fetchFn, timeoutMs }) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchFn(RESEND_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        'Content-Type': 'application/json',
+        'Idempotency-Key': idempotencyKey,
+      },
+      body: JSON.stringify({ from: config.from, to, ...email }),
+      signal: controller.signal,
+    });
+    let data = null;
+    try { data = await response.json(); } catch { /* opcional */ }
+    if (response.ok && cleanString(data?.id)) return { ok: true, providerId: data.id };
+    return { ok: false, retryable: response.status === 429 || response.status >= 500, code: `RESEND_HTTP_${response.status}` };
+  } catch (error) {
+    return { ok: false, retryable: true, code: error?.name === 'AbortError' ? 'RESEND_TIMEOUT' : 'RESEND_NETWORK_ERROR' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function readItems(db, orderId) {
+  const result = await db.prepare(
+    'SELECT title,quantity,unit_price_uyu,line_total_uyu FROM order_items WHERE order_id=? ORDER BY created_at,id'
+  ).bind(orderId).all();
+  const items = Array.isArray(result?.results) ? result.results : [];
+  if (items.length === 0) throw new Error('ORDER_ITEMS_UNAVAILABLE');
+  return items;
+}
+
+function createTrackedSender({ fetchFn = globalThis.fetch, sleep = ms => new Promise(resolve => setTimeout(resolve, ms)), timeoutMs = REQUEST_TIMEOUT_MS } = {}) {
+  return async function send({ db, env, order, payment, now, audience }) {
+    const config = emailConfig(env);
+    const customer = audience === 'customer';
+    const recipient = customer ? [cleanString(order.buyer_email).toLowerCase()] : config?.internalTo;
+    if (!config || recipient.length === 0 || !recipient[0]) return { ok: false, skipped: true, code: 'EMAIL_CONFIG_MISSING' };
+
+    const method = payment.method === 'bank_transfer' ? 'transfer' : 'mercado-pago';
+    const eventId = `order-email:${audience}:${method}:${order.id}`;
+    const eventType = customer ? 'customer_order_email' : 'internal_transfer_email';
+    const claimed = await claim(db, eventId, order.id, eventType, now);
+    if (!claimed.ok) return { ok: true, skipped: true, reason: claimed.reason };
+
+    let items;
+    try { items = await readItems(db, order.id); }
+    catch {
+      await updateClaim(db, eventId, claimed.payload, { status: 'failed', attempt: claimed.attempt, attempted_at: now.toISOString(), failure_code: 'ORDER_ITEMS_UNAVAILABLE' }).catch(() => {});
+      return { ok: false, code: 'ORDER_ITEMS_UNAVAILABLE' };
+    }
+    const email = customer
+      ? buildCustomerOrderEmail({ order, items, payment })
+      : buildInternalTransferEmail({ order, items, payment });
+
+    let result;
+    for (let attempt = 1; attempt <= MAX_SEND_ATTEMPTS; attempt++) {
+      result = await postEmail({ config, to: recipient, email, idempotencyKey: eventId, fetchFn, timeoutMs });
+      if (result.ok || !result.retryable || attempt === MAX_SEND_ATTEMPTS) break;
+      await sleep(250 * (2 ** (attempt - 1)));
+    }
+    const state = result?.ok
+      ? { status: 'sent', attempt: claimed.attempt, attempted_at: now.toISOString(), sent_at: now.toISOString(), provider: 'resend', provider_id: result.providerId }
+      : { status: 'failed', attempt: claimed.attempt, attempted_at: now.toISOString(), failure_code: cleanString(result?.code) || 'RESEND_ERROR' };
+    await updateClaim(db, eventId, claimed.payload, state).catch(() => {});
+    return result?.ok ? { ok: true, providerId: result.providerId } : { ok: false, code: state.failure_code };
+  };
+}
+
+export function createOrderEmailService(options = {}) {
+  const sendTracked = createTrackedSender(options);
+  return {
+    sendPaidCustomer: args => sendTracked({ ...args, audience: 'customer' }),
+    async sendTransferNotifications(args) {
+      const [customer, internal] = await Promise.all([
+        sendTracked({ ...args, audience: 'customer' }),
+        sendTracked({ ...args, audience: 'internal' }),
+      ]);
+      return { customer, internal };
+    },
+  };
+}
+
+export const orderEmailService = createOrderEmailService();

--- a/functions/api/_orders_handler.js
+++ b/functions/api/_orders_handler.js
@@ -6,6 +6,7 @@ import {
   calculateTotals,
   generateFingerprint,
   generatePublicCode,
+  normalizeBuyerEmail,
   EXPIRY_MINUTES,
   MAX_BODY_BYTES,
 } from './_orders_logic.js';
@@ -159,7 +160,7 @@ export function createOrdersHandler({ fetchCatalog, getNow = () => new Date(), v
       'INSERT INTO orders (' +
         'id, public_code, idempotency_key, request_fingerprint, ' +
         'status, payment_status, ' +
-        'buyer_name, buyer_phone, ' +
+        'buyer_name, buyer_phone, buyer_email, ' +
         'delivery_type, ' +
         'address, locality, department, ' +
         'requested_delivery_date, requested_delivery_from, requested_delivery_to, delivery_notes, ' +
@@ -168,7 +169,7 @@ export function createOrdersHandler({ fetchCatalog, getNow = () => new Date(), v
       ') VALUES (' +
         '?, ?, ?, ?, ' +
         "'open', 'not_started', " +
-        '?, ?, ' +
+        '?, ?, ?, ' +
         '?, ' +
         '?, ?, ?, ' +
         '?, ?, ?, ?, ' +
@@ -182,6 +183,7 @@ export function createOrdersHandler({ fetchCatalog, getNow = () => new Date(), v
       fingerprint,
       body.buyer.name.trim(),
       body.buyer.phone.trim(),
+      normalizeBuyerEmail(body.buyer.email),
       body.delivery_type,
       typeof shipping.address === 'string' ? shipping.address.trim() : null,
       typeof shipping.locality === 'string' ? shipping.locality.trim() : null,

--- a/functions/api/_orders_logic.js
+++ b/functions/api/_orders_logic.js
@@ -10,6 +10,7 @@ export const MAX_IDEMPOTENCY_KEY_LEN = 128;
 export const MAX_PRODUCT_ID_LEN      = 120;
 export const MAX_NAME_LEN            = 120;
 export const MAX_PHONE_LEN           = 40;
+export const MAX_EMAIL_LEN           = 254;
 export const MAX_ADDRESS_LEN         = 200;
 export const MAX_LOCALITY_LEN        = 120;
 export const MAX_DEPARTMENT_LEN      = 80;
@@ -37,6 +38,13 @@ function isValidTimeString(value) {
   if (typeof value !== 'string' || !/^\d{2}:\d{2}$/.test(value)) return false;
   const [hour, minute] = value.split(':').map(Number);
   return hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59;
+}
+
+export function normalizeBuyerEmail(value) {
+  if (typeof value !== 'string') return null;
+  const email = value.trim().toLowerCase();
+  if (email.length < 5 || email.length > MAX_EMAIL_LEN) return null;
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : null;
 }
 
 export function validateBody(body) {
@@ -75,6 +83,7 @@ export function validateBody(body) {
   if (body.buyer.name.trim().length > MAX_NAME_LEN) return 'Nombre demasiado largo.';
   if (!isNonEmptyString(body.buyer.phone)) return 'Teléfono del comprador requerido.';
   if (body.buyer.phone.trim().length > MAX_PHONE_LEN) return 'Teléfono demasiado largo.';
+  if (!normalizeBuyerEmail(body.buyer.email)) return 'Correo del comprador inválido.';
 
   if (body.delivery_type === 'shipping') {
     if (!isRecord(body.shipping)) return 'Falta shipping.';
@@ -357,6 +366,7 @@ export function generateFingerprint(body, consolidatedItems) {
     buyer: {
       name: body.buyer.name.trim(),
       phone: body.buyer.phone.trim(),
+      email: normalizeBuyerEmail(body.buyer.email),
     },
   };
 

--- a/functions/api/_transfer_options_handler.js
+++ b/functions/api/_transfer_options_handler.js
@@ -1,5 +1,6 @@
 import { calculateTransferTotals, MAX_BODY_BYTES } from './_orders_logic.js';
 import { resolveConfig } from './_env_config.js';
+import { orderEmailService as defaultOrderEmailService } from './_order_email.js';
 
 // Datos públicos de cobro, deliberadamente fuera del HTML estático. Se
 // entregan únicamente después de autenticar una orden abierta con su código
@@ -60,7 +61,10 @@ export const PAYER_CHANNELS = Object.freeze([
   Object.freeze({ id: 'other', name: 'Otro banco o billetera', url: null }),
 ]);
 
-export function createTransferOptionsHandler({ getNow = () => new Date() } = {}) {
+export function createTransferOptionsHandler({
+  getNow = () => new Date(),
+  orderEmails = defaultOrderEmailService,
+} = {}) {
   return async function onRequest(context) {
     const { request, env } = context;
     if (request.method !== 'POST') {
@@ -115,7 +119,8 @@ export function createTransferOptionsHandler({ getNow = () => new Date() } = {})
     let order;
     try {
       order = await db.prepare(
-        'SELECT public_code,status,payment_status,expires_at,products_total_uyu,' +
+        'SELECT id,public_code,status,payment_status,expires_at,buyer_name,buyer_phone,buyer_email,' +
+        'delivery_type,address,locality,department,products_total_uyu,' +
         'pickup_discount_uyu,shipping_cost_uyu,payable_total_uyu,currency ' +
         'FROM orders WHERE public_code=? AND idempotency_key=?'
       ).bind(publicCode, idempotencyKey).first();
@@ -151,6 +156,22 @@ export function createTransferOptionsHandler({ getNow = () => new Date() } = {})
 
     const { transferProductsTotal, transferDiscount, transferPayableTotal } =
       calculateTransferTotals({ productsTotal, pickupDiscount, shippingCost });
+
+    const emailTask = Promise.resolve(orderEmails.sendTransferNotifications({
+      db,
+      env,
+      order,
+      payment: {
+        method: 'bank_transfer',
+        transfer_discount_uyu: transferDiscount,
+        total_uyu: transferPayableTotal,
+      },
+      now,
+    })).catch(error => {
+      console.error('[transfer-options] email task error', safeErrorName(error));
+    });
+    if (typeof context.waitUntil === 'function') context.waitUntil(emailTask);
+    else await emailTask;
 
     return json({
       payment: {

--- a/migrations/0006_orders_buyer_email.sql
+++ b/migrations/0006_orders_buyer_email.sql
@@ -1,0 +1,4 @@
+-- EMAIL-COMPRA-2: el checkout guarda el correo normalizado para enviar la
+-- confirmación correcta según el medio de pago. Las órdenes históricas quedan
+-- con NULL; las nuevas lo exigen en la validación de la API.
+ALTER TABLE orders ADD COLUMN buyer_email TEXT;


### PR DESCRIPTION
## Qué cambia

- Solicita y valida el email del comprador en cliente y servidor.
- Mercado Pago envía “Pago confirmado” solamente después de verificar el webhook aprobado.
- Transferencia envía “Pedido recibido, pendiente de comprobante”.
- Amado recibe el aviso interno del pedido por transferencia, marcado como pendiente.
- Registra envíos de forma idempotente para evitar duplicados.
- Un fallo de correo no revierte pagos ni rompe el checkout.

## Por qué

El checkout no pedía email, por lo que el cliente no podía recibir confirmación. Además, las transferencias no generaban un aviso interno equivalente.

## Validación

- Suite completa aprobada.
- Migración D1 validada.
- Builds con checkout ON y OFF aprobados.
- Rama aislada de STOCK-AVISO-2 y PICKUP-CX-2.

## Despliegue

PR en borrador. No mergear ni desplegar hasta completar revisión y prueba de Preview.