### PR TITLE
Crear landings SEO regionales por especialidad

### DIFF
--- a/functions/__tests__/seo-specialty-pages.test.js
+++ b/functions/__tests__/seo-specialty-pages.test.js
@@ -1,0 +1,119 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { CATALOG_URL } from '../_shared/catalog.js';
+import {
+  dedupeSpecialtyItems,
+  isSpecialtyMatch,
+  SEO_SPECIALTIES,
+  specialtyPath,
+} from '../_shared/seo-specialties.js';
+import { onRequest } from '../especialidades/[[path]].js';
+import { STATIC_SITEMAP_PAGES } from '../sitemap-pages.xml.js';
+
+const ITEMS = [
+  { id: 'MLU1', title: 'Manual de medicina clínica', author: 'Autora Médica', price: 2100, available_quantity: 1, status: 'active', thumbnail: 'https://img.example/1.jpg' },
+  { id: 'MLU2', title: 'Tratado de retina y glaucoma', author: 'Autor Ocular', price: 3200, available_quantity: 1, status: 'active', thumbnail: 'https://img.example/2.jpg' },
+  { id: 'MLU3', title: 'Técnicas de cirugía laparoscópica', author: 'Autor Quirúrgico', price: 4100, available_quantity: 1, status: 'active', thumbnail: 'https://img.example/3.jpg' },
+  { id: 'MLU4', title: 'Agricultura: cultivos, suelos y riego', author: 'Autora Agrícola', price: 1800, available_quantity: 1, status: 'active', thumbnail: 'https://img.example/4.jpg' },
+  { id: 'MLU5', title: 'Electrotecnia y máquinas eléctricas', author: 'Autor Técnico', isbn: '9780000000002', price: 2700, available_quantity: 1, status: 'active', thumbnail: 'https://img.example/5.jpg' },
+  { id: 'MLU7', title: 'Máquinas eléctricas: Electrotecnia', author: 'Autor Técnico', isbn: '9780000000002', price: 2800, available_quantity: 1, status: 'active', thumbnail: 'https://img.example/7.jpg' },
+  { id: 'MLU6', title: 'Cirugía agotada', price: 999, available_quantity: 0, status: 'paused' },
+];
+
+function context(id, { appEnv = 'production', query = '' } = {}) {
+  return {
+    request: new Request(`https://www.amadolibros.com${specialtyPath(id)}${query}`),
+    params: { path: [id] },
+    env: { APP_ENV: appEnv },
+    data: {},
+    waitUntil() {},
+  };
+}
+
+test.beforeEach(() => {
+  globalThis.caches = {
+    default: {
+      async match(request) {
+        if (request.url === CATALOG_URL) return Response.json({ items: ITEMS });
+        return null;
+      },
+      async put() {},
+    },
+  };
+});
+
+test('publica cinco especialidades fuertes, diferenciadas y sin páginas por país', () => {
+  assert.equal(SEO_SPECIALTIES.length, 5);
+  assert.equal(new Set(SEO_SPECIALTIES.map(item => item.id)).size, 5);
+  assert.equal(new Set(SEO_SPECIALTIES.map(item => item.title)).size, 5);
+  assert.equal(new Set(SEO_SPECIALTIES.map(item => item.h1)).size, 5);
+  assert.equal(new Set(SEO_SPECIALTIES.map(item => item.description)).size, 5);
+  assert.equal(new Set(SEO_SPECIALTIES.map(item => item.intro)).size, 5);
+  for (const item of SEO_SPECIALTIES) {
+    assert.ok(item.title.length <= 60, item.id);
+    assert.ok(item.description.length >= 135, item.id);
+    assert.ok(item.intro.length >= 220, item.id);
+    assert.ok(item.topics.length >= 6, item.id);
+    assert.ok(item.keywords.length >= 7, item.id);
+  }
+});
+
+test('cada landing muestra catálogo real filtrado y SEO regional verificable', async () => {
+  for (const specialty of SEO_SPECIALTIES) {
+    const response = await onRequest(context(specialty.id));
+    const html = await response.text();
+    const expectedItem = ITEMS.find(item => isSpecialtyMatch(item, specialty) && item.status === 'active');
+
+    assert.equal(response.status, 200, specialty.id);
+    assert.ok(html.includes(`<title>${specialty.title}</title>`), specialty.id);
+    assert.ok(html.includes(`<h1>${specialty.h1}</h1>`), specialty.id);
+    assert.ok(html.includes(`href="https://www.amadolibros.com${specialtyPath(specialty.id)}"`), specialty.id);
+    assert.match(html, /<meta name="robots" content="index, follow">/);
+    assert.match(html, /"@type":"CollectionPage"/);
+    assert.match(html, /"@type":"ItemList"/);
+    assert.match(html, /"@type":"Service"/);
+    assert.match(html, /"areaServed":\{"@type":"Country","name":"Uruguay"\}/);
+    assert.match(html, /¿Consultás desde España o Latinoamérica\?/);
+    assert.match(html, /eventual envío internacional se confirman caso a caso/);
+    assert.doesNotMatch(html, /hreflang/);
+    assert.ok(html.includes(expectedItem.title), specialty.id);
+    assert.doesNotMatch(html, /Cirugía agotada/);
+  }
+});
+
+test('las especialidades no repiten dos publicaciones de la misma edición', () => {
+  const electrotechnics = SEO_SPECIALTIES.find(item => item.id === 'electrotecnia');
+  const matches = ITEMS.filter(item => isSpecialtyMatch(item, electrotechnics));
+  assert.equal(matches.length, 2);
+  assert.equal(dedupeSpecialtyItems(matches).length, 1);
+});
+
+test('el filtro exige palabras completas y evita coincidencias por fragmentos', () => {
+  const agriculture = SEO_SPECIALTIES.find(item => item.id === 'agricultura');
+  assert.equal(isSpecialtyMatch({ title: 'Las experiencias de Tiresias y el hombre griego' }, agriculture), false);
+  const medicine = SEO_SPECIALTIES.find(item => item.id === 'medicina');
+  assert.equal(isSpecialtyMatch({ title: 'Dosificación de medicamentos en el caballo' }, medicine), false);
+});
+
+test('preview, parámetros y slugs no autorizados no crean URLs indexables', async () => {
+  const preview = await onRequest(context('medicina', { appEnv: 'preview' }));
+  assert.match(await preview.text(), /<meta name="robots" content="noindex, follow">/);
+
+  const filtered = await onRequest(context('medicina', { query: '?utm_source=regional' }));
+  assert.match(await filtered.text(), /<meta name="robots" content="noindex, follow">/);
+
+  const unknown = await onRequest(context('tema-inventado'));
+  assert.equal(unknown.status, 404);
+  assert.match(await unknown.text(), /noindex, nofollow/);
+});
+
+test('sitemap y landing de encargos enlazan las cinco especialidades', async () => {
+  const { onRequest: renderPillar } = await import('../libros-agotados-importados-uruguay.js');
+  const pillar = await (await renderPillar()).text();
+  for (const specialty of SEO_SPECIALTIES) {
+    const path = specialtyPath(specialty.id);
+    assert.ok(STATIC_SITEMAP_PAGES.includes(`https://www.amadolibros.com${path}`), specialty.id);
+    assert.ok(pillar.includes(`href="${path}"`), specialty.id);
+  }
+});

--- a/functions/_shared/seo-specialties.js
+++ b/functions/_shared/seo-specialties.js
@@ -1,0 +1,113 @@
+/**
+ * Especialidades con landing SEO autorizada.
+ *
+ * La lista es deliberadamente corta. Cada página debe responder una intención
+ * comercial concreta, mostrar catálogo real y tener contenido propio. No se
+ * crean variantes por país hasta que existan precios, pagos y logística
+ * internacional específicos para esas variantes.
+ */
+export const SEO_SPECIALTIES = Object.freeze([
+  {
+    id: 'medicina',
+    name: 'Medicina',
+    title: 'Libros de Medicina de España y Latinoamérica | Amado',
+    h1: 'Libros de medicina de España y Latinoamérica',
+    description: 'Buscá libros de medicina publicados en España y Latinoamérica. Catálogo disponible en Uruguay y búsqueda manual de ediciones técnicas por autor, ISBN o especialidad.',
+    audience: 'estudiantes, docentes, residentes y profesionales de la salud',
+    intro: 'Reunimos textos de medicina disponibles en Uruguay y buscamos por encargo ediciones publicadas en España, Argentina y otros mercados editoriales. Trabajamos con la referencia exacta para distinguir una edición nueva de una reimpresión y evitar ofrecer un manual desactualizado.',
+    topics: ['medicina clínica y diagnóstico', 'anatomía y fisiología', 'farmacología y terapéutica', 'patología', 'especialidades médicas', 'preparación académica y residencia'],
+    keywords: ['medicina', 'medico', 'medica', 'anatomia', 'fisiologia', 'farmacologia', 'patologia', 'diagnostico clinico', 'terapeutica'],
+    excludeKeywords: ['medicalizacion de', 'anatomia del espiritu'],
+  },
+  {
+    id: 'oftalmologia',
+    name: 'Oftalmología',
+    title: 'Libros de Oftalmología de España y Latinoamérica | Amado',
+    h1: 'Libros de oftalmología de España y Latinoamérica',
+    description: 'Libros de oftalmología, retina, córnea, glaucoma y optometría. Consultá títulos de España y Latinoamérica, stock en Uruguay o búsqueda por encargo.',
+    audience: 'oftalmólogos, residentes, optometristas, docentes y estudiantes',
+    intro: 'Buscamos bibliografía de oftalmología por subespecialidad, autor, editorial, ISBN y edición. Podemos revisar catálogos de España, Argentina y otros países cuando el título no está disponible en Uruguay, confirmando siempre idioma, año de edición, formato, precio y plazo antes de cotizar.',
+    topics: ['retina y vítreo', 'córnea y superficie ocular', 'glaucoma', 'cirugía ocular', 'diagnóstico por imágenes', 'optometría y baja visión'],
+    keywords: ['oftalmologia', 'oftalmologico', 'oftalmologica', 'retina', 'cornea', 'glaucoma', 'optometria', 'refraccion ocular', 'cirugia ocular'],
+  },
+  {
+    id: 'cirugia',
+    name: 'Cirugía',
+    title: 'Libros de Cirugía de España y Latinoamérica | Amado',
+    h1: 'Libros de cirugía de España y Latinoamérica',
+    description: 'Libros de cirugía general y especialidades quirúrgicas publicados en España y Latinoamérica. Catálogo en Uruguay y búsqueda manual de ediciones profesionales.',
+    audience: 'cirujanos, residentes, instrumentistas, docentes y estudiantes de ciencias de la salud',
+    intro: 'La bibliografía quirúrgica cambia según técnica, especialidad y edición. Por eso buscamos la referencia concreta y verificamos si se trata de cirugía general, abordajes mínimamente invasivos, anestesia, cuidados perioperatorios o instrumental, sin presentar una reimpresión como actualización.',
+    topics: ['cirugía general', 'técnicas quirúrgicas', 'laparoscopia y cirugía mínimamente invasiva', 'anestesia', 'cuidados perioperatorios', 'instrumentación quirúrgica'],
+    keywords: ['cirugia', 'quirurgico', 'quirurgica', 'laparoscopia', 'perioperatorio', 'perioperatoria', 'anestesia', 'instrumental quirurgico'],
+  },
+  {
+    id: 'agricultura',
+    name: 'Agricultura',
+    title: 'Libros de Agricultura de España y Latinoamérica | Amado',
+    h1: 'Libros de agricultura de España y Latinoamérica',
+    description: 'Libros de agricultura, cultivos, suelos, riego y maquinaria agrícola de España y Latinoamérica. Comprá en Uruguay o pedí una búsqueda técnica por encargo.',
+    audience: 'productores, técnicos rurales, ingenieros agrónomos, docentes y estudiantes',
+    intro: 'Seleccionamos y buscamos bibliografía agrícola según cultivo, sistema productivo y nivel técnico. Consultamos ediciones de España, Argentina y otros mercados latinoamericanos, aclarando cuando una norma, producto fitosanitario o práctica depende del país de publicación.',
+    topics: ['cultivos y producción vegetal', 'suelos y fertilidad', 'riego', 'sanidad vegetal', 'horticultura y fruticultura', 'maquinaria y agricultura sostenible'],
+    keywords: ['agricultura', 'agronomia', 'agricola', 'cultivo', 'suelos', 'riego', 'fitosanitaria', 'horticultura', 'fruticultura', 'citricultura', 'agroecologia'],
+  },
+  {
+    id: 'electrotecnia',
+    name: 'Electrotecnia',
+    title: 'Libros de Electrotecnia de España y Latinoamérica | Amado',
+    h1: 'Libros de electrotecnia de España y Latinoamérica',
+    description: 'Libros de electrotecnia, instalaciones, máquinas eléctricas y automatización publicados en España y Latinoamérica. Catálogo en Uruguay y encargos técnicos.',
+    audience: 'técnicos, instaladores, ingenieros, docentes y estudiantes',
+    intro: 'Buscamos manuales y textos de electrotecnia por tema, nivel, autor, editorial o ISBN. Antes de ofrecer una edición verificamos el país y el año, porque la normativa eléctrica, las unidades y los criterios de instalación pueden variar entre España, Uruguay y otros países latinoamericanos.',
+    topics: ['instalaciones eléctricas', 'circuitos y medidas', 'máquinas eléctricas', 'automatización industrial', 'protecciones y tableros', 'seguridad y normativa'],
+    keywords: ['electrotecnia', 'instalaciones electricas', 'maquinas electricas', 'circuitos electricos', 'electricidad industrial', 'automatizacion industrial', 'tableros electricos', 'alta tension'],
+  },
+]);
+
+export const SEO_SPECIALTY_IDS = new Set(SEO_SPECIALTIES.map(item => item.id));
+
+export function findSeoSpecialty(id) {
+  return SEO_SPECIALTIES.find(item => item.id === id) || null;
+}
+
+export function specialtyPath(id) {
+  return `/especialidades/${id}`;
+}
+
+export function normalizeSpecialtyText(value) {
+  return String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}
+
+export function isSpecialtyMatch(item, specialty) {
+  const haystack = normalizeSpecialtyText([
+    item?.title,
+    item?.author,
+  ].filter(Boolean).join(' '));
+  const padded = ` ${haystack.replace(/[^a-z0-9]+/g, ' ').trim()} `;
+  const containsKeyword = keyword => padded.includes(` ${normalizeSpecialtyText(keyword).replace(/[^a-z0-9]+/g, ' ').trim()} `);
+  if ((specialty.excludeKeywords || []).some(containsKeyword)) return false;
+  return specialty.keywords.some(containsKeyword);
+}
+
+function isbnKey(value) {
+  const digits = String(value || '').replace(/\D/g, '');
+  return digits.length === 10 || digits.length === 13 ? digits : '';
+}
+
+export function dedupeSpecialtyItems(items) {
+  const seen = new Set();
+  return items.filter(item => {
+    const isbn = isbnKey(item?.isbn);
+    const title = normalizeSpecialtyText(item?.title).replace(/[^a-z0-9]+/g, ' ').trim();
+    const author = normalizeSpecialtyText(item?.author).replace(/[^a-z0-9]+/g, ' ').trim();
+    const key = isbn ? `isbn:${isbn}` : (title && author ? `title-author:${title}|${author}` : '');
+    if (!key) return true;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/functions/especialidades/[[path]].js
+++ b/functions/especialidades/[[path]].js
@@ -1,0 +1,149 @@
+import { BASE, fetchCatalog } from '../_shared/catalog.js';
+import { slugify } from '../_shared/slug.js';
+import {
+  BRAND,
+  faviconHeadHtml,
+  footerHtml,
+  FOOTER_STYLES,
+  waFloatHtml,
+  WA_FLOAT_STYLES,
+} from '../_shared/brand.js';
+import {
+  dedupeSpecialtyItems,
+  findSeoSpecialty,
+  isSpecialtyMatch,
+  SEO_SPECIALTIES,
+  specialtyPath,
+} from '../_shared/seo-specialties.js';
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function safeJson(value) {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+function secureImage(item) {
+  const image = item?.pictures?.[0] || item?.thumbnail || '';
+  return String(image).replace(/^http:/, 'https:');
+}
+
+function isAvailable(item) {
+  return item?.status !== 'paused' && Number(item?.available_quantity || 0) > 0;
+}
+
+function errorPage() {
+  return new Response('<!doctype html><html lang="es"><head><meta charset="utf-8"><meta name="robots" content="noindex, nofollow"><title>Especialidad no encontrada | Amado Libros</title></head><body><main><h1>Especialidad no encontrada</h1><p><a href="/libros-agotados-importados-uruguay">Ver libros por encargo</a></p></main></body></html>', {
+    status: 404,
+    headers: { 'content-type': 'text/html;charset=UTF-8', 'cache-control': 'public,max-age=300' },
+  });
+}
+
+function bookCard(item) {
+  const href = `/libro/${encodeURIComponent(item.id)}/${slugify(item.title)}`;
+  const image = secureImage(item);
+  const price = Number(item.price || 0);
+  const formattedPrice = price > 0 ? price.toLocaleString('es-UY') : '';
+  return `<article class="book-card">
+    <a class="cover" href="${href}">${image
+      ? `<img src="${escapeHtml(image)}" alt="${escapeHtml(item.title)}" loading="lazy" width="240" height="360">`
+      : '<span aria-hidden="true">Libro sin imagen</span>'}</a>
+    <div class="book-info"><p class="stock">Disponible</p><h3><a href="${href}">${escapeHtml(item.title)}</a></h3>
+    ${item.author ? `<p class="author">${escapeHtml(item.author)}</p>` : ''}
+    ${formattedPrice ? `<p class="price">$${formattedPrice} UYU</p>` : ''}
+    <a class="book-link" href="${href}">Ver libro</a></div>
+  </article>`;
+}
+
+export async function onRequest(ctx) {
+  const parts = Array.isArray(ctx.params.path) ? ctx.params.path : [ctx.params.path].filter(Boolean);
+  const specialty = parts.length === 1 ? findSeoSpecialty(String(parts[0]).toLowerCase()) : null;
+  if (!specialty) return errorPage();
+
+  const requestUrl = new URL(ctx.request.url);
+  const hasParameters = requestUrl.search.length > 0;
+  const isProduction = ctx.env?.APP_ENV === 'production';
+  const robots = isProduction && !hasParameters ? 'index, follow' : 'noindex, follow';
+  const canonical = `${BASE}${specialtyPath(specialty.id)}`;
+  const catalog = await fetchCatalog(ctx);
+  const items = dedupeSpecialtyItems((Array.isArray(catalog?.items) ? catalog.items : [])
+    .filter(isAvailable)
+    .filter(item => isSpecialtyMatch(item, specialty)))
+    .slice(0, 24);
+  const requestPath = `/pedir-libro?tipo=novedades-tecnicas&q=${encodeURIComponent(`Libros de ${specialty.name}`)}`;
+  const waMessage = `Hola Amado Libros, busco un libro de ${specialty.name}. Estoy en [país y ciudad]. Los datos del libro son:`;
+  const related = SEO_SPECIALTIES.filter(item => item.id !== specialty.id);
+
+  const collectionSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: specialty.h1,
+    description: specialty.description,
+    url: canonical,
+    inLanguage: 'es',
+    isPartOf: { '@type': 'WebSite', name: BRAND.name, url: BASE },
+    publisher: { '@type': 'BookStore', name: BRAND.name, url: BASE },
+  };
+  const itemListSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: `Catálogo de ${specialty.name}`,
+    numberOfItems: items.length,
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.title,
+      url: `${BASE}/libro/${item.id}/${slugify(item.title)}`,
+    })),
+  };
+  const serviceSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    name: `Búsqueda por encargo de libros de ${specialty.name}`,
+    description: specialty.description,
+    url: canonical,
+    areaServed: { '@type': 'Country', name: 'Uruguay' },
+    serviceType: 'Búsqueda e importación de libros por encargo',
+    provider: { '@type': 'BookStore', name: BRAND.name, url: BASE },
+  };
+  const breadcrumbSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Inicio', item: `${BASE}/` },
+      { '@type': 'ListItem', position: 2, name: 'Libros por encargo', item: `${BASE}/libros-agotados-importados-uruguay` },
+      { '@type': 'ListItem', position: 3, name: specialty.name, item: canonical },
+    ],
+  };
+
+  const html = `<!doctype html><html lang="es"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(specialty.title)}</title><meta name="description" content="${escapeHtml(specialty.description)}"><meta name="robots" content="${robots}">
+<link rel="canonical" href="${canonical}">${faviconHeadHtml()}
+<meta property="og:type" content="website"><meta property="og:locale" content="es_UY"><meta property="og:site_name" content="${BRAND.name}">
+<meta property="og:title" content="${escapeHtml(specialty.title)}"><meta property="og:description" content="${escapeHtml(specialty.description)}"><meta property="og:url" content="${canonical}"><meta property="og:image" content="${BASE}${BRAND.logo}">
+<meta name="twitter:card" content="summary_large_image"><meta name="twitter:title" content="${escapeHtml(specialty.title)}"><meta name="twitter:description" content="${escapeHtml(specialty.description)}"><meta name="twitter:image" content="${BASE}${BRAND.logo}">
+<script type="application/ld+json">${safeJson(collectionSchema)}</script><script type="application/ld+json">${safeJson(itemListSchema)}</script><script type="application/ld+json">${safeJson(serviceSchema)}</script><script type="application/ld+json">${safeJson(breadcrumbSchema)}</script>
+<style>*{box-sizing:border-box;margin:0;padding:0}body{font-family:Inter,system-ui,sans-serif;background:#f8f5ef;color:#18120e;line-height:1.65}a{color:inherit}.head{background:#18120e;color:#fff}.head-in,.crumbs,main{max-width:1100px;margin:auto}.head-in{padding:.75rem 1rem}.brand{display:flex;align-items:center;gap:.7rem;text-decoration:none;font-weight:900}.brand img{width:50px;height:50px;object-fit:contain}.crumbs{padding:1rem;color:#6b6157;font-size:.84rem}.crumbs a{color:#a94e3d;text-decoration:none}main{padding:0 1rem 3rem}.hero{padding:clamp(1.4rem,5vw,3.5rem);background:#fff;border:1px solid #e2dbd0;border-radius:1.2rem}.eyebrow{color:#a94e3d;font-size:.73rem;font-weight:900;letter-spacing:.08em;text-transform:uppercase}h1{max-width:22ch;margin:.55rem 0 1rem;font:700 clamp(2rem,6vw,3.5rem)/1.06 Georgia,serif;letter-spacing:-.025em}.lead{max-width:72ch;color:#574d45;font-size:1.03rem}.actions{display:flex;flex-wrap:wrap;gap:.7rem;margin-top:1.4rem}.btn{display:inline-flex;min-height:48px;align-items:center;justify-content:center;padding:.72rem 1rem;border-radius:.7rem;text-decoration:none;font-weight:850}.primary{background:#18120e;color:#fff}.secondary{border:1px solid #d2c7bb;background:#f8f5ef}.truth{margin-top:1.2rem;padding:1rem;border-left:4px solid #e49982;background:#fff8f4;color:#6b4b3f}.section{padding-top:2.5rem}.section h2,.closing h2{font:700 clamp(1.45rem,4vw,2rem)/1.2 Georgia,serif}.section-intro{max-width:72ch;margin-top:.65rem;color:#6b6157}.topic-grid,.process-grid,.books-grid{display:grid;gap:1rem;margin-top:1.1rem}.card{padding:1.2rem;background:#fff;border:1px solid #e2dbd0;border-radius:.85rem}.card h3{font-size:1rem;margin-bottom:.35rem}.card p{color:#6b6157;font-size:.92rem}.books-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.book-card{overflow:hidden;background:#fff;border:1px solid #e2dbd0;border-radius:.85rem}.cover{display:flex;aspect-ratio:2/3;align-items:center;justify-content:center;background:#eee8df;color:#6b6157;text-decoration:none}.cover img{width:100%;height:100%;object-fit:contain;background:#fff}.book-info{display:flex;min-height:190px;flex-direction:column;padding:.8rem}.stock{color:#16763c;font-size:.72rem;font-weight:850;text-transform:uppercase}.book-info h3{margin-top:.35rem;font-size:.84rem;line-height:1.35}.book-info h3 a{text-decoration:none}.author{margin-top:.3rem;color:#6b6157;font-size:.75rem}.price{margin-top:.55rem;font-weight:900}.book-link{margin-top:auto;padding-top:.7rem;color:#a94e3d;font-size:.78rem;font-weight:850}.international{margin-top:2.5rem;padding:1.4rem;background:#fff;border:1px solid #e2dbd0;border-radius:1rem}.international p{max-width:75ch;margin-top:.6rem;color:#574d45}.links{display:flex;flex-wrap:wrap;gap:.55rem;margin-top:1rem}.links a{padding:.55rem .75rem;border:1px solid #e2dbd0;border-radius:999px;background:#fff;text-decoration:none;font-size:.8rem}.closing{margin-top:2.5rem;padding:1.5rem;border-radius:1rem;background:#18120e;color:#fff}.closing p{margin:.5rem 0 1rem;color:#d8d0c8}@media(min-width:650px){.books-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.topic-grid,.process-grid{grid-template-columns:repeat(3,1fr)}}@media(min-width:980px){.books-grid{grid-template-columns:repeat(4,minmax(0,1fr))}}${FOOTER_STYLES}${WA_FLOAT_STYLES}</style></head>
+<body><header class="head"><div class="head-in"><a class="brand" href="/"><img src="${BRAND.logo}" alt="${BRAND.logoAlt}" width="50" height="50"><span>Amado Libros</span></a></div></header>
+<nav class="crumbs" aria-label="Migas de pan"><a href="/">Inicio</a> › <a href="/libros-agotados-importados-uruguay">Libros por encargo</a> › ${escapeHtml(specialty.name)}</nav>
+<main><section class="hero"><p class="eyebrow">Ediciones de España, Argentina y otros mercados</p><h1>${escapeHtml(specialty.h1)}</h1><p class="lead">${escapeHtml(specialty.intro)}</p>
+<div class="actions"><a class="btn primary" href="${requestPath}">Pedir una búsqueda</a><a class="btn secondary" href="/catalogo?q=${encodeURIComponent(specialty.name)}">Buscar en el catálogo</a></div>
+<p class="truth"><strong>Información verificable:</strong> confirmamos título, autor, ISBN, editorial, edición, idioma, formato, precio y plazo. No prometemos disponibilidad ni presentamos una reimpresión como edición actualizada.</p></section>
+<section class="section"><h2>Libros de ${escapeHtml(specialty.name)} disponibles</h2><p class="section-intro">Estos resultados provienen del catálogo vigente de Amado Libros. Si no aparece la referencia exacta, podés pedir una búsqueda manual.</p>
+${items.length ? `<div class="books-grid">${items.map(bookCard).join('')}</div>` : `<div class="card"><h3>No hay coincidencias disponibles ahora</h3><p>La página sigue sirviendo para solicitar una edición concreta por encargo. Pasanos autor, ISBN, editorial o una foto de la tapa.</p></div>`}</section>
+<section class="section"><h2>Áreas que podemos buscar</h2><div class="topic-grid">${specialty.topics.map(topic => `<article class="card"><h3>${escapeHtml(topic)}</h3><p>Buscamos por referencia bibliográfica y verificamos la edición antes de cotizar.</p></article>`).join('')}</div></section>
+<section class="international"><h2>¿Consultás desde España o Latinoamérica?</h2><p>Podés enviarnos el país, la ciudad y los datos del libro. La venta, el medio de pago y un eventual envío internacional se confirman caso a caso antes de asumir cualquier compromiso. Los precios visibles en el catálogo están expresados en pesos uruguayos.</p><div class="actions"><a class="btn secondary" href="${requestPath}">Enviar país y libro buscado</a></div></section>
+<section class="section"><h2>Cómo funciona la búsqueda</h2><div class="process-grid"><article class="card"><h3>1. Identificamos el libro</h3><p>Usamos título, autor, ISBN, editorial, edición o foto para evitar confusiones.</p></article><article class="card"><h3>2. Verificamos mercados</h3><p>Revisamos disponibilidad real en Uruguay, España, Argentina y otros orígenes pertinentes.</p></article><article class="card"><h3>3. Confirmamos antes de vender</h3><p>Informamos edición, formato, moneda, precio, plazo y destino posible antes de avanzar.</p></article></div></section>
+<section class="section"><h2>Otras especialidades</h2><nav class="links" aria-label="Otras especialidades">${related.map(item => `<a href="${specialtyPath(item.id)}">${escapeHtml(item.name)}</a>`).join('')}</nav></section>
+<section class="closing"><h2>¿Qué libro de ${escapeHtml(specialty.name)} necesitás?</h2><p>Mandanos la referencia y tu país. Una persona de Amado Libros revisa la búsqueda.</p><a class="btn secondary" href="${requestPath}">Pedir que lo busquemos</a></section></main>${footerHtml()}${waFloatHtml(waMessage)}</body></html>`;
+
+  return new Response(html, {
+    headers: { 'content-type': 'text/html;charset=UTF-8', 'cache-control': 'public,max-age=3600' },
+  });
+}

--- a/functions/libros-agotados-importados-uruguay.js
+++ b/functions/libros-agotados-importados-uruguay.js
@@ -14,6 +14,7 @@ import {
     WA_FLOAT_STYLES,
     waHref,
 } from './_shared/brand.js';
+import { SEO_SPECIALTIES, specialtyPath } from './_shared/seo-specialties.js';
 
 const PATH = '/libros-agotados-importados-uruguay';
 const TITLE = 'Libros agotados e importados en Uruguay | Amado Libros';
@@ -89,6 +90,7 @@ export async function onRequest() {
     .card p{color:#6b6157;font-size:.92rem}
     .closing{margin-top:2.5rem;padding:1.5rem;background:#18120e;color:#fff;border-radius:1rem}
     .closing p{margin:.5rem 0 1rem;color:rgba(255,255,255,.72)}
+    .specialties{display:flex;flex-wrap:wrap;gap:.55rem;margin-top:1.25rem}.specialties a{padding:.55rem .75rem;border:1px solid #e2dbd0;border-radius:999px;background:#fff;text-decoration:none;font-size:.82rem}
     @media(min-width:720px){.hero{grid-template-columns:1.45fr .75fr;align-items:center}.steps{grid-template-columns:repeat(3,1fr)}.types{grid-template-columns:repeat(2,1fr)}}
     ${FOOTER_STYLES}
     ${WA_FLOAT_STYLES}
@@ -135,6 +137,14 @@ export async function onRequest() {
         <article class="card"><h3>Textos académicos y profesionales</h3><p>Material especializado, manuales, libros universitarios y ediciones concretas identificadas por ISBN.</p></article>
         <article class="card"><h3>Idiomas, formatos y ediciones específicas</h3><p>Tapa dura o blanda, idioma original, editorial determinada o una edición que querés volver a encontrar.</p></article>
       </div>
+    </section>
+
+    <section class="section">
+      <h2>Libros técnicos importados por especialidad</h2>
+      <p class="lead">Explorá catálogo disponible y pedí búsquedas manuales de ediciones publicadas en España, Argentina y otros mercados.</p>
+      <nav class="specialties" aria-label="Especialidades profesionales">
+        ${SEO_SPECIALTIES.map(item => `<a href="${specialtyPath(item.id)}">${item.name}</a>`).join('')}
+      </nav>
     </section>
 
     <section class="closing">

--- a/functions/sitemap-pages.xml.js
+++ b/functions/sitemap-pages.xml.js
@@ -1,5 +1,6 @@
 import { BASE } from './_shared/catalog.js';
 import { urlsetXml, xmlResponse } from './_shared/sitemap.js';
+import { SEO_SPECIALTIES, specialtyPath } from './_shared/seo-specialties.js';
 
 export const STATIC_SITEMAP_PAGES = Object.freeze([
   `${BASE}/`,
@@ -13,6 +14,7 @@ export const STATIC_SITEMAP_PAGES = Object.freeze([
   `${BASE}/terminos`,
   `${BASE}/privacidad`,
   `${BASE}/contacto`,
+  ...SEO_SPECIALTIES.map(item => `${BASE}${specialtyPath(item.id)}`),
 ]);
 
 export async function onRequest() {


### PR DESCRIPTION
## Qué cambia
- Publica cinco landings diferenciadas: Medicina, Oftalmología, Cirugía, Agricultura y Electrotecnia.
- Muestra catálogo activo real, deduplicado por ISBN/edición y evita coincidencias por fragmentos.
- Refuerza España y Latinoamérica sin prometer envíos internacionales no confirmados.
- Agrega enlaces internos, schema, canonical y las cinco URLs al sitemap.

## Validación
- 12 pruebas específicas en verde.
- Build Astro validado con checkout activado y desactivado.
- Auditoría contra catálogo real: Medicina 73, Cirugía 10, Agricultura 9, Electrotecnia 1; Oftalmología usa captación honesta cuando no hay stock real.