### PR TITLE
Reordenar la portada según intención de compra

### DIFF
--- a/astro-front/src/pages/index.astro
+++ b/astro-front/src/pages/index.astro
@@ -23,9 +23,9 @@ import TrustStrip          from '../components/TrustStrip.astro';
   <Header showSearch={false} showMobileDeliveryBanner={true} />
   <main>
     <Hero />
-    <BookDiscovery />
     <CategoryAccess />
     <BestsellerSection />
+    <BookDiscovery />
     <HowToBuy />
     <ShippingPayments />
     <TrustStrip />

--- a/functions/__tests__/manual-book-discovery.test.js
+++ b/functions/__tests__/manual-book-discovery.test.js
@@ -21,6 +21,18 @@ test('la portada incorpora descubrimiento por preguntas mobile-first', () => {
   assert.match(discovery, /@media \(min-width: 980px\)/);
 });
 
+test('la portada prioriza búsqueda, categorías y libros antes del descubrimiento asistido', () => {
+  const heroPosition = home.indexOf('<Hero />');
+  const categoriesPosition = home.indexOf('<CategoryAccess />');
+  const booksPosition = home.indexOf('<BestsellerSection />');
+  const discoveryPosition = home.indexOf('<BookDiscovery />');
+
+  assert.ok(heroPosition >= 0, 'falta el buscador principal');
+  assert.ok(categoriesPosition > heroPosition, 'las categorías deben seguir al buscador');
+  assert.ok(booksPosition > categoriesPosition, 'los libros deben seguir a las categorías');
+  assert.ok(discoveryPosition > booksPosition, 'las preguntas deben aparecer después de los libros');
+});
+
 test('las preguntas cubren diferenciales concretos y conducen al formulario', () => {
   for (const type of ['agotado', 'novedades-tecnicas', 'digital', 'antiguo', 'tapa', 'bibliografia']) {
     assert.match(discovery, new RegExp(`type: '${type}'`));


### PR DESCRIPTION
## Qué cambia

- Mantiene el buscador principal como primer camino.
- Mueve las categorías antes de los productos.
- Mantiene «Incorporaciones recientes» antes de las seis preguntas.
- Conserva «Lo conseguimos para vos» en la portada y `/pedir-libro` como destino.
- Agrega una prueba que fija este orden comercial.

## Por qué

Los clientes que ya saben qué buscan acceden primero al catálogo y al stock. El descubrimiento asistido permanece como segundo camino para agotados, técnicos, digitales y antiguos.

## Validación local

- `node --test functions/__tests__/manual-book-discovery.test.js`: 5/5.
- `astro build`: 11 páginas generadas.
- HTML construido verificado en orden: categorías → incorporaciones → preguntas.