### PR TITLE
Alinear contadores con resultados deduplicados

### DIFF
--- a/functions/__tests__/search-suggestions.test.js
+++ b/functions/__tests__/search-suggestions.test.js
@@ -18,3 +18,11 @@ test('autocompletado elimina sugerencias repetidas', () => {
   const repeated = buildSuggestions([...items, items[0]], 'kama');
   assert.equal(repeated.filter(item => item.value === items[0].title).length, 1);
 });
+
+test('una palabra exacta se prioriza sobre una coincidencia parcial', () => {
+  const suggestions = buildSuggestions([
+    { title: 'Cracking The Coding Interview - Gayle Laakmann' },
+    { title: 'Edipo Gay' },
+  ], 'gay');
+  assert.equal(suggestions[0].value, 'Edipo Gay');
+});

--- a/functions/api/search-suggestions.js
+++ b/functions/api/search-suggestions.js
@@ -22,10 +22,11 @@ export function buildSuggestions(items, rawQuery, limit = 10) {
       const key = `${field.type}:${normalized}`;
       if (seen.has(key)) continue;
       seen.add(key);
+      const exactWord = normalized.split(/[^a-z0-9]+/).includes(query);
       candidates.push({
         value,
         label: `${field.type}: ${value}`,
-        score: field.score + (normalized.startsWith(query) ? 0 : 1),
+        score: field.score + (normalized.startsWith(query) || exactWord ? 0 : 1),
       });
     }
   }

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -612,11 +612,15 @@ export async function onRequest(ctx) {
     const scopedMatches = strictMatches
         .filter(b => (categoria ? (categoryItems[b.id] || [])[0] === categoria : true))
         .filter(b => (subcategoria ? (categoryItems[b.id] || [])[1] === subcategoria : true));
-    const availableCount = scopedMatches.filter(b =>
+    // Los contadores de pestañas deben medir el mismo universo visible que
+    // la grilla. Si se calculan antes de deduplicar, “Todos 9” puede terminar
+    // mostrando “7 resultados”, contradicción directa para el comprador.
+    const dedupedScopedMatches = dedupeCatalogResults(scopedMatches);
+    const availableCount = dedupedScopedMatches.filter(b =>
         b.status === 'active' && Number(b.available_quantity) > 0
     ).length;
-    const orderCount = scopedMatches.filter(b => b.status === 'paused').length;
-    const availabilityMatches = scopedMatches.filter(b => {
+    const orderCount = dedupedScopedMatches.filter(b => b.status === 'paused').length;
+    const availabilityMatches = dedupedScopedMatches.filter(b => {
         if (disponibilidad === 'disponibles') {
             return b.status === 'active' && Number(b.available_quantity) > 0;
         }


### PR DESCRIPTION
## Corrección

- Calcula `Todos`, `Disponibles ahora` y `Por encargo` sobre el mismo universo deduplicado que la grilla.
- Evita contradicciones como `Todos 9` junto a `7 resultados`.
- Prioriza palabras exactas en el autocompletado (`Edipo Gay`) sobre coincidencias parciales (`Gayle`).

## Validación

103 pruebas verdes de catálogo, filtros, paginación, imágenes, sugerencias y fichas.