### PR TITLE
Agregar descubrimiento manual de libros difíciles

### DIFF
--- a/astro-front/src/components/BookDiscovery.astro
+++ b/astro-front/src/components/BookDiscovery.astro
@@ -1,0 +1,173 @@
+---
+const questions = [
+  {
+    type: 'agotado',
+    title: '¿Buscás un libro agotado o descatalogado?',
+    text: 'Pasános el título, autor o ISBN y revisamos opciones reales.',
+  },
+  {
+    type: 'novedades-tecnicas',
+    title: '¿Querés novedades de oftalmología, cirugía u otra especialidad?',
+    text: 'Decinos el tema y el nivel; hacemos la búsqueda manual.',
+  },
+  {
+    type: 'digital',
+    title: '¿Necesitás una edición digital?',
+    text: 'Buscamos por título, idioma y dispositivo que usás.',
+  },
+  {
+    type: 'antiguo',
+    title: '¿Buscás un libro antiguo o de hace varios siglos?',
+    text: 'Aclaramos si querés un original, facsímil o reedición.',
+  },
+  {
+    type: 'tapa',
+    title: '¿Sólo recordás la tapa o una parte del título?',
+    text: 'Contanos lo que recordás y después nos mandás la foto.',
+  },
+  {
+    type: 'bibliografia',
+    title: '¿Necesitás bibliografía técnica para estudiar o trabajar?',
+    text: 'Indicá tema, nivel e idioma y te ayudamos a ubicarla.',
+  },
+];
+---
+
+<section class="discovery" aria-labelledby="discovery-title">
+  <div class="discovery-inner">
+    <div class="discovery-heading">
+      <p class="discovery-kicker">El buscador humano de libros difíciles</p>
+      <h2 id="discovery-title">¿Qué libro querés que encontremos?</h2>
+      <p>
+        Puede ser un ISBN, una foto, una edición digital o un libro de hace 400 años.
+        Contanos lo que sabés: una persona de Amado Libros hace la búsqueda.
+      </p>
+    </div>
+
+    <div class="question-grid">
+      {questions.map((question, index) => (
+        <a class="question-card" href={`/pedir-libro?tipo=${question.type}`}>
+          <span class="question-number" aria-hidden="true">{String(index + 1).padStart(2, '0')}</span>
+          <strong>{question.title}</strong>
+          <span>{question.text}</span>
+          <b>Empezar búsqueda →</b>
+        </a>
+      ))}
+    </div>
+
+    <p class="discovery-note">
+      Sin respuestas automáticas: verificamos edición, disponibilidad, precio y plazo antes de ofrecerte una opción.
+    </p>
+  </div>
+</section>
+
+<style>
+  .discovery {
+    padding: clamp(2.8rem, 7vw, 5rem) 1.25rem;
+    background: #fff;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .discovery-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+
+  .discovery-heading {
+    max-width: 760px;
+  }
+
+  .discovery-kicker {
+    color: var(--salmon-hover);
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+  }
+
+  .discovery h2 {
+    margin-top: 0.45rem;
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 6vw, 3.35rem);
+    letter-spacing: -0.035em;
+    line-height: 1.08;
+  }
+
+  .discovery-heading > p:last-child {
+    max-width: 64ch;
+    margin-top: 0.85rem;
+    color: var(--ink-2);
+    font-size: 0.98rem;
+  }
+
+  .question-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.8rem;
+    margin-top: 1.65rem;
+  }
+
+  .question-card {
+    position: relative;
+    display: flex;
+    min-height: 178px;
+    flex-direction: column;
+    padding: 1.2rem;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: 1rem;
+    background: var(--bg);
+    transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
+  }
+
+  .question-card:hover,
+  .question-card:focus-visible {
+    border-color: var(--salmon);
+    box-shadow: 0 10px 30px rgba(24, 18, 14, 0.08);
+    transform: translateY(-2px);
+    outline: none;
+  }
+
+  .question-number {
+    color: var(--salmon-hover);
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+  }
+
+  .question-card strong {
+    max-width: 30ch;
+    margin-top: 0.6rem;
+    color: var(--ink);
+    font-size: 0.97rem;
+    line-height: 1.35;
+  }
+
+  .question-card > span:not(.question-number) {
+    margin-top: 0.45rem;
+    color: var(--ink-2);
+    font-size: 0.8rem;
+    line-height: 1.45;
+  }
+
+  .question-card b {
+    margin-top: auto;
+    padding-top: 0.9rem;
+    color: var(--salmon-hover);
+    font-size: 0.78rem;
+  }
+
+  .discovery-note {
+    margin-top: 1rem;
+    color: var(--ink-2);
+    font-size: 0.76rem;
+  }
+
+  @media (min-width: 650px) {
+    .question-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  }
+
+  @media (min-width: 980px) {
+    .question-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  }
+</style>

--- a/astro-front/src/components/Footer.astro
+++ b/astro-front/src/components/Footer.astro
@@ -20,6 +20,7 @@ const YEAR = new Date().getFullYear();
     <div class="footer-info">
       <p class="footer-info-title">Cómo comprás</p>
       <ul class="footer-list">
+        <li><a href="/pedir-libro">¿No encontraste el libro?</a></li>
         <li><a href="/libros-agotados-importados-uruguay">Libros por encargo</a></li>
         <li><a href="/envios">Envíos y retiro</a></li>
         <li><a href="/devoluciones">Devoluciones y reembolsos</a></li>

--- a/astro-front/src/components/Hero.astro
+++ b/astro-front/src/components/Hero.astro
@@ -1,7 +1,4 @@
 ---
-const requestText =
-  'Hola Amado Libros, estoy buscando un libro. Les paso título, autor, ISBN o una foto de la tapa:';
-const requestHref = `https://wa.me/59899841325?text=${encodeURIComponent(requestText)}`;
 ---
 
 <section class="hero-shell">
@@ -108,12 +105,10 @@ const requestHref = `https://wa.me/59899841325?text=${encodeURIComponent(request
           </a>
         </div>
         <a
-          href={requestHref}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Pedir un libro por WhatsApp"
+          href="/pedir-libro?tipo=exacto"
+          aria-label="Contar qué libro buscás"
         >
-          Pedir un libro por WhatsApp
+          Contanos qué libro buscás
         </a>
       </div>
     </aside>

--- a/astro-front/src/pages/index.astro
+++ b/astro-front/src/pages/index.astro
@@ -4,6 +4,7 @@
 import BaseLayout          from '../layouts/BaseLayout.astro';
 import Header              from '../components/Header.astro';
 import Hero                from '../components/Hero.astro';
+import BookDiscovery       from '../components/BookDiscovery.astro';
 import CategoryAccess      from '../components/CategoryAccess.astro';
 import BestsellerSection   from '../components/BestsellerSection.astro';
 import Footer              from '../components/Footer.astro';
@@ -22,6 +23,7 @@ import TrustStrip          from '../components/TrustStrip.astro';
   <Header showSearch={false} showMobileDeliveryBanner={true} />
   <main>
     <Hero />
+    <BookDiscovery />
     <CategoryAccess />
     <BestsellerSection />
     <HowToBuy />

--- a/astro-front/src/pages/pedir-libro.astro
+++ b/astro-front/src/pages/pedir-libro.astro
@@ -1,0 +1,430 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import WAFloat from '../components/WAFloat.astro';
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  name: 'Búsqueda manual de libros por encargo',
+  serviceType: 'Búsqueda de libros agotados, importados y difíciles de conseguir',
+  areaServed: { '@type': 'Country', name: 'Uruguay' },
+  provider: {
+    '@type': 'BookStore',
+    name: 'Amado Libros',
+    url: 'https://www.amadolibros.com/',
+  },
+};
+---
+
+<BaseLayout
+  title="Pedí una búsqueda de libro | Amado Libros"
+  description="Contanos qué libro buscás. Revisamos manualmente títulos agotados, importados, digitales, técnicos y ediciones antiguas para clientes en Uruguay."
+  canonical="https://www.amadolibros.com/pedir-libro"
+  jsonLd={jsonLd}
+>
+  <Header />
+  <main class="request-page">
+    <div class="request-shell">
+      <nav class="breadcrumbs" aria-label="Migas de pan">
+        <a href="/">Inicio</a><span aria-hidden="true">›</span><span>Pedir una búsqueda</span>
+      </nav>
+
+      <section class="request-intro" aria-labelledby="request-title">
+        <p class="eyebrow">Búsqueda manual, persona a persona</p>
+        <h1 id="request-title">Contanos qué libro querés encontrar</h1>
+        <p>
+          No necesitás tener todos los datos. Con un título incompleto, autor, ISBN,
+          tema o foto de la tapa podemos empezar.
+        </p>
+        <ul aria-label="Cómo funciona">
+          <li><strong>1.</strong> Completás lo que sabés.</li>
+          <li><strong>2.</strong> Se abre WhatsApp con el pedido ordenado.</li>
+          <li><strong>3.</strong> Nuestro equipo hace la búsqueda y te responde.</li>
+        </ul>
+      </section>
+
+      <form id="manual-book-request" class="request-form">
+        <div class="field field-wide">
+          <label for="request-type">¿Qué tipo de búsqueda necesitás?</label>
+          <select id="request-type" name="request_type" required>
+            <option value="exacto">Un título, autor o ISBN concreto</option>
+            <option value="agotado">Un libro agotado o descatalogado</option>
+            <option value="novedades-tecnicas">Novedades de una especialidad</option>
+            <option value="digital">Una edición digital</option>
+            <option value="antiguo">Un libro antiguo, facsímil o reedición</option>
+            <option value="tapa">Sólo recuerdo la tapa o parte del título</option>
+            <option value="bibliografia">Bibliografía técnica o de estudio</option>
+            <option value="regalo">Recomendación para un regalo</option>
+          </select>
+        </div>
+
+        <div class="field field-wide">
+          <label for="main-query">¿Qué estás buscando?</label>
+          <input
+            id="main-query"
+            name="query"
+            type="text"
+            required
+            minlength="2"
+            maxlength="300"
+            placeholder="Título, tema, especialidad o lo que recuerdes"
+            autocomplete="off"
+          >
+          <small id="query-help">Escribí lo más concreto que puedas.</small>
+        </div>
+
+        <div class="field">
+          <label for="author-isbn">Autor, editorial o ISBN</label>
+          <input
+            id="author-isbn"
+            name="author_isbn"
+            type="text"
+            maxlength="180"
+            placeholder="Opcional"
+            autocomplete="off"
+          >
+        </div>
+
+        <div class="field">
+          <label for="book-format">Formato preferido</label>
+          <select id="book-format" name="format">
+            <option value="Me sirve cualquier formato">Me sirve cualquier formato</option>
+            <option value="Libro físico">Libro físico</option>
+            <option value="Edición digital">Edición digital</option>
+            <option value="Original antiguo">Original antiguo</option>
+            <option value="Facsímil o reedición">Facsímil o reedición</option>
+          </select>
+        </div>
+
+        <div class="field">
+          <label for="language">Idioma</label>
+          <select id="language" name="language">
+            <option value="Español">Español</option>
+            <option value="Puede ser otro idioma">Puede ser otro idioma</option>
+            <option value="Inglés">Inglés</option>
+            <option value="Portugués">Portugués</option>
+            <option value="Francés">Francés</option>
+            <option value="Italiano">Italiano</option>
+          </select>
+        </div>
+
+        <div class="field">
+          <label for="budget">Presupuesto aproximado en pesos</label>
+          <input
+            id="budget"
+            name="budget"
+            type="number"
+            min="0"
+            max="999999"
+            step="100"
+            inputmode="numeric"
+            placeholder="Opcional"
+          >
+        </div>
+
+        <div class="field field-wide">
+          <label for="details">Otros datos que nos puedan ayudar</label>
+          <textarea
+            id="details"
+            name="details"
+            rows="4"
+            maxlength="800"
+            placeholder="Año aproximado, país, edición, para qué lo necesitás o cualquier dato útil"
+          ></textarea>
+        </div>
+
+        <p id="photo-note" class="context-note" hidden>
+          Cuando se abra WhatsApp, mandanos la foto de la tapa en el siguiente mensaje.
+        </p>
+
+        <div class="form-actions field-wide">
+          <button type="submit">Enviar pedido por WhatsApp</button>
+          <a id="catalog-search-link" href="/catalogo">Buscar primero en el catálogo</a>
+        </div>
+
+        <p class="privacy-note field-wide">
+          Este formulario no guarda datos en la web. Al continuar se abre WhatsApp con la información ordenada para que podamos buscarla manualmente.
+        </p>
+      </form>
+    </div>
+  </main>
+  <Footer />
+  <WAFloat />
+</BaseLayout>
+
+<script>
+  const WA_NUMBER = '59899841325';
+  const typeLabels = {
+    exacto: 'Título, autor o ISBN concreto',
+    agotado: 'Libro agotado o descatalogado',
+    'sin-resultados': 'No apareció en el catálogo',
+    'novedades-tecnicas': 'Novedades de una especialidad',
+    digital: 'Edición digital',
+    antiguo: 'Libro antiguo, facsímil o reedición',
+    tapa: 'Sólo recuerda la tapa o parte del título',
+    bibliografia: 'Bibliografía técnica o de estudio',
+    regalo: 'Recomendación para un regalo',
+  };
+  const queryHelp = {
+    digital: 'Indicá el título o tema y, si podés, el dispositivo donde lo leerías.',
+    antiguo: 'Aclarar si buscás un original, un facsímil o una reedición evita búsquedas equivocadas.',
+    'novedades-tecnicas': 'Indicá especialidad, tema y si es para estudiante, residente o profesional.',
+    bibliografia: 'Indicá tema, nivel, carrera, curso o finalidad profesional.',
+    regalo: 'Contanos para quién es, edad aproximada, intereses y presupuesto.',
+    tapa: 'Escribí cualquier palabra, color, dibujo o detalle que recuerdes.',
+  };
+
+  const form = document.querySelector('#manual-book-request');
+  const typeSelect = document.querySelector('#request-type');
+  const queryInput = document.querySelector('#main-query');
+  const queryHelpEl = document.querySelector('#query-help');
+  const photoNote = document.querySelector('#photo-note');
+  const catalogLink = document.querySelector('#catalog-search-link');
+  const params = new URLSearchParams(window.location.search);
+  const requestedType = params.get('tipo') || 'exacto';
+  const initialQuery = (params.get('q') || '').trim().slice(0, 300);
+  const normalizedType = requestedType === 'sin-resultados' ? 'exacto' : requestedType;
+
+  if ([...typeSelect.options].some(option => option.value === normalizedType)) {
+    typeSelect.value = normalizedType;
+  }
+  if (initialQuery) queryInput.value = initialQuery;
+
+  function effectiveType() {
+    return requestedType === 'sin-resultados' && typeSelect.value === 'exacto'
+      ? 'sin-resultados'
+      : typeSelect.value;
+  }
+
+  function updateContext() {
+    const type = effectiveType();
+    queryHelpEl.textContent = queryHelp[typeSelect.value] || 'Escribí lo más concreto que puedas.';
+    photoNote.hidden = typeSelect.value !== 'tapa';
+    const query = queryInput.value.trim();
+    catalogLink.href = query ? `/catalogo?q=${encodeURIComponent(query)}` : '/catalogo';
+  }
+
+  let started = false;
+  form.addEventListener('input', () => {
+    updateContext();
+    if (!started) {
+      started = true;
+      window.gtag?.('event', 'book_request_started', { request_type: effectiveType() });
+    }
+  });
+  typeSelect.addEventListener('change', () => {
+    updateContext();
+    window.gtag?.('event', 'book_request_type_selected', { request_type: effectiveType() });
+  });
+
+  form.addEventListener('submit', event => {
+    event.preventDefault();
+    if (!form.reportValidity()) return;
+
+    const data = new FormData(form);
+    const type = effectiveType();
+    const lines = [
+      'Hola Amado Libros, quiero pedir una búsqueda manual.',
+      '',
+      `Tipo de búsqueda: ${typeLabels[type] || typeLabels.exacto}`,
+      `Busco: ${String(data.get('query') || '').trim()}`,
+    ];
+    const authorIsbn = String(data.get('author_isbn') || '').trim();
+    const budget = String(data.get('budget') || '').trim();
+    const details = String(data.get('details') || '').trim();
+    if (authorIsbn) lines.push(`Autor, editorial o ISBN: ${authorIsbn}`);
+    lines.push(`Formato: ${data.get('format')}`);
+    lines.push(`Idioma: ${data.get('language')}`);
+    if (budget) lines.push(`Presupuesto aproximado: $${budget} UYU`);
+    if (details) lines.push(`Otros datos: ${details}`);
+    if (typeSelect.value === 'tapa') lines.push('Voy a mandar la foto de la tapa en el próximo mensaje.');
+    lines.push('', 'Quedo a la espera de las opciones que encuentren. Gracias.');
+
+    window.gtag?.('event', 'book_request_submitted', { request_type: type });
+    window.location.href = `https://wa.me/${WA_NUMBER}?text=${encodeURIComponent(lines.join('\n'))}`;
+  });
+
+  updateContext();
+</script>
+
+<style>
+  .request-page {
+    padding: 0 1rem 3.5rem;
+    background:
+      radial-gradient(circle at 85% 8%, rgba(228, 153, 130, 0.13), transparent 32%),
+      var(--bg);
+  }
+
+  .request-shell {
+    width: 100%;
+    max-width: 960px;
+    margin: 0 auto;
+  }
+
+  .breadcrumbs {
+    display: flex;
+    gap: 0.45rem;
+    padding: 1rem 0;
+    color: var(--ink-2);
+    font-size: 0.78rem;
+  }
+
+  .breadcrumbs a { color: var(--salmon-hover); }
+
+  .request-intro {
+    padding: clamp(1.4rem, 5vw, 3rem);
+    border: 1px solid var(--border);
+    border-radius: 1.15rem 1.15rem 0 0;
+    background: var(--ink);
+    color: #fff;
+  }
+
+  .eyebrow {
+    color: var(--salmon);
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+  }
+
+  .request-intro h1 {
+    max-width: 18ch;
+    margin-top: 0.45rem;
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 7vw, 3.5rem);
+    letter-spacing: -0.035em;
+    line-height: 1.06;
+  }
+
+  .request-intro > p:not(.eyebrow) {
+    max-width: 62ch;
+    margin-top: 0.9rem;
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 0.94rem;
+  }
+
+  .request-intro ul {
+    display: grid;
+    gap: 0.55rem;
+    margin-top: 1.2rem;
+    padding: 0;
+    list-style: none;
+  }
+
+  .request-intro li {
+    display: flex;
+    gap: 0.5rem;
+    color: rgba(255, 255, 255, 0.82);
+    font-size: 0.82rem;
+  }
+
+  .request-intro li strong { color: var(--salmon); }
+
+  .request-form {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    padding: clamp(1.2rem, 4vw, 2.3rem);
+    border: 1px solid var(--border);
+    border-top: 0;
+    border-radius: 0 0 1.15rem 1.15rem;
+    background: #fff;
+  }
+
+  .field {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .field label {
+    color: var(--ink);
+    font-size: 0.78rem;
+    font-weight: 800;
+  }
+
+  .field input,
+  .field select,
+  .field textarea {
+    width: 100%;
+    min-height: 48px;
+    padding: 0.75rem 0.8rem;
+    border: 1px solid #d7cec3;
+    border-radius: 0.65rem;
+    outline: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font: 500 0.95rem/1.35 var(--font-ui);
+  }
+
+  .field textarea {
+    min-height: 118px;
+    resize: vertical;
+  }
+
+  .field input:focus,
+  .field select:focus,
+  .field textarea:focus {
+    border-color: var(--salmon-hover);
+    box-shadow: 0 0 0 3px rgba(228, 153, 130, 0.16);
+  }
+
+  .field small,
+  .privacy-note,
+  .context-note {
+    color: var(--ink-2);
+    font-size: 0.72rem;
+    line-height: 1.45;
+  }
+
+  .context-note {
+    grid-column: 1 / -1;
+    padding: 0.75rem;
+    border-left: 3px solid var(--salmon);
+    background: #fff7f3;
+  }
+
+  .form-actions {
+    display: grid;
+    gap: 0.7rem;
+    margin-top: 0.35rem;
+  }
+
+  .form-actions button,
+  .form-actions a {
+    display: inline-flex;
+    min-height: 50px;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1rem;
+    border-radius: 0.7rem;
+    font-size: 0.86rem;
+    font-weight: 800;
+    text-align: center;
+    cursor: pointer;
+  }
+
+  .form-actions button {
+    border: 0;
+    background: var(--wa);
+    color: #102516;
+  }
+
+  .form-actions button:hover { background: var(--wa-hover); }
+
+  .form-actions a {
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--ink);
+  }
+
+  @media (min-width: 720px) {
+    .request-intro ul { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .request-form { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .field-wide { grid-column: 1 / -1; }
+    .form-actions { grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr); }
+  }
+</style>

--- a/functions/__tests__/catalog-display.test.js
+++ b/functions/__tests__/catalog-display.test.js
@@ -302,6 +302,10 @@ test('una búsqueda sin coincidencias reales termina en cero resultados', async 
 
   assert.match(html, /No encontramos resultados/);
   assert.doesNotMatch(html, /class="rc-card/);
+  assert.match(html, /Que no aparezca acá no significa que no podamos encontrarlo/);
+  assert.match(html, /href="\/pedir-libro\?tipo=sin-resultados&amp;q=zzzinexistente999"/);
+  assert.match(html, />Pedir que lo busquemos</);
+  assert.match(html, />Ir directo a WhatsApp</);
 });
 
 test('el catálogo indexable comunica el umbral real de envío gratis', async () => {

--- a/functions/__tests__/home-commercial-fold.test.js
+++ b/functions/__tests__/home-commercial-fold.test.js
@@ -1,7 +1,7 @@
 // Contrato del primer pantallazo comercial de la portada.
 //
 // Hero.astro no se puede importar directamente con node --test. Estas pruebas
-// estructurales fijan el mensaje comercial aprobado y el CTA de WhatsApp sin
+// estructurales fijan el mensaje comercial aprobado y el CTA guiado sin
 // depender de un navegador ni de servicios externos.
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -23,13 +23,11 @@ test('Hero: muestra las cuatro ventajas comerciales sin prometer cuotas sin inte
   assert.doesNotMatch(heroAstro, /cuotas sin interés/i);
 });
 
-test('Hero: el CTA de encargos abre WhatsApp con los datos necesarios prellenados', () => {
-  assert.match(heroAstro, /https:\/\/wa\.me\/59899841325\?text=/);
-  assert.match(heroAstro, /encodeURIComponent\(requestText\)/);
-  assert.match(heroAstro, /título, autor, ISBN o una foto de la tapa/i);
-  assert.match(heroAstro, />\s*Pedir un libro por WhatsApp\s*</);
-  assert.match(heroAstro, /target="_blank"/);
-  assert.match(heroAstro, /rel="noopener noreferrer"/);
+test('Hero: el CTA de encargos inicia la búsqueda manual guiada', () => {
+  assert.match(heroAstro, /href="\/pedir-libro\?tipo=exacto"/);
+  assert.match(heroAstro, /Buscamos agotados, importados y ediciones difíciles/i);
+  assert.match(heroAstro, />\s*Contanos qué libro buscás\s*</);
+  assert.doesNotMatch(heroAstro, /https:\/\/wa\.me/);
 });
 
 test('Hero: enlaza la explicación indexable del servicio de encargos', () => {

--- a/functions/__tests__/manual-book-discovery.test.js
+++ b/functions/__tests__/manual-book-discovery.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const read = relativePath => readFileSync(path.join(ROOT, relativePath), 'utf8');
+const home = read('astro-front/src/pages/index.astro');
+const discovery = read('astro-front/src/components/BookDiscovery.astro');
+const requestPage = read('astro-front/src/pages/pedir-libro.astro');
+const footer = read('astro-front/src/components/Footer.astro');
+
+test('la portada incorpora descubrimiento por preguntas mobile-first', () => {
+  assert.match(home, /import BookDiscovery/);
+  assert.match(home, /<BookDiscovery\s*\/>/);
+  assert.match(discovery, /¿Qué libro querés que encontremos\?/);
+  assert.equal((discovery.match(/type: '/g) || []).length, 6);
+  assert.match(discovery, /grid-template-columns: 1fr/);
+  assert.match(discovery, /@media \(min-width: 650px\)/);
+  assert.match(discovery, /@media \(min-width: 980px\)/);
+});
+
+test('las preguntas cubren diferenciales concretos y conducen al formulario', () => {
+  for (const type of ['agotado', 'novedades-tecnicas', 'digital', 'antiguo', 'tapa', 'bibliografia']) {
+    assert.match(discovery, new RegExp(`type: '${type}'`));
+  }
+  assert.match(discovery, /href={`\/pedir-libro\?tipo=\$\{question\.type\}`}/);
+  assert.match(discovery, /una persona de Amado Libros hace la búsqueda/i);
+});
+
+test('el pedido ordena los datos y termina en WhatsApp sin guardar información', () => {
+  for (const field of ['request_type', 'query', 'author_isbn', 'format', 'language', 'budget', 'details']) {
+    assert.match(requestPage, new RegExp(`name="${field}"`));
+  }
+  assert.match(requestPage, /Este formulario no guarda datos en la web/);
+  assert.match(requestPage, /https:\/\/wa\.me\/\$\{WA_NUMBER\}\?text=/);
+  assert.match(requestPage, /const WA_NUMBER = '59899841325'/);
+  assert.doesNotMatch(requestPage, /Claude|Anthropic|anthropic/i);
+  assert.doesNotMatch(requestPage, /localStorage|sessionStorage/);
+});
+
+test('el formulario recupera búsquedas sin resultado y conserva acceso desde el footer', () => {
+  assert.match(requestPage, /params\.get\('q'\)/);
+  assert.match(requestPage, /requestedType === 'sin-resultados'/);
+  assert.match(footer, /href="\/pedir-libro"/);
+  assert.match(footer, /¿No encontraste el libro\?/);
+});

--- a/functions/__tests__/sitemap-segmentation.test.js
+++ b/functions/__tests__/sitemap-segmentation.test.js
@@ -21,6 +21,7 @@ test('sitemap.xml indexa sólo segmentos actualmente indexables', () => {
 
 test('pages y categorías quedan separados para observabilidad', () => {
   assert.ok(STATIC_SITEMAP_PAGES.includes('https://www.amadolibros.com/catalogo'));
+  assert.ok(STATIC_SITEMAP_PAGES.includes('https://www.amadolibros.com/pedir-libro'));
   assert.ok(STATIC_SITEMAP_PAGES.includes('https://www.amadolibros.com/libros-agotados-importados-uruguay'));
   assert.ok(!STATIC_SITEMAP_PAGES.some(url => url.includes('/libros/')));
 

--- a/functions/__tests__/smoke-sitemap-index.test.js
+++ b/functions/__tests__/smoke-sitemap-index.test.js
@@ -39,7 +39,7 @@ test('el índice no admite pausados ni segmentos inesperados', () => {
 
 test('pages exige todas las páginas estáticas relevantes', () => {
   const pages = [
-    '/', '/catalogo', '/libros-maria-montessori-uruguay', '/politicas', '/envios',
+    '/', '/catalogo', '/pedir-libro', '/libros-maria-montessori-uruguay', '/politicas', '/envios',
     '/devoluciones', '/terminos', '/privacidad', '/contacto',
   ];
   const valid = xml(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${pages.map(path => `<url>${loc(`${BASE}${path}`)}</url>`).join('')}</urlset>`);

--- a/functions/_shared/brand.js
+++ b/functions/_shared/brand.js
@@ -67,6 +67,7 @@ export const CONTACT = {
 
 
 export const FOOTER_LINKS = [
+    { href: '/pedir-libro', label: '¿No encontraste el libro?' },
     { href: '/libros-agotados-importados-uruguay', label: 'Libros por encargo' },
     { href: '/envios',       label: 'Envíos y retiro' },
     { href: '/devoluciones', label: 'Devoluciones y reembolsos' },

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -777,8 +777,16 @@ export async function onRequest(ctx) {
                     ? `Catálogo de libros — Página ${page} | Amado Libros`
                     : 'Comprar libros disponibles y por encargo | Amado Libros';
     const emptyMessage = rawQ
-        ? `Sin resultados para &ldquo;${safeQ}&rdquo;${filterLabel ? ` en ${filterLabel}` : ''}. Intentá con otras palabras${categoria ? ' o cambiá de categoría' : ''} o <a href="/">volvé al catálogo</a>.<br><br>¿No encontrás lo que buscás? <a class="wa-link" href="${WA}?text=${encodeURIComponent(`Hola Amado Libros, busco: ${rawQ}`)}" target="_blank" rel="noopener noreferrer">Consultanos por WhatsApp</a> y te ayudamos.`
-        : `Todavía no hay resultados en esta categoría. <a href="/catalogo">Volvé a Todos los libros</a>.`;
+        ? `<p>Sin resultados para &ldquo;${safeQ}&rdquo;${filterLabel ? ` en ${filterLabel}` : ''}. Intentá con otras palabras${categoria ? ' o cambiá de categoría' : ''}.</p>
+    <section class="manual-request" aria-label="Pedir una búsqueda manual">
+      <strong>Que no aparezca acá no significa que no podamos encontrarlo.</strong>
+      <span>Contanos lo que sabés. Una persona de Amado Libros hace la búsqueda y verifica la edición antes de ofrecerte una opción.</span>
+      <div class="manual-request-actions">
+        <a class="manual-request-primary" href="/pedir-libro?tipo=sin-resultados&amp;q=${encodeURIComponent(rawQ)}">Pedir que lo busquemos</a>
+        <a class="wa-link" href="${WA}?text=${encodeURIComponent(`Hola Amado Libros, busqué “${rawQ}” y no apareció en el catálogo.`)}" target="_blank" rel="noopener noreferrer">Ir directo a WhatsApp</a>
+      </div>
+    </section>`
+        : `<p>Todavía no hay resultados en esta categoría. <a href="/catalogo">Volvé a Todos los libros</a>.</p>`;
 
     // Chips de filtros activos — visibilidad clara de qué está aplicado.
     const chips = [];
@@ -910,6 +918,14 @@ export async function onRequest(ctx) {
     .rc-cta.rc-wa{color:#117a37;border-color:#b9dfc7;background:#effaf3}
     .rc-card:hover .rc-cta.rc-wa{background:#dcf5e5}
     .empty{padding:2rem 0;color:#64748b;font-size:.95rem}
+    .manual-request{max-width:720px;margin-top:1.35rem;padding:1.25rem;border:1px solid #ead8cc;border-radius:1rem;background:#fff7f3;color:#1e293b}
+    .manual-request strong,.manual-request span{display:block}
+    .manual-request strong{font-size:1.05rem;line-height:1.35}
+    .manual-request span{margin-top:.45rem;color:#64748b;font-size:.88rem}
+    .manual-request-actions{display:flex;flex-wrap:wrap;gap:.7rem;margin-top:1rem}
+    .manual-request-actions a{display:inline-flex;min-height:46px;align-items:center;justify-content:center;padding:.7rem 1rem;border-radius:.65rem;font-weight:800;text-decoration:none}
+    .manual-request-primary{background:#e49982;color:#fff}
+    .manual-request-actions .wa-link{border:1px solid #b9dfc7;background:#effaf3;color:#117a37}
     footer{margin-top:2.5rem;padding-top:1rem;border-top:1px solid #e2e8f0;
            font-size:.78rem;color:#94a3b8}
     footer a{color:#cbd5e1;text-decoration:none}
@@ -928,7 +944,7 @@ export async function onRequest(ctx) {
   <p class="sub">${subText}</p>
   ${totalResults > 0
     ? `<div class="grid">\n${cards}\n</div>\n${paginationBlock}`
-    : `<p class="empty">${emptyMessage}</p>`
+    : `<div class="empty">${emptyMessage}</div>`
   }
   <footer>
     <a href="/">Inicio</a> · <a href="/libros-agotados-importados-uruguay">Libros agotados e importados</a> · <a href="/politicas">Políticas</a> ·

--- a/functions/sitemap-pages.xml.js
+++ b/functions/sitemap-pages.xml.js
@@ -4,6 +4,7 @@ import { urlsetXml, xmlResponse } from './_shared/sitemap.js';
 export const STATIC_SITEMAP_PAGES = Object.freeze([
   `${BASE}/`,
   `${BASE}/catalogo`,
+  `${BASE}/pedir-libro`,
   `${BASE}/libros-agotados-importados-uruguay`,
   `${BASE}/libros-maria-montessori-uruguay`,
   `${BASE}/politicas`,

--- a/scripts/smoke-production.js
+++ b/scripts/smoke-production.js
@@ -61,6 +61,7 @@ const ROUTES = [
   { path: '/', kind: 'html', canonical: `${BASE_URL}/`, robots: 'index, follow' },
   { path: '/catalogo', kind: 'html', canonical: `${BASE_URL}/catalogo`, robots: 'index, follow' },
   { path: '/catalogo?q=zzzinexistente999', kind: 'html', canonical: `${BASE_URL}/catalogo`, robots: 'noindex, follow' },
+  { path: '/pedir-libro', kind: 'html', canonical: `${BASE_URL}/pedir-libro`, robots: 'index, follow' },
   { path: '/carrito/', kind: 'cart' },
   { path: '/robots.txt', kind: 'robots' },
   { path: '/sitemap.xml', kind: 'sitemap-index' },
@@ -267,7 +268,7 @@ function analyzeSitemapBody(body, kind) {
 
   if (kind === 'sitemap-pages') {
     const requiredPaths = [
-      '/', '/catalogo', '/libros-maria-montessori-uruguay', '/politicas', '/envios',
+      '/', '/catalogo', '/pedir-libro', '/libros-maria-montessori-uruguay', '/politicas', '/envios',
       '/devoluciones', '/terminos', '/privacidad', '/contacto',
     ];
     for (const path of requiredPaths) {


### PR DESCRIPTION
## Qué cambia

- agrega en la portada seis preguntas de descubrimiento para libros agotados, técnicos, digitales, antiguos, por tapa y bibliografía
- incorpora `/pedir-libro`, un formulario mobile-first que ordena el pedido y abre WhatsApp sin guardar datos
- convierte las búsquedas sin resultado en una salida útil hacia la búsqueda humana
- agrega el acceso al footer y publica la nueva ruta en el sitemap
- extiende el smoke productivo para verificar canonical, robots y disponibilidad de la página

## Por qué

Amado Libros puede conseguir títulos que no aparecen en el catálogo. Este flujo comunica ese diferencial y captura pedidos con datos suficientes sin depender de Claude ni de automatización conversacional.

## Impacto

El cliente recibe una alternativa concreta cuando no sabe qué buscar o el catálogo no encuentra coincidencias. El equipo sigue resolviendo manualmente desde WhatsApp y puede operar desde el celular.

## Validación

- 416/416 pruebas del código
- build Astro productivo con checkout OFF
- build Astro productivo con checkout ON
- `/pedir-libro` indexable, canónica y presente en sitemap
- pruebas estructurales del flujo mobile-first y búsqueda sin resultados
