### PR TITLE
Corregir jerarquía de precios, beneficios y copia bancaria

### DIFF
--- a/.github/workflows/deploy-price-bank-preview.yml
+++ b/.github/workflows/deploy-price-bank-preview.yml
@@ -1,0 +1,115 @@
+name: Deploy PRICE-BANK Preview
+
+on:
+  push:
+    branches:
+      - agent/price-icons-bank-copy-fix
+
+permissions:
+  contents: read
+
+concurrency:
+  group: price-bank-preview-112
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Guard Preview ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Block every other branch
+        run: |
+          if [ "${GITHUB_REF}" != "refs/heads/agent/price-icons-bank-copy-fix" ]; then
+            echo "Deploy bloqueado: rama incorrecta."
+            exit 1
+          fi
+
+  validate:
+    name: Validate exact PR code
+    needs: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: astro-front/package-lock.json
+      - name: Validate shared suite
+        run: bash scripts/validate-ci.sh
+
+  deploy-preview:
+    name: Deploy isolated Preview
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: astro-front/package-lock.json
+
+      - name: Install Astro dependencies
+        working-directory: astro-front
+        run: npm ci --no-audit --no-fund
+
+      - name: Build protected Preview with checkout visible
+        working-directory: astro-front
+        env:
+          PUBLIC_INDEXABLE: 'false'
+          PUBLIC_GA_ID: ''
+          PUBLIC_CHECKOUT_ENABLED: 'true'
+          PUBLIC_TURNSTILE_SITE_KEY: '0x4AAAAAAD6E9kz8K3comwjj'
+          PUBLIC_TURNSTILE_ALLOWED_HOSTS: '.amadolibros-web.pages.dev'
+        run: npm run build
+
+      - name: Deploy branch to Cloudflare Pages Preview
+        run: >
+          npx wrangler@3.114.17 pages deploy ./astro-front/dist
+          --project-name amadolibros-web
+          --branch price-bank-preview-112
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Smoke price hierarchy, benefits and transfer copy
+        env:
+          PREVIEW_URL: https://price-bank-preview-112.amadolibros-web.pages.dev
+        run: |
+          ready=false
+          for attempt in 1 2 3 4 5 6; do
+            code=$(curl -sSL -o /tmp/book.html -w '%{http_code}' \
+              "$PREVIEW_URL/libro/MLU1001092502/prueba" || true)
+            if [ "$code" = "200" ] && grep -Fq 'class="price-main"' /tmp/book.html; then
+              ready=true
+              break
+            fi
+            sleep 10
+          done
+          test "$ready" = "true"
+
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const html = fs.readFileSync('/tmp/book.html', 'utf8');
+          const price = html.indexOf('class="price-main"');
+          const installments = html.indexOf('class="price-installment"');
+          const transfer = html.indexOf('class="price-transfer"');
+          if (!(price >= 0 && price < installments && installments < transfer)) {
+            throw new Error('La ficha no conserva precio → cuotas → transferencia.');
+          }
+          if (!html.includes('🏷️') || !html.includes('🚚')) {
+            throw new Error('Faltan los iconos comerciales en la ficha elegible.');
+          }
+          NODE
+
+          curl -sSL "$PREVIEW_URL/carrito/" -o /tmp/cart.html
+          grep -Fq 'data-online-checkout="enabled"' /tmp/cart.html
+          grep -Fq 'id="btn-copy-all"' /tmp/cart.html
+          grep -Fq '>Copiar datos</button>' /tmp/cart.html
+          ! grep -Fq '¿Desde qué banco o app pagás?' /tmp/cart.html
+          ! grep -Fq 'Copiar y abrir mi banco' /tmp/cart.html
+          ! grep -Fq 'id="payer-channel"' /tmp/cart.html

--- a/.github/workflows/deploy-price-bank-preview.yml
+++ b/.github/workflows/deploy-price-bank-preview.yml
@@ -95,13 +95,14 @@ jobs:
           node - <<'NODE'
           const fs = require('node:fs');
           const html = fs.readFileSync('/tmp/book.html', 'utf8');
-          const price = html.indexOf('class="price-main"');
-          const installments = html.indexOf('class="price-installment"');
-          const transfer = html.indexOf('class="price-transfer"');
+          const body = html.slice(html.indexOf('<body'));
+          const price = body.indexOf('class="price-main"');
+          const installments = body.indexOf('class="price-installment"');
+          const transfer = body.indexOf('class="price-transfer"');
           if (!(price >= 0 && price < installments && installments < transfer)) {
             throw new Error('La ficha no conserva precio → cuotas → transferencia.');
           }
-          if (!html.includes('🏷️') || !html.includes('🚚')) {
+          if (!body.includes('🏷️') || !body.includes('🚚')) {
             throw new Error('Faltan los iconos comerciales en la ficha elegible.');
           }
           NODE
@@ -109,7 +110,7 @@ jobs:
           curl -sSL "$PREVIEW_URL/carrito/" -o /tmp/cart.html
           grep -Fq 'data-online-checkout="enabled"' /tmp/cart.html
           grep -Fq 'id="btn-copy-all"' /tmp/cart.html
-          grep -Fq '>Copiar datos</button>' /tmp/cart.html
+          grep -Fq 'Copiar datos</button>' /tmp/cart.html
           ! grep -Fq '¿Desde qué banco o app pagás?' /tmp/cart.html
           ! grep -Fq 'Copiar y abrir mi banco' /tmp/cart.html
           ! grep -Fq 'id="payer-channel"' /tmp/cart.html

--- a/astro-front/src/components/BookCard.astro
+++ b/astro-front/src/components/BookCard.astro
@@ -78,8 +78,8 @@ const hasFreeShipping = book.price >= FREE_SHIPPING_THRESHOLD;
           ? `12 cuotas sin recargo de ${installment}`
           : '12 cuotas sin recargo'}
       </span>
-      <span class="bc-price-transfer">12% menos por transferencia: {transferPrice}</span>
-      {hasFreeShipping && <span class="bc-free-shipping">Envío gratis</span>}
+      <span class="bc-price-transfer"><span aria-hidden="true">🏷️</span> 12% menos por transferencia: {transferPrice}</span>
+      {hasFreeShipping && <span class="bc-free-shipping"><span aria-hidden="true">🚚</span> Envío gratis</span>}
     </div>
 
     <div class="bc-actions">

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -299,16 +299,8 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
 
           <div id="transfer-account-detail" class="transfer-account-detail" aria-live="polite"></div>
 
-          <div class="payer-channel-field">
-            <label for="payer-channel" class="form-label">¿Desde qué banco o app pagás?</label>
-            <select id="payer-channel" class="form-input"></select>
-            <p class="payer-channel-help">Lo recordamos sólo en esta pestaña para ahorrarte pasos.</p>
-          </div>
-
           <div class="transfer-actions">
-            <button type="button" id="btn-copy-account" class="btn-copy-account">Copiar número</button>
-            <button type="button" id="btn-copy-open-bank" class="btn-open-bank">Copiar y abrir mi banco</button>
-            <button type="button" id="btn-copy-all" class="btn-copy-all">Copiar todos los datos</button>
+            <button type="button" id="btn-copy-all" class="btn-copy-all">Copiar datos</button>
           </div>
 
           <p id="copy-feedback" class="copy-feedback" role="status" aria-live="polite"></p>
@@ -1057,13 +1049,9 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
   :global(.transfer-account-detail p) { color: var(--ink-2); font-size: .8rem; margin: 0; }
   :global(.transfer-account-detail p + p) { margin-top: .35rem; }
   :global(.transfer-account-number) { color: var(--ink); display: block; font: 750 1.18rem/1.3 ui-monospace,SFMono-Regular,Consolas,monospace; letter-spacing: .025em; margin-top: .15rem; overflow-wrap: anywhere; }
-  .payer-channel-field { margin-bottom: .85rem; }
-  .payer-channel-help { color: var(--ink-2); font-size: .72rem; margin: .35rem 0 0; }
   .transfer-actions { display: grid; gap: .55rem; }
   .transfer-actions button { border-radius: var(--r); cursor: pointer; min-height: 48px; padding: .72rem 1rem; font: 700 .84rem/1.2 var(--font-ui); }
-  .btn-copy-account { background: #177a43; border: 1px solid #177a43; color: #fff; }
-  .btn-open-bank { background: var(--ink); border: 1px solid var(--ink); color: #fff; }
-  .btn-copy-all { background: transparent; border: 1px solid var(--border); color: var(--ink); }
+  .btn-copy-all { background: #177a43; border: 1px solid #177a43; color: #fff; }
   .copy-feedback { color: #176f3e; font-size: .78rem; font-weight: 650; min-height: 1.2rem; margin: .5rem 0 0; }
   .transfer-finish { border-top: 1px solid var(--border); margin-top: 1rem; padding-top: 1rem; }
   .transfer-finish > p:first-child { color: var(--ink); font-size: .86rem; margin: 0 0 .75rem; }
@@ -1257,7 +1245,6 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     var transferStepEl       = document.getElementById('transfer-payment-step');
     var transferAccountsEl   = document.getElementById('transfer-accounts');
     var transferDetailEl     = document.getElementById('transfer-account-detail');
-    var payerChannelEl       = document.getElementById('payer-channel');
     var copyFeedbackEl       = document.getElementById('copy-feedback');
     var btnTransfer          = document.getElementById('btn-transfer-order');
     var transferData         = null;
@@ -1352,7 +1339,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     }
 
     // ── Persistencia de la etapa y los datos mínimos ─────────────────────
-    // sessionStorage sobrevive a recargas y al salto a una app bancaria, pero
+    // sessionStorage sobrevive a recargas y al salto a WhatsApp, pero
     // se elimina al cerrar la pestaña. Así no guardamos PII indefinidamente.
     var draftFieldIds = [
       'buyer-name', 'buyer-phone', 'buyer-email', 'delivery-address', 'delivery-barrio',
@@ -1391,7 +1378,6 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
           step: transferStepEl && !transferStepEl.hidden ? 'transfer' : 'edit',
           transfer_auth: transferAuth,
           selected_account_id: selectedAccountId,
-          payer_channel_id: payerChannelEl ? payerChannelEl.value : '',
           scroll_y: Math.max(0, Math.round(window.scrollY || 0)),
         }));
       } catch (_) {}
@@ -2029,14 +2015,6 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       return transferData.accounts[0] || null;
     }
 
-    function selectedPayerChannel() {
-      if (!transferData || !Array.isArray(transferData.payer_channels) || !payerChannelEl) return null;
-      for (var i = 0; i < transferData.payer_channels.length; i++) {
-        if (transferData.payer_channels[i].id === payerChannelEl.value) return transferData.payer_channels[i];
-      }
-      return null;
-    }
-
     function setCopyFeedback(message) {
       if (!copyFeedbackEl) return;
       copyFeedbackEl.textContent = message;
@@ -2119,20 +2097,6 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       renderTransferAccountDetail();
     }
 
-    function renderPayerChannels(preferredId) {
-      if (!transferData || !payerChannelEl) return;
-      while (payerChannelEl.firstChild) payerChannelEl.removeChild(payerChannelEl.firstChild);
-      for (var i = 0; i < transferData.payer_channels.length; i++) {
-        var channel = transferData.payer_channels[i];
-        var option = document.createElement('option');
-        option.value = channel.id;
-        option.textContent = channel.name;
-        payerChannelEl.appendChild(option);
-      }
-      payerChannelEl.value = preferredId || 'brou';
-      if (!payerChannelEl.value && payerChannelEl.options.length) payerChannelEl.selectedIndex = 0;
-    }
-
     function buildTransferWhatsAppHref() {
       if (!transferData || !transferData.payment || !window.AmadoCart) return '#';
       var payment = transferData.payment;
@@ -2159,7 +2123,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       return 'https://wa.me/' + WHATSAPP_NUMBER + '?text=' + encodeURIComponent(lines.join('\n'));
     }
 
-    function renderTransferPayment(preferredPayerId) {
+    function renderTransferPayment() {
       if (!transferData || !transferData.payment) return;
       var payment = transferData.payment;
       document.getElementById('transfer-order-code').textContent = payment.public_code;
@@ -2167,16 +2131,15 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       document.getElementById('transfer-saving').textContent = '− ' + fmt.format(payment.transfer_discount_uyu);
       document.getElementById('transfer-final-total').textContent = fmt.format(payment.transfer_total_uyu);
       renderTransferAccounts();
-      renderPayerChannels(preferredPayerId);
       var wa = document.getElementById('btn-transfer-whatsapp');
       if (wa) wa.href = buildTransferWhatsAppHref();
     }
 
-    function showTransferStep(preferredPayerId, scrollY) {
+    function showTransferStep(scrollY) {
       if (checkoutEditStepEl) checkoutEditStepEl.hidden = true;
       if (transferStepEl) transferStepEl.hidden = false;
       if (cartPageEl) cartPageEl.dataset.overlaySuppressed = 'true';
-      renderTransferPayment(preferredPayerId);
+      renderTransferPayment();
       saveDraft();
       requestAnimationFrame(function () {
         if (Number.isFinite(scrollY)) window.scrollTo(0, scrollY);
@@ -2302,7 +2265,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
           if (!order) { resetTransferButton(); return; }
           btnTransfer.textContent = 'Cargando cuentas oficiales…';
           transferData = await fetchTransferOptions(order.public_code, transferIdempotencyKey);
-          showTransferStep('brou');
+          showTransferStep();
         } catch (error) {
           showCheckoutError(error.message || 'No pudimos preparar la transferencia. Intentá de nuevo.');
         } finally {
@@ -2327,40 +2290,6 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       });
     }
 
-    if (payerChannelEl) {
-      payerChannelEl.addEventListener('change', function () { saveDraft(); });
-    }
-
-    var btnCopyAccount = document.getElementById('btn-copy-account');
-    if (btnCopyAccount) {
-      btnCopyAccount.addEventListener('click', function () {
-        var account = selectedTransferAccount();
-        if (!account) return;
-        copyText(account.account_number)
-          .then(function () { setCopyFeedback('Número copiado: ' + account.account_number); })
-          .catch(function () { setCopyFeedback('No se pudo copiar. Mantené apretado el número para copiarlo.'); });
-      });
-    }
-
-    var btnCopyOpenBank = document.getElementById('btn-copy-open-bank');
-    if (btnCopyOpenBank) {
-      btnCopyOpenBank.addEventListener('click', function () {
-        var account = selectedTransferAccount();
-        var channel = selectedPayerChannel();
-        if (!account || !channel) return;
-        var copyPromise = copyText(account.account_number);
-        if (channel.url) window.open(channel.url, '_blank', 'noopener,noreferrer');
-        copyPromise.then(function () {
-          setCopyFeedback(channel.url
-            ? 'Número copiado. Pegalo en tu banco para transferir.'
-            : 'Número copiado. Abrí tu app bancaria y pegalo.');
-          saveDraft();
-        }).catch(function () {
-          setCopyFeedback('Abrimos el canal elegido, pero no pudimos copiar el número automáticamente.');
-        });
-      });
-    }
-
     var btnCopyAll = document.getElementById('btn-copy-all');
     if (btnCopyAll) {
       btnCopyAll.addEventListener('click', function () {
@@ -2376,7 +2305,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
           'Total exacto: ' + fmt.format(payment.transfer_total_uyu) + ' UYU',
         ].join('\n');
         copyText(text)
-          .then(function () { setCopyFeedback('Todos los datos quedaron copiados.'); })
+          .then(function () { setCopyFeedback('Datos copiados. Pegalos en tu banco para transferir.'); })
           .catch(function () { setCopyFeedback('No se pudieron copiar los datos automáticamente.'); });
       });
     }
@@ -2588,7 +2517,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         fetchTransferOptions(restoredDraft.transfer_auth.public_code, transferIdempotencyKey)
           .then(function (data) {
             transferData = data;
-            showTransferStep(restoredDraft.payer_channel_id, restoredDraft.scroll_y);
+            showTransferStep(restoredDraft.scroll_y);
           })
           .catch(function (error) {
             transferData = null;

--- a/functions/__tests__/catalog-display.test.js
+++ b/functions/__tests__/catalog-display.test.js
@@ -240,7 +240,7 @@ test('la búsqueda Preview usa el índice activo compacto y conserva el precio',
   const html = await response.text();
 
   assert.match(html, /Alpha disponible/);
-  assert.match(html, /Transferencia:/);
+  assert.match(html, /12% menos por transferencia:/);
   assert.match(html, /Precio web\/tarjeta:/);
   assert.equal(requests.includes(CATALOG_URL), false);
   assert.match(response.headers.get('server-timing'), /active_index_parse/);
@@ -258,9 +258,30 @@ test('el catálogo prioriza precio web y cuotas antes que transferencia', async 
 
   assert.match(prices, /Precio web\/tarjeta:<\/span> \$1[.,]000 UYU/);
   assert.match(prices, /Hasta 12 cuotas de aprox\. \$83 UYU/);
-  assert.match(prices, /Transferencia: \$880 UYU/);
+  assert.match(prices, /🏷️<\/span> 12% menos por transferencia: \$880 UYU/);
   assert.ok(prices.indexOf('Precio web/tarjeta:') < prices.indexOf('Hasta 12 cuotas'));
-  assert.ok(prices.indexOf('Hasta 12 cuotas') < prices.indexOf('Transferencia:'));
+  assert.ok(prices.indexOf('Hasta 12 cuotas') < prices.indexOf('12% menos por transferencia:'));
+});
+
+test('el catálogo marca con iconos el 12% y el envío gratis sólo desde el umbral', async () => {
+  const paidResponse = await catalogRequest(
+    context('https://preview.example/catalogo?q=Alpha')
+  );
+  const paidHtml = await paidResponse.text();
+  assert.match(paidHtml, /🏷️<\/span> 12% menos por transferencia/);
+  assert.doesNotMatch(paidHtml, /🚚<\/span> Envío gratis/);
+
+  const originalPrice = CATALOG.items[0].price;
+  CATALOG.items[0].price = 2100;
+  try {
+    const freeResponse = await catalogRequest(
+      context('https://preview.example/catalogo?q=Alpha')
+    );
+    const freeHtml = await freeResponse.text();
+    assert.match(freeHtml, /🚚<\/span> Envío gratis/);
+  } finally {
+    CATALOG.items[0].price = originalPrice;
+  }
 });
 
 test('el precio principal del catálogo tiene más fuerza visual que transferencia', async () => {

--- a/functions/__tests__/checkout-single-step.test.js
+++ b/functions/__tests__/checkout-single-step.test.js
@@ -96,14 +96,18 @@ test('carrito.astro: no publica cuentas ni cédula en el HTML estático', () => 
   assert.doesNotMatch(carritoAstro, /00065582200001|1960816881|8969114|2373466|57211|28688206/);
 });
 
-test('carrito.astro: transferencia permite copiar, abrir banco y copiar todo', () => {
-  assert.match(carritoAstro, /id="btn-copy-account"/);
-  assert.match(carritoAstro, /id="btn-copy-open-bank"/);
+test('carrito.astro: transferencia sólo ofrece copiar todos los datos', () => {
   assert.match(carritoAstro, /id="btn-copy-all"/);
+  assert.match(carritoAstro, />Copiar datos<\/button>/);
   assert.match(carritoAstro, /navigator\.clipboard\.writeText/);
+  assert.doesNotMatch(carritoAstro, /id="btn-copy-account"/);
+  assert.doesNotMatch(carritoAstro, /¿Desde qué banco o app pagás\?/);
+  assert.doesNotMatch(carritoAstro, /id="payer-channel"/);
+  assert.doesNotMatch(carritoAstro, /Copiar y abrir mi banco/);
+  assert.doesNotMatch(carritoAstro, /btn-copy-open-bank/);
 });
 
-test('carrito.astro: formulario y paso se restauran tras banco, WhatsApp o recarga', () => {
+test('carrito.astro: formulario y paso se restauran tras WhatsApp o recarga', () => {
   assert.match(carritoAstro, /amado-checkout-draft-v2/);
   assert.match(carritoAstro, /sessionStorage\.setItem\(CHECKOUT_DRAFT_KEY/);
   assert.match(carritoAstro, /restoredDraft\.step === 'transfer'/);

--- a/functions/__tests__/ficha-pricing-cta-order.test.js
+++ b/functions/__tests__/ficha-pricing-cta-order.test.js
@@ -1,6 +1,6 @@
 // AL-WEB: jerarquía de precios y orden de acciones en la ficha individual
 // (functions/libro/[[path]].js). Cubre las dos correcciones comerciales:
-// 1. Transferencia y ahorro primero, precio web/tarjeta y cuotas debajo.
+// 1. Precio web/tarjeta y cuotas primero; transferencia como beneficio secundario.
 // 2. Agregar al carrito → WhatsApp → Mercado Libre, con Mercado Libre
 //    visualmente subordinado (sin el relleno amarillo dominante que tenía).
 import test from 'node:test';
@@ -34,37 +34,45 @@ function extractBlock(html, className) {
     return match[0];
 }
 
-test('1. Transferencia aparece primero y muestra el 12% y el ahorro exacto', () => {
+test('1. Precio web/tarjeta aparece primero y transferencia muestra el 12% y el ahorro exacto', () => {
     const html = renderPage(book({ price: 1200 }), 'un-libro-de-prueba', false, '');
-    assert.match(html, /Precio web\/tarjeta:<\/span> \$1\.200 UYU/);
+    assert.match(html, /Precio web\/tarjeta:<\/span>\s*<strong>\$1\.200 UYU<\/strong>/);
     assert.match(html, /12% menos por transferencia/);
-    assert.match(html, /<strong>\$1\.056 UYU<\/strong>/); // 1200 * 0.88 = 1056
+    assert.match(html, /12% menos por transferencia: <strong>\$1\.056 UYU<\/strong>/); // 1200 * 0.88 = 1056
     assert.match(html, /Ahorrás \$144 UYU/);
     const priceBox = extractBlock(html, 'price-box');
     const priceIdx = priceBox.indexOf('Precio web/tarjeta:');
     const transferIdx = priceBox.indexOf('12% menos por transferencia');
     assert.ok(priceIdx > -1 && transferIdx > -1);
-    assert.ok(transferIdx < priceIdx, 'la transferencia debe aparecer antes que tarjeta');
+    assert.ok(priceIdx < transferIdx, 'el precio web/tarjeta debe aparecer antes que transferencia');
 });
 
-test('2. Tarjeta y cuotas quedan visibles debajo de transferencia', () => {
+test('2. Tarjeta y cuotas quedan visibles antes de transferencia', () => {
     const html = renderPage(book({ price: 1200 }), 'un-libro-de-prueba', false, '');
     assert.match(html, /Hasta 12 cuotas de aprox\. \$100 UYU/); // 1200 / 12 = 100
     const priceBox = extractBlock(html, 'price-box');
     const priceIdx = priceBox.indexOf('Precio web/tarjeta:');
     const installmentIdx = priceBox.indexOf('Hasta 12 cuotas');
     const transferIdx = priceBox.indexOf('12% menos por transferencia');
-    assert.ok(transferIdx < priceIdx, 'transferencia debe ir antes que tarjeta');
     assert.ok(priceIdx < installmentIdx, 'tarjeta debe ir antes que las cuotas');
+    assert.ok(installmentIdx < transferIdx, 'las cuotas deben ir antes que transferencia');
 });
 
-test('3. Transferencia usa la jerarquía visual principal y tarjeta la secundaria', () => {
+test('3. Precio web/tarjeta usa la jerarquía visual principal y transferencia la secundaria', () => {
     const html = renderPage(book({ price: 1200 }), 'un-libro-de-prueba', false, '');
     assert.match(html, /class="price-transfer"/);
-    assert.match(html, /class="price-card"/);
-    assert.match(html, /\.price-transfer strong\{font-size:1\.55rem;font-weight:850/);
-    assert.match(html, /\.price-card\{font-size:\.9rem;font-weight:600/);
-    assert.match(html, /\.price-transfer-kicker\{display:inline-flex;background:#166534;color:#fff/);
+    assert.match(html, /class="price-main"/);
+    assert.match(html, /\.price-main strong\{font-size:1\.55rem;font-weight:850/);
+    assert.match(html, /\.price-transfer-line\{font-size:\.88rem;font-weight:700/);
+    assert.match(html, /\.price-transfer-line strong\{font-size:1rem;font-weight:850/);
+    assert.match(html, /🏷️/);
+});
+
+test('3b. La ficha muestra envío gratis sólo cuando el precio llega al umbral', () => {
+    const free = renderPage(book({ price: 2100 }), 'un-libro', false, '');
+    const paid = renderPage(book({ price: 1990 }), 'un-libro', false, '');
+    assert.match(extractBlock(free, 'price-box'), /🚚<\/span> Envío gratis/);
+    assert.doesNotMatch(extractBlock(paid, 'price-box'), /Envío gratis/);
 });
 
 test('4. Orden de botones: Agregar al carrito → WhatsApp → Mercado Libre (dentro del bloque .cta, no de la hoja de estilos)', () => {

--- a/functions/api/__tests__/transfer_options.test.js
+++ b/functions/api/__tests__/transfer_options.test.js
@@ -3,7 +3,6 @@ import assert from 'node:assert/strict';
 import {
   createTransferOptionsHandler,
   TRANSFER_ACCOUNTS,
-  PAYER_CHANNELS,
 } from '../_transfer_options_handler.js';
 
 const NOW = new Date('2026-08-09T15:00:00.000Z');
@@ -157,8 +156,9 @@ test('transfer: respuestas son no-store y noindex', async () => {
   assert.equal(response.headers.get('X-Robots-Tag'), 'noindex, nofollow');
 });
 
-test('transfer: datos y canales públicos quedan centralizados fuera del HTML', () => {
+test('transfer: sólo conserva las cuentas de destino; no devuelve bancos de origen ni enlaces', async () => {
   assert.equal(TRANSFER_ACCOUNTS.length, 5);
-  assert.equal(PAYER_CHANNELS.length, 5);
-  assert.equal(PAYER_CHANNELS.every(channel => channel.id === 'other' || channel.url?.startsWith('https://')), true);
+  const { data } = await call();
+  assert.equal(Object.hasOwn(data, 'payer_channels'), false);
+  assert.equal(JSON.stringify(data).includes('https://'), false);
 });

--- a/functions/api/_transfer_options_handler.js
+++ b/functions/api/_transfer_options_handler.js
@@ -49,18 +49,6 @@ export const TRANSFER_ACCOUNTS = Object.freeze([
   }),
 ]);
 
-// Enlaces oficiales verificados el 9/8/2026. No son deep links: ningún banco
-// uruguayo documenta un esquema universal que permita precargar destinatario
-// e importe de manera segura desde una web. El checkout copia primero el dato
-// y abre el canal oficial elegido.
-export const PAYER_CHANNELS = Object.freeze([
-  Object.freeze({ id: 'brou', name: 'BROU / eBROU', url: 'https://ebanking.brou.com.uy/frontend/' }),
-  Object.freeze({ id: 'itau', name: 'Itaú', url: 'https://www.itau.com.uy/' }),
-  Object.freeze({ id: 'oca', name: 'OCA / OCA Blue', url: 'https://oca.uy/descarga-app/' }),
-  Object.freeze({ id: 'prex', name: 'Prex', url: 'https://www.prexcard.com/' }),
-  Object.freeze({ id: 'other', name: 'Otro banco o billetera', url: null }),
-]);
-
 export function createTransferOptionsHandler({
   getNow = () => new Date(),
   orderEmails = defaultOrderEmailService,
@@ -188,7 +176,6 @@ export function createTransferOptionsHandler({
         expires_at: order.expires_at,
       },
       accounts: TRANSFER_ACCOUNTS,
-      payer_channels: PAYER_CHANNELS,
     });
   };
 }

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -56,6 +56,7 @@ import { previewCoverUrl } from './_shared/preview-cover.js';
 
 const MAX_RESULTS = 48;
 const WA = 'https://wa.me/59899841325';
+const FREE_SHIPPING_THRESHOLD_UYU = 2000;
 
 function escapeHtml(str) {
     if (str == null) return '';
@@ -587,6 +588,7 @@ export async function onRequest(ctx) {
         const transfer  = Math.round(price * 0.88).toLocaleString('es-UY');
         const priceStr  = price.toLocaleString('es-UY');
         const installment = Math.round(price / 12).toLocaleString('es-UY');
+        const hasFreeShipping = price >= FREE_SHIPPING_THRESHOLD_UYU;
         const loading  = idx < 8 ? 'eager' : 'lazy';
         const waHref = `${WA}?text=${encodeURIComponent(`Hola Amado Libros, quiero consultar por encargo: ${b.title}`)}`;
         const orderWaHref = `${WA}?text=${encodeURIComponent(buildOrderWaMessage(b, href))}`;
@@ -604,7 +606,8 @@ export async function onRequest(ctx) {
             ? `<div class="rc-prices">
       <span class="rc-base"><span class="rc-lbl">Precio web/tarjeta:</span> $${escapeHtml(priceStr)} UYU</span>
       <span class="rc-installment">Hasta 12 cuotas de aprox. $${escapeHtml(installment)} UYU</span>
-      <span class="rc-transfer">Transferencia: $${escapeHtml(transfer)} UYU</span>
+      <span class="rc-transfer"><span aria-hidden="true">🏷️</span> 12% menos por transferencia: $${escapeHtml(transfer)} UYU</span>
+      ${hasFreeShipping ? '<span class="rc-free-shipping"><span aria-hidden="true">🚚</span> Envío gratis</span>' : ''}
     </div>
     <a href="${href}" class="rc-cta">Ver ficha →</a>`
             : isPaused
@@ -749,10 +752,11 @@ export async function onRequest(ctx) {
     .rc-author{font-size:.82rem;color:#6b6157;
                white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
     .rc-prices{display:flex;flex-direction:column;gap:.2rem;margin-top:.35rem}
-    .rc-base,.rc-installment,.rc-transfer{line-height:1.3}
+    .rc-base,.rc-installment,.rc-transfer,.rc-free-shipping{line-height:1.3}
     .rc-base{font-size:.95rem;color:#18120e;font-weight:700}
     .rc-installment{font-size:.82rem;color:#374151;font-weight:600}
     .rc-transfer{font-size:.78rem;color:#a94e3d;font-weight:600}
+    .rc-free-shipping{font-size:.78rem;color:#267a42;font-weight:700}
     .rc-lbl{font-weight:700}
     .wa-link{color:#15803d;font-weight:500}
     .rc-badge{display:inline-flex;align-self:flex-start;padding:.18rem .55rem;

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -27,6 +27,7 @@ import {
 } from '../_shared/brand.js';
 
 const WA = '59899841325';
+const FREE_SHIPPING_THRESHOLD_UYU = 2000;
 
 // ---------------------------------------------------------------------------
 // Utilidades
@@ -254,6 +255,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     const installment   = Math.round(price / 12).toLocaleString('es-UY');
     const stockQty      = Number(item.available_quantity) || 0;
     const inStock       = item.status === 'active' && stockQty > 0;
+    const hasFreeShipping = inStock && price >= FREE_SHIPPING_THRESHOLD_UYU;
     const condition     = formatCondition(item.condition);
     const dimensions    = formatDimensions(item.dimensions);
     const waMsg         = encodeURIComponent(
@@ -324,13 +326,16 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
 
     const priceHtml = inStock
         ? `<div class="price-box">
+      <div class="price-main">
+        <span class="price-main-label">Precio web/tarjeta:</span>
+        <strong>$${priceUY} UYU</strong>
+      </div>
+      <div class="price-installment">Hasta 12 cuotas de aprox. $${installment} UYU</div>
       <div class="price-transfer">
-        <span class="price-transfer-kicker">12% menos por transferencia</span>
-        <strong>$${transferPrice} UYU</strong>
+        <span class="price-transfer-line"><span aria-hidden="true">🏷️</span> 12% menos por transferencia: <strong>$${transferPrice} UYU</strong></span>
         <span class="price-saving">Ahorrás $${transferSaving} UYU</span>
       </div>
-      <div class="price-card"><span class="price-label">Precio web/tarjeta:</span> $${priceUY} UYU</div>
-      <div class="price-installment">Hasta 12 cuotas de aprox. $${installment} UYU</div>
+      ${hasFreeShipping ? '<div class="price-free-shipping"><span aria-hidden="true">🚚</span> Envío gratis</div>' : ''}
     </div>`
         : `<div class="order-box">
       <strong>¿Buscás este libro?</strong>
@@ -506,19 +511,18 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     .detail-row:last-child{border-bottom:0}
     .detail-row dt{font-weight:700;color:#334155}
     .detail-row dd{color:#475569}
-    .price-box{background:#f0fdf4;border:1px solid #86efac;border-radius:.65rem;
+    .price-box{background:#fff;border:1px solid #d8d1c7;border-radius:.65rem;
                padding:1rem 1.25rem;margin:.875rem 0}
-    .price-transfer{display:flex;flex-direction:column;align-items:flex-start;gap:.1rem}
-    .price-transfer-kicker{display:inline-flex;background:#166534;color:#fff;border-radius:999px;
-                           padding:.2rem .65rem;font-size:.74rem;font-weight:800;
-                           letter-spacing:.035em;text-transform:uppercase;line-height:1.35}
-    .price-transfer strong{font-size:1.55rem;font-weight:850;color:#14532d;line-height:1.25;
-                           margin-top:.2rem}
-    .price-saving{font-size:.88rem;font-weight:700;color:#166534}
-    .price-card{font-size:.9rem;font-weight:600;color:#334155;margin-top:.8rem;
-                padding-top:.7rem;border-top:1px solid #bbf7d0}
-    .price-label{font-weight:700}
-    .price-installment{font-size:.88rem;font-weight:600;color:#475569;margin-top:.2rem}
+    .price-main{display:flex;flex-direction:column;align-items:flex-start;gap:.12rem}
+    .price-main-label{font-size:.82rem;font-weight:700;color:#334155}
+    .price-main strong{font-size:1.55rem;font-weight:850;color:#18120e;line-height:1.25}
+    .price-installment{font-size:.88rem;font-weight:600;color:#475569;margin-top:.15rem}
+    .price-transfer{display:flex;flex-direction:column;align-items:flex-start;gap:.12rem;
+                    margin-top:.75rem;padding-top:.7rem;border-top:1px solid #e2e8f0}
+    .price-transfer-line{font-size:.88rem;font-weight:700;color:#a94e3d;line-height:1.35}
+    .price-transfer-line strong{font-size:1rem;font-weight:850;color:#8f4436}
+    .price-saving{font-size:.78rem;font-weight:650;color:#64748b}
+    .price-free-shipping{font-size:.86rem;font-weight:750;color:#267a42;margin-top:.5rem}
     .order-box{display:flex;flex-direction:column;gap:.25rem;background:#fff7e8;
                border:1px solid #efd2a6;border-radius:.5rem;padding:1rem 1.25rem;
                margin:.875rem 0;color:#6b4218}


### PR DESCRIPTION
## Qué cambia

- Corrige la ficha individual para mostrar primero el precio web/tarjeta, después las cuotas y luego el precio con 12% menos por transferencia.
- Agrega 🏷️ al beneficio por transferencia y 🚚 a los libros con envío gratis, tanto en portada como en catálogo y ficha.
- El indicador de envío gratis aparece sólo cuando el precio llega al umbral real de $2.000.
- Elimina del flujo de transferencia la pregunta sobre el banco de origen, los enlaces externos y el botón “Copiar y abrir mi banco”.
- Deja un solo botón “Copiar datos”, que copia cuenta, titular, número, código de pedido y total exacto.
- La API ya no devuelve bancos del pagador ni URLs externas.

## Causa raíz

El PR #106 había invertido la jerarquía únicamente en la ficha: transferencia quedó como precio principal, aunque catálogo y decisión comercial establecían precio web/tarjeta primero. El selector de banco de origen además elegía BROU por defecto, por lo que el botón podía abrir eBROU aunque el cliente pagara desde otro banco.

## Impacto

No cambia precios, cálculo del 12%, cuotas, umbral de envío gratis, cuentas de destino, Mercado Pago, stock ni D1. Cambia presentación comercial y simplifica el copiado de datos bancarios.

## Validación

- `scripts/validate-ci.sh`: OK.
- Suite completa: 242/242 pruebas de API + suites restantes verdes.
- Build Astro con checkout OFF: OK.
- Build Astro con checkout ON: OK.
- Árbol remoto idéntico al árbol local validado: `312f6bff2c0c00774a0545e2c35b9d935e17697f`.