### PR TITLE
Publicar guía citable para verificar ediciones por ISBN

### DIFF
--- a/astro-front/src/components/Footer.astro
+++ b/astro-front/src/components/Footer.astro
@@ -22,6 +22,7 @@ const YEAR = new Date().getFullYear();
       <ul class="footer-list">
         <li><a href="/quienes-somos">Quiénes somos y cómo trabajamos</a></li>
         <li><a href="/pedir-libro">¿No encontraste el libro?</a></li>
+        <li><a href="/como-identificar-edicion-correcta-isbn">Guía para verificar un ISBN</a></li>
         <li><a href="/libros-agotados-importados-uruguay">Libros por encargo</a></li>
         <li><a href="/envios">Envíos y retiro</a></li>
         <li><a href="/devoluciones">Devoluciones y reembolsos</a></li>

--- a/astro-front/src/pages/como-identificar-edicion-correcta-isbn.astro
+++ b/astro-front/src/pages/como-identificar-edicion-correcta-isbn.astro
@@ -1,0 +1,317 @@
+---
+import TrustPageLayout from '../layouts/TrustPageLayout.astro';
+
+const canonical = 'https://www.amadolibros.com/como-identificar-edicion-correcta-isbn';
+const whatsapp = 'https://wa.me/59899841325?text=' + encodeURIComponent(
+  'Hola Amado Libros, quiero verificar la edición correcta de un libro. Les paso el ISBN y los datos que tengo: '
+);
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': ['Organization', 'BookStore'],
+      '@id': 'https://www.amadolibros.com/#bookstore',
+      name: 'Amado Libros',
+      url: 'https://www.amadolibros.com/',
+      logo: 'https://www.amadolibros.com/images/logo-amado.webp',
+    },
+    {
+      '@type': 'Article',
+      '@id': `${canonical}#article`,
+      url: canonical,
+      headline: 'Cómo identificar la edición correcta de un libro por ISBN',
+      description: 'Guía práctica para comparar ISBN, editorial, año, idioma y formato antes de comprar o encargar una edición concreta en Uruguay.',
+      datePublished: '2026-08-12',
+      dateModified: '2026-08-12',
+      inLanguage: 'es-UY',
+      author: { '@id': 'https://www.amadolibros.com/#bookstore' },
+      publisher: { '@id': 'https://www.amadolibros.com/#bookstore' },
+      reviewedBy: { '@id': 'https://www.amadolibros.com/#bookstore' },
+      mainEntityOfPage: canonical,
+      about: [
+        { '@type': 'Thing', name: 'ISBN' },
+        { '@type': 'Thing', name: 'Ediciones de libros' },
+      ],
+    },
+    {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Inicio',
+          item: 'https://www.amadolibros.com/',
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'Cómo identificar una edición por ISBN',
+          item: canonical,
+        },
+      ],
+    },
+  ],
+};
+---
+
+<TrustPageLayout
+  title="Cómo identificar la edición correcta por ISBN | Amado Libros"
+  description="Compará ISBN, editorial, año, idioma y formato para reconocer la edición correcta de un libro. Guía revisada por Amado Libros en Uruguay."
+  canonical={canonical}
+  heading="Cómo identificar la edición correcta de un libro por ISBN"
+  updated="12 de agosto de 2026"
+  breadcrumbLabel="Guía de ISBN"
+  breadcrumbHref={null}
+  jsonLd={jsonLd}
+>
+  <p class="trust-lead">
+    <strong>La forma más segura de reconocer una edición concreta es comparar el ISBN completo y confirmar editorial, idioma y formato.</strong>
+    El título y el autor identifican la obra, pero no necesariamente la edición que necesitás.
+  </p>
+
+  <div class="answer-box">
+    <strong>Respuesta corta:</strong> si dos ejemplares tienen distinto ISBN, no deben tratarse como el mismo producto editorial.
+    Puede haber cambiado la edición, la encuadernación, el idioma, el formato digital o el editor responsable.
+    Si el ISBN coincide, igualmente conviene revisar los demás datos porque una ficha de catálogo puede estar mal cargada.
+  </div>
+
+  <nav class="guide-index" aria-label="Contenido de la guía">
+    <strong>En esta guía</strong>
+    <a href="#que-es">Qué identifica el ISBN</a>
+    <a href="#pasos">Cómo verificarlo</a>
+    <a href="#cambia">Cuándo cambia</a>
+    <a href="#isbn-10">ISBN-10 e ISBN-13</a>
+    <a href="#sin-isbn">Si no tenés el ISBN</a>
+  </nav>
+
+  <h2 id="que-es">Qué identifica exactamente un ISBN</h2>
+  <p>
+    El ISBN es el número internacional normalizado que identifica una publicación monográfica.
+    Desde 2007 los ISBN nuevos tienen 13 dígitos. El número permite distinguir un título,
+    una edición y un formato publicados por un editor determinado.
+  </p>
+  <p>
+    <strong>No identifica un ejemplar físico individual</strong>, no garantiza que haya stock y no demuestra por sí solo
+    el estado de conservación de un libro usado. Tampoco es lo mismo que el código de barras: el código de barras es
+    la representación gráfica que puede contener el ISBN u otro identificador comercial.
+  </p>
+
+  <h2 id="pasos">Cómo verificar una edición, paso a paso</h2>
+  <ol class="checklist">
+    <li>
+      <strong>Buscá el ISBN en el propio libro.</strong> Suele estar en la página de créditos o legales,
+      y también puede aparecer cerca del código de barras de la contratapa.
+    </li>
+    <li>
+      <strong>Compará todos los dígitos.</strong> Para la comparación podés ignorar espacios y guiones,
+      pero no quitar, completar ni cambiar números.
+    </li>
+    <li>
+      <strong>Confirmá editorial y número de edición.</strong> Revisá además el año, el idioma,
+      el traductor o coordinador cuando sea relevante y cualquier indicación como “edición revisada”.
+    </li>
+    <li>
+      <strong>Confirmá el formato.</strong> Tapa dura, tapa blanda, EPUB, PDF y otros formatos pueden tener ISBN diferentes,
+      aunque el texto y la tapa se parezcan.
+    </li>
+    <li>
+      <strong>Resolvé las contradicciones antes de comprar.</strong> Si una publicación anuncia un ISBN pero muestra otra editorial,
+      edición o encuadernación, pedí una foto de la página de créditos o consultá al vendedor.
+    </li>
+  </ol>
+
+  <div class="trust-note">
+    <strong>Para bibliografía académica o profesional:</strong> no reemplaces una edición indicada por un docente,
+    una cátedra o una institución solamente porque el título coincide. Verificá el ISBN solicitado o confirmá
+    si aceptan otra edición.
+  </div>
+
+  <h2 id="cambia">Cuándo corresponde un ISBN diferente</h2>
+  <div class="table-wrap" tabindex="0" aria-label="Comparación de cambios que afectan el ISBN">
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">Cambio en la publicación</th>
+          <th scope="col">Qué esperar</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Nueva edición o revisión con cambios de contenido</td>
+          <td>ISBN diferente</td>
+        </tr>
+        <tr>
+          <td>Tapa dura, tapa blanda u otro formato físico</td>
+          <td>ISBN diferente</td>
+        </tr>
+        <tr>
+          <td>EPUB, PDF u otro formato digital comercializado por separado</td>
+          <td>ISBN diferente</td>
+        </tr>
+        <tr>
+          <td>Traducción a otro idioma</td>
+          <td>ISBN diferente</td>
+        </tr>
+        <tr>
+          <td>Cambio del editor responsable</td>
+          <td>ISBN diferente</td>
+        </tr>
+        <tr>
+          <td>Reimpresión sin cambios sustanciales</td>
+          <td>Puede conservar el ISBN</td>
+        </tr>
+        <tr>
+          <td>Cambio de precio</td>
+          <td>No requiere otro ISBN</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p>
+    Por eso, “segunda edición” y “segunda reimpresión” no significan lo mismo. Una nueva edición supone cambios
+    relevantes en la publicación; una reimpresión puede limitarse a producir más ejemplares sin modificaciones sustanciales.
+  </p>
+
+  <h2 id="isbn-10">Qué hacer con un ISBN de 10 dígitos</h2>
+  <p>
+    Los ISBN tenían 10 dígitos hasta fines de 2006. Un libro anterior puede mostrar solamente ese número,
+    y una base de datos moderna puede mostrar su equivalente de 13 dígitos. No compares ambos formatos a simple vista
+    ni supongas que alcanza con agregar “978”: la conversión incluye un dígito de control calculado.
+  </p>
+  <p>
+    Para buscar, enviá cualquiera de los dos números tal como aparece. Si tenés acceso al libro,
+    una foto de la página de créditos ayuda a confirmar que ambos registros corresponden a la misma edición.
+  </p>
+
+  <h2 id="sin-isbn">Si no tenés el ISBN</h2>
+  <p>
+    Todavía se puede buscar la edición. Reuní la mayor cantidad posible de estos datos:
+  </p>
+  <ul>
+    <li>título y autor completos;</li>
+    <li>editorial o sello;</li>
+    <li>año aproximado y número de edición;</li>
+    <li>idioma, traductor o coordinador;</li>
+    <li>tapa dura o blanda, cantidad aproximada de páginas y tamaño;</li>
+    <li>foto de la tapa, contratapa o página de créditos.</li>
+  </ul>
+  <p>
+    En Amado Libros separamos primero la obra de la edición y luego contrastamos los datos disponibles.
+    Podés conocer <a href="/quienes-somos">nuestro método de búsqueda y verificación</a> o consultar
+    <a href="/libros-agotados-importados-uruguay">cómo funciona un encargo de libros agotados o importados</a>.
+  </p>
+
+  <h2>Fuentes oficiales consultadas</h2>
+  <ul class="sources">
+    <li>
+      <a href="https://www.bibna.gub.uy/isbn/" target="_blank" rel="noopener noreferrer">Agencia ISBN de la Biblioteca Nacional de Uruguay</a>:
+      definición, ubicación del número y casos que requieren un nuevo ISBN.
+    </li>
+    <li>
+      <a href="https://www.isbn-international.org/index.php/content/what-isbn/10" target="_blank" rel="noopener noreferrer">Agencia Internacional del ISBN</a>:
+      estructura del ISBN y alcance como identificador de edición y formato.
+    </li>
+  </ul>
+
+  <h2>Quién revisó esta guía</h2>
+  <p>
+    Contenido revisado por el equipo de Amado Libros, que atiende consultas y realiza búsquedas manuales
+    por título, autor, editorial, ISBN, idioma y formato. La fecha visible indica la última revisión.
+  </p>
+
+  <div class="closing-cta" data-cta-location="isbn_guide">
+    <strong>¿Querés confirmar una edición antes de encargarla?</strong>
+    <p>Mandanos el ISBN y los demás datos que tengas. Si hay una contradicción, la revisamos antes de presentarte una opción.</p>
+    <div class="cta-links">
+      <a class="cta-primary" href="/pedir-libro?tipo=exacto">Enviar pedido ordenado</a>
+      <a href={whatsapp} target="_blank" rel="noopener noreferrer">Consultar por WhatsApp</a>
+    </div>
+  </div>
+</TrustPageLayout>
+
+<style>
+  .trust-lead {
+    font-size: 1.05rem;
+    line-height: 1.75;
+    margin-bottom: 1.25rem;
+  }
+
+  .answer-box {
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    background: var(--bg);
+    color: var(--ink-2);
+  }
+
+  .answer-box strong { color: var(--ink); }
+
+  .guide-index {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem 0.9rem;
+    margin: 1.5rem 0 2rem;
+    padding: 1rem;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+
+  .guide-index strong { width: 100%; }
+  .checklist { padding-left: 1.25rem; }
+  .checklist li + li { margin-top: 0.75rem; }
+
+  .table-wrap {
+    overflow-x: auto;
+    margin: 1rem 0;
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+  }
+
+  table {
+    width: 100%;
+    min-width: 560px;
+    border-collapse: collapse;
+    color: var(--ink-2);
+    font-size: 0.9rem;
+  }
+
+  th, td {
+    padding: 0.75rem;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+    vertical-align: top;
+  }
+
+  th { background: var(--bg); color: var(--ink); }
+  tr:last-child td { border-bottom: 0; }
+  td:last-child { font-weight: 700; color: var(--ink); }
+
+  .sources { font-size: 0.92rem; }
+
+  .closing-cta {
+    margin-top: 2rem;
+    padding: 1.25rem;
+    border-radius: var(--r);
+    background: var(--ink);
+    color: white;
+  }
+
+  .closing-cta strong { color: white; }
+  .closing-cta p { margin: 0.5rem 0 1rem; color: rgba(255, 255, 255, 0.72); }
+  .cta-links { display: flex; flex-wrap: wrap; align-items: center; gap: 0.75rem 1rem; }
+  .closing-cta a { color: white; }
+  .closing-cta .cta-primary {
+    display: inline-flex;
+    min-height: 44px;
+    align-items: center;
+    padding: 0.65rem 0.9rem;
+    border-radius: 0.6rem;
+    background: var(--salmon);
+    color: var(--ink);
+    font-weight: 800;
+    text-decoration: none;
+  }
+</style>

--- a/astro-front/src/pages/quienes-somos.astro
+++ b/astro-front/src/pages/quienes-somos.astro
@@ -123,7 +123,9 @@ const jsonLd = {
 
   <h2>Qué datos ayudan a encontrar la edición correcta</h2>
   <p>
-    El dato más preciso suele ser el <strong>ISBN</strong>, pero también sirven el nombre completo
+    El dato más preciso suele ser el <strong>ISBN</strong>. Si necesitás comparar dos ejemplares,
+    consultá nuestra <a href="/como-identificar-edicion-correcta-isbn">guía para identificar la edición correcta por ISBN</a>.
+    También sirven el nombre completo
     del autor, la editorial, el año aproximado, el idioma, el tipo de encuadernación o una foto.
     En bibliografía técnica conviene agregar la especialidad, el nivel de estudio y para qué se necesita.
   </p>

--- a/functions/__tests__/isbn-guide-authority.test.js
+++ b/functions/__tests__/isbn-guide-authority.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { FOOTER_LINKS } from '../_shared/brand.js';
+import { STATIC_SITEMAP_PAGES } from '../sitemap-pages.xml.js';
+
+const root = (rel) => fileURLToPath(new URL('../../' + rel, import.meta.url));
+const read = (rel) => readFileSync(root(rel), 'utf8');
+const page = read('astro-front/src/pages/como-identificar-edicion-correcta-isbn.astro');
+
+test('la guía responde de forma directa y distingue obra, edición y formato', () => {
+  assert.match(page, /forma más segura.*comparar el ISBN completo/is);
+  assert.match(page, /si dos ejemplares tienen distinto ISBN/i);
+  assert.match(page, /ISBN de 10 dígitos/i);
+  assert.match(page, /Reimpresión sin cambios sustanciales/);
+  assert.match(page, /Cambio de precio/);
+});
+
+test('la guía identifica revisión, fecha y fuentes oficiales visibles', () => {
+  assert.match(page, /revisado por el equipo de Amado Libros/i);
+  assert.match(page, /12 de agosto de 2026/);
+  assert.match(page, /https:\/\/www\.bibna\.gub\.uy\/isbn\//);
+  assert.match(page, /https:\/\/www\.isbn-international\.org\//);
+});
+
+test('el schema Article declara autor, revisión, fechas y breadcrumb', () => {
+  assert.match(page, /'@type': 'Article'/);
+  assert.match(page, /datePublished: '2026-08-12'/);
+  assert.match(page, /dateModified: '2026-08-12'/);
+  assert.match(page, /reviewedBy/);
+  assert.match(page, /'@type': 'BreadcrumbList'/);
+});
+
+test('la guía convierte y es descubrible desde el sitio completo', () => {
+  const path = '/como-identificar-edicion-correcta-isbn';
+  assert.match(page, /\/pedir-libro\?tipo=exacto/);
+  assert.match(page, /wa\.me\/59899841325/);
+  assert.ok(FOOTER_LINKS.some(link => link.href === path));
+  assert.ok(STATIC_SITEMAP_PAGES.includes(`https://www.amadolibros.com${path}`));
+  assert.match(read('astro-front/src/pages/quienes-somos.astro'), new RegExp(path));
+  assert.match(read('functions/libros-agotados-importados-uruguay.js'), new RegExp(path));
+});

--- a/functions/_shared/brand.js
+++ b/functions/_shared/brand.js
@@ -69,6 +69,7 @@ export const CONTACT = {
 export const FOOTER_LINKS = [
     { href: '/quienes-somos', label: 'Quiénes somos y cómo trabajamos' },
     { href: '/pedir-libro', label: '¿No encontraste el libro?' },
+    { href: '/como-identificar-edicion-correcta-isbn', label: 'Guía para verificar un ISBN' },
     { href: '/libros-agotados-importados-uruguay', label: 'Libros por encargo' },
     { href: '/envios',       label: 'Envíos y retiro' },
     { href: '/devoluciones', label: 'Devoluciones y reembolsos' },

--- a/functions/libros-agotados-importados-uruguay.js
+++ b/functions/libros-agotados-importados-uruguay.js
@@ -91,6 +91,7 @@ export async function onRequest() {
     .closing{margin-top:2.5rem;padding:1.5rem;background:#18120e;color:#fff;border-radius:1rem}
     .closing p{margin:.5rem 0 1rem;color:rgba(255,255,255,.72)}
     .specialties{display:flex;flex-wrap:wrap;gap:.55rem;margin-top:1.25rem}.specialties a{padding:.55rem .75rem;border:1px solid #e2dbd0;border-radius:999px;background:#fff;text-decoration:none;font-size:.82rem}
+    .guide-link{margin-top:1rem;color:#6b6157}.guide-link a{color:#8f4436;font-weight:700;text-underline-offset:.15em}
     @media(min-width:720px){.hero{grid-template-columns:1.45fr .75fr;align-items:center}.steps{grid-template-columns:repeat(3,1fr)}.types{grid-template-columns:repeat(2,1fr)}}
     ${FOOTER_STYLES}
     ${WA_FLOAT_STYLES}
@@ -127,6 +128,7 @@ export async function onRequest() {
         <article class="card"><span class="step-number">2</span><h3>Buscamos y verificamos</h3><p>Revisamos disponibilidad en proveedores del exterior y comparamos edición, idioma, formato y estado.</p></article>
         <article class="card"><span class="step-number">3</span><h3>Vos decidís</h3><p>Te informamos precio, seña y plazo estimado. La gestión empieza únicamente después de tu confirmación.</p></article>
       </div>
+      <p class="guide-link">¿No sabés si una publicación corresponde a la que necesitás? Consultá la <a href="/como-identificar-edicion-correcta-isbn">guía para identificar la edición correcta por ISBN</a>.</p>
     </section>
 
     <section class="section">

--- a/functions/sitemap-pages.xml.js
+++ b/functions/sitemap-pages.xml.js
@@ -6,6 +6,7 @@ export const STATIC_SITEMAP_PAGES = Object.freeze([
   `${BASE}/`,
   `${BASE}/catalogo`,
   `${BASE}/pedir-libro`,
+  `${BASE}/como-identificar-edicion-correcta-isbn`,
   `${BASE}/libros-agotados-importados-uruguay`,
   `${BASE}/libros-maria-montessori-uruguay`,
   `${BASE}/politicas`,

--- a/scripts/smoke-production.js
+++ b/scripts/smoke-production.js
@@ -62,6 +62,7 @@ const ROUTES = [
   { path: '/catalogo', kind: 'html', canonical: `${BASE_URL}/catalogo`, robots: 'index, follow' },
   { path: '/catalogo?q=zzzinexistente999', kind: 'html', canonical: `${BASE_URL}/catalogo`, robots: 'noindex, follow' },
   { path: '/pedir-libro', kind: 'html', canonical: `${BASE_URL}/pedir-libro`, robots: 'index, follow' },
+  { path: '/como-identificar-edicion-correcta-isbn', kind: 'html', canonical: `${BASE_URL}/como-identificar-edicion-correcta-isbn`, robots: 'index, follow' },
   { path: '/carrito/', kind: 'cart' },
   { path: '/robots.txt', kind: 'robots' },
   { path: '/sitemap.xml', kind: 'sitemap-index' },


### PR DESCRIPTION
## Resultado

Publica una guía verificable y enlazable para responder cómo distinguir la edición correcta de un libro por ISBN, una brecha temática prioritaria para Search, ChatGPT y Gemini.

## Incluye

- respuesta directa y guía paso a paso;
- diferencias entre edición, reimpresión, formato, idioma e ISBN-10/ISBN-13;
- fuentes oficiales de la Biblioteca Nacional de Uruguay y la Agencia Internacional del ISBN;
- autoría/revisión visible y schema `Organization/BookStore + Article + BreadcrumbList`;
- CTA tipificado a `/pedir-libro?tipo=exacto` y WhatsApp contextual;
- enlaces desde el footer global, Quiénes somos y la landing de encargos;
- inclusión en sitemap y smoke de Producción.

No agrega `llms.txt` ni marcado especial para IA: Google indica que sus experiencias generativas dependen de los fundamentos de Search y OpenAI pide acceso de `OAI-SearchBot`, ya habilitado en el sitio.

## Validación

- `bash scripts/validate-ci.sh`
- 72 tests de worker-sync: OK
- 242 tests de sitio/API: OK
- builds checkout OFF y ON: OK
- render SEO: canonical, robots, H1, JSON-LD, fuentes y CTA: OK