### PR TITLE
Open Graph completo y políticas comerciales estructuradas

### DIFF
--- a/astro-front/src/layouts/BaseLayout.astro
+++ b/astro-front/src/layouts/BaseLayout.astro
@@ -4,17 +4,24 @@ interface Props {
   description?: string;
   indexable?: boolean;
   canonical?: string;
+  image?: string;
+  imageAlt?: string;
+  jsonLd?: Record<string, unknown>;
 }
 const {
   title = 'Amado Libros — Librería uruguaya',
   description = 'Libros importados y por encargo en Uruguay. Entrega hoy en Montevideo, envíos a todo el país.',
   indexable: indexableProp,
   canonical,
+  image = 'https://www.amadolibros.com/images/logo-amado.webp',
+  imageAlt = 'Amado Libros, librería uruguaya',
+  jsonLd,
 } = Astro.props;
 
 const indexable  = indexableProp !== undefined ? indexableProp : import.meta.env.PUBLIC_INDEXABLE === 'true';
 const gaId       = import.meta.env.PUBLIC_GA_ID;
 const enableGA4  = indexable && !!gaId;
+const socialUrl  = canonical || 'https://www.amadolibros.com/';
 ---
 <!doctype html>
 <html lang="es">
@@ -32,6 +39,20 @@ const enableGA4  = indexable && !!gaId;
   <title>{title}</title>
   <meta name="description" content={description}>
   {canonical && <link rel="canonical" href={canonical}>}
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="es_UY">
+  <meta property="og:site_name" content="Amado Libros">
+  <meta property="og:title" content={title}>
+  <meta property="og:description" content={description}>
+  <meta property="og:url" content={socialUrl}>
+  <meta property="og:image" content={image}>
+  <meta property="og:image:alt" content={imageAlt}>
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content={title}>
+  <meta name="twitter:description" content={description}>
+  <meta name="twitter:image" content={image}>
+  <meta name="twitter:image:alt" content={imageAlt}>
+  {jsonLd && <script type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>}
   {enableGA4 && (
     <>
       <script async src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}></script>

--- a/astro-front/src/layouts/TrustPageLayout.astro
+++ b/astro-front/src/layouts/TrustPageLayout.astro
@@ -10,11 +10,12 @@ interface Props {
   canonical: string;
   heading: string;
   updated?: string;
+  jsonLd?: Record<string, unknown>;
 }
 
-const { title, description, canonical, heading, updated = '29 de julio de 2026' } = Astro.props;
+const { title, description, canonical, heading, updated = '29 de julio de 2026', jsonLd } = Astro.props;
 ---
-<BaseLayout title={title} description={description} canonical={canonical}>
+<BaseLayout title={title} description={description} canonical={canonical} jsonLd={jsonLd}>
   <Header />
   <main class="trust-page">
     <article class="trust-card">

--- a/astro-front/src/pages/devoluciones.astro
+++ b/astro-front/src/pages/devoluciones.astro
@@ -1,11 +1,30 @@
 ---
 import TrustPageLayout from '../layouts/TrustPageLayout.astro';
+const returnPolicy = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  '@id': 'https://www.amadolibros.com/#organization',
+  name: 'Amado Libros',
+  url: 'https://www.amadolibros.com/',
+  hasMerchantReturnPolicy: {
+    '@type': 'MerchantReturnPolicy',
+    '@id': 'https://www.amadolibros.com/devoluciones#merchant-return-policy',
+    applicableCountry: 'UY',
+    returnPolicyCountry: 'UY',
+    returnPolicyCategory: 'https://schema.org/MerchantReturnFiniteReturnWindow',
+    merchantReturnDays: 5,
+    returnFees: 'https://schema.org/ReturnFeesCustomerResponsibility',
+    merchantReturnLink: 'https://www.amadolibros.com/devoluciones',
+  },
+};
 ---
 <TrustPageLayout
   title="Devoluciones y reembolsos — Amado Libros"
   description="Política de devoluciones, derecho de retracto y reembolsos para compras online en Amado Libros."
   canonical="https://www.amadolibros.com/devoluciones"
   heading="Devoluciones y reembolsos"
+  updated="11 de agosto de 2026"
+  jsonLd={returnPolicy}
 >
   <h2>Derecho de retracto en compras a distancia</h2>
   <p>En las compras realizadas por internet podés dejar sin efecto la compra sin indicar motivo. Debés comunicarlo dentro de los <strong>5 días hábiles</strong> contados desde la contratación o desde la recepción del producto, a tu elección, conforme al artículo 16 de la Ley 17.250.</p>

--- a/astro-front/src/pages/envios.astro
+++ b/astro-front/src/pages/envios.astro
@@ -1,11 +1,53 @@
 ---
 import TrustPageLayout from '../layouts/TrustPageLayout.astro';
+const shippingDestination = { '@type': 'DefinedRegion', addressCountry: 'UY' };
+const transitTime = {
+  '@type': 'ServicePeriod',
+  duration: { '@type': 'QuantitativeValue', minValue: 0, maxValue: 3, unitCode: 'DAY' },
+  businessDays: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+};
+const shippingPolicy = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  '@id': 'https://www.amadolibros.com/#organization',
+  name: 'Amado Libros',
+  url: 'https://www.amadolibros.com/',
+  hasShippingService: {
+    '@type': 'ShippingService',
+    '@id': 'https://www.amadolibros.com/envios#shipping-service',
+    name: 'Envíos de Amado Libros en Uruguay',
+    fulfillmentType: 'https://schema.org/FulfillmentTypeDelivery',
+    handlingTime: {
+      '@type': 'ServicePeriod',
+      duration: { '@type': 'QuantitativeValue', minValue: 0, maxValue: 2, unitCode: 'DAY' },
+      businessDays: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+    },
+    shippingConditions: [
+      {
+        '@type': 'ShippingConditions',
+        shippingDestination,
+        orderValue: { '@type': 'MonetaryAmount', minValue: 0, maxValue: 1499.99, currency: 'UYU' },
+        shippingRate: { '@type': 'MonetaryAmount', value: 250, currency: 'UYU' },
+        transitTime,
+      },
+      {
+        '@type': 'ShippingConditions',
+        shippingDestination,
+        orderValue: { '@type': 'MonetaryAmount', minValue: 1500, currency: 'UYU' },
+        shippingRate: { '@type': 'MonetaryAmount', value: 0, currency: 'UYU' },
+        transitTime,
+      },
+    ],
+  },
+};
 ---
 <TrustPageLayout
   title="Política de envíos y retiro — Amado Libros"
   description="Costos y condiciones de envío de Amado Libros para Montevideo y el interior de Uruguay, retiro y seguimiento."
   canonical="https://www.amadolibros.com/envios"
   heading="Envíos y retiro"
+  updated="11 de agosto de 2026"
+  jsonLd={shippingPolicy}
 >
   <h2>Cobertura y costo</h2>
   <ul>

--- a/functions/__tests__/catalogo-paginacion.test.js
+++ b/functions/__tests__/catalogo-paginacion.test.js
@@ -267,6 +267,15 @@ test('19c. cada página limpia tiene title, H1, descripción y schema propios', 
   assert.match(html, /"url":"https:\/\/www\.amadolibros\.com\/catalogo\?page=2"/);
 });
 
+test('19d. el catálogo expone Open Graph y Twitter completos', async () => {
+  const { html } = await render(BASE_URL);
+  assert.match(html, /<meta property="og:title" content="Comprar libros disponibles y por encargo \| Amado Libros">/);
+  assert.match(html, /<meta property="og:url" content="https:\/\/www\.amadolibros\.com\/catalogo">/);
+  assert.match(html, /<meta property="og:image" content="https:\/\/www\.amadolibros\.com\/images\/logo-amado\.webp">/);
+  assert.match(html, /<meta name="twitter:card" content="summary_large_image">/);
+  assert.match(html, /<meta name="twitter:description"/);
+});
+
 // ── 6. Marcado y accesibilidad ──────────────────────────────────────────────
 
 test('20. la navegación son enlaces HTML reales, sin JavaScript', async () => {

--- a/functions/__tests__/seo-commercial-intents.test.js
+++ b/functions/__tests__/seo-commercial-intents.test.js
@@ -23,6 +23,8 @@ test('landing de agotados e importados es indexable, canónica y accionable', as
   assert.match(html, /Pedir búsqueda por WhatsApp/);
   assert.match(html, /"@type":"Service"/);
   assert.match(html, /disponibilidad real/);
+  assert.match(html, /<meta property="og:image" content="https:\/\/www\.amadolibros\.com\/images\/logo-amado\.webp">/);
+  assert.match(html, /<meta name="twitter:card" content="summary_large_image">/);
 });
 
 test('home posiciona el diferencial y enlaza la landing desde el footer', () => {

--- a/functions/__tests__/social-merchant-policies.test.js
+++ b/functions/__tests__/social-merchant-policies.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { renderPage } from '../libro/[[path]].js';
+
+const root = rel => fileURLToPath(new URL('../../' + rel, import.meta.url));
+const read = rel => readFileSync(root(rel), 'utf8');
+
+function productSchemaFromHtml(html) {
+  for (const match of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    const parsed = JSON.parse(match[1]);
+    const types = Array.isArray(parsed['@type']) ? parsed['@type'] : [parsed['@type']];
+    if (types.includes('Product')) return parsed;
+  }
+  throw new Error('Product JSON-LD no encontrado');
+}
+
+function item(overrides = {}) {
+  return {
+    id: 'MLU123456789',
+    title: 'Libro de prueba',
+    author: 'Autora Real',
+    isbn: '9781234567897',
+    publisher: 'Editorial Real',
+    price: 1500,
+    available_quantity: 2,
+    status: 'active',
+    condition: 'new',
+    permalink: 'https://articulo.mercadolibre.com.uy/MLU-123456789',
+    pictures: ['https://http2.mlstatic.com/test.jpg'],
+    ...overrides,
+  };
+}
+
+test('BaseLayout completa Open Graph y Twitter para las páginas Astro', () => {
+  const layout = read('astro-front/src/layouts/BaseLayout.astro');
+  for (const property of ['og:type', 'og:locale', 'og:site_name', 'og:title', 'og:description', 'og:url', 'og:image', 'og:image:alt']) {
+    assert.match(layout, new RegExp(`property="${property}"`));
+  }
+  for (const name of ['twitter:card', 'twitter:title', 'twitter:description', 'twitter:image', 'twitter:image:alt']) {
+    assert.match(layout, new RegExp(`name="${name}"`));
+  }
+});
+
+test('la política global de envíos modela exactamente el umbral de $1.500', () => {
+  const page = read('astro-front/src/pages/envios.astro');
+  assert.match(page, /'@type': 'ShippingService'/);
+  assert.match(page, /maxValue: 1499\.99/);
+  assert.match(page, /minValue: 1500/);
+  assert.match(page, /value: 250, currency: 'UYU'/);
+  assert.match(page, /value: 0, currency: 'UYU'/);
+  assert.match(page, /addressCountry: 'UY'/);
+});
+
+test('la política global de devoluciones refleja la página visible', () => {
+  const page = read('astro-front/src/pages/devoluciones.astro');
+  assert.match(page, /'@type': 'MerchantReturnPolicy'/);
+  assert.match(page, /merchantReturnDays: 5/);
+  assert.match(page, /ReturnFeesCustomerResponsibility/);
+  assert.match(page, /devoluciones#merchant-return-policy/);
+});
+
+test('las ofertas activas referencian la política global y las pausadas no crean Offer', () => {
+  const active = productSchemaFromHtml(renderPage(item(), 'libro-de-prueba', false, ''));
+  assert.deepEqual(active.offers.hasMerchantReturnPolicy, {
+    '@id': 'https://www.amadolibros.com/devoluciones#merchant-return-policy',
+  });
+  assert.deepEqual(active.offers.seller, {
+    '@type': 'Organization',
+    name: 'Amado Libros',
+    url: 'https://www.amadolibros.com',
+  });
+
+  const paused = productSchemaFromHtml(renderPage(
+    item({ status: 'paused', available_quantity: 0 }),
+    'libro-de-prueba',
+    false,
+    '',
+  ));
+  assert.equal(paused.offers, undefined);
+});

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -798,6 +798,18 @@ export async function onRequest(ctx) {
   <meta name="description" content="${metaDescription}">
   <link rel="canonical" href="${escapeHtml(canonicalHref)}">
   <meta name="robots" content="${robotsMeta}">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="es_UY">
+  <meta property="og:site_name" content="Amado Libros">
+  <meta property="og:title" content="${pageTitle}">
+  <meta property="og:description" content="${metaDescription}">
+  <meta property="og:url" content="${escapeHtml(canonicalHref)}">
+  <meta property="og:image" content="${BASE}/images/logo-amado.webp">
+  <meta property="og:image:alt" content="Amado Libros, librería uruguaya">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="${pageTitle}">
+  <meta name="twitter:description" content="${metaDescription}">
+  <meta name="twitter:image" content="${BASE}/images/logo-amado.webp">
   ${faviconHeadHtml()}
   ${jsonLd}
   <style>

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -247,6 +247,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     const safeAuthor   = item.author ? escapeHtml(item.author) : null;
     const images       = normalizeImages(item, previewCoverSrc);
     const img          = images[0] || '';
+    const socialImage  = img || `${BASE}/images/logo-amado.webp`;
     const price         = Number(item.price) || 0;
     const priceUY       = price.toLocaleString('es-UY');
     const transferAmount = Math.round(price * 0.88);
@@ -302,7 +303,10 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
             'priceCurrency':'UYU',
             'price':        String(price),
             'availability': 'https://schema.org/InStock',
-            'seller': { '@type': 'Organization', 'name': 'Amado Libros' },
+            'seller': { '@type': 'Organization', 'name': 'Amado Libros', 'url': BASE },
+            'hasMerchantReturnPolicy': {
+                '@id': `${BASE}/devoluciones#merchant-return-policy`,
+            },
         };
     }
     if (item.author) {
@@ -404,14 +408,16 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
   <meta property="og:url"         content="${canonicalUrl}">
   <meta property="og:title"       content="${safeTitle} | Amado Libros">
   <meta property="og:description" content="${metaDesc}">
-  <meta property="og:image"       content="${escapeHtml(img)}">
+  <meta property="og:image"       content="${escapeHtml(socialImage)}">
+  <meta property="og:image:alt"   content="Portada de ${safeTitle}">
   <meta property="og:locale"      content="es_UY">
   <meta property="og:site_name"   content="Amado Libros">
 
   <meta name="twitter:card"        content="summary_large_image">
   <meta name="twitter:title"       content="${safeTitle} | Amado Libros">
   <meta name="twitter:description" content="${metaDesc}">
-  <meta name="twitter:image"       content="${escapeHtml(img)}">
+  <meta name="twitter:image"       content="${escapeHtml(socialImage)}">
+  <meta name="twitter:image:alt"   content="Portada de ${safeTitle}">
 
   <script type="application/ld+json">${JSON.stringify(schemaProduct)}</script>
   <script type="application/ld+json">${JSON.stringify(schemaBreadcrumb)}</script>

--- a/functions/libros-agotados-importados-uruguay.js
+++ b/functions/libros-agotados-importados-uruguay.js
@@ -53,6 +53,12 @@ export async function onRequest() {
   <meta property="og:title" content="${TITLE}">
   <meta property="og:description" content="${DESCRIPTION}">
   <meta property="og:url" content="${canonical}">
+  <meta property="og:image" content="${BASE}/images/logo-amado.webp">
+  <meta property="og:image:alt" content="Amado Libros, librería uruguaya">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="${TITLE}">
+  <meta name="twitter:description" content="${DESCRIPTION}">
+  <meta name="twitter:image" content="${BASE}/images/logo-amado.webp">
   <script type="application/ld+json">${JSON.stringify(schema)}</script>
   <style>
     *{box-sizing:border-box;margin:0;padding:0}


### PR DESCRIPTION
## Qué cambia
- completa Open Graph y Twitter Cards en páginas Astro, catálogo, landing y fichas
- agrega fallback social cuando una ficha no tiene portada
- publica la política estándar de envíos como `Organization > ShippingService`
- modela $250 debajo de $1.500 y envío gratis desde $1.500, con destino Uruguay
- publica `MerchantReturnPolicy` global y hace que las ofertas activas la referencien por `@id`
- mantiene las fichas pausadas sin `Offer`

## Criterio técnico
Sigue la documentación de Google Search Central actualizada el 7-Jul-2026: políticas estándar a nivel Organization; referencias globales por `@id` desde Offer. Evita duplicar o contradecir el umbral por carrito.

## Validación local
- 51/51 pruebas específicas
- build Astro correcto
- JSON-LD renderizado y parseado correctamente en `/envios` y `/devoluciones`

## Riesgo
Sólo metadata y JSON-LD; no altera checkout, precio, inventario ni sincronización.