### PR TITLE
Publicar identidad y método verificable de Amado Libros

### DIFF
--- a/astro-front/src/components/Footer.astro
+++ b/astro-front/src/components/Footer.astro
@@ -20,6 +20,7 @@ const YEAR = new Date().getFullYear();
     <div class="footer-info">
       <p class="footer-info-title">Cómo comprás</p>
       <ul class="footer-list">
+        <li><a href="/quienes-somos">Quiénes somos y cómo trabajamos</a></li>
         <li><a href="/pedir-libro">¿No encontraste el libro?</a></li>
         <li><a href="/libros-agotados-importados-uruguay">Libros por encargo</a></li>
         <li><a href="/envios">Envíos y retiro</a></li>

--- a/astro-front/src/layouts/TrustPageLayout.astro
+++ b/astro-front/src/layouts/TrustPageLayout.astro
@@ -11,9 +11,20 @@ interface Props {
   heading: string;
   updated?: string;
   jsonLd?: Record<string, unknown>;
+  breadcrumbLabel?: string;
+  breadcrumbHref?: string | null;
 }
 
-const { title, description, canonical, heading, updated = '29 de julio de 2026', jsonLd } = Astro.props;
+const {
+  title,
+  description,
+  canonical,
+  heading,
+  updated = '29 de julio de 2026',
+  jsonLd,
+  breadcrumbLabel = 'Políticas',
+  breadcrumbHref = '/politicas',
+} = Astro.props;
 ---
 <BaseLayout title={title} description={description} canonical={canonical} jsonLd={jsonLd}>
   <Header />
@@ -22,7 +33,9 @@ const { title, description, canonical, heading, updated = '29 de julio de 2026',
       <nav class="trust-breadcrumb" aria-label="Migas de pan">
         <a href="/">Inicio</a>
         <span aria-hidden="true">/</span>
-        <a href="/politicas">Políticas</a>
+        {breadcrumbHref
+          ? <a href={breadcrumbHref}>{breadcrumbLabel}</a>
+          : <span>{breadcrumbLabel}</span>}
       </nav>
       <h1>{heading}</h1>
       <p class="trust-updated">Última actualización: {updated}</p>

--- a/astro-front/src/pages/quienes-somos.astro
+++ b/astro-front/src/pages/quienes-somos.astro
@@ -1,0 +1,163 @@
+---
+import TrustPageLayout from '../layouts/TrustPageLayout.astro';
+
+const canonical = 'https://www.amadolibros.com/quienes-somos';
+const whatsapp = 'https://wa.me/59899841325?text=' + encodeURIComponent(
+  'Hola Amado Libros, quiero consultar por un libro. Tengo estos datos: '
+);
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': ['Organization', 'BookStore'],
+      '@id': 'https://www.amadolibros.com/#bookstore',
+      name: 'Amado Libros',
+      url: 'https://www.amadolibros.com/',
+      logo: 'https://www.amadolibros.com/images/logo-amado.webp',
+      image: 'https://www.amadolibros.com/images/logo-amado.webp',
+      description: 'Librería online uruguaya, familiar y atendida por sus dueños. Vende libros disponibles y realiza búsquedas manuales de títulos agotados, importados o difíciles de conseguir.',
+      telephone: '+59899841325',
+      email: 'adm@amadolibros.com',
+      address: {
+        '@type': 'PostalAddress',
+        streetAddress: 'Rincón 608',
+        addressLocality: 'Montevideo',
+        addressCountry: 'UY',
+      },
+      areaServed: {
+        '@type': 'Country',
+        name: 'Uruguay',
+      },
+      contactPoint: {
+        '@type': 'ContactPoint',
+        contactType: 'customer service',
+        telephone: '+59899841325',
+        email: 'adm@amadolibros.com',
+        availableLanguage: 'Spanish',
+      },
+      knowsAbout: [
+        'Libros importados',
+        'Libros agotados y descatalogados',
+        'Identificación de ediciones por ISBN',
+        'Bibliografía técnica y profesional',
+      ],
+    },
+    {
+      '@type': 'WebSite',
+      '@id': 'https://www.amadolibros.com/#website',
+      url: 'https://www.amadolibros.com/',
+      name: 'Amado Libros',
+      publisher: { '@id': 'https://www.amadolibros.com/#bookstore' },
+      inLanguage: 'es-UY',
+    },
+    {
+      '@type': 'AboutPage',
+      '@id': `${canonical}#webpage`,
+      url: canonical,
+      name: 'Quiénes somos y cómo trabajamos — Amado Libros',
+      description: 'Qué hace Amado Libros, cómo verifica una edición y cómo realiza búsquedas manuales de libros para clientes en Uruguay.',
+      isPartOf: { '@id': 'https://www.amadolibros.com/#website' },
+      about: { '@id': 'https://www.amadolibros.com/#bookstore' },
+      mainEntity: { '@id': 'https://www.amadolibros.com/#bookstore' },
+      reviewedBy: { '@id': 'https://www.amadolibros.com/#bookstore' },
+      dateModified: '2026-08-12',
+      inLanguage: 'es-UY',
+    },
+    {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Inicio',
+          item: 'https://www.amadolibros.com/',
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'Quiénes somos y cómo trabajamos',
+          item: canonical,
+        },
+      ],
+    },
+  ],
+};
+---
+
+<TrustPageLayout
+  title="Quiénes somos y cómo trabajamos | Amado Libros"
+  description="Amado Libros es una librería online uruguaya, familiar y atendida por sus dueños. Conocé cómo buscamos y verificamos libros por título, autor, ISBN y edición."
+  canonical={canonical}
+  heading="Quiénes somos y cómo trabajamos"
+  updated="12 de agosto de 2026"
+  breadcrumbLabel="Quiénes somos"
+  breadcrumbHref={null}
+  jsonLd={jsonLd}
+>
+  <p class="trust-lead">
+    <strong>Amado Libros es una librería online uruguaya, familiar y atendida por sus dueños.</strong>
+    Vendemos libros disponibles en nuestro catálogo y buscamos manualmente títulos agotados,
+    importados o difíciles de conseguir para clientes en Uruguay.
+  </p>
+
+  <h2>Qué hacemos</h2>
+  <ul>
+    <li><strong>Catálogo disponible:</strong> publicamos libros que se pueden consultar y comprar desde el sitio.</li>
+    <li><strong>Búsqueda manual:</strong> si el libro no aparece, una persona revisa los datos y busca opciones.</li>
+    <li><strong>Identificación de la edición:</strong> usamos título, autor, editorial, ISBN, idioma, formato o una foto de la tapa para reducir errores.</li>
+    <li><strong>Encargos:</strong> antes de confirmar, informamos la opción encontrada y las condiciones disponibles para ese pedido.</li>
+  </ul>
+
+  <h2>Cómo verificamos un libro</h2>
+  <ol>
+    <li><strong>Recibimos la referencia.</strong> No es obligatorio tener el ISBN: podemos empezar con información incompleta.</li>
+    <li><strong>Separamos obra de edición.</strong> Comparamos autor, editorial, año, idioma, formato e ISBN cuando esos datos existen.</li>
+    <li><strong>Revisamos disponibilidad.</strong> Contrastamos el catálogo y las opciones de proveedores antes de responder.</li>
+    <li><strong>Te presentamos la opción.</strong> La disponibilidad, el precio y las condiciones se confirman para cada caso antes de asumir un compromiso.</li>
+  </ol>
+
+  <div class="trust-note">
+    <strong>Nuestro criterio:</strong> si no podemos verificar que una opción corresponde al libro o a la edición solicitada, lo aclaramos. No tratamos como equivalentes dos ediciones solamente porque compartan título.
+  </div>
+
+  <h2>Qué datos ayudan a encontrar la edición correcta</h2>
+  <p>
+    El dato más preciso suele ser el <strong>ISBN</strong>, pero también sirven el nombre completo
+    del autor, la editorial, el año aproximado, el idioma, el tipo de encuadernación o una foto.
+    En bibliografía técnica conviene agregar la especialidad, el nivel de estudio y para qué se necesita.
+  </p>
+
+  <h2>Quién revisa este contenido</h2>
+  <p>
+    Esta página fue revisada por el equipo de Amado Libros, el mismo que atiende las consultas y
+    realiza las búsquedas. La fecha visible indica la última revisión del procedimiento publicado.
+  </p>
+
+  <h2>Datos verificables y contacto</h2>
+  <ul>
+    <li><strong>Nombre comercial:</strong> Amado Libros.</li>
+    <li><strong>Actividad:</strong> librería online uruguaya.</li>
+    <li><strong>Domicilio comercial:</strong> Rincón 608, Ciudad Vieja, Montevideo, Uruguay.</li>
+    <li><strong>WhatsApp y teléfono:</strong> <a href="https://wa.me/59899841325">099 841 325</a>.</li>
+    <li><strong>Correo:</strong> <a href="mailto:adm@amadolibros.com">adm@amadolibros.com</a>.</li>
+    <li><strong>Información operativa:</strong> <a href="/contacto">contacto y horarios</a>, <a href="/envios">envíos y retiro</a> y <a href="/devoluciones">devoluciones</a>.</li>
+  </ul>
+
+  <p class="trust-note" data-cta-location="about_method">
+    <strong>¿Buscás un libro concreto?</strong><br>
+    Podés <a href="/pedir-libro">enviar un pedido de búsqueda ordenado</a> o
+    <a href={whatsapp} target="_blank" rel="noopener noreferrer">escribirnos por WhatsApp</a>.
+  </p>
+</TrustPageLayout>
+
+<style>
+  .trust-lead {
+    font-size: 1.05rem;
+    line-height: 1.75;
+    margin-bottom: 1.5rem;
+  }
+
+  ol { padding-left: 1.25rem; }
+  li + li { margin-top: 0.6rem; }
+</style>

--- a/functions/__tests__/institutional-authority.test.js
+++ b/functions/__tests__/institutional-authority.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { FOOTER_LINKS } from '../_shared/brand.js';
+import { STATIC_SITEMAP_PAGES } from '../sitemap-pages.xml.js';
+
+const root = (rel) => fileURLToPath(new URL('../../' + rel, import.meta.url));
+const read = (rel) => readFileSync(root(rel), 'utf8');
+const page = read('astro-front/src/pages/quienes-somos.astro');
+
+test('la página institucional publica identidad, método y responsable visibles', () => {
+  assert.match(page, /librería online uruguaya, familiar y atendida por sus dueños/i);
+  assert.match(page, /Cómo verificamos un libro/);
+  assert.match(page, /ISBN/);
+  assert.match(page, /revisada por el equipo de Amado Libros/);
+  assert.match(page, /12 de agosto de 2026/);
+});
+
+test('la identidad estructurada conecta BookStore, WebSite y AboutPage', () => {
+  assert.match(page, /'@type': \['Organization', 'BookStore'\]/);
+  assert.match(page, /'@type': 'WebSite'/);
+  assert.match(page, /'@type': 'AboutPage'/);
+  assert.match(page, /reviewedBy/);
+  assert.match(page, /Rincón 608/);
+  assert.doesNotMatch(page, /sameAs:/, 'no debe inventar perfiles externos no verificados');
+});
+
+test('la página es descubrible desde el footer global y el sitemap', () => {
+  assert.ok(FOOTER_LINKS.some(link => link.href === '/quienes-somos'));
+  assert.ok(STATIC_SITEMAP_PAGES.includes('https://www.amadolibros.com/quienes-somos'));
+});

--- a/functions/_shared/brand.js
+++ b/functions/_shared/brand.js
@@ -67,6 +67,7 @@ export const CONTACT = {
 
 
 export const FOOTER_LINKS = [
+    { href: '/quienes-somos', label: 'Quiénes somos y cómo trabajamos' },
     { href: '/pedir-libro', label: '¿No encontraste el libro?' },
     { href: '/libros-agotados-importados-uruguay', label: 'Libros por encargo' },
     { href: '/envios',       label: 'Envíos y retiro' },

--- a/functions/sitemap-pages.xml.js
+++ b/functions/sitemap-pages.xml.js
@@ -14,6 +14,7 @@ export const STATIC_SITEMAP_PAGES = Object.freeze([
   `${BASE}/terminos`,
   `${BASE}/privacidad`,
   `${BASE}/contacto`,
+  `${BASE}/quienes-somos`,
   ...SEO_SPECIALTIES.map(item => `${BASE}${specialtyPath(item.id)}`),
 ]);
 


### PR DESCRIPTION
## Qué cambia

- publica `/quienes-somos` con identidad, datos de contacto y método de búsqueda verificable;
- incorpora datos estructurados conectados `Organization` + `BookStore` + `WebSite` + `AboutPage`;
- agrega autoría institucional, fecha de revisión y criterio explícito para distinguir ediciones;
- enlaza la página desde los footers Astro y SSR y la incluye en el sitemap;
- evita declarar perfiles externos que todavía no estén verificados.

## Impacto

Da a Google y a los asistentes de IA una fuente institucional única, rastreable y citable, y lleva al visitante a un pedido de búsqueda o WhatsApp sin promesas de disponibilidad no verificadas.

## Validación

- `node --test functions/__tests__/institutional-authority.test.js functions/__tests__/global-shell-parity.test.js functions/__tests__/seo-specialty-pages.test.js`
- `bash scripts/validate-ci.sh` con suite completa y builds de checkout OFF/ON: verde.