### PR TITLE
Catálogo por disponibilidad y envío gratis desde $1.500

### DIFF
--- a/astro-front/src/components/BookCard.astro
+++ b/astro-front/src/components/BookCard.astro
@@ -23,8 +23,8 @@ interface Props {
 const { book } = Astro.props;
 
 // Debe coincidir con FREE_SHIPPING_THRESHOLD en functions/api/_orders_logic.js
-// (control previo HOME-COMERCIAL-1: el checkout real usa $2.000, no $1.500).
-const FREE_SHIPPING_THRESHOLD = 2000;
+// La tarjeta y el checkout deben comunicar y aplicar el mismo umbral.
+const FREE_SHIPPING_THRESHOLD = 1500;
 
 function slugify(text: string): string {
   return (text || '')

--- a/astro-front/src/components/Hero.astro
+++ b/astro-front/src/components/Hero.astro
@@ -103,6 +103,9 @@ const requestHref = `https://wa.me/59899841325?text=${encodeURIComponent(request
         <div>
           <strong>¿No encontrás el libro?</strong>
           <span>Buscamos agotados, importados y ediciones difíciles.</span>
+          <a class="request-guide" href="/libros-agotados-importados-uruguay">
+            Cómo funciona nuestro servicio de encargos →
+          </a>
         </div>
         <a
           href={requestHref}
@@ -316,6 +319,28 @@ const requestHref = `https://wa.me/59899841325?text=${encodeURIComponent(request
   .request-box strong,
   .request-box span {
     display: block;
+  }
+
+  .request-box .request-guide {
+    display: inline-block;
+    min-height: 0;
+    margin-top: 0.45rem;
+    padding: 0;
+    border-radius: 0;
+    background: transparent;
+    color: #fff;
+    font-size: 0.76rem;
+    font-weight: 700;
+    line-height: 1.35;
+    text-align: left;
+    text-decoration: underline;
+    text-decoration-color: rgba(255, 255, 255, 0.45);
+    text-underline-offset: 0.18em;
+  }
+
+  .request-box .request-guide:hover {
+    background: transparent;
+    text-decoration-color: #fff;
   }
 
   .request-box strong {

--- a/astro-front/src/components/ShippingPayments.astro
+++ b/astro-front/src/components/ShippingPayments.astro
@@ -16,7 +16,7 @@
         <ul class="sp-list">
           <li>Entrega en 2 horas en Montevideo.*</li>
           <li>Envíos a todo Uruguay.</li>
-          <li>Envío gratis desde $2.000.</li>
+          <li>Envío gratis desde $1.500.</li>
         </ul>
         <p class="sp-disclaimer">*El plazo depende de la zona y del horario del pedido. Coordinamos la entrega con vos.</p>
       </div>
@@ -33,7 +33,7 @@
         <ul class="sp-list">
           <li><strong class="sp-highlight">12% de descuento</strong> pagando por transferencia bancaria.</li>
           <li>12 cuotas sin recargo con Mercado Pago.</li>
-          <li>Envío gratis desde $2.000.</li>
+          <li>Envío gratis desde $1.500.</li>
         </ul>
       </div>
 

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -110,7 +110,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
               <span class="delivery-opt-content">
                 <strong class="delivery-opt-name">Envío a domicilio</strong>
                 <span class="delivery-opt-meta">Coordinamos contigo y el cadete entrega en una franja horaria de tu conveniencia.</span>
-                <span class="delivery-opt-badge">Envío gratis en compras desde $2.000</span>
+                <span class="delivery-opt-badge">Envío gratis en compras desde $1.500</span>
               </span>
             </label>
           </div>
@@ -1216,7 +1216,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     // ── Constantes ──────────────────────────────────────────────────────
     var RETIRO_DISCOUNT             = 150;
     var SHIPPING_COST               = 250;
-    var FREE_SHIPPING_THRESHOLD_UYU = 2000;
+    var FREE_SHIPPING_THRESHOLD_UYU = 1500;
     var CHECKOUT_DRAFT_KEY           = 'amado-checkout-draft-v2';
     var WHATSAPP_NUMBER              = '59899841325';
 

--- a/astro-front/src/pages/envios.astro
+++ b/astro-front/src/pages/envios.astro
@@ -10,8 +10,8 @@ import TrustPageLayout from '../layouts/TrustPageLayout.astro';
   <h2>Cobertura y costo</h2>
   <ul>
     <li>Realizamos envíos a los 19 departamentos de Uruguay.</li>
-    <li>El envío cuesta <strong>$250 UYU</strong> en compras inferiores a $2.000 UYU.</li>
-    <li>El envío es <strong>gratis desde $2.000 UYU</strong>.</li>
+    <li>El envío cuesta <strong>$250 UYU</strong> en compras inferiores a $1.500 UYU.</li>
+    <li>El envío es <strong>gratis desde $1.500 UYU</strong>.</li>
     <li>El costo definitivo se muestra en el carrito antes de continuar a Mercado Pago.</li>
   </ul>
 

--- a/functions/__tests__/catalog-display.test.js
+++ b/functions/__tests__/catalog-display.test.js
@@ -272,7 +272,7 @@ test('el catálogo marca con iconos el 12% y el envío gratis sólo desde el umb
   assert.doesNotMatch(paidHtml, /🚚<\/span> Envío gratis/);
 
   const originalPrice = CATALOG.items[0].price;
-  CATALOG.items[0].price = 2100;
+  CATALOG.items[0].price = 1500;
   try {
     const freeResponse = await catalogRequest(
       context('https://preview.example/catalogo?q=Alpha')
@@ -311,8 +311,8 @@ test('el catálogo indexable comunica el umbral real de envío gratis', async ()
   const html = await response.text();
   const description = html.match(/<meta name="description" content="([^"]+)">/)?.[1] || '';
 
-  assert.match(description, /envío gratis desde \$2\.000/);
-  assert.doesNotMatch(description, /envío gratis desde \$1\.500/);
+  assert.match(description, /envío gratis desde \$1\.500/);
+  assert.doesNotMatch(description, /envío gratis desde \$2\.000/);
 });
 
 test('la ficha pausada queda noindex, sin precio ni compra directa', async () => {

--- a/functions/__tests__/catalogo-paginacion.test.js
+++ b/functions/__tests__/catalogo-paginacion.test.js
@@ -167,6 +167,27 @@ test('13. ?page=1 explícito con q conserva q al redirigir', async () => {
   assert.equal(response.headers.get('Location'), '/catalogo?q=prueba');
 });
 
+test('13b. disponibilidad se conserva en la paginación y no crea páginas indexables', async () => {
+  const { html } = await render(`${BASE_URL}?disponibilidad=disponibles&page=2`);
+  assert.match(html, /<meta name="robots" content="noindex, follow">/);
+  assert.match(html, /<link rel="canonical" href="https:\/\/www\.amadolibros\.com\/catalogo">/);
+  assert.match(html, /href="\/catalogo\?disponibilidad=disponibles&amp;page=3"/);
+});
+
+test('13c. un valor de disponibilidad inválido redirige a la URL limpia', async () => {
+  const { response } = await render(`${BASE_URL}?disponibilidad=agotados`);
+  assert.equal(response.status, 301);
+  assert.equal(response.headers.get('Location'), '/catalogo');
+});
+
+test('13d. los tres filtros de disponibilidad son enlaces accesibles con conteos', async () => {
+  const { html } = await render(BASE_URL);
+  assert.match(html, /aria-label="Filtrar por disponibilidad"/);
+  assert.match(html, /aria-current="page">Todos <span>100<\/span>/);
+  assert.match(html, />Disponibles ahora <span>100<\/span>/);
+  assert.match(html, />Por encargo <span>0<\/span>/);
+});
+
 // ── 4. Integridad de la secuencia ───────────────────────────────────────────
 
 test('14. no hay ids duplicados entre páginas consecutivas', async () => {

--- a/functions/__tests__/ficha-pricing-cta-order.test.js
+++ b/functions/__tests__/ficha-pricing-cta-order.test.js
@@ -69,8 +69,8 @@ test('3. Precio web/tarjeta usa la jerarquía visual principal y transferencia l
 });
 
 test('3b. La ficha muestra envío gratis sólo cuando el precio llega al umbral', () => {
-    const free = renderPage(book({ price: 2100 }), 'un-libro', false, '');
-    const paid = renderPage(book({ price: 1990 }), 'un-libro', false, '');
+    const free = renderPage(book({ price: 1500 }), 'un-libro', false, '');
+    const paid = renderPage(book({ price: 1490 }), 'un-libro', false, '');
     assert.match(extractBlock(free, 'price-box'), /🚚<\/span> Envío gratis/);
     assert.doesNotMatch(extractBlock(paid, 'price-box'), /Envío gratis/);
 });

--- a/functions/__tests__/home-commercial-fold.test.js
+++ b/functions/__tests__/home-commercial-fold.test.js
@@ -31,3 +31,8 @@ test('Hero: el CTA de encargos abre WhatsApp con los datos necesarios prellenado
   assert.match(heroAstro, /target="_blank"/);
   assert.match(heroAstro, /rel="noopener noreferrer"/);
 });
+
+test('Hero: enlaza la explicación indexable del servicio de encargos', () => {
+  assert.match(heroAstro, /href="\/libros-agotados-importados-uruguay"/);
+  assert.match(heroAstro, /Cómo funciona nuestro servicio de encargos/);
+});

--- a/functions/__tests__/merchant-trust-pages.test.js
+++ b/functions/__tests__/merchant-trust-pages.test.js
@@ -24,8 +24,8 @@ test('shipping policy matches checkout cost and free-shipping threshold', () => 
   const page = read('astro-front/src/pages/envios.astro');
   const logic = read('functions/api/_orders_logic.js');
   assert.match(page, /\$250 UYU/);
-  assert.match(page, /gratis desde \$2\.000 UYU/);
-  assert.match(logic, /FREE_SHIPPING_THRESHOLD = 2000/);
+  assert.match(page, /gratis desde \$1\.500 UYU/);
+  assert.match(logic, /FREE_SHIPPING_THRESHOLD = 1500/);
   assert.match(logic, /SHIPPING_COST\s+= 250/);
 });
 

--- a/functions/__tests__/pickup-cx-2.test.js
+++ b/functions/__tests__/pickup-cx-2.test.js
@@ -19,7 +19,7 @@ test('pickup-cx-2: ninguna forma de entrega viene preseleccionada', () => {
 
 test('pickup-cx-2: los beneficios se anuncian dentro de su opción', () => {
   assert.match(carrito, /value="pickup"[\s\S]*?Ahorrás \$150 retirando aquí/);
-  assert.match(carrito, /value="shipping"[\s\S]*?Envío gratis en compras desde \$2\.000/);
+  assert.match(carrito, /value="shipping"[\s\S]*?Envío gratis en compras desde \$1\.500/);
 });
 
 test('pickup-cx-2: sin selección o sin productos comprables no muestra descuentos', () => {

--- a/functions/api/__tests__/orders.test.js
+++ b/functions/api/__tests__/orders.test.js
@@ -16,6 +16,7 @@ const CATALOG = { items: [
   { id:'A', title:'Alpha', price:1000, available_quantity:5, status:'active', thumbnail:null },
   { id:'B', title:'Beta', price:1250, available_quantity:3, status:'active', thumbnail:null },
   { id:'G', title:'Gamma', price:800, available_quantity:5, status:'active', thumbnail:null },
+  { id:'T', title:'Umbral', price:500, available_quantity:5, status:'active', thumbnail:null },
   { id:'P', title:'Pausado', price:300, available_quantity:10, status:'paused', thumbnail:null },
   { id:'X', title:'Precio roto', price:'NaN', available_quantity:2, status:'active', thumbnail:null },
 ] };
@@ -58,8 +59,10 @@ async function call(body, db=dbMock(), opts={}, h=handler()){ const response=awa
 
 test('reglas comerciales: retiro, envío pago y umbral inclusivo', async()=>{
   let r=await call(pickup()); assert.equal(r.data.order.payable_total_uyu,3100);
-  r=await call(shipping()); assert.equal(r.data.order.payable_total_uyu,2050);
+  r=await call(shipping()); assert.equal(r.data.order.payable_total_uyu,1800);
+  r=await call(shipping('paid',{items:[{product_id:'G',quantity:1}]})); assert.equal(r.data.order.shipping_cost_uyu,250); assert.equal(r.data.order.payable_total_uyu,1050);
   r=await call(shipping('t',{items:[{product_id:'A',quantity:2}]})); assert.equal(r.data.order.shipping_cost_uyu,0); assert.equal(r.data.order.payable_total_uyu,2000);
+  r=await call(shipping('threshold',{items:[{product_id:'A',quantity:1},{product_id:'T',quantity:1}]})); assert.equal(r.data.order.shipping_cost_uyu,0); assert.equal(r.data.order.payable_total_uyu,1500);
 });
 
 test('expira exactamente en 60 minutos y no expone UUID', async()=>{

--- a/functions/api/_orders_logic.js
+++ b/functions/api/_orders_logic.js
@@ -1,6 +1,6 @@
 export const RETIRO_DISCOUNT         = 150;
 export const SHIPPING_COST           = 250;
-export const FREE_SHIPPING_THRESHOLD = 2000;
+export const FREE_SHIPPING_THRESHOLD = 1500;
 export const TRANSFER_FACTOR         = 0.88;
 export const EXPIRY_MINUTES          = 60;
 export const MAX_BODY_BYTES          = 32 * 1024;

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -56,7 +56,7 @@ import { previewCoverUrl } from './_shared/preview-cover.js';
 
 const MAX_RESULTS = 48;
 const WA = 'https://wa.me/59899841325';
-const FREE_SHIPPING_THRESHOLD_UYU = 2000;
+const FREE_SHIPPING_THRESHOLD_UYU = 1500;
 
 function escapeHtml(str) {
     if (str == null) return '';
@@ -217,9 +217,13 @@ async function fetchActiveCategories(ctx) {
     }
 }
 
-function filtersBarHtml({ categories, categoria, subcategoria, rawQ, safeQ, selectedCategory }) {
+function filtersBarHtml({ categories, categoria, subcategoria, disponibilidad, rawQ, safeQ, selectedCategory }) {
+    const availabilityInput = disponibilidad
+        ? `<input type="hidden" name="disponibilidad" value="${escapeHtml(disponibilidad)}">`
+        : '';
     if (!categories || categories.length === 0) {
         return `<form class="filters-bar" action="/catalogo" method="get">
+    ${availabilityInput}
     <input type="search" name="q" value="${safeQ}" placeholder="Buscar por título, autor o ISBN" aria-label="Buscar libros">
     <button type="submit">Buscar</button>
   </form>`;
@@ -247,12 +251,19 @@ function filtersBarHtml({ categories, categoria, subcategoria, rawQ, safeQ, sele
         : '';
 
     const hasAnyFilter = Boolean(rawQ) || Boolean(categoria) || Boolean(subcategoria);
-    const clearHref = rawQ ? `/catalogo?q=${encodeURIComponent(rawQ)}` : '/catalogo';
+    const clearHref = catalogPath({
+        q: rawQ,
+        categoria: '',
+        subcategoria: '',
+        disponibilidad,
+        page: 1,
+    });
     const clearLink = hasAnyFilter && (categoria || subcategoria)
         ? `<a class="clear-filters" href="${escapeHtml(clearHref)}">Limpiar filtros ✕</a>`
         : '';
 
     return `<form class="filters-bar" action="/catalogo" method="get">
+    ${availabilityInput}
     <input type="search" name="q" value="${safeQ}" placeholder="Buscar por título, autor o ISBN" aria-label="Buscar libros">
     <label class="cat-select-wrap">
       <span class="sr-only">Categoría</span>
@@ -264,6 +275,26 @@ function filtersBarHtml({ categories, categoria, subcategoria, rawQ, safeQ, sele
     <button type="submit">Buscar</button>
   </form>
   ${clearLink}`;
+}
+
+function availabilityTabsHtml({ disponibilidad, rawQ, categoria, subcategoria, availableCount, orderCount }) {
+    const options = [
+        { value: '', label: 'Todos', count: availableCount + orderCount },
+        { value: 'disponibles', label: 'Disponibles ahora', count: availableCount },
+        { value: 'encargo', label: 'Por encargo', count: orderCount },
+    ];
+    const links = options.map(option => {
+        const current = option.value === disponibilidad;
+        const href = catalogPath({
+            q: rawQ,
+            categoria,
+            subcategoria,
+            disponibilidad: option.value,
+            page: 1,
+        });
+        return `<a class="availability-tab${current ? ' is-current' : ''}" href="${escapeHtml(href)}"${current ? ' aria-current="page"' : ''}>${option.label} <span>${option.count}</span></a>`;
+    }).join('');
+    return `<nav class="availability-tabs" aria-label="Filtrar por disponibilidad">${links}</nav>`;
 }
 
 const CAT_SELECT_STYLES = `
@@ -281,6 +312,17 @@ const CAT_SELECT_STYLES = `
                  background:#efe6db;border-radius:999px;font-size:.75rem;color:#4a3d30;font-weight:600}
     .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
              clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .availability-tabs{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.45rem;
+                       margin:0 0 1rem}
+    .availability-tab{display:flex;align-items:center;justify-content:center;gap:.35rem;
+                      min-height:44px;padding:.55rem .65rem;border:1px solid #d1c8be;
+                      border-radius:.65rem;background:#fff;color:#4a3d30;font-size:.78rem;
+                      font-weight:700;text-align:center;text-decoration:none}
+    .availability-tab span{color:#7c6b59;font-size:.7rem;font-weight:600}
+    .availability-tab:hover{background:#f5efe6}
+    .availability-tab.is-current{border-color:#18120e;background:#18120e;color:#fff}
+    .availability-tab.is-current span{color:#e8ded3}
+    .availability-tab:focus-visible{outline:2px solid #a94e3d;outline-offset:2px}
     @media (max-width: 480px){
       .filters-bar{flex-direction:column}
       .filters-bar input[type=search],.cat-select-wrap select{width:100%}
@@ -321,11 +363,12 @@ function parsePageParam(raw) {
 // Forma canónica de una URL del catálogo: siempre el mismo orden de
 // parámetros y sin `page` cuando es la primera. Se usa para el canonical y
 // para cada enlace de paginación, así una misma vista tiene una sola URL.
-function catalogPath({ q, categoria, subcategoria, page }) {
+function catalogPath({ q, categoria, subcategoria, disponibilidad, page }) {
     const params = new URLSearchParams();
     if (q) params.set('q', q);
     if (categoria) params.set('categoria', categoria);
     if (subcategoria) params.set('subcategoria', subcategoria);
+    if (disponibilidad) params.set('disponibilidad', disponibilidad);
     if (page && page > 1) params.set('page', String(page));
     const qs = params.toString();
     return qs ? `/catalogo?${qs}` : '/catalogo';
@@ -412,6 +455,19 @@ export async function onRequest(ctx) {
     ensurePerf(ctx);
     const url  = new URL(ctx.request.url);
     const rawQ = url.searchParams.get('q')?.trim() ?? '';
+    const rawDisponibilidad = url.searchParams.get('disponibilidad')?.trim() ?? '';
+    const disponibilidad = ['disponibles', 'encargo'].includes(rawDisponibilidad)
+        ? rawDisponibilidad
+        : '';
+
+    if (rawDisponibilidad && !disponibilidad) {
+        const clean = new URL(url);
+        clean.searchParams.delete('disponibilidad');
+        return new Response(null, {
+            status: 301,
+            headers: { Location: `${clean.pathname}${clean.search}` },
+        });
+    }
 
     // Una sola URL por vista: `?page=1` y cualquier `page` inválido redirigen
     // a la forma limpia. Va antes de tocar R2 — no hace falta el catálogo
@@ -490,7 +546,7 @@ export async function onRequest(ctx) {
         return true;
     });
     const safeQ = escapeHtml(rawQ);
-    const hasFilter = Boolean(rawQ) || Boolean(categoria);
+    const hasFilter = Boolean(rawQ) || Boolean(categoria) || Boolean(disponibilidad);
 
     // ── Pipeline único de filtrado + orden — usado tanto para "Todos" (sin
     // filtro) como para búsqueda/categoría. CF-CATEGORÍAS-2D punto 4.1: la
@@ -517,9 +573,21 @@ export async function onRequest(ctx) {
         const fuzzy = eligibleItems.filter(b => fuzzyMatches(b, queryTokens));
         if (fuzzy.length > 0) { strictMatches = fuzzy; usedFuzzy = true; }
     }
-    const filtered = strictMatches
+    const scopedMatches = strictMatches
         .filter(b => (categoria ? (categoryItems[b.id] || [])[0] === categoria : true))
-        .filter(b => (subcategoria ? (categoryItems[b.id] || [])[1] === subcategoria : true))
+        .filter(b => (subcategoria ? (categoryItems[b.id] || [])[1] === subcategoria : true));
+    const availableCount = scopedMatches.filter(b =>
+        b.status === 'active' && Number(b.available_quantity) > 0
+    ).length;
+    const orderCount = scopedMatches.filter(b => b.status === 'paused').length;
+    const availabilityMatches = scopedMatches.filter(b => {
+        if (disponibilidad === 'disponibles') {
+            return b.status === 'active' && Number(b.available_quantity) > 0;
+        }
+        if (disponibilidad === 'encargo') return b.status === 'paused';
+        return true;
+    });
+    const filtered = availabilityMatches
         .map(b => ({ book: b, rank: usedFuzzy ? RANK.FUZZY : relevanceRank(b, rankCtx) }))
         .sort((a, b) => {
             if (a.rank !== b.rank) return a.rank - b.rank;
@@ -645,12 +713,17 @@ export async function onRequest(ctx) {
     if (categoria) filterLabelParts.push(escapeHtml(selectedCategory.name));
     if (subcategoria) filterLabelParts.push(escapeHtml(selectedSubcategoryName));
     const filterLabel = filterLabelParts.join(' › ');
+    const availabilityLabel = disponibilidad === 'disponibles'
+        ? 'Disponibles ahora'
+        : disponibilidad === 'encargo'
+            ? 'Libros por encargo'
+            : '';
 
     const heading = rawQ && filterLabel
         ? `Resultados para &ldquo;${safeQ}&rdquo; en ${filterLabel}`
         : rawQ
             ? `Resultados para &ldquo;${safeQ}&rdquo;`
-            : filterLabel || (page > 1
+            : filterLabel || availabilityLabel || (page > 1
                 ? `Libros disponibles y por encargo — Página ${page}`
                 : 'Libros disponibles y por encargo');
     const pageTitle = rawQ && filterLabel
@@ -671,6 +744,7 @@ export async function onRequest(ctx) {
     if (rawQ) chips.push(`<span class="filter-chip">“${safeQ}”</span>`);
     if (categoria) chips.push(`<span class="filter-chip">${escapeHtml(selectedCategory.name)}</span>`);
     if (subcategoria) chips.push(`<span class="filter-chip">${escapeHtml(selectedSubcategoryName)}</span>`);
+    if (availabilityLabel) chips.push(`<span class="filter-chip">${availabilityLabel}</span>`);
     const chipsHtml = chips.length > 0 ? `<div class="active-filters">${chips.join('')}</div>` : '';
 
     // Sin filtro: página de índice, indexable, con metadatos/JSON-LD ricos
@@ -680,24 +754,24 @@ export async function onRequest(ctx) {
     const metaDescription = isIndex
         ? page > 1
             ? `Página ${page} de ${totalPages} del catálogo de Amado Libros: títulos disponibles y por encargo, con envíos a todo Uruguay.`
-            : `${activeItems.length} libros disponibles y ${pausedItems.length} por encargo en Uruguay; ediciones agotadas e importadas de Europa; envío gratis desde $2.000.`
+            : `${activeItems.length} libros disponibles y ${pausedItems.length} por encargo en Uruguay; ediciones agotadas e importadas de Europa; envío gratis desde $1.500.`
         : 'Resultados en Amado Libros.';
     // Las búsquedas internas no se indexan, pero sí se siguen: `follow` deja
     // que el crawler descubra las fichas enlazadas desde los resultados.
     const robotsMeta = isIndex
         ? 'index, follow'
-        : rawQ ? 'noindex, follow' : 'noindex';
+        : (rawQ || disponibilidad) ? 'noindex, follow' : 'noindex';
     // La secuencia limpia /catalogo?page=N tiene canonical propio. Las vistas
     // con búsqueda/categoría/subcategoría siguen noindex y canonicalizan al
     // catálogo limpio: no abrimos un segundo espacio SEO de filtros.
     const canonicalHref = isIndex
-        ? `${BASE}${catalogPath({ q: '', categoria: '', subcategoria: '', page })}`
+        ? `${BASE}${catalogPath({ q: '', categoria: '', subcategoria: '', disponibilidad: '', page })}`
         : `${BASE}/catalogo`;
     const paginationBlock = paginationHtml({
         page,
         totalPages,
         hrefFor: target => catalogPath({
-            q: rawQ, categoria, subcategoria, page: target,
+            q: rawQ, categoria, subcategoria, disponibilidad, page: target,
         }),
     });
     const jsonLd = isIndex
@@ -794,7 +868,8 @@ export async function onRequest(ctx) {
 <body>
 <div class="wrap">
   <nav><a href="/">← Amado Libros</a></nav>
-  ${filtersBarHtml({ categories, categoria, subcategoria, rawQ, safeQ, selectedCategory })}
+  ${filtersBarHtml({ categories, categoria, subcategoria, disponibilidad, rawQ, safeQ, selectedCategory })}
+  ${availabilityTabsHtml({ disponibilidad, rawQ, categoria, subcategoria, availableCount, orderCount })}
   ${chipsHtml}
   <h1>${heading}</h1>
   <p class="sub">${subText}</p>

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -27,7 +27,7 @@ import {
 } from '../_shared/brand.js';
 
 const WA = '59899841325';
-const FREE_SHIPPING_THRESHOLD_UYU = 2000;
+const FREE_SHIPPING_THRESHOLD_UYU = 1500;
 
 // ---------------------------------------------------------------------------
 // Utilidades
@@ -612,7 +612,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     </div>
     ${!inStock && detailRows ? `<dl class="details">${detailRows}</dl>` : ''}
     <p class="shipping">${inStock
-      ? '🚚 Entrega en 2 horas en Montevideo · Envíos a todo Uruguay · Envío gratis desde $2.000.'
+      ? '🚚 Entrega en 2 horas en Montevideo · Envíos a todo Uruguay · Envío gratis desde $1.500.'
       : '🌎 Si preferís no esperar, también podemos buscarlo por encargo en el exterior.'
     } <a href="/politicas#envios">Ver política de envíos</a>.</p>
   </div>


### PR DESCRIPTION
## Qué cambia
- agrega filtros visibles `Todos`, `Disponibles ahora` y `Por encargo`, con conteos y paginación conservada
- mantiene las vistas filtradas fuera del índice y canonicalizadas al catálogo
- enlaza la home con la guía indexable del servicio de encargos
- baja el envío gratis a **$1.500 UYU** en cálculo de pedidos, carrito, catálogo, fichas y políticas

## Beneficio esperado
- reduce la confusión entre compra inmediata y encargo
- acerca el diferencial de encargos a una página que explica y convierte por WhatsApp
- mejora la propuesta comercial con un umbral competitivo sin inconsistencias entre UI y backend

## Validación local
- 126/126 pruebas relevantes
- build Astro correcto
- pruebas de borde: $1.490 paga envío; $1.500 tiene envío gratis

## Riesgo y rollback
No modifica inventario, Mercado Libre ni datos R2. El umbral sí afecta el total del checkout; está cubierto por pruebas de backend y frontend.