### PR TITLE
Corregir los 8 títulos con caracteres dañados

### DIFF
--- a/worker-sync/__tests__/meli-catalog.test.js
+++ b/worker-sync/__tests__/meli-catalog.test.js
@@ -6,6 +6,7 @@ import {
   enrichCatalogDescriptions,
   extractBibliographicDetails,
   extractDimensions,
+  repairKnownTitle,
   sanitizeDescription,
   slimItem,
 } from '../meli-catalog.js';
@@ -399,6 +400,26 @@ test('conserva atributos bibliográficos reales de ML y omite No aplica', () => 
   assert.deepEqual(slimItem({ id: 'MLU-BIB', attributes }).bibliographic,
     extractBibliographicDetails(attributes));
   assert.equal(extractBibliographicDetails([]), null);
+});
+
+test('corrige sólo los ocho fragmentos mojibake verificados y se vuelve inerte al corregir ML', () => {
+  const cases = [
+    ['MLU636926011', 'Libro Ãâ¿dãâ³nde Se Esconde', 'Libro ¿Dónde Se Esconde'],
+    ['MLU640799107', 'Yo Juego, Ãâ¿y Tãâº?', 'Yo Juego, ¿Y Tú?'],
+    ['MLU643854765', 'Ãâ¡es Primavera!', '¡Es Primavera!'],
+    ['MLU657172162', 'Tu Ãâ¡ngel Custodio', 'Tu Ángel Custodio'],
+    ['MLU673139908', 'Libro Ãâ¡esto Es Todo', 'Libro ¡Esto Es Todo'],
+    ['MLU682128938', 'Ãâ¿y La Abuela?', '¿Y La Abuela?'],
+    ['MLU702548132', 'Ãâ¿que Haceis Aqui?', '¿Qué Haceis Aqui?'],
+    ['MLU710532848', 'Libro Â¡a Dibujar!', 'Libro ¡A Dibujar!'],
+  ];
+  for (const [id, broken, corrected] of cases) {
+    assert.equal(repairKnownTitle(id, broken), corrected);
+  }
+
+  assert.equal(repairKnownTitle('MLU636926011', 'Libro ¿Dónde Se Esconde'), 'Libro ¿Dónde Se Esconde');
+  assert.equal(repairKnownTitle('MLU-OTRO', 'PsicologÃ­a'), 'PsicologÃ­a');
+  assert.equal(repairKnownTitle('MLU-OTRO', null), null);
 });
 
 test('descripciones ML usan caché y un cupo incremental sin bloquear faltantes', async () => {

--- a/worker-sync/meli-catalog.js
+++ b/worker-sync/meli-catalog.js
@@ -37,6 +37,21 @@ const DESCRIPTION_MAX_CHARS = 5000;
 const ML_ATTRIBUTES    =       // campos que necesita slim_item + AUTHOR + enriched fields
   'id,title,price,status,available_quantity,thumbnail,pictures,permalink,start_time,attributes,condition,catalog_listing,catalog_product_id';
 
+// Excepciones verificadas el 2026-08-11 sobre el catálogo productivo. Se
+// reemplaza sólo la secuencia dañada y únicamente para el ID afectado. Si el
+// título se corrige en ML, el fragmento deja de coincidir y el override queda
+// automáticamente inerte.
+const KNOWN_TITLE_REPAIRS = new Map([
+  ['MLU636926011', ['Ãâ¿dãâ³nde', '¿Dónde']],
+  ['MLU640799107', ['Ãâ¿y Tãâº?', '¿Y Tú?']],
+  ['MLU643854765', ['Ãâ¡es', '¡Es']],
+  ['MLU657172162', ['Ãâ¡ngel', 'Ángel']],
+  ['MLU673139908', ['Ãâ¡esto', '¡Esto']],
+  ['MLU682128938', ['Ãâ¿y', '¿Y']],
+  ['MLU702548132', ['Ãâ¿que', '¿Qué']],
+  ['MLU710532848', ['Â¡a', '¡A']],
+]);
+
 export const ML_MAX_RETRIES = 6;
 export const ML_BASE_BACKOFF_MS = 1000;
 export const ML_MAX_BACKOFF_MS = 30000;
@@ -223,7 +238,7 @@ export function slimItem(raw, dataQuality = createDataQualitySummary()) {
   const attrs = raw.attributes || [];
   return {
     id:                 raw.id,
-    title:              raw.title        || null,
+    title:              repairKnownTitle(raw.id, raw.title),
     author:             extractAuthor(raw),
     price:              raw.price        ?? null,
     status:             raw.status       || null,
@@ -243,6 +258,16 @@ export function slimItem(raw, dataQuality = createDataQualitySummary()) {
     bibliographic:      extractBibliographicDetails(attrs),
     dimensions:         extractDimensions(attrs, dataQuality),
   };
+}
+
+export function repairKnownTitle(id, title) {
+  if (!title) return null;
+  const repair = KNOWN_TITLE_REPAIRS.get(String(id || ''));
+  if (!repair) return title;
+  const [broken, corrected] = repair;
+  return String(title).includes(broken)
+    ? String(title).replace(broken, corrected)
+    : title;
 }
 
 /**


### PR DESCRIPTION
## Resultado

Corrige los ocho fragmentos mojibake verificados en el catálogo productivo.

- alcance cerrado por ID de publicación
- reemplazo sólo del fragmento dañado
- si el título se corrige en Mercado Libre, el override queda inerte
- no modifica automáticamente ningún otro título

## Evidencia

Simulación sobre el catálogo R2 de producción:

- activos analizados: 7.141
- títulos detectados antes: 8
- títulos detectados después: 0
- cambios fuera de los ocho IDs: 0

## Validación

- 19/19 tests de sync y catálogo
- ejecución real de `auditCatalog` sobre R2
- `git diff --check`