### PR TITLE
Medir captación por IA y clics de WhatsApp

### DIFF
--- a/astro-front/public/analytics-events.js
+++ b/astro-front/public/analytics-events.js
@@ -1,0 +1,133 @@
+(function () {
+  'use strict';
+
+  var MEASUREMENT_ID = 'G-SDX45VEPP3';
+  var PRODUCTION_HOSTS = new Set(['amadolibros.com', 'www.amadolibros.com']);
+
+  if (!PRODUCTION_HOSTS.has(window.location.hostname)) return;
+
+  function measuredPageLocation() {
+    var allowedParameters = new Set([
+      'utm_id',
+      'utm_source',
+      'utm_medium',
+      'utm_campaign',
+      'utm_term',
+      'utm_content',
+      'gclid',
+      'dclid',
+      'gbraid',
+      'wbraid',
+    ]);
+    var url = new URL(window.location.href);
+    Array.from(url.searchParams.keys()).forEach(function (key) {
+      if (!allowedParameters.has(key)) url.searchParams.delete(key);
+    });
+    url.hash = '';
+    return url.toString();
+  }
+
+  function ensureGoogleTag() {
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = window.gtag || function () {
+      window.dataLayer.push(arguments);
+    };
+
+    var selector = 'script[src*="googletagmanager.com/gtag/js?id=' + MEASUREMENT_ID + '"]';
+    if (document.querySelector(selector)) return;
+
+    window.gtag('js', new Date());
+    window.gtag('config', MEASUREMENT_ID, {
+      page_location: measuredPageLocation(),
+    });
+
+    var tag = document.createElement('script');
+    tag.async = true;
+    tag.src = 'https://www.googletagmanager.com/gtag/js?id=' + encodeURIComponent(MEASUREMENT_ID);
+    document.head.appendChild(tag);
+  }
+
+  function safeToken(value, fallback) {
+    var normalized = String(value || '')
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '_')
+      .replace(/^_+|_+$/g, '')
+      .slice(0, 60);
+    return normalized || fallback;
+  }
+
+  function pageContext() {
+    var path = window.location.pathname;
+    var productMatch = path.match(/^\/libro\/(MLU\d+)(?:\/|$)/i);
+    var specialtyMatch = path.match(/^\/especialidades\/([^/]+)(?:\/|$)/i);
+    var pageType = 'content';
+
+    if (path === '/') pageType = 'home';
+    else if (productMatch) pageType = 'product';
+    else if (/^\/libros\//.test(path)) pageType = 'category';
+    else if (specialtyMatch) pageType = 'specialty';
+    else if (path === '/catalogo') pageType = 'catalog';
+    else if (path === '/carrito') pageType = 'cart';
+    else if (path === '/pedir-libro') pageType = 'book_request';
+    else if (path === '/contacto') pageType = 'contact';
+
+    return {
+      pageType: pageType,
+      productId: productMatch ? productMatch[1].toUpperCase() : '',
+      topic: specialtyMatch ? safeToken(specialtyMatch[1], '') : '',
+    };
+  }
+
+  function ctaLocation(element) {
+    var explicit = element && element.closest('[data-cta-location]');
+    if (explicit) return safeToken(explicit.getAttribute('data-cta-location'), 'content');
+    if (element && element.closest('.wa-float')) return 'floating';
+    if (element && element.closest('header')) return 'header';
+    if (element && element.closest('footer')) return 'footer';
+    if (element && element.closest('.closing')) return 'closing';
+    if (element && element.closest('.btn-wa,.cta-primary,.wa-link')) return 'primary';
+    return 'content';
+  }
+
+  function isWhatsAppUrl(href) {
+    try {
+      var url = new URL(href, window.location.href);
+      return url.protocol === 'whatsapp:' || [
+        'wa.me',
+        'api.whatsapp.com',
+        'web.whatsapp.com',
+      ].includes(url.hostname.toLowerCase());
+    } catch (_error) {
+      return false;
+    }
+  }
+
+  function trackWhatsApp(options) {
+    options = options || {};
+    var context = pageContext();
+    var params = {
+      page_type: context.pageType,
+      cta_location: safeToken(options.ctaLocation, 'content'),
+    };
+
+    var topic = safeToken(options.topic || context.topic, '');
+    if (topic) params.topic = topic;
+    if (context.productId) params.product_id = context.productId;
+
+    window.gtag('event', 'whatsapp_click', params);
+  }
+
+  ensureGoogleTag();
+
+  window.AmadoAnalytics = Object.assign({}, window.AmadoAnalytics, {
+    trackWhatsApp: trackWhatsApp,
+  });
+
+  document.addEventListener('click', function (event) {
+    var anchor = event.target && event.target.closest
+      ? event.target.closest('a[href]')
+      : null;
+    if (!anchor || !isWhatsAppUrl(anchor.href)) return;
+    trackWhatsApp({ ctaLocation: ctaLocation(anchor) });
+  }, true);
+})();

--- a/astro-front/src/components/SearchOverlay.astro
+++ b/astro-front/src/components/SearchOverlay.astro
@@ -202,6 +202,9 @@
   function sendWA() {
     var q = input.value.trim();
     if (!q) return;
+    if (window.AmadoAnalytics) {
+      window.AmadoAnalytics.trackWhatsApp({ ctaLocation: 'search_overlay' });
+    }
     window.open(buildWaUrl(q), '_blank', 'noopener,noreferrer');
     closeOverlay();
   }

--- a/astro-front/src/layouts/BaseLayout.astro
+++ b/astro-front/src/layouts/BaseLayout.astro
@@ -3,6 +3,7 @@ interface Props {
   title?: string;
   description?: string;
   indexable?: boolean;
+  analytics?: boolean;
   canonical?: string;
   image?: string;
   imageAlt?: string;
@@ -12,6 +13,7 @@ const {
   title = 'Amado Libros — Librería uruguaya',
   description = 'Libros importados y por encargo en Uruguay. Entrega hoy en Montevideo, envíos a todo el país.',
   indexable: indexableProp,
+  analytics: analyticsProp,
   canonical,
   image = 'https://www.amadolibros.com/images/logo-amado.webp',
   imageAlt = 'Amado Libros, librería uruguaya',
@@ -20,7 +22,7 @@ const {
 
 const indexable  = indexableProp !== undefined ? indexableProp : import.meta.env.PUBLIC_INDEXABLE === 'true';
 const gaId       = import.meta.env.PUBLIC_GA_ID;
-const enableGA4  = indexable && !!gaId;
+const enableGA4  = (analyticsProp !== undefined ? analyticsProp : indexable) && !!gaId;
 const socialUrl  = canonical || 'https://www.amadolibros.com/';
 ---
 <!doctype html>
@@ -59,9 +61,19 @@ const socialUrl  = canonical || 'https://www.amadolibros.com/';
       <script is:inline define:vars={{ gaId }}>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
+        const measuredUrl = new URL(window.location.href);
+        const allowedParameters = new Set([
+          'utm_id', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_term',
+          'utm_content', 'gclid', 'dclid', 'gbraid', 'wbraid',
+        ]);
+        Array.from(measuredUrl.searchParams.keys()).forEach((key) => {
+          if (!allowedParameters.has(key)) measuredUrl.searchParams.delete(key);
+        });
+        measuredUrl.hash = '';
         gtag('js', new Date());
-        gtag('config', gaId);
+        gtag('config', gaId, { page_location: measuredUrl.toString() });
       </script>
+      <script is:inline src="/analytics-events.js"></script>
     </>
   )}
   <!-- Astro build OK — lote 2-A -->

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -20,6 +20,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
   title="Tu carrito — Amado Libros"
   description="Revisá los libros que querés pedir en Amado Libros."
   indexable={false}
+  analytics={true}
 >
   <Header />
 
@@ -1992,6 +1993,9 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         if (email) lines.push('Correo: ' + email);
 
         var msg = encodeURIComponent(lines.join('\n'));
+        if (window.AmadoAnalytics) {
+          window.AmadoAnalytics.trackWhatsApp({ ctaLocation: 'checkout_order' });
+        }
         window.open('https://wa.me/59899841325?text=' + msg, '_blank', 'noopener,noreferrer');
       });
     }

--- a/astro-front/src/pages/pedir-libro.astro
+++ b/astro-front/src/pages/pedir-libro.astro
@@ -243,6 +243,10 @@ const jsonLd = {
     lines.push('', 'Quedo a la espera de las opciones que encuentren. Gracias.');
 
     window.gtag?.('event', 'book_request_submitted', { request_type: type });
+    window.AmadoAnalytics?.trackWhatsApp({
+      ctaLocation: 'book_request_form',
+      topic: type,
+    });
     window.location.href = `https://wa.me/${WA_NUMBER}?text=${encodeURIComponent(lines.join('\n'))}`;
   });
 

--- a/docs/seo/ai-discovery-measurement-2026-08-12.md
+++ b/docs/seo/ai-discovery-measurement-2026-08-12.md
@@ -1,6 +1,6 @@
 # Descubrimiento por IA y Google — dictamen y medición
 
-Fecha del dictamen: 2026-08-12  
+Fecha del dictamen: 2026-08-12
 Alcance de este lote: medición, auditoría de las cinco especialidades y criterios de decisión. No autoriza ni ejecuta un despliegue productivo.
 
 ## Dictamen ejecutivo

--- a/docs/seo/ai-discovery-measurement-2026-08-12.md
+++ b/docs/seo/ai-discovery-measurement-2026-08-12.md
@@ -1,0 +1,117 @@
+# Descubrimiento por IA y Google — dictamen y medición
+
+Fecha del dictamen: 2026-08-12  
+Alcance de este lote: medición, auditoría de las cinco especialidades y criterios de decisión. No autoriza ni ejecuta un despliegue productivo.
+
+## Dictamen ejecutivo
+
+La prioridad correcta no es publicar más contenido: es cerrar la brecha de medición del sitio que ya existe. Las páginas Astro cargaban GA4, pero las fichas, el catálogo, las categorías y las especialidades se renderizan con Cloudflare Pages Functions y no cargaban GA4. Por eso, antes de este lote una visita podía terminar en WhatsApp sin conservar una sesión atribuible.
+
+La recomendación experta es:
+
+1. desplegar una medición única en ambos caminos de renderizado;
+2. marcar `whatsapp_click` como evento clave en GA4;
+3. medir durante dos ventanas consecutivas de 14 días;
+4. recién entonces elegir qué especialidad, guía o conjunto de fichas merece inversión.
+
+No se recomienda crear páginas especiales “para la IA”. Google indica que sus funciones de IA no requieren archivos, marcado ni optimizaciones especiales: siguen dependiendo de los fundamentos de Search. OpenAI pide que el sitio sea público y que `OAI-SearchBot` no esté bloqueado. Amado Libros ya cumple esto último y mantiene `GPTBot` bloqueado, separando descubrimiento en Search de uso para entrenamiento.
+
+Fuentes primarias:
+
+- [Google: AI features and your website](https://developers.google.com/search/docs/appearance/ai-features)
+- [Google: helpful, reliable, people-first content](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+- [Google: general structured-data guidelines](https://developers.google.com/search/docs/appearance/structured-data/sd-policies)
+- [OpenAI: Publishers and Developers FAQ](https://help.openai.com/en/articles/12627856-publishers-and-developers-faq)
+
+## Contrato de medición
+
+| Nivel | Definición | Uso |
+|---|---|---|
+| Resultado de negocio | Compra confirmada o recompra | Verdad comercial; no se sustituye por tráfico |
+| Conversión principal digital | Sesión con `whatsapp_click` | Intención de contacto atribuible |
+| Conversión de mayor intención | `book_request_submitted` | Formulario de búsqueda completado antes de abrir WhatsApp |
+| Captación IA | Sesiones con fuente ChatGPT, Claude, Gemini, Perplexity o Copilot | Tráfico clicado desde asistentes; no equivale a todas las citas |
+| Captación Google | Impresiones, clics y posición por landing en GSC | Descubrimiento orgánico, incluido el tráfico agregado de funciones de IA |
+
+KPI primario:
+
+`tasa de intención WhatsApp = sesiones con whatsapp_click / sesiones`
+
+Se calcula por landing, fuente/medio y período. El exportador deja el numerador en `whatsapp-intent` y el denominador compatible en `all-landing-pages`.
+
+Parámetros permitidos en `whatsapp_click`:
+
+- `page_type`
+- `cta_location`
+- `topic`, sólo para taxonomías controladas
+- `product_id`, sólo el identificador MLU de la ficha
+
+No se envían a GA4 el mensaje de WhatsApp, la URL de destino, términos de búsqueda, nombre, correo, teléfono ni datos del checkout. La URL de página conserva sólo parámetros de campaña (`utm_*`, `gclid`, `gbraid`, etc.) para mantener la atribución sin exportar las consultas internas.
+
+## Auditoría de las cinco especialidades
+
+| Landing | Estado técnico | Decisión |
+|---|---|---|
+| Medicina | indexable en producción, canonical, catálogo real, `CollectionPage` + `ItemList` + `Service` + breadcrumbs | mantener y medir |
+| Oftalmología | igual; contenido y taxonomía propios | mantener y medir |
+| Cirugía | igual; filtro por palabras completas | mantener y medir |
+| Agricultura | igual; evita coincidencias por fragmentos | mantener y medir |
+| Electrotecnia | igual; deduplica publicaciones con el mismo ISBN | mantener y medir |
+
+Fortalezas verificadas:
+
+- títulos, H1, descripciones e introducciones diferenciados;
+- catálogo vigente, sólo con disponibilidad y sin inventar libros;
+- canonical único y `noindex` para preview, parámetros y slugs no autorizados;
+- enlace desde sitemap y desde la landing pilar de encargos;
+- datos estructurados que reflejan contenido visible;
+- WhatsApp contextual disponible y formulario de búsqueda manual.
+
+Límites actuales:
+
+- las cinco páginas comparten una plantilla fuerte, pero no deben multiplicarse sin evidencia;
+- son landings de descubrimiento y conversión, no guías profundas citables por sí solas;
+- falta una página institucional sólida que explique quién revisa las búsquedas, experiencia real, método y relación verificable con el negocio. Google recomienda concentrar el marcado de organización en la home o en una página institucional, y valora que el sitio haga visible quién creó o revisó el contenido;
+- el schema ayuda a comprender entidades, pero Google no garantiza visibilidad ni ranking por usarlo.
+
+## Baselines que deben ejecutarse
+
+Los workflows ya existen, pero todavía no tienen runs para estos cortes:
+
+| Evidencia | Período exacto | Workflow |
+|---|---|---|
+| LOGS-3 limpio | 2026-08-09 a 2026-08-10 UTC | `SEO crawl report` |
+| GA4 previo a esta instrumentación | 2026-07-01 a 2026-08-11 | `GA4 manual export` |
+| GSC histórico fijo | 2026-05-11 a 2026-08-08 | `GSC manual export` |
+
+El informe generativo nuevo de Search Console se está desplegando sólo a un subconjunto de sitios; no existe una activación manual que el repositorio pueda forzar. Si aparece en la propiedad, se guarda una captura de día 0. Mientras tanto, sus datos siguen agregados en el informe Web. Fuente: [Google Search Generative AI performance reports](https://developers.google.com/search/blog/2026/06/gen-ai-performance-reports).
+
+## Reglas de decisión
+
+### Control de implementación
+
+- En las primeras 24 horas: `whatsapp_click` debe aparecer en DebugView/Realtime y en el inventario de eventos.
+- En GA4 Admin: marcar `whatsapp_click` como evento clave. El clic expresa intención; no se renombra `generate_lead` porque no prueba que el mensaje haya sido enviado.
+- Verificar un clic de cada familia: home, catálogo, ficha, especialidad, buscador, formulario de encargo y carrito.
+
+### Ventana de 14 días
+
+- Confirmar que las cinco URLs aparecen en GSC y separar problema de indexación de falta de demanda.
+- Comparar sesiones, sesiones con intención de WhatsApp y fuente/medio.
+- No interpretar cero referidos de IA como cero citas: GA4 sólo observa citas que generan clic.
+
+### Ventana de 28 días
+
+- Priorizar la especialidad que produzca al menos una consulta de WhatsApp o que muestre crecimiento de impresiones en dos cortes consecutivos.
+- Si ninguna especialidad produce señal, no publicar otras cinco: revisar intención de búsqueda, enlazado interno y claridad de la oferta.
+- Publicar la primera guía sólo cuando una especialidad o una consulta real revele una pregunta repetida que Amado Libros pueda responder con experiencia propia y casos anonimizados.
+- No ampliar fichas en masa: seleccionar el siguiente lote con facturación, impresiones y consultas, no sólo por cantidad de SKU.
+
+## Próximo lote recomendado
+
+Después de desplegar y validar esta medición:
+
+1. página “Quiénes somos y cómo trabajamos”, con autoría/revisión visible y schema `BookStore`/`Organization` coherente;
+2. verificación manual de la identidad externa que pueda enlazarse con `sameAs`, sin declarar perfiles que no hayan sido confirmados;
+3. circuito de reseña post-entrega y seguimiento de recompra;
+4. primera guía basada en demanda observada, no en una lista genérica de temas.

--- a/functions/__tests__/analytics-events.test.js
+++ b/functions/__tests__/analytics-events.test.js
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { runInNewContext } from 'node:vm';
+
+const analytics = readFileSync('astro-front/public/analytics-events.js', 'utf8');
+const baseLayout = readFileSync('astro-front/src/layouts/BaseLayout.astro', 'utf8');
+const brand = readFileSync('functions/_shared/brand.js', 'utf8');
+const bookRequest = readFileSync('astro-front/src/pages/pedir-libro.astro', 'utf8');
+const cart = readFileSync('astro-front/src/pages/carrito.astro', 'utf8');
+const orderStatus = readFileSync('astro-front/src/pages/pedido.astro', 'utf8');
+const searchOverlay = readFileSync('astro-front/src/components/SearchOverlay.astro', 'utf8');
+
+test('carga la medición compartida en páginas Astro y SSR', () => {
+  assert.match(baseLayout, /<script is:inline src="\/analytics-events\.js"><\/script>/);
+  assert.match(brand, /<script src="\/analytics-events\.js"><\/script>/);
+});
+
+test('el evento cubre enlaces y aperturas programáticas de WhatsApp', () => {
+  assert.match(analytics, /'whatsapp_click'/);
+  assert.match(analytics, /'wa\.me'/);
+  assert.match(analytics, /'api\.whatsapp\.com'/);
+  assert.match(bookRequest, /trackWhatsApp\(\{[\s\S]*book_request_form/);
+  assert.match(cart, /trackWhatsApp\(\{ ctaLocation: 'checkout_order' \}\)/);
+  assert.match(searchOverlay, /trackWhatsApp\(\{ ctaLocation: 'search_overlay' \}\)/);
+});
+
+test('no envía la URL de WhatsApp, el mensaje ni parámetros de búsqueda a GA4', () => {
+  const eventCall = analytics.slice(analytics.indexOf("window.gtag('event', 'whatsapp_click'"));
+  assert.doesNotMatch(eventCall, /link_url|searchParams|location\.search|href:/);
+  assert.match(analytics, /page_type/);
+  assert.match(analytics, /cta_location/);
+  assert.match(analytics, /product_id/);
+  assert.match(analytics, /topic/);
+  assert.match(analytics, /allowedParameters/);
+  assert.match(baseLayout, /allowedParameters/);
+});
+
+test('GA4 queda apagado fuera de los dominios productivos', () => {
+  assert.match(analytics, /PRODUCTION_HOSTS/);
+  assert.match(analytics, /if \(!PRODUCTION_HOSTS\.has\(window\.location\.hostname\)\) return/);
+});
+
+test('mide el carrito noindex sin habilitar Analytics en el estado del pedido', () => {
+  assert.match(cart, /indexable=\{false\}[\s\S]*analytics=\{true\}/);
+  assert.match(orderStatus, /indexable=\{false\}/);
+  assert.doesNotMatch(orderStatus, /analytics=\{true\}/);
+  assert.match(baseLayout, /analyticsProp !== undefined \? analyticsProp : indexable/);
+});
+
+test('el payload real usa contexto estable y descarta la query sensible', () => {
+  const listeners = {};
+  const window = {
+    location: {
+      hostname: 'www.amadolibros.com',
+      pathname: '/especialidades/oftalmologia',
+      href: 'https://www.amadolibros.com/especialidades/oftalmologia?q=consulta-privada&utm_source=chatgpt.com',
+    },
+    dataLayer: [],
+  };
+  const document = {
+    querySelector: () => null,
+    createElement: () => ({}),
+    head: { appendChild: () => {} },
+    addEventListener: (name, handler) => { listeners[name] = handler; },
+  };
+
+  runInNewContext(analytics, { document, window, URL, Set, Date, Object, String, encodeURIComponent });
+  const [, , config] = Array.from(window.dataLayer.find((entry) => Array.from(entry)[0] === 'config'));
+  assert.equal(
+    config.page_location,
+    'https://www.amadolibros.com/especialidades/oftalmologia?utm_source=chatgpt.com',
+  );
+  window.AmadoAnalytics.trackWhatsApp({ ctaLocation: 'hero principal' });
+
+  const [eventCommand, eventName, params] = Array.from(window.dataLayer.at(-1));
+  assert.equal(eventCommand, 'event');
+  assert.equal(eventName, 'whatsapp_click');
+  assert.deepEqual({ ...params }, {
+    page_type: 'specialty',
+    cta_location: 'hero_principal',
+    topic: 'oftalmologia',
+  });
+  assert.equal(JSON.stringify(params).includes('consulta-privada'), false);
+  assert.equal(typeof listeners.click, 'function');
+});

--- a/functions/__tests__/ga4-export.test.js
+++ b/functions/__tests__/ga4-export.test.js
@@ -3,7 +3,14 @@ import { createRequire } from 'node:module';
 import test from 'node:test';
 
 const require = createRequire(import.meta.url);
-const { assertDate, buildRequest, normalizeReport, toCsv } = require('../../scripts/ga4-export.js');
+const {
+  AI_REFERRAL_SOURCES,
+  REPORTS,
+  assertDate,
+  buildRequest,
+  normalizeReport,
+  toCsv,
+} = require('../../scripts/ga4-export.js');
 
 test('valida fechas reales en formato ISO', () => {
   assert.doesNotThrow(() => assertDate('2026-07-31', 'fecha'));
@@ -53,4 +60,30 @@ test('normaliza la respuesta exacta de GA4 y genera CSV seguro', () => {
   );
   assert.equal(normalized.rows[0].metrics.sessions, '17');
   assert.match(toCsv(normalized), /"'=malicious","17"/);
+});
+
+test('separa referidos de asistentes de IA y exporta la intención de WhatsApp', () => {
+  assert.deepEqual(
+    AI_REFERRAL_SOURCES.filter((source) => ['chatgpt.com', 'claude.ai', 'gemini.google.com'].includes(source)),
+    ['chatgpt.com', 'claude.ai', 'gemini.google.com'],
+  );
+
+  const aiReport = REPORTS.find((report) => report.id === 'ai-referral-landing-pages');
+  assert.ok(aiReport);
+  assert.equal(aiReport.filter.filter.fieldName, 'sessionSource');
+  assert.equal(aiReport.filter.filter.inListFilter.caseSensitive, false);
+  assert.ok(aiReport.dimensions.includes('landingPagePlusQueryString'));
+
+  const whatsappReport = REPORTS.find((report) => report.id === 'whatsapp-intent');
+  assert.ok(whatsappReport);
+  assert.equal(whatsappReport.filter.filter.fieldName, 'eventName');
+  assert.equal(whatsappReport.filter.filter.stringFilter.value, 'whatsapp_click');
+  assert.ok(whatsappReport.dimensions.includes('landingPagePlusQueryString'));
+
+  const denominator = REPORTS.find((report) => report.id === 'all-landing-pages');
+  assert.ok(denominator);
+  assert.deepEqual(denominator.dimensions, whatsappReport.dimensions);
+
+  const clickPages = REPORTS.find((report) => report.id === 'whatsapp-click-pages');
+  assert.ok(clickPages.dimensions.includes('pagePath'));
 });

--- a/functions/__tests__/seo-specialty-pages.test.js
+++ b/functions/__tests__/seo-specialty-pages.test.js
@@ -73,6 +73,7 @@ test('cada landing muestra catálogo real filtrado y SEO regional verificable', 
     assert.match(html, /"@type":"CollectionPage"/);
     assert.match(html, /"@type":"ItemList"/);
     assert.match(html, /"@type":"Service"/);
+    assert.match(html, /<script src="\/analytics-events\.js"><\/script>/);
     assert.match(html, /"areaServed":\{"@type":"Country","name":"Uruguay"\}/);
     assert.match(html, /¿Consultás desde España o Latinoamérica\?/);
     assert.match(html, /eventual envío internacional se confirman caso a caso/);

--- a/functions/_shared/brand.js
+++ b/functions/_shared/brand.js
@@ -99,6 +99,7 @@ export function faviconHeadHtml() {
         `<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?${v}">`,
         `<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?${v}">`,
         `<link rel="manifest" href="/site.webmanifest?${v}">`,
+        '<script src="/analytics-events.js"></script>',
     ].join('\n  ');
 }
 

--- a/functions/libros-maria-montessori-uruguay.js
+++ b/functions/libros-maria-montessori-uruguay.js
@@ -128,6 +128,7 @@ export async function onRequest(ctx) {
   <meta property="og:url"         content="${BASE}/libros-maria-montessori-uruguay">
   <meta property="og:title"       content="Libros de María Montessori en Uruguay | Amado Libros">
   <meta property="og:description" content="Libros de María Montessori disponibles en Uruguay. Consultá stock por WhatsApp, comprá online o pedí libros difíciles de ubicar.">
+  <script src="/analytics-events.js"></script>
   <meta property="og:image"       content="${BASE}/images/logo-amado.png">
   <meta property="og:locale"      content="es_UY">
 

--- a/scripts/ga4-export.js
+++ b/scripts/ga4-export.js
@@ -11,6 +11,33 @@ const ORGANIC_FILTER = {
   },
 };
 
+const AI_REFERRAL_SOURCES = [
+  'chatgpt.com',
+  'chat.openai.com',
+  'claude.ai',
+  'gemini.google.com',
+  'bard.google.com',
+  'perplexity.ai',
+  'copilot.microsoft.com',
+];
+
+const AI_REFERRAL_FILTER = {
+  filter: {
+    fieldName: 'sessionSource',
+    inListFilter: {
+      values: AI_REFERRAL_SOURCES,
+      caseSensitive: false,
+    },
+  },
+};
+
+const WHATSAPP_EVENT_FILTER = {
+  filter: {
+    fieldName: 'eventName',
+    stringFilter: { matchType: 'EXACT', value: 'whatsapp_click' },
+  },
+};
+
 const REPORTS = [
   {
     id: 'organic-summary',
@@ -64,6 +91,56 @@ const REPORTS = [
     id: 'event-inventory',
     dimensions: ['eventName'],
     metrics: ['eventCount', 'totalUsers'],
+  },
+  {
+    id: 'all-landing-pages',
+    dimensions: ['sessionSource', 'sessionMedium', 'landingPagePlusQueryString'],
+    metrics: [
+      'sessions',
+      'totalUsers',
+      'engagedSessions',
+      'engagementRate',
+      'keyEvents',
+      'sessionKeyEventRate',
+    ],
+  },
+  {
+    id: 'ai-referral-sources',
+    dimensions: ['sessionSource', 'sessionMedium'],
+    metrics: [
+      'sessions',
+      'totalUsers',
+      'engagedSessions',
+      'engagementRate',
+      'keyEvents',
+      'sessionKeyEventRate',
+    ],
+    filter: AI_REFERRAL_FILTER,
+  },
+  {
+    id: 'ai-referral-landing-pages',
+    dimensions: ['sessionSource', 'sessionMedium', 'landingPagePlusQueryString'],
+    metrics: [
+      'sessions',
+      'totalUsers',
+      'engagedSessions',
+      'engagementRate',
+      'keyEvents',
+      'sessionKeyEventRate',
+    ],
+    filter: AI_REFERRAL_FILTER,
+  },
+  {
+    id: 'whatsapp-intent',
+    dimensions: ['sessionSource', 'sessionMedium', 'landingPagePlusQueryString'],
+    metrics: ['sessions', 'totalUsers', 'eventCount'],
+    filter: WHATSAPP_EVENT_FILTER,
+  },
+  {
+    id: 'whatsapp-click-pages',
+    dimensions: ['pagePath'],
+    metrics: ['eventCount', 'totalUsers'],
+    filter: WHATSAPP_EVENT_FILTER,
   },
   {
     id: 'organic-ecommerce-events',
@@ -241,4 +318,11 @@ if (require.main === module) {
   });
 }
 
-module.exports = { REPORTS, assertDate, buildRequest, normalizeReport, toCsv };
+module.exports = {
+  AI_REFERRAL_SOURCES,
+  REPORTS,
+  assertDate,
+  buildRequest,
+  normalizeReport,
+  toCsv,
+};


### PR DESCRIPTION
## Qué cambia

- carga GA4 también en catálogo, fichas, categorías y especialidades renderizadas por Functions;
- registra `whatsapp_click` en enlaces y aperturas programáticas;
- conserva atribución UTM sin enviar consultas internas, mensajes ni datos del checkout;
- separa referidos de ChatGPT, Claude, Gemini, Perplexity y Copilot en los exportes;
- documenta KPI, auditoría de las cinco especialidades y reglas de decisión.

## Por qué

Había una brecha entre las páginas Astro y las páginas SSR: una consulta podía terminar en WhatsApp sin conservar una sesión atribuible. Sin esa medición no es posible decidir con rigor qué landings, fichas o guías merecen inversión.

## Impacto

No cambia precios, checkout, pagos ni catálogo. Añade medición de intención comercial y mantiene fuera de Analytics la página de estado del pedido.

## Validación

- suite completa de JavaScript verde;
- pruebas focalizadas de Analytics, GA4, shell, especialidades y schema verdes;
- build Astro con checkout OFF verde;
- build Astro con checkout ON verde;
- `git diff --check` y sintaxis JS verdes.