### PR TITLE
Corregir orden del secreto Resend en Worker

### DIFF
--- a/.github/workflows/deploy-worker-sync.yml
+++ b/.github/workflows/deploy-worker-sync.yml
@@ -37,6 +37,17 @@ jobs:
         with:
           node-version: '22.12.0'
 
+      - name: Deploy amadolibros-sync Worker
+        run: |
+          cd worker-sync
+          npx wrangler@3 deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      # Cloudflare sólo permite editar secretos cuando la versión más reciente
+      # ya está desplegada. El trigger ocurre después de este paso, por lo que
+      # el Worker nunca procesa reposiciones sin la clave configurada.
       - name: Sync Resend secret to Worker
         run: |
           if [ -z "$RESEND_API_KEY" ]; then
@@ -49,14 +60,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-
-      - name: Deploy amadolibros-sync Worker
-        run: |
-          cd worker-sync
-          npx wrangler@3 deploy
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Wait for Worker propagation
         if: ${{ inputs.run_trigger == true }}

--- a/functions/__tests__/stock-aviso-2-migration.test.js
+++ b/functions/__tests__/stock-aviso-2-migration.test.js
@@ -6,6 +6,7 @@ import path from 'node:path';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const migration = readFileSync(path.join(ROOT, 'migrations/0007_stock_waitlist_customer_notification.sql'), 'utf8');
+const deployWorkflow = readFileSync(path.join(ROOT, '.github/workflows/deploy-worker-sync.yml'), 'utf8');
 
 test('stock-aviso-2: migración agrega outbox sin tocar pedidos', () => {
   assert.match(migration, /customer_notification_status/);
@@ -13,4 +14,14 @@ test('stock-aviso-2: migración agrega outbox sin tocar pedidos', () => {
   assert.match(migration, /last_notification_attempt_at/);
   assert.doesNotMatch(migration, /ALTER TABLE\s+(orders|order_items|order_events)/i);
   assert.doesNotMatch(migration, /DROP TABLE/i);
+});
+
+test('stock-aviso-2: despliega la versión antes de editar el secreto de Resend', () => {
+  const deployStep = deployWorkflow.indexOf('- name: Deploy amadolibros-sync Worker');
+  const secretStep = deployWorkflow.indexOf('- name: Sync Resend secret to Worker');
+  const triggerStep = deployWorkflow.indexOf('- name: Trigger catalog sync');
+
+  assert.ok(deployStep >= 0, 'falta el deploy del Worker');
+  assert.ok(secretStep > deployStep, 'Cloudflare exige desplegar la versión antes de editar secretos');
+  assert.ok(triggerStep > secretStep, 'el sync no debe ejecutarse antes de cargar RESEND_API_KEY');
 });


### PR DESCRIPTION
## Diagnóstico

Cloudflare rechazó `wrangler secret put` porque el workflow intentaba editar el secreto antes de desplegar la versión más reciente del Worker.

## Corrección

- Despliega `amadolibros-sync` primero.
- Carga `RESEND_API_KEY` inmediatamente después.
- Mantiene el trigger posterior a ambos pasos.
- Agrega una prueba de regresión para fijar ese orden.

## Validación

- Prueba específica: 2/2 aprobadas.
- `git diff --check`: aprobado.

Hotfix del deploy fallido del commit `0a62272a`.