### PR TITLE
Requerir selección explícita de entrega o retiro

### DIFF
--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -77,10 +77,10 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
 
         <!-- Entrega -->
         <section class="cart-section">
-          <h2 class="cart-section-h2">Tipo de entrega</h2>
-          <div class="delivery-opts">
+          <h2 class="cart-section-h2">¿Cómo querés recibir tu pedido?</h2>
+          <div class="delivery-opts" role="radiogroup" aria-describedby="err-delivery">
             <label class="delivery-opt">
-              <input type="radio" name="delivery" value="pickup" checked>
+              <input type="radio" name="delivery" value="pickup">
               <span class="delivery-opt-content">
                 <strong class="delivery-opt-name">Pick up a pasos de Plaza Matriz</strong>
                 <span class="delivery-opt-meta">Lunes a viernes, de 8 a 17 h</span>
@@ -91,7 +91,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
 
           <!-- PICKUP-CX-1: aviso y aceptación obligatoria. Solo visible con
                retiro seleccionado; al pasar a envío se oculta y se limpia. -->
-          <div id="pickup-ack-box" class="pickup-ack">
+          <div id="pickup-ack-box" class="pickup-ack" hidden>
             <p class="pickup-ack-notice">
               Para evitar que vengas en vano, esperá nuestra confirmación por
               WhatsApp antes de venir. Te avisaremos apenas tu pedido esté
@@ -110,9 +110,11 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
               <span class="delivery-opt-content">
                 <strong class="delivery-opt-name">Envío a domicilio</strong>
                 <span class="delivery-opt-meta">Coordinamos contigo y el cadete entrega en una franja horaria de tu conveniencia.</span>
+                <span class="delivery-opt-badge">Envío gratis en compras desde $2.000</span>
               </span>
             </label>
           </div>
+          <span class="field-error delivery-error" id="err-delivery" role="alert" hidden></span>
           <div id="shipping-fields" class="shipping-fields" hidden>
             <div class="form-field">
               <label for="delivery-address" class="form-label">Dirección <span class="form-req" aria-hidden="true">*</span></label>
@@ -462,14 +464,26 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     display: flex;
     align-items: flex-start;
     gap: 0.6rem;
+    min-height: 44px;
+    padding: 0.85rem;
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    background: #fff;
     font-size: 0.9rem;
     color: var(--ink);
     cursor: pointer;
   }
 
+  .delivery-opt:has(input[type="radio"]:checked) {
+    border-color: #267a42;
+    background: rgba(37, 160, 80, 0.06);
+    box-shadow: 0 0 0 1px rgba(37, 160, 80, 0.18);
+  }
+
   .delivery-opt input[type="radio"] {
     margin-top: 0.2rem;
     flex-shrink: 0;
+    accent-color: #267a42;
   }
 
   .delivery-opt-content {
@@ -499,6 +513,13 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     padding: 0.1rem 0.5rem;
     align-self: flex-start;
   }
+
+  .delivery-error {
+    display: block;
+    margin-top: 0.65rem;
+  }
+
+  .delivery-error[hidden] { display: none; }
 
   .shipping-fields {
     display: flex;
@@ -1190,7 +1211,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     var RETIRO_DISCOUNT             = 150;
     var SHIPPING_COST               = 250;
     var FREE_SHIPPING_THRESHOLD_UYU = 2000;
-    var CHECKOUT_DRAFT_KEY           = 'amado-checkout-draft-v1';
+    var CHECKOUT_DRAFT_KEY           = 'amado-checkout-draft-v2';
     var WHATSAPP_NUMBER              = '59899841325';
 
     // ── Elementos ───────────────────────────────────────────────────────
@@ -1284,7 +1305,32 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     // ── Tipo de entrega ──────────────────────────────────────────────────
     function getDeliveryType() {
       var checked = document.querySelector('input[name="delivery"]:checked');
-      return checked ? checked.value : 'pickup';
+      return checked ? checked.value : '';
+    }
+
+    function requireDeliveryType() {
+      var deliveryType = getDeliveryType();
+      if (deliveryType) return deliveryType;
+      var errEl = document.getElementById('err-delivery');
+      if (errEl) {
+        errEl.textContent = 'Elegí envío o retiro para continuar.';
+        errEl.hidden = false;
+      }
+      var firstDelivery = document.querySelector('input[name="delivery"]');
+      if (firstDelivery) {
+        firstDelivery.setAttribute('aria-invalid', 'true');
+        firstDelivery.focus();
+        firstDelivery.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+      return '';
+    }
+
+    function clearDeliveryError() {
+      var errEl = document.getElementById('err-delivery');
+      if (errEl) { errEl.textContent = ''; errEl.hidden = true; }
+      document.querySelectorAll('input[name="delivery"]').forEach(function (radio) {
+        radio.removeAttribute('aria-invalid');
+      });
     }
 
     // ── Persistencia de la etapa y los datos mínimos ─────────────────────
@@ -1363,6 +1409,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     }
     document.querySelectorAll('input[name="delivery"]').forEach(function (radio) {
       radio.addEventListener('change', saveDraft);
+      radio.addEventListener('change', clearDeliveryError);
     });
     window.addEventListener('pagehide', saveDraft);
 
@@ -1437,7 +1484,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     function syncPaymentAvailability() {
       var cart = window.AmadoCart ? window.AmadoCart.get() : { items: [] };
       var canPay = cartValidationReady && !cartValidationFailed &&
-        !validationRequest && getSellableItems(cart).length > 0;
+        !validationRequest && getSellableItems(cart).length > 0 && !!getDeliveryType();
       var transferButton = document.getElementById('btn-transfer-order');
       var mercadoPagoButton = document.getElementById('btn-prepare-order');
       if (transferButton && !transferButton.hasAttribute('aria-busy')) transferButton.disabled = !canPay;
@@ -1537,6 +1584,18 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       var isPickup     = deliveryType === 'pickup';
 
       if (subtotalEl) subtotalEl.textContent = fmt.format(subtotal);
+
+      if (!deliveryType || subtotal <= 0) {
+        if (discountLineEl)      discountLineEl.hidden      = true;
+        if (totalLineEl)         totalLineEl.hidden         = true;
+        if (shippingNoteEl)      shippingNoteEl.hidden      = true;
+        if (transferNoteEl)      transferNoteEl.hidden      = true;
+        if (shippingCostLineEl)  shippingCostLineEl.hidden  = true;
+        if (totalShippingLineEl) totalShippingLineEl.hidden = true;
+        if (shippingMsgEl)       shippingMsgEl.hidden       = true;
+        if (stickyTotalEl)       stickyTotalEl.textContent  = fmt.format(subtotal);
+        return;
+      }
 
       if (isPickup) {
         var total = Math.max(0, subtotal - RETIRO_DISCOUNT);
@@ -1804,6 +1863,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       radio.addEventListener('change', function () {
         syncShippingFields();
         updateTotals();
+        syncPaymentAvailability();
       });
     });
     syncShippingFields();
@@ -1878,6 +1938,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         var name         = ((document.getElementById('buyer-name')            || {}).value || '').trim();
         var phone        = ((document.getElementById('buyer-phone')           || {}).value || '').trim();
 
+        if (!deliveryType) { requireDeliveryType(); return; }
         if (deliveryType === 'shipping') {
           if (!address) {
             alert('Por favor ingresá la dirección de entrega.');
@@ -2150,6 +2211,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
 
       clearCheckoutError();
       clearFieldErrors();
+      if (!deliveryType) { requireDeliveryType(); return null; }
       if (!name) { showFieldError('buyer-name', 'Por favor ingresá tu nombre.'); return null; }
       if (!phone) { showFieldError('buyer-phone', 'Por favor ingresá tu teléfono o WhatsApp.'); return null; }
       if (deliveryType === 'shipping') {
@@ -2331,6 +2393,11 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         var prepNotes    = ((document.getElementById('delivery-notes')        || {}).value || '').trim();
         var prepName     = ((document.getElementById('buyer-name')            || {}).value || '').trim();
         var prepPhone    = ((document.getElementById('buyer-phone')           || {}).value || '').trim();
+
+        if (!deliveryType) {
+          requireDeliveryType();
+          return;
+        }
 
         // Primer campo inválido gana — mismo orden que antes, ahora con
         // error inline debajo del campo en vez de un alert() bloqueante.

--- a/functions/__tests__/checkout-single-step.test.js
+++ b/functions/__tests__/checkout-single-step.test.js
@@ -103,7 +103,7 @@ test('carrito.astro: transferencia permite copiar, abrir banco y copiar todo', (
 });
 
 test('carrito.astro: formulario y paso se restauran tras banco, WhatsApp o recarga', () => {
-  assert.match(carritoAstro, /amado-checkout-draft-v1/);
+  assert.match(carritoAstro, /amado-checkout-draft-v2/);
   assert.match(carritoAstro, /sessionStorage\.setItem\(CHECKOUT_DRAFT_KEY/);
   assert.match(carritoAstro, /restoredDraft\.step === 'transfer'/);
 });

--- a/functions/__tests__/pickup-cx-2.test.js
+++ b/functions/__tests__/pickup-cx-2.test.js
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const carrito = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'pages', 'carrito.astro'),
+  'utf8',
+);
+
+test('pickup-cx-2: ninguna forma de entrega viene preseleccionada', () => {
+  const deliveryInputs = carrito.match(/<input type="radio" name="delivery"[^>]*>/g) || [];
+  assert.equal(deliveryInputs.length, 2);
+  for (const input of deliveryInputs) assert.doesNotMatch(input, /\schecked(?:\s|>)/);
+  assert.match(carrito, /return checked \? checked\.value : '';/);
+});
+
+test('pickup-cx-2: los beneficios se anuncian dentro de su opción', () => {
+  assert.match(carrito, /value="pickup"[\s\S]*?Ahorrás \$150 retirando aquí/);
+  assert.match(carrito, /value="shipping"[\s\S]*?Envío gratis en compras desde \$2\.000/);
+});
+
+test('pickup-cx-2: sin selección o sin productos comprables no muestra descuentos', () => {
+  const start = carrito.indexOf('function updateTotals');
+  const end = carrito.indexOf('// ── Construir fila de item', start);
+  const fn = carrito.slice(start, end);
+  assert.match(fn, /if \(!deliveryType \|\| subtotal <= 0\)/);
+  assert.match(fn, /discountLineEl\.hidden\s*=\s*true/);
+  assert.match(fn, /totalLineEl\.hidden\s*=\s*true/);
+  assert.match(fn, /shippingCostLineEl\.hidden\s*=\s*true/);
+  assert.match(fn, /totalShippingLineEl\.hidden\s*=\s*true/);
+});
+
+test('pickup-cx-2: elegir entrega recalcula y habilita el pago', () => {
+  assert.match(carrito, /getSellableItems\(cart\)\.length > 0 && !!getDeliveryType\(\)/);
+  const start = carrito.indexOf("radio.addEventListener('change', function () {");
+  const listener = carrito.slice(start, start + 300);
+  assert.match(listener, /updateTotals\(\)/);
+  assert.match(listener, /syncPaymentAvailability\(\)/);
+});
+
+test('pickup-cx-2: invalida el borrador viejo que guardaba retiro por defecto', () => {
+  assert.match(carrito, /amado-checkout-draft-v2/);
+  assert.doesNotMatch(carrito, /amado-checkout-draft-v1/);
+});
+
+test('pickup-cx-2: los tres caminos exigen una elección explícita', () => {
+  assert.match(carrito, /function requireDeliveryType/);
+  assert.match(carrito, /Elegí envío o retiro para continuar/);
+  const calls = carrito.match(/requireDeliveryType\(\)/g) || [];
+  assert.ok(calls.length >= 4, 'definición + WhatsApp + transferencia + Mercado Pago');
+});


### PR DESCRIPTION
## Qué cambia

- Ninguna opción de entrega aparece preseleccionada.
- El resumen inicial muestra solamente el total de productos.
- El descuento de $150 aparece únicamente al elegir retiro.
- El costo de envío aparece únicamente al elegir envío.
- Invalida la selección heredada de la versión anterior.
- Evita mostrar ahorro por retiro cuando todos los productos están agotados.

## Por qué

El checkout podía preseleccionar retiro y descontar $150 antes de que el cliente eligiera una modalidad, incluso con un carrito de total $0.

## Validación

- Suite completa aprobada.
- Builds con checkout ON y OFF aprobados.
- Rama aislada de STOCK-AVISO-2 y EMAIL-COMPRA-2.

## Despliegue

PR en borrador. No mergear ni desplegar hasta completar revisión y prueba de Preview.