### PR TITLE
Activar autocompletado global y portadas sociales propias

### DIFF
--- a/astro-front/public/search-autocomplete.js
+++ b/astro-front/public/search-autocomplete.js
@@ -1,0 +1,43 @@
+(() => {
+  const inputs = [...document.querySelectorAll('form[action="/catalogo"] input[name="q"]')];
+  if (!inputs.length) return;
+
+  inputs.forEach((input, index) => {
+    const list = document.createElement('datalist');
+    list.id = `amado-search-suggestions-${index + 1}`;
+    document.body.appendChild(list);
+    input.setAttribute('list', list.id);
+    input.setAttribute('autocomplete', 'off');
+    input.setAttribute('aria-autocomplete', 'list');
+
+    let timer;
+    let controller;
+    input.addEventListener('input', () => {
+      clearTimeout(timer);
+      const query = input.value.trim();
+      if (query.length < 2) {
+        list.replaceChildren();
+        return;
+      }
+      timer = setTimeout(async () => {
+        controller?.abort();
+        controller = new AbortController();
+        try {
+          const response = await fetch(`/api/search-suggestions?q=${encodeURIComponent(query)}`, {
+            signal: controller.signal,
+          });
+          if (!response.ok) return;
+          const data = await response.json();
+          list.replaceChildren(...(data.suggestions || []).map(suggestion => {
+            const option = document.createElement('option');
+            option.value = suggestion.value;
+            option.label = suggestion.label;
+            return option;
+          }));
+        } catch (error) {
+          if (error.name !== 'AbortError') list.replaceChildren();
+        }
+      }, 180);
+    });
+  });
+})();

--- a/astro-front/src/layouts/BaseLayout.astro
+++ b/astro-front/src/layouts/BaseLayout.astro
@@ -72,6 +72,7 @@ const socialUrl  = canonical || 'https://www.amadolibros.com/';
   >
   <script src="/cart.js" defer></script>
   <script src="/orders-guard.js" defer></script>
+  <script src="/search-autocomplete.js" defer></script>
   <style is:global>
     /* ── Custom properties ─────────────────────────────────── */
     :root {

--- a/functions/__tests__/social-cover-global-autocomplete.test.js
+++ b/functions/__tests__/social-cover-global-autocomplete.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { onRequest as coverRequest, primaryCoverSource } from '../book-cover/[[path]].js';
+import { renderPage } from '../libro/[[path]].js';
+import { CATALOG_URL } from '../_shared/catalog.js';
+
+const item = {
+  id: 'MLU1430305290', title: 'Flauta Yamaha', status: 'active', available_quantity: 1,
+  price: 1190, pictures: ['https://http2.mlstatic.com/D_PORTADA-O.jpg'],
+  thumbnail: 'https://http2.mlstatic.com/D_PORTADA-I.jpg', permalink: 'https://example.com/item',
+};
+
+test('la ficha usa portada social del dominio y carga autocompletado global', () => {
+  const html = renderPage(item, 'flauta-yamaha', false, '');
+  const expected = 'https://www.amadolibros.com/book-cover/MLU1430305290/cover.jpg';
+  assert.match(html, new RegExp(`<meta property="og:image"\\s+content="${expected}">`));
+  assert.match(html, new RegExp(`<meta property="og:image:secure_url" content="${expected}">`));
+  assert.match(html, /<script src="\/search-autocomplete\.js" defer><\/script>/);
+});
+
+test('el proxy solo acepta portada mlstatic y pide variante grande', () => {
+  assert.equal(primaryCoverSource({ thumbnail: 'http://http2.mlstatic.com/D_ABC-I.jpg' }), 'https://http2.mlstatic.com/D_ABC-O.jpg');
+  assert.equal(primaryCoverSource({ thumbnail: 'https://evil.example/cover.jpg' }), '');
+});
+
+test('el proxy entrega bytes de imagen con caché pública y admite HEAD', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.caches = { default: { async match() { return null; }, async put() {} } };
+  globalThis.fetch = async input => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url === CATALOG_URL) return Response.json({ items: [item] });
+    if (url === item.pictures[0]) return new Response(new Uint8Array([1, 2, 3]), { headers: { 'content-type': 'image/jpeg' } });
+    throw new Error(`fetch inesperado: ${url}`);
+  };
+  try {
+    const ctx = method => ({ request: new Request('https://www.amadolibros.com/book-cover/MLU1430305290/cover.jpg', { method }), params: { path: ['MLU1430305290', 'cover.jpg'] }, env: { APP_ENV: 'production' }, waitUntil() {} });
+    const get = await coverRequest(ctx('GET'));
+    assert.equal(get.status, 200);
+    assert.equal(get.headers.get('content-type'), 'image/jpeg');
+    assert.match(get.headers.get('cache-control'), /s-maxage=604800/);
+    assert.deepEqual([...new Uint8Array(await get.arrayBuffer())], [1, 2, 3]);
+    const head = await coverRequest(ctx('HEAD'));
+    assert.equal(head.status, 200);
+    assert.equal((await head.arrayBuffer()).byteLength, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('el script compartido apunta a todos los buscadores del catálogo', () => {
+  const script = readFileSync(new URL('../../astro-front/public/search-autocomplete.js', import.meta.url), 'utf8');
+  assert.match(script, /form\[action="\/catalogo"\] input\[name="q"\]/);
+  assert.match(script, /api\/search-suggestions/);
+  assert.match(script, /aria-autocomplete/);
+});

--- a/functions/book-cover/[[path]].js
+++ b/functions/book-cover/[[path]].js
@@ -1,0 +1,75 @@
+import { fetchCatalog, fetchPausedItem } from '../_shared/catalog.js';
+
+const PRODUCT_ID_RE = /^MLU\d+$/;
+
+function largeMlImage(raw) {
+  if (typeof raw !== 'string' || !raw.trim()) return '';
+  try {
+    const url = new URL(raw.trim());
+    if (url.hostname !== 'http2.mlstatic.com' || !['http:', 'https:'].includes(url.protocol)) return '';
+    url.protocol = 'https:';
+    url.hash = '';
+    url.pathname = url.pathname.replace(/-I\.(jpg|jpeg|png|webp)$/i, '-O.$1');
+    return url.toString();
+  } catch {
+    return '';
+  }
+}
+
+export function primaryCoverSource(item) {
+  const picture = Array.isArray(item?.pictures) ? item.pictures.find(value => typeof value === 'string') : '';
+  return largeMlImage(picture || item?.thumbnail || '');
+}
+
+function responseHeaders(source, contentType) {
+  return {
+    'content-type': contentType?.startsWith('image/') ? contentType : 'image/jpeg',
+    'cache-control': 'public, max-age=86400, s-maxage=604800, stale-while-revalidate=2592000',
+    'x-content-type-options': 'nosniff',
+    'access-control-allow-origin': '*',
+    'x-cover-source': source ? 'mercadolibre' : 'fallback',
+  };
+}
+
+export async function onRequest(ctx) {
+  if (!['GET', 'HEAD'].includes(ctx.request.method)) {
+    return new Response('Method Not Allowed', { status: 405, headers: { allow: 'GET, HEAD' } });
+  }
+  const parts = Array.isArray(ctx.params.path) ? ctx.params.path : [ctx.params.path].filter(Boolean);
+  const id = String(parts[0] || '').toUpperCase();
+  if (!PRODUCT_ID_RE.test(id) || parts.length > 2) {
+    return new Response('Not Found', { status: 404, headers: { 'cache-control': 'public,max-age=300' } });
+  }
+
+  const cache = caches.default;
+  const cacheKey = new Request(new URL(ctx.request.url).origin + `/book-cover/${id}/cover.jpg`);
+  const cached = await cache.match(cacheKey);
+  if (cached) {
+    return ctx.request.method === 'HEAD'
+      ? new Response(null, { status: cached.status, headers: cached.headers })
+      : cached;
+  }
+
+  const catalog = await fetchCatalog(ctx);
+  let item = Array.isArray(catalog?.items) ? catalog.items.find(candidate => candidate.id === id) : null;
+  if (!item && ['preview', 'production'].includes(ctx.env?.APP_ENV)) item = await fetchPausedItem(ctx, id);
+  const source = primaryCoverSource(item);
+  let imageResponse = source
+    ? await fetch(source, { headers: { 'user-agent': 'Mozilla/5.0 (compatible; AmadoLibrosCover/1.0)' } }).catch(() => null)
+    : null;
+
+  if (!imageResponse?.ok || !String(imageResponse.headers.get('content-type') || '').startsWith('image/')) {
+    const fallbackUrl = new URL('/images/logo-amado.webp', ctx.request.url);
+    imageResponse = await fetch(fallbackUrl).catch(() => null);
+  }
+  if (!imageResponse?.ok) return new Response('Not Found', { status: 404 });
+
+  const response = new Response(imageResponse.body, {
+    status: 200,
+    headers: responseHeaders(source, imageResponse.headers.get('content-type')),
+  });
+  if (typeof ctx.waitUntil === 'function') ctx.waitUntil(cache.put(cacheKey, response.clone()));
+  return ctx.request.method === 'HEAD'
+    ? new Response(null, { status: 200, headers: response.headers })
+    : response;
+}

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -935,40 +935,7 @@ export async function onRequest(ctx) {
     &copy; 2026 Amado Libros
   </footer>
 </div>
-<script>
-(() => {
-  const input = document.querySelector('[data-search-autocomplete]');
-  if (!input) return;
-  const list = document.createElement('datalist');
-  list.id = 'book-search-suggestions';
-  document.body.appendChild(list);
-  input.setAttribute('list', list.id);
-  let timer;
-  let controller;
-  input.addEventListener('input', () => {
-    clearTimeout(timer);
-    const q = input.value.trim();
-    if (q.length < 2) { list.replaceChildren(); return; }
-    timer = setTimeout(async () => {
-      if (controller) controller.abort();
-      controller = new AbortController();
-      try {
-        const response = await fetch('/api/search-suggestions?q=' + encodeURIComponent(q), { signal: controller.signal });
-        if (!response.ok) return;
-        const data = await response.json();
-        list.replaceChildren(...(data.suggestions || []).map(suggestion => {
-          const option = document.createElement('option');
-          option.value = suggestion.value;
-          option.label = suggestion.label;
-          return option;
-        }));
-      } catch (error) {
-        if (error.name !== 'AbortError') list.replaceChildren();
-      }
-    }, 180);
-  });
-})();
-</script>
+<script src="/search-autocomplete.js" defer></script>
 </body>
 </html>`;
 

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -262,7 +262,10 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     const safeAuthor   = item.author ? escapeHtml(item.author) : null;
     const images       = normalizeImages(item, previewCoverSrc);
     const img          = images[0] || '';
-    const socialImage  = img || `${BASE}/images/logo-amado.webp`;
+    // Las redes sociales suelen bloquear imágenes servidas directamente por
+    // mlstatic. La portada social sale desde nuestro dominio y el proxy valida
+    // el MLU antes de obtenerla, para que WhatsApp/Facebook reciban HTTP 200.
+    const socialImage  = `${BASE}/book-cover/${encodeURIComponent(item.id)}/cover.jpg`;
     const price         = Number(item.price) || 0;
     const priceUY       = price.toLocaleString('es-UY');
     const transferAmount = Math.round(price * 0.88);
@@ -468,6 +471,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
   <meta property="og:title"       content="${safeTitle} | Amado Libros">
   <meta property="og:description" content="${metaDesc}">
   <meta property="og:image"       content="${escapeHtml(socialImage)}">
+  <meta property="og:image:secure_url" content="${escapeHtml(socialImage)}">
   <meta property="og:image:alt"   content="Portada de ${safeTitle}">
   <meta property="og:locale"      content="es_UY">
   <meta property="og:site_name"   content="Amado Libros">
@@ -481,6 +485,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
   <script type="application/ld+json">${safeJson(schemaProduct)}</script>
   <script type="application/ld+json">${safeJson(schemaBreadcrumb)}</script>
   <script src="/cart.js" defer></script>
+  <script src="/search-autocomplete.js" defer></script>
 
   <style>
     *{box-sizing:border-box;margin:0;padding:0}

--- a/functions/libros/[[path]].js
+++ b/functions/libros/[[path]].js
@@ -294,6 +294,7 @@ ${headerHtml()}
 </main>
 ${footerHtml()}
 ${waFloatHtml(`Hola, busco un libro de ${category.name}.`)}
+<script src="/search-autocomplete.js" defer></script>
 </body>
 </html>`;
 }


### PR DESCRIPTION
## Qué cambia

- Activa las sugerencias de búsqueda en todos los buscadores del sitio, incluidas las fichas de producto y la portada.
- Reutiliza un único script compartido para catálogo, categorías y páginas Astro.
- Sirve la portada usada por WhatsApp/Facebook desde `amadolibros.com`, con caché, validación estricta de `mlstatic.com` y fallback de marca.
- Añade `og:image:secure_url` y pruebas de regresión.

## Causa raíz

El autocompletado anterior se había implementado sólo dentro de `/catalogo`. Además, las fichas exponían como `og:image` una URL directa de Mercado Libre que respondía 403 a rastreadores sociales.

## Impacto

El buscador sugiere títulos desde cualquier cabecera y los enlaces de fichas pueden generar una tarjeta social con imagen accesible para WhatsApp/Facebook.

## Validación

- Suite completa de funciones y APIs en verde.
- Pruebas específicas de autocompletado global y proxy de portada en verde.
- Build Astro con checkout OFF y ON en verde.
- `git diff --check` en verde.