### PR TITLE
Posicionar libros agotados, importados y por encargo

### DIFF
--- a/astro-front/src/components/Footer.astro
+++ b/astro-front/src/components/Footer.astro
@@ -20,6 +20,7 @@ const YEAR = new Date().getFullYear();
     <div class="footer-info">
       <p class="footer-info-title">Cómo comprás</p>
       <ul class="footer-list">
+        <li><a href="/libros-agotados-importados-uruguay">Libros por encargo</a></li>
         <li><a href="/envios">Envíos y retiro</a></li>
         <li><a href="/devoluciones">Devoluciones y reembolsos</a></li>
         <li><a href="/terminos">Términos y cancelaciones</a></li>

--- a/astro-front/src/components/Hero.astro
+++ b/astro-front/src/components/Hero.astro
@@ -12,7 +12,7 @@ const requestHref = `https://wa.me/59899841325?text=${encodeURIComponent(request
       <h1 class="hero-h1">Especialistas en libros difíciles de conseguir.</h1>
 
       <p class="hero-lead">
-        Buscá entre nuestros libros disponibles y los que conseguimos por encargo en todo el mundo.
+        Buscá entre nuestros libros disponibles o pedinos ediciones agotadas e importadas de Europa y otros mercados.
       </p>
 
       <form class="hero-search" action="/catalogo" method="get" role="search">
@@ -92,7 +92,7 @@ const requestHref = `https://wa.me/59899841325?text=${encodeURIComponent(request
           </span>
           <span>
             <strong>Libros por encargo</strong>
-            <small>Los buscamos en el exterior</small>
+            <small>Europa y otros mercados</small>
           </span>
         </li>
       </ul>
@@ -102,7 +102,7 @@ const requestHref = `https://wa.me/59899841325?text=${encodeURIComponent(request
       <div class="request-box">
         <div>
           <strong>¿No encontrás el libro?</strong>
-          <span>Lo buscamos por vos en el exterior.</span>
+          <span>Buscamos agotados, importados y ediciones difíciles.</span>
         </div>
         <a
           href={requestHref}

--- a/astro-front/src/pages/index.astro
+++ b/astro-front/src/pages/index.astro
@@ -15,8 +15,9 @@ import ShippingPayments    from '../components/ShippingPayments.astro';
 import TrustStrip          from '../components/TrustStrip.astro';
 ---
 <BaseLayout
+  title="Libros difíciles, agotados e importados | Amado Libros"
   canonical="https://www.amadolibros.com/"
-  description="Libros importados y por encargo en Uruguay. Entrega en 2 horas en Montevideo y envíos a todo el país."
+  description="Conseguimos libros agotados, importados y difíciles de ubicar en Uruguay. Encargos desde Europa y otros mercados, con envíos a todo el país."
 >
   <Header showSearch={false} showMobileDeliveryBanner={true} />
   <main>

--- a/functions/__tests__/catalogo-paginacion.test.js
+++ b/functions/__tests__/catalogo-paginacion.test.js
@@ -230,6 +230,22 @@ test('19. el catálogo sin filtros sigue siendo index, follow en cualquier pági
   assert.match(html, /<meta name="robots" content="index, follow">/);
 });
 
+test('19b. la portada del catálogo comunica disponibles y encargos sin duplicar la home', async () => {
+  const { html } = await render(BASE_URL);
+  assert.match(html, /<title>Comprar libros disponibles y por encargo \| Amado Libros<\/title>/);
+  assert.match(html, /<h1>Libros disponibles y por encargo<\/h1>/);
+  assert.match(html, /100 libros disponibles y 0 por encargo en Uruguay/);
+  assert.match(html, /ediciones agotadas e importadas de Europa/);
+});
+
+test('19c. cada página limpia tiene title, H1, descripción y schema propios', async () => {
+  const { html } = await render(`${BASE_URL}?page=2`);
+  assert.match(html, /<title>Catálogo de libros — Página 2 \| Amado Libros<\/title>/);
+  assert.match(html, /<h1>Libros disponibles y por encargo — Página 2<\/h1>/);
+  assert.match(html, /Página 2 de 3 del catálogo de Amado Libros/);
+  assert.match(html, /"url":"https:\/\/www\.amadolibros\.com\/catalogo\?page=2"/);
+});
+
 // ── 6. Marcado y accesibilidad ──────────────────────────────────────────────
 
 test('20. la navegación son enlaces HTML reales, sin JavaScript', async () => {

--- a/functions/__tests__/seo-commercial-intents.test.js
+++ b/functions/__tests__/seo-commercial-intents.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { onRequest } from '../libros-agotados-importados-uruguay.js';
+
+const root = rel => fileURLToPath(new URL('../../' + rel, import.meta.url));
+const read = rel => readFileSync(root(rel), 'utf8');
+
+test('landing de agotados e importados es indexable, canónica y accionable', async () => {
+  const response = await onRequest();
+  const html = await response.text();
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get('Content-Type'), /text\/html/);
+  assert.match(html, /<title>Libros agotados e importados en Uruguay \| Amado Libros<\/title>/);
+  assert.match(html, /<meta name="robots" content="index, follow">/);
+  assert.match(html, /<link rel="canonical" href="https:\/\/www\.amadolibros\.com\/libros-agotados-importados-uruguay">/);
+  assert.match(html, /<h1>Conseguimos libros agotados, importados y difíciles de encontrar<\/h1>/);
+  assert.match(html, /título, autor, ISBN o foto/);
+  assert.match(html, /Europa y otros mercados/);
+  assert.match(html, /Pedir búsqueda por WhatsApp/);
+  assert.match(html, /"@type":"Service"/);
+  assert.match(html, /disponibilidad real/);
+});
+
+test('home posiciona el diferencial y enlaza la landing desde el footer', () => {
+  const home = read('astro-front/src/pages/index.astro');
+  const hero = read('astro-front/src/components/Hero.astro');
+  const footer = read('astro-front/src/components/Footer.astro');
+
+  assert.match(home, /title="Libros difíciles, agotados e importados \| Amado Libros"/);
+  assert.match(home, /Encargos desde Europa y otros mercados/);
+  assert.match(hero, /ediciones agotadas e importadas de Europa/);
+  assert.match(footer, /href="\/libros-agotados-importados-uruguay"/);
+});

--- a/functions/__tests__/sitemap-segmentation.test.js
+++ b/functions/__tests__/sitemap-segmentation.test.js
@@ -21,6 +21,7 @@ test('sitemap.xml indexa sólo segmentos actualmente indexables', () => {
 
 test('pages y categorías quedan separados para observabilidad', () => {
   assert.ok(STATIC_SITEMAP_PAGES.includes('https://www.amadolibros.com/catalogo'));
+  assert.ok(STATIC_SITEMAP_PAGES.includes('https://www.amadolibros.com/libros-agotados-importados-uruguay'));
   assert.ok(!STATIC_SITEMAP_PAGES.some(url => url.includes('/libros/')));
 
   const categories = categorySitemapEntries();

--- a/functions/_shared/brand.js
+++ b/functions/_shared/brand.js
@@ -67,6 +67,7 @@ export const CONTACT = {
 
 
 export const FOOTER_LINKS = [
+    { href: '/libros-agotados-importados-uruguay', label: 'Libros por encargo' },
     { href: '/envios',       label: 'Envíos y retiro' },
     { href: '/devoluciones', label: 'Devoluciones y reembolsos' },
     { href: '/terminos',     label: 'Términos y cancelaciones' },

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -680,7 +680,7 @@ export async function onRequest(ctx) {
     const metaDescription = isIndex
         ? page > 1
             ? `Página ${page} de ${totalPages} del catálogo de Amado Libros: títulos disponibles y por encargo, con envíos a todo Uruguay.`
-            : `${activeItems.length} libros disponibles y ${pausedItems.length} por encargo en Uruguay. Buscamos ediciones agotadas e importadas de Europa y otros mercados.`
+            : `${activeItems.length} libros disponibles y ${pausedItems.length} por encargo en Uruguay; ediciones agotadas e importadas de Europa; envío gratis desde $2.000.`
         : 'Resultados en Amado Libros.';
     // Las búsquedas internas no se indexan, pero sí se siguen: `follow` deja
     // que el crawler descubra las fichas enlazadas desde los resultados.

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -650,14 +650,18 @@ export async function onRequest(ctx) {
         ? `Resultados para &ldquo;${safeQ}&rdquo; en ${filterLabel}`
         : rawQ
             ? `Resultados para &ldquo;${safeQ}&rdquo;`
-            : filterLabel || 'Catálogo completo';
+            : filterLabel || (page > 1
+                ? `Libros disponibles y por encargo — Página ${page}`
+                : 'Libros disponibles y por encargo');
     const pageTitle = rawQ && filterLabel
         ? `${safeQ} en ${filterLabel} — Amado Libros`
         : rawQ
             ? `Resultados para &ldquo;${safeQ}&rdquo; — Amado Libros`
             : filterLabel
                 ? `${filterLabel} — Amado Libros`
-                : 'Comprar libros online en Uruguay | Amado Libros';
+                : page > 1
+                    ? `Catálogo de libros — Página ${page} | Amado Libros`
+                    : 'Comprar libros disponibles y por encargo | Amado Libros';
     const emptyMessage = rawQ
         ? `Sin resultados para &ldquo;${safeQ}&rdquo;${filterLabel ? ` en ${filterLabel}` : ''}. Intentá con otras palabras${categoria ? ' o cambiá de categoría' : ''} o <a href="/">volvé al catálogo</a>.<br><br>¿No encontrás lo que buscás? <a class="wa-link" href="${WA}?text=${encodeURIComponent(`Hola Amado Libros, busco: ${rawQ}`)}" target="_blank" rel="noopener noreferrer">Consultanos por WhatsApp</a> y te ayudamos.`
         : `Todavía no hay resultados en esta categoría. <a href="/catalogo">Volvé a Todos los libros</a>.`;
@@ -674,7 +678,9 @@ export async function onRequest(ctx) {
     // contenido delgado/duplicado en resultados de búsqueda/categoría.
     const isIndex = !hasFilter;
     const metaDescription = isIndex
-        ? `${activeItems.length} libros para comprar online en Uruguay. 12% de descuento por transferencia y envío gratis desde $2.000. Envíos a todo el país.`
+        ? page > 1
+            ? `Página ${page} de ${totalPages} del catálogo de Amado Libros: títulos disponibles y por encargo, con envíos a todo Uruguay.`
+            : `${activeItems.length} libros disponibles y ${pausedItems.length} por encargo en Uruguay. Buscamos ediciones agotadas e importadas de Europa y otros mercados.`
         : 'Resultados en Amado Libros.';
     // Las búsquedas internas no se indexan, pero sí se siguen: `follow` deja
     // que el crawler descubra las fichas enlazadas desde los resultados.
@@ -698,9 +704,11 @@ export async function onRequest(ctx) {
         ? `<script type="application/ld+json">${JSON.stringify({
             '@context':   'https://schema.org',
             '@type':      'CollectionPage',
-            'name':       'Catálogo de libros importados y por encargo en Uruguay',
-            'url':        `${BASE}/catalogo`,
-            'description':'Catálogo de Amado Libros con libros importados, libros por encargo y títulos difíciles de conseguir en Uruguay.',
+            'name':       page > 1
+                ? `Catálogo de libros importados y por encargo — Página ${page}`
+                : 'Catálogo de libros importados y por encargo en Uruguay',
+            'url':        canonicalHref,
+            'description': metaDescription,
             'isPartOf':   { '@type': 'WebSite', 'name': 'Amado Libros', 'url': BASE },
             'publisher':  { '@type': 'BookStore', 'name': 'Amado Libros', 'url': BASE },
           })}</script>`
@@ -795,7 +803,7 @@ export async function onRequest(ctx) {
     : `<p class="empty">${emptyMessage}</p>`
   }
   <footer>
-    <a href="/">Volver al catálogo</a> · <a href="/politicas">Políticas</a> ·
+    <a href="/">Inicio</a> · <a href="/libros-agotados-importados-uruguay">Libros agotados e importados</a> · <a href="/politicas">Políticas</a> ·
     &copy; 2026 Amado Libros
   </footer>
 </div>

--- a/functions/libros-agotados-importados-uruguay.js
+++ b/functions/libros-agotados-importados-uruguay.js
@@ -1,0 +1,151 @@
+/**
+ * Landing comercial indexable para búsquedas de libros agotados, importados
+ * y difíciles de conseguir. No publica inventario ni promete disponibilidad:
+ * explica el servicio de búsqueda por encargo y deriva la consulta a WhatsApp.
+ */
+
+import { BASE } from './_shared/catalog.js';
+import {
+    BRAND,
+    faviconHeadHtml,
+    footerHtml,
+    FOOTER_STYLES,
+    waFloatHtml,
+    WA_FLOAT_STYLES,
+    waHref,
+} from './_shared/brand.js';
+
+const PATH = '/libros-agotados-importados-uruguay';
+const TITLE = 'Libros agotados e importados en Uruguay | Amado Libros';
+const DESCRIPTION = 'Buscamos libros agotados, importados y difíciles de conseguir en Europa y otros mercados. Consultá por título, autor, ISBN o foto desde Uruguay.';
+const REQUEST_MESSAGE = 'Hola Amado Libros, busco un libro por encargo. Les paso título, autor, ISBN o una foto de la tapa:';
+
+export async function onRequest() {
+    const canonical = `${BASE}${PATH}`;
+    const requestHref = waHref(REQUEST_MESSAGE);
+    const schema = {
+        '@context': 'https://schema.org',
+        '@type': 'Service',
+        'name': 'Búsqueda de libros agotados e importados por encargo',
+        'description': DESCRIPTION,
+        'url': canonical,
+        'areaServed': { '@type': 'Country', 'name': 'Uruguay' },
+        'provider': {
+            '@type': 'BookStore',
+            'name': BRAND.name,
+            'url': BASE,
+        },
+    };
+
+    const html = `<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${TITLE}</title>
+  <meta name="description" content="${DESCRIPTION}">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="${canonical}">
+  ${faviconHeadHtml()}
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="es_UY">
+  <meta property="og:site_name" content="${BRAND.name}">
+  <meta property="og:title" content="${TITLE}">
+  <meta property="og:description" content="${DESCRIPTION}">
+  <meta property="og:url" content="${canonical}">
+  <script type="application/ld+json">${JSON.stringify(schema)}</script>
+  <style>
+    *{box-sizing:border-box;margin:0;padding:0}
+    body{font-family:Inter,system-ui,-apple-system,"Segoe UI",sans-serif;background:#f8f5ef;color:#18120e;line-height:1.65}
+    a{color:inherit}
+    .site-header{background:#18120e;color:#fff}
+    .header-inner{max-width:1100px;margin:0 auto;padding:.75rem 1rem;display:flex;align-items:center;gap:.75rem}
+    .brand-link{display:flex;align-items:center;gap:.7rem;text-decoration:none;font-weight:800}
+    .brand-link img{width:58px;height:57px;object-fit:contain}
+    .crumbs{max-width:1100px;margin:0 auto;padding:1rem;color:#6b6157;font-size:.85rem}
+    .crumbs a{color:#a94e3d;text-decoration:none}
+    main{max-width:1100px;margin:0 auto;padding:1rem 1rem 3rem}
+    .hero{display:grid;gap:1.5rem;padding:clamp(1.5rem,5vw,3.5rem);background:#fff;border:1px solid #e2dbd0;border-radius:1.25rem;box-shadow:0 12px 36px rgba(24,18,14,.06)}
+    .eyebrow{color:#a94e3d;font-size:.75rem;font-weight:800;letter-spacing:.09em;text-transform:uppercase}
+    h1{max-width:18ch;margin-top:.55rem;font-family:Georgia,"Times New Roman",serif;font-size:clamp(2rem,7vw,3.6rem);line-height:1.05;letter-spacing:-.03em}
+    .lead{max-width:64ch;margin-top:1rem;color:#574d45;font-size:1.05rem}
+    .cta-row{display:flex;flex-wrap:wrap;gap:.75rem;margin-top:1.35rem}
+    .cta{display:inline-flex;min-height:48px;align-items:center;justify-content:center;padding:.75rem 1.1rem;border-radius:.7rem;text-decoration:none;font-weight:800}
+    .cta-primary{background:#25d366;color:#102516}
+    .cta-secondary{border:1px solid #d2c7bb;background:#f8f5ef}
+    .truth{padding:1rem;border-left:4px solid #e49982;background:#fff8f4;color:#6b4b3f;font-size:.9rem}
+    .section{padding:2.5rem 0 0}
+    h2{font-family:Georgia,"Times New Roman",serif;font-size:clamp(1.45rem,4vw,2rem);line-height:1.2}
+    .steps,.types{display:grid;gap:1rem;margin-top:1.25rem}
+    .card{padding:1.2rem;background:#fff;border:1px solid #e2dbd0;border-radius:.85rem}
+    .step-number{display:inline-grid;width:2rem;height:2rem;place-items:center;margin-bottom:.65rem;border-radius:50%;background:#18120e;color:#fff;font-weight:800}
+    .card h3{font-size:1rem;margin-bottom:.35rem}
+    .card p{color:#6b6157;font-size:.92rem}
+    .closing{margin-top:2.5rem;padding:1.5rem;background:#18120e;color:#fff;border-radius:1rem}
+    .closing p{margin:.5rem 0 1rem;color:rgba(255,255,255,.72)}
+    @media(min-width:720px){.hero{grid-template-columns:1.45fr .75fr;align-items:center}.steps{grid-template-columns:repeat(3,1fr)}.types{grid-template-columns:repeat(2,1fr)}}
+    ${FOOTER_STYLES}
+    ${WA_FLOAT_STYLES}
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-inner">
+      <a class="brand-link" href="/" aria-label="Amado Libros — inicio">
+        <img src="${BRAND.logo}" alt="${BRAND.logoAlt}" width="58" height="57">
+        <span>Amado Libros</span>
+      </a>
+    </div>
+  </header>
+  <nav class="crumbs" aria-label="Migas de pan"><a href="/">Inicio</a> › Libros agotados e importados</nav>
+  <main>
+    <section class="hero">
+      <div>
+        <p class="eyebrow">Búsqueda por encargo desde Uruguay</p>
+        <h1>Conseguimos libros agotados, importados y difíciles de encontrar</h1>
+        <p class="lead">Si no aparece en el catálogo local, lo buscamos por título, autor, ISBN o foto de la tapa. Consultamos opciones en Europa y otros mercados y te confirmamos edición, precio y plazo antes de avanzar.</p>
+        <div class="cta-row">
+          <a class="cta cta-primary" href="${requestHref}" target="_blank" rel="noopener noreferrer">Pedir búsqueda por WhatsApp</a>
+          <a class="cta cta-secondary" href="/catalogo">Buscar en el catálogo</a>
+        </div>
+      </div>
+      <p class="truth"><strong>Información clara:</strong> un libro agotado no está disponible para entrega inmediata. La posibilidad de conseguirlo, su edición, precio y demora dependen del proveedor y se confirman en cada consulta.</p>
+    </section>
+
+    <section class="section">
+      <h2>Cómo pedir un libro por encargo</h2>
+      <div class="steps">
+        <article class="card"><span class="step-number">1</span><h3>Mandanos los datos</h3><p>Título, autor, ISBN, editorial o una foto. Cuanta más precisión tengamos, mejor podemos buscar la edición correcta.</p></article>
+        <article class="card"><span class="step-number">2</span><h3>Buscamos y verificamos</h3><p>Revisamos disponibilidad en proveedores del exterior y comparamos edición, idioma, formato y estado.</p></article>
+        <article class="card"><span class="step-number">3</span><h3>Vos decidís</h3><p>Te informamos precio, seña y plazo estimado. La gestión empieza únicamente después de tu confirmación.</p></article>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Qué podemos buscar</h2>
+      <div class="types">
+        <article class="card"><h3>Ediciones agotadas o fuera de plaza</h3><p>Buscamos ejemplares que ya no aparecen en librerías uruguayas, siempre sujetos a disponibilidad real.</p></article>
+        <article class="card"><h3>Libros importados de Europa y otros mercados</h3><p>Consultamos ediciones de España, Argentina, Estados Unidos y otros orígenes según el título.</p></article>
+        <article class="card"><h3>Textos académicos y profesionales</h3><p>Material especializado, manuales, libros universitarios y ediciones concretas identificadas por ISBN.</p></article>
+        <article class="card"><h3>Idiomas, formatos y ediciones específicas</h3><p>Tapa dura o blanda, idioma original, editorial determinada o una edición que querés volver a encontrar.</p></article>
+      </div>
+    </section>
+
+    <section class="closing">
+      <h2>¿Cuál libro estás buscando?</h2>
+      <p>Mandanos los datos que tengas. Te respondemos con una búsqueda concreta, sin compromiso.</p>
+      <a class="cta cta-primary" href="${requestHref}" target="_blank" rel="noopener noreferrer">Consultar por WhatsApp</a>
+    </section>
+  </main>
+  ${footerHtml()}
+  ${waFloatHtml(REQUEST_MESSAGE)}
+</body>
+</html>`;
+
+    return new Response(html, {
+        headers: {
+            'Content-Type': 'text/html;charset=UTF-8',
+            'Cache-Control': 'public, max-age=3600',
+        },
+    });
+}

--- a/functions/sitemap-pages.xml.js
+++ b/functions/sitemap-pages.xml.js
@@ -4,6 +4,7 @@ import { urlsetXml, xmlResponse } from './_shared/sitemap.js';
 export const STATIC_SITEMAP_PAGES = Object.freeze([
   `${BASE}/`,
   `${BASE}/catalogo`,
+  `${BASE}/libros-agotados-importados-uruguay`,
   `${BASE}/libros-maria-montessori-uruguay`,
   `${BASE}/politicas`,
   `${BASE}/envios`,


### PR DESCRIPTION
## Qué cambia

- refuerza el title, la descripción y el contenido visible de la home para libros difíciles, agotados e importados;
- diferencia la metadata del catálogo y de cada página paginada;
- agrega la landing indexable `/libros-agotados-importados-uruguay`, con proceso claro y CTA a WhatsApp;
- incorpora la landing al sitemap y al enlazado interno global;
- evita prometer stock o plazos para títulos agotados.

## Validación

- 63 pruebas SEO, sitemap, catálogo y shell: OK;
- 338 pruebas de worker, API y librería: OK;
- build Astro con checkout OFF: OK;
- build Astro con checkout ON: OK;
- `git diff --check`: OK.

El PR se abre como draft para validar Preview y metadatos antes de mergear.