### PR TITLE
Corregir duplicados, portadas y autocompletado del catálogo

### DIFF
--- a/functions/__tests__/catalog-dedupe-images.test.js
+++ b/functions/__tests__/catalog-dedupe-images.test.js
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { dedupeCatalogResults } from '../catalogo.js';
+import { normalizeImages } from '../libro/[[path]].js';
+import { dedupeCategoryResults } from '../libros/[[path]].js';
+
+test('catálogo muestra una sola oferta por mismo ISBN, estado y condición', () => {
+  const result = dedupeCatalogResults([
+    { id: 'MLU1', title: 'Libro', author: 'Autora', isbn: '978-84-123456-7-8', status: 'active', condition: 'new' },
+    { id: 'MLU2', title: 'Libro - edición ampliada', author: 'Autora', isbn: '9788412345678', status: 'active', condition: 'new' },
+  ]);
+  assert.deepEqual(result.map(item => item.id), ['MLU1']);
+});
+
+test('catálogo conserva ediciones, condiciones y estados realmente distintos', () => {
+  const result = dedupeCatalogResults([
+    { id: 'MLU1', title: 'Libro', author: 'Autora', isbn: '9788412345678', status: 'active', condition: 'new' },
+    { id: 'MLU2', title: 'Libro', author: 'Autora', isbn: '9788412345679', status: 'active', condition: 'new' },
+    { id: 'MLU3', title: 'Libro', author: 'Autora', isbn: '9788412345678', status: 'active', condition: 'used' },
+    { id: 'MLU4', title: 'Libro', author: 'Autora', isbn: '9788412345678', status: 'paused', condition: 'new' },
+  ]);
+  assert.deepEqual(result.map(item => item.id), ['MLU1', 'MLU2', 'MLU3', 'MLU4']);
+});
+
+test('sin ISBN solo elimina título+autor exactamente repetidos', () => {
+  const result = dedupeCatalogResults([
+    { id: 'MLU1', title: 'Árbol rojo', author: 'Ana Pérez', status: 'active' },
+    { id: 'MLU2', title: 'Arbol rojo', author: 'Ana Perez', status: 'active' },
+    { id: 'MLU3', title: 'Árbol rojo - segunda edición', author: 'Ana Pérez', status: 'active' },
+  ]);
+  assert.deepEqual(result.map(item => item.id), ['MLU1', 'MLU3']);
+});
+
+test('ficha descarta las placas verificadas y no repite thumbnail como foto', () => {
+  const images = normalizeImages({
+    pictures: [
+      'http://http2.mlstatic.com/PORTADA-O.jpg',
+      'https://http2.mlstatic.com/D_768794-MLU78243849622_082024-O.jpg',
+      'https://http2.mlstatic.com/D_823347-MLU78243898758_082024-O.jpg',
+    ],
+    thumbnail: 'https://http2.mlstatic.com/PORTADA-I.jpg',
+  });
+  assert.deepEqual(images, ['https://http2.mlstatic.com/PORTADA-O.jpg']);
+});
+
+test('la copia R2 validada reemplaza la portada de origen', () => {
+  assert.deepEqual(
+    normalizeImages({ pictures: ['https://http2.mlstatic.com/PORTADA-O.jpg'] }, '/preview-cover/MLU1/0/hash.jpg'),
+    ['/preview-cover/MLU1/0/hash.jpg'],
+  );
+});
+
+test('la portada primaria convierte miniatura -I en imagen grande -O', () => {
+  assert.deepEqual(
+    normalizeImages({ thumbnail: 'http://http2.mlstatic.com/D_PORTADA-I.jpg' }),
+    ['https://http2.mlstatic.com/D_PORTADA-O.jpg'],
+  );
+});
+
+test('las landings de categoría tampoco repiten la misma edición', () => {
+  const result = dedupeCategoryResults([
+    { id: 'MLU1', title: 'Están aquí', author: 'J. J. Benítez', isbn: '9788400000001', condition: 'new' },
+    { id: 'MLU2', title: 'Están aquí - J. J. Benítez', author: 'J. J. Benítez', isbn: '9788400000001', condition: 'new' },
+  ]);
+  assert.deepEqual(result.map(item => item.id), ['MLU1']);
+});

--- a/functions/__tests__/search-suggestions.test.js
+++ b/functions/__tests__/search-suggestions.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSuggestions } from '../api/search-suggestions.js';
+
+const items = [
+  { title: 'El Kama Sutra Gay del Siglo XXI', author: 'Gabriel J. Martín', isbn: '9788417001439' },
+  { title: 'Otro libro', author: 'Gabriel García Márquez', isbn: '9780000000002' },
+];
+
+test('autocompleta por título, autor e ISBN desde dos caracteres', () => {
+  assert.equal(buildSuggestions(items, 'kama')[0].value, 'El Kama Sutra Gay del Siglo XXI');
+  assert.ok(buildSuggestions(items, 'gabriel').some(item => item.label.startsWith('Autor:')));
+  assert.ok(buildSuggestions(items, '9788417').some(item => item.label.startsWith('ISBN:')));
+  assert.deepEqual(buildSuggestions(items, 'g'), []);
+});
+
+test('autocompletado elimina sugerencias repetidas', () => {
+  const repeated = buildSuggestions([...items, items[0]], 'kama');
+  assert.equal(repeated.filter(item => item.value === items[0].title).length, 1);
+});

--- a/functions/api/search-suggestions.js
+++ b/functions/api/search-suggestions.js
@@ -1,0 +1,50 @@
+import { fetchActiveIndex, fetchPausedIndex } from '../_shared/catalog.js';
+
+function normalize(value = '') {
+  return String(value).normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().trim();
+}
+
+export function buildSuggestions(items, rawQuery, limit = 10) {
+  const query = normalize(rawQuery);
+  if (query.length < 2) return [];
+  const candidates = [];
+  const seen = new Set();
+  for (const item of items) {
+    const fields = [
+      { value: item.title, type: 'Título', score: 0 },
+      { value: item.author, type: 'Autor', score: 2 },
+      { value: item.isbn, type: 'ISBN', score: 4 },
+    ];
+    for (const field of fields) {
+      const value = String(field.value || '').trim();
+      const normalized = normalize(value);
+      if (!value || !normalized.includes(query)) continue;
+      const key = `${field.type}:${normalized}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      candidates.push({
+        value,
+        label: `${field.type}: ${value}`,
+        score: field.score + (normalized.startsWith(query) ? 0 : 1),
+      });
+    }
+  }
+  return candidates.sort((a, b) => a.score - b.score || a.value.localeCompare(b.value, 'es'))
+    .slice(0, limit).map(({ value, label }) => ({ value, label }));
+}
+
+export async function onRequest(ctx) {
+  const url = new URL(ctx.request.url);
+  const query = (url.searchParams.get('q') || '').slice(0, 100);
+  if (normalize(query).length < 2) {
+    return Response.json({ suggestions: [] }, { headers: { 'cache-control': 'no-store' } });
+  }
+  const [active, paused] = await Promise.all([fetchActiveIndex(ctx), fetchPausedIndex(ctx)]);
+  const items = [
+    ...(Array.isArray(active?.items) ? active.items : []),
+    ...(Array.isArray(paused?.items) ? paused.items : []),
+  ];
+  return Response.json({ suggestions: buildSuggestions(items, query) }, {
+    headers: { 'cache-control': 'public,max-age=300', 'x-robots-tag': 'noindex' },
+  });
+}

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -84,6 +84,40 @@ function onlyDigits(value = '') {
     return String(value).replace(/\D/g, '');
 }
 
+function validIsbnKey(value = '') {
+    const digits = onlyDigits(value);
+    return digits.length === 10 || digits.length === 13 ? digits : '';
+}
+
+/**
+ * Evita repetir la misma obra/edición en la grilla pública sin confundir
+ * variantes reales. ISBN identifica edición y formato; el estado comercial
+ * mantiene separadas una oferta disponible y otra que solo puede encargarse.
+ * Cuando falta ISBN, solo agrupamos coincidencias exactas de título+autor.
+ * El array ya llega ordenado por relevancia/criterio comercial, por eso se
+ * conserva siempre el primer representante.
+ */
+export function dedupeCatalogResults(items) {
+    const seen = new Set();
+    return items.filter(item => {
+        const isbn = validIsbnKey(item.isbn);
+        const status = item.status === 'paused' ? 'paused' : 'active';
+        const condition = normalizeText(item.condition || 'unknown');
+        let key = '';
+        if (isbn) {
+            key = `isbn:${isbn}|${status}|${condition}`;
+        } else {
+            const title = normalizeText(item.title).replace(/[^a-z0-9]+/g, ' ').trim();
+            const author = normalizeText(item.author).replace(/[^a-z0-9]+/g, ' ').trim();
+            if (title && author) key = `title-author:${title}|${author}|${status}|${condition}`;
+        }
+        if (!key) return true;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+    });
+}
+
 function tokenMatches(queryToken, itemTokens) {
     return itemTokens.some(t => t === queryToken || t.startsWith(queryToken));
 }
@@ -178,7 +212,9 @@ function commercialTier(b) {
 }
 
 function httpsImg(url) {
-    return (url || '').replace('http://', 'https://');
+    return (url || '')
+        .replace('http://', 'https://')
+        .replace(/-I\.(jpg|jpeg|png|webp)(?=($|\?))/i, '-O.$1');
 }
 
 // CF-CATEGORÍAS-2 — artefacto compacto mlu->[categoryId,subcategoryId?],
@@ -224,7 +260,7 @@ function filtersBarHtml({ categories, categoria, subcategoria, disponibilidad, r
     if (!categories || categories.length === 0) {
         return `<form class="filters-bar" action="/catalogo" method="get">
     ${availabilityInput}
-    <input type="search" name="q" value="${safeQ}" placeholder="Buscar por título, autor o ISBN" aria-label="Buscar libros">
+    <input type="search" name="q" value="${safeQ}" placeholder="Buscar por título, autor o ISBN" aria-label="Buscar libros" autocomplete="off" data-search-autocomplete>
     <button type="submit">Buscar</button>
   </form>`;
     }
@@ -264,7 +300,7 @@ function filtersBarHtml({ categories, categoria, subcategoria, disponibilidad, r
 
     return `<form class="filters-bar" action="/catalogo" method="get">
     ${availabilityInput}
-    <input type="search" name="q" value="${safeQ}" placeholder="Buscar por título, autor o ISBN" aria-label="Buscar libros">
+    <input type="search" name="q" value="${safeQ}" placeholder="Buscar por título, autor o ISBN" aria-label="Buscar libros" autocomplete="off" data-search-autocomplete>
     <label class="cat-select-wrap">
       <span class="sr-only">Categoría</span>
       <select name="categoria" id="cat-select" onchange="this.form.submit()">
@@ -587,7 +623,7 @@ export async function onRequest(ctx) {
         if (disponibilidad === 'encargo') return b.status === 'paused';
         return true;
     });
-    const filtered = availabilityMatches
+    const ranked = availabilityMatches
         .map(b => ({ book: b, rank: usedFuzzy ? RANK.FUZZY : relevanceRank(b, rankCtx) }))
         .sort((a, b) => {
             if (a.rank !== b.rank) return a.rank - b.rank;
@@ -601,6 +637,7 @@ export async function onRequest(ctx) {
             return String(a.book.id).localeCompare(String(b.book.id));
         })
         .map(x => x.book);
+    const filtered = dedupeCatalogResults(ranked);
     recordPerf(ctx, 'search', searchStartedAt);
 
     const totalResults = filtered.length;
@@ -832,8 +869,8 @@ export async function onRequest(ctx) {
              transition:box-shadow .15s}
     .rc-card:hover{box-shadow:0 4px 16px rgba(24,18,14,.1)}
     .rc-card.is-order{border-color:#e8c9a0}
-    .rc-img{display:block;aspect-ratio:3/4;background:#ede9e1;overflow:hidden}
-    .rc-img img{width:100%;height:100%;object-fit:cover;display:block;
+    .rc-img{display:block;aspect-ratio:3/4;background:#ede9e1;overflow:hidden;padding:.35rem}
+    .rc-img img{width:100%;height:100%;object-fit:contain;display:block;
                 transition:transform .25s}
     .rc-card:hover .rc-img img{transform:scale(1.04)}
     .rc-no-img{width:100%;height:100%;display:flex;align-items:center;
@@ -894,6 +931,40 @@ export async function onRequest(ctx) {
     &copy; 2026 Amado Libros
   </footer>
 </div>
+<script>
+(() => {
+  const input = document.querySelector('[data-search-autocomplete]');
+  if (!input) return;
+  const list = document.createElement('datalist');
+  list.id = 'book-search-suggestions';
+  document.body.appendChild(list);
+  input.setAttribute('list', list.id);
+  let timer;
+  let controller;
+  input.addEventListener('input', () => {
+    clearTimeout(timer);
+    const q = input.value.trim();
+    if (q.length < 2) { list.replaceChildren(); return; }
+    timer = setTimeout(async () => {
+      if (controller) controller.abort();
+      controller = new AbortController();
+      try {
+        const response = await fetch('/api/search-suggestions?q=' + encodeURIComponent(q), { signal: controller.signal });
+        if (!response.ok) return;
+        const data = await response.json();
+        list.replaceChildren(...(data.suggestions || []).map(suggestion => {
+          const option = document.createElement('option');
+          option.value = suggestion.value;
+          option.label = suggestion.label;
+          return option;
+        }));
+      } catch (error) {
+        if (error.name !== 'AbortError') list.replaceChildren();
+      }
+    }, 180);
+  });
+})();
+</script>
 </body>
 </html>`;
 

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -49,22 +49,33 @@ function safeJson(value) {
 
 
 function httpsImg(url) {
-    return (url || '').replace('http://', 'https://');
+    return (url || '')
+        .replace('http://', 'https://')
+        .replace(/-I\.(jpg|jpeg|png|webp)(?=($|\?))/i, '-O.$1');
 }
 
-function normalizeImages(item, previewCoverSrc = '') {
-    const urls = [];
+export function normalizeImages(item, previewCoverSrc = '') {
+    const NON_BOOK_IMAGE_ASSETS = new Set([
+        'D_768794-MLU78243849622_082024-O.jpg',
+        'D_823347-MLU78243898758_082024-O.jpg',
+    ]);
+    const pictures = [];
 
     if (Array.isArray(item.pictures)) {
         for (const picture of item.pictures) {
-            if (typeof picture === 'string') urls.push(picture);
+            if (typeof picture !== 'string') continue;
+            const normalized = httpsImg(picture);
+            const asset = normalized.split('/').pop()?.split('?')[0] || '';
+            if (!NON_BOOK_IMAGE_ASSETS.has(asset)) pictures.push(normalized);
         }
     }
 
-    if (item.thumbnail) urls.push(item.thumbnail);
-
-    const normalized = [...new Set(urls.map(httpsImg).filter(Boolean))].slice(0, 6);
+    // `thumbnail` es una versión -I de la primera portada y no una foto
+    // adicional. Solo se usa como fallback si ML no entregó pictures[].
+    if (pictures.length === 0 && item.thumbnail) pictures.push(httpsImg(item.thumbnail));
+    const normalized = [...new Set(pictures.filter(Boolean))].slice(0, 6);
     if (previewCoverSrc && normalized.length > 0) normalized[0] = previewCoverSrc;
+    if (previewCoverSrc && normalized.length === 0) normalized.push(previewCoverSrc);
     return normalized;
 }
 

--- a/functions/libros/[[path]].js
+++ b/functions/libros/[[path]].js
@@ -82,7 +82,32 @@ function safeJson(value) {
 }
 
 function httpsImg(url) {
-    return String(url || '').replace('http://', 'https://');
+    return String(url || '')
+        .replace('http://', 'https://')
+        .replace(/-I\.(jpg|jpeg|png|webp)(?=($|\?))/i, '-O.$1');
+}
+
+function normalizeIdentity(value = '') {
+    return String(value).toLowerCase().normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '').replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+export function dedupeCategoryResults(items) {
+    const seen = new Set();
+    return items.filter(item => {
+        const digits = String(item.isbn || '').replace(/\D/g, '');
+        const isbn = digits.length === 10 || digits.length === 13 ? digits : '';
+        const condition = normalizeIdentity(item.condition || 'unknown');
+        const title = normalizeIdentity(item.title);
+        const author = normalizeIdentity(item.author);
+        const key = isbn
+            ? `isbn:${isbn}|${condition}`
+            : title && author ? `title-author:${title}|${author}|${condition}` : '';
+        if (!key) return true;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+    });
 }
 
 async function fetchCategoryData(ctx) {
@@ -251,6 +276,7 @@ function renderPage({ category, items, isPreview, hasUnexpectedParameters, navig
   <script type="application/ld+json">${safeJson(breadcrumbSchema)}</script>
   <style>
     *{box-sizing:border-box;margin:0;padding:0}body{font-family:Inter,system-ui,-apple-system,sans-serif;background:#f8f5ef;color:#18120e;line-height:1.55}a{color:inherit}.category-header{position:sticky;top:0;z-index:40;background:rgba(18,14,11,.97);color:#fff;border-bottom:1px solid rgba(255,255,255,.08)}.header-inner{max-width:1200px;height:72px;margin:auto;padding:0 1rem;display:grid;grid-template-columns:auto minmax(220px,1fr) auto;align-items:center;gap:1rem}.brand-link{display:flex;align-items:center;gap:.55rem;text-decoration:none}.brand-link img{width:44px;height:44px}.brand-link span{display:flex;flex-direction:column}.brand-link strong{font-size:.92rem}.brand-link small{color:rgba(255,255,255,.55);font-size:.7rem}.header-search{height:42px;display:flex;max-width:620px;width:100%;justify-self:center}.header-search input{min-width:0;flex:1;border:0;border-radius:999px 0 0 999px;padding:0 1rem;font:inherit}.header-search button{border:0;border-radius:0 999px 999px 0;padding:0 1rem;background:#e49982;color:#18120e;font-weight:800;cursor:pointer}.cart-link{min-height:42px;display:inline-flex;align-items:center;padding:0 .9rem;border:1px solid rgba(255,255,255,.2);border-radius:999px;text-decoration:none;font-size:.82rem}.breadcrumbs{max-width:1120px;margin:0 auto;padding:1rem;font-size:.82rem;color:#6b6157}.breadcrumbs a{color:#8f493b}.category-main{max-width:1120px;margin:0 auto;padding:0 1rem 3rem}.intro{padding:clamp(1.25rem,3vw,2rem);background:#fff;border:1px solid #e2dbd0;border-radius:1rem}.intro h1{font-family:Georgia,serif;font-size:clamp(1.75rem,5vw,2.6rem);line-height:1.12;margin-bottom:.8rem}.intro p{max-width:78ch;color:#5f554c}.benefits{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:1rem}.benefits span{padding:.35rem .65rem;border-radius:999px;background:#f5f0ea;color:#50463e;font-size:.75rem;font-weight:700}.results-head{display:flex;align-items:end;justify-content:space-between;gap:1rem;margin:2rem 0 1rem}.results-head h2{font-size:1.15rem}.results-head p{color:#6b6157;font-size:.84rem}.books-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.8rem}.book-card{display:flex;flex-direction:column;min-width:0;background:#fff;border:1px solid #e2dbd0;border-radius:.8rem;overflow:hidden}.book-image{display:grid;place-items:center;aspect-ratio:3/4;background:#eee7de;overflow:hidden}.book-image img{width:100%;height:100%;object-fit:cover;transition:transform .2s}.book-card:hover .book-image img{transform:scale(1.025)}.book-placeholder{font-size:2.5rem}.book-body{display:flex;flex:1;flex-direction:column;align-items:flex-start;gap:.4rem;padding:.8rem}.stock-badge{padding:.16rem .48rem;border-radius:999px;background:#eaf7ee;color:#267a42;font-size:.64rem;font-weight:800;text-transform:uppercase}.book-body h2{font-size:.86rem;line-height:1.3}.book-body h2 a{text-decoration:none}.book-author{width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#6b6157;font-size:.75rem}.book-prices{display:flex;flex-direction:column;gap:.15rem;margin-top:.2rem;font-size:.72rem}.book-prices strong{font-size:.9rem}.book-prices .transfer{color:#a94e3d;font-weight:700}.book-cta{margin-top:auto;padding:.38rem .7rem;border-radius:999px;background:#18120e;color:#fff;text-decoration:none;font-size:.73rem;font-weight:700}.category-nav{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.55rem;margin-top:2.5rem;padding:1rem;background:#fff;border:1px solid #e2dbd0;border-radius:1rem}.category-nav a{padding:.55rem .7rem;border-radius:.55rem;background:#f8f5ef;text-decoration:none;font-size:.78rem}.category-nav a[aria-current="page"]{background:#18120e;color:#fff}.empty{margin-top:1.5rem;padding:1.5rem;background:#fff;border:1px solid #e2dbd0;border-radius:.8rem}${PAGINATION_STYLES}${FOOTER_STYLES}${WA_FLOAT_STYLES}@media(min-width:640px){.books-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.category-nav{grid-template-columns:repeat(4,minmax(0,1fr))}}@media(min-width:900px){.books-grid{grid-template-columns:repeat(4,minmax(0,1fr))}}@media(max-width:620px){.header-inner{height:auto;min-height:68px;grid-template-columns:1fr auto;padding:.55rem .8rem}.brand-link small,.cart-link{display:none}.header-search{grid-column:1/-1;grid-row:2;margin-bottom:.2rem}.category-header{position:relative}}
+    .book-image{padding:.35rem}.book-image img{object-fit:contain}
   </style>
 </head>
 <body>
@@ -319,9 +345,15 @@ export async function onRequest(ctx) {
         );
     }
 
-    const items = activeItems
+    const categoryItems = activeItems
         .filter(item => (categoryData.items[item.id] || [])[0] === category.id)
-        .sort((a, b) => String(a.id).localeCompare(String(b.id)));
+        .sort((a, b) => {
+            const stock = Number(b.available_quantity || 0) - Number(a.available_quantity || 0);
+            if (stock) return stock;
+            const price = Number(a.price || Infinity) - Number(b.price || Infinity);
+            return price || String(a.id).localeCompare(String(b.id));
+        });
+    const items = dedupeCategoryResults(categoryItems);
     const totalPages = Math.max(1, Math.ceil(items.length / MAX_RESULTS));
     if (pageParam.page > totalPages) {
         return errorPage(404, 'Página no encontrada', 'La página de esta categoría que buscás no existe.');


### PR DESCRIPTION
## Qué corrige

- Deduplica resultados de búsqueda y categorías por ISBN/edición, preservando estados y condiciones distintos.
- Usa portadas grandes de Mercado Libre y `object-fit: contain` para evitar pixelado y recortes.
- Elimina las placas verificadas de Amado y la miniatura repetida en la ficha reportada.
- Agrega autocompletado por título, autor e ISBN desde dos caracteres.

## Causa raíz

Las búsquedas mostraban publicaciones distintas de la misma edición; las categorías no aplicaban deduplicación. Además, las tarjetas ampliaban miniaturas `-I`, usaban `cover`, y una ficha incorporaba placas comerciales y el thumbnail como fotos adicionales.

## Validación

- 57 pruebas relevantes verdes.
- Cobertura específica para deduplicación, variantes reales, categorías, portadas, galería y sugerencias.
- Sin cambios en Mercado Libre, stock, precios ni checkout.