### PR TITLE
Mejora autoridad SEO y enlaces de guías

### DIFF
--- a/astro-front/src/components/GuideAccess.astro
+++ b/astro-front/src/components/GuideAccess.astro
@@ -1,0 +1,140 @@
+---
+const guides = [
+  {
+    eyebrow: 'Elegir la edición',
+    title: 'Cómo identificar la edición correcta por ISBN',
+    text: 'Compará ISBN, editorial, idioma y formato antes de comprar o encargar.',
+    href: '/como-identificar-edicion-correcta-isbn',
+    action: 'Leer la guía',
+  },
+  {
+    eyebrow: 'Conseguir un agotado',
+    title: 'Cómo funciona la búsqueda de libros por encargo',
+    text: 'Qué datos mandar, qué verificamos y cuándo confirmamos precio y plazo.',
+    href: '/libros-agotados-importados-uruguay',
+    action: 'Ver cómo trabajamos',
+  },
+  {
+    eyebrow: 'Conocer la librería',
+    title: 'Quiénes somos y cómo verificamos cada búsqueda',
+    text: 'Nuestro método para distinguir obras, ediciones y opciones disponibles.',
+    href: '/quienes-somos',
+    action: 'Conocer a Amado Libros',
+  },
+];
+---
+
+<section class="guides" aria-labelledby="guides-title">
+  <div class="guides-inner">
+    <div class="guides-heading">
+      <p class="guides-kicker">Información revisada por Amado Libros</p>
+      <h2 id="guides-title">Guías para encontrar y encargar el libro correcto</h2>
+      <p>Respuestas claras para evitar una edición equivocada y saber qué esperar de una búsqueda por encargo.</p>
+    </div>
+
+    <div class="guides-grid">
+      {guides.map(guide => (
+        <article class="guide-card">
+          <p>{guide.eyebrow}</p>
+          <h3><a href={guide.href}>{guide.title}</a></h3>
+          <span>{guide.text}</span>
+          <a class="guide-action" href={guide.href} aria-label={`${guide.action}: ${guide.title}`}>
+            {guide.action} →
+          </a>
+        </article>
+      ))}
+    </div>
+  </div>
+</section>
+
+<style>
+  .guides {
+    padding: clamp(2.8rem, 7vw, 5rem) 1.25rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
+  }
+
+  .guides-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+
+  .guides-heading { max-width: 760px; }
+
+  .guides-kicker {
+    color: var(--salmon-hover);
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+  }
+
+  .guides h2 {
+    margin-top: 0.45rem;
+    font-family: var(--font-display);
+    font-size: clamp(1.85rem, 5vw, 3rem);
+    letter-spacing: -0.03em;
+    line-height: 1.1;
+  }
+
+  .guides-heading > p:last-child {
+    max-width: 64ch;
+    margin-top: 0.8rem;
+    color: var(--ink-2);
+  }
+
+  .guides-grid {
+    display: grid;
+    gap: 0.85rem;
+    margin-top: 1.6rem;
+  }
+
+  .guide-card {
+    display: flex;
+    min-height: 230px;
+    flex-direction: column;
+    padding: 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: 1rem;
+    background: #fff;
+  }
+
+  .guide-card > p {
+    color: var(--salmon-hover);
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+  }
+
+  .guide-card h3 {
+    margin-top: 0.65rem;
+    font-family: var(--font-display);
+    font-size: 1.3rem;
+    line-height: 1.25;
+  }
+
+  .guide-card h3 a:hover,
+  .guide-card h3 a:focus-visible { text-decoration: underline; text-underline-offset: 0.16em; }
+
+  .guide-card > span {
+    margin-top: 0.65rem;
+    color: var(--ink-2);
+    font-size: 0.85rem;
+  }
+
+  .guide-action {
+    margin-top: auto;
+    padding-top: 1rem;
+    color: var(--salmon-hover);
+    font-size: 0.8rem;
+    font-weight: 800;
+  }
+
+  .guide-action:hover,
+  .guide-action:focus-visible { text-decoration: underline; text-underline-offset: 0.16em; }
+
+  @media (min-width: 760px) {
+    .guides-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  }
+</style>

--- a/astro-front/src/pages/index.astro
+++ b/astro-front/src/pages/index.astro
@@ -5,6 +5,7 @@ import BaseLayout          from '../layouts/BaseLayout.astro';
 import Header              from '../components/Header.astro';
 import Hero                from '../components/Hero.astro';
 import BookDiscovery       from '../components/BookDiscovery.astro';
+import GuideAccess         from '../components/GuideAccess.astro';
 import CategoryAccess      from '../components/CategoryAccess.astro';
 import BestsellerSection   from '../components/BestsellerSection.astro';
 import Footer              from '../components/Footer.astro';
@@ -14,11 +15,51 @@ import CatalogSearchOverlay  from '../components/CatalogSearchOverlay.astro';
 import HowToBuy           from '../components/HowToBuy.astro';
 import ShippingPayments    from '../components/ShippingPayments.astro';
 import TrustStrip          from '../components/TrustStrip.astro';
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': ['Organization', 'BookStore'],
+      '@id': 'https://www.amadolibros.com/#bookstore',
+      name: 'Amado Libros',
+      url: 'https://www.amadolibros.com/',
+      logo: 'https://www.amadolibros.com/images/logo-amado.webp',
+      image: 'https://www.amadolibros.com/images/logo-amado.webp',
+      description: 'Librería online uruguaya, familiar y atendida por sus dueños. Vende libros disponibles y realiza búsquedas manuales de títulos agotados, importados o difíciles de conseguir.',
+      telephone: '+59899841325',
+      email: 'adm@amadolibros.com',
+      address: {
+        '@type': 'PostalAddress',
+        streetAddress: 'Rincón 608',
+        addressLocality: 'Montevideo',
+        addressCountry: 'UY',
+      },
+      areaServed: { '@type': 'Country', name: 'Uruguay' },
+      contactPoint: {
+        '@type': 'ContactPoint',
+        contactType: 'customer service',
+        telephone: '+59899841325',
+        email: 'adm@amadolibros.com',
+        availableLanguage: 'Spanish',
+      },
+    },
+    {
+      '@type': 'WebSite',
+      '@id': 'https://www.amadolibros.com/#website',
+      url: 'https://www.amadolibros.com/',
+      name: 'Amado Libros',
+      publisher: { '@id': 'https://www.amadolibros.com/#bookstore' },
+      inLanguage: 'es-UY',
+    },
+  ],
+};
 ---
 <BaseLayout
   title="Libros difíciles, agotados e importados | Amado Libros"
   canonical="https://www.amadolibros.com/"
   description="Conseguimos libros agotados, importados y difíciles de ubicar en Uruguay. Encargos desde Europa y otros mercados, con envíos a todo el país."
+  jsonLd={jsonLd}
 >
   <Header showSearch={false} showMobileDeliveryBanner={true} />
   <main>
@@ -26,6 +67,7 @@ import TrustStrip          from '../components/TrustStrip.astro';
     <CategoryAccess />
     <BestsellerSection />
     <BookDiscovery />
+    <GuideAccess />
     <HowToBuy />
     <ShippingPayments />
     <TrustStrip />

--- a/astro-front/src/pages/pedir-libro.astro
+++ b/astro-front/src/pages/pedir-libro.astro
@@ -46,6 +46,14 @@ const jsonLd = {
       </section>
 
       <form id="manual-book-request" class="request-form">
+        <aside class="request-guides field-wide" aria-labelledby="request-guides-title">
+          <strong id="request-guides-title">¿Querés verificar los datos antes de enviar?</strong>
+          <p>
+            Consultá <a href="/como-identificar-edicion-correcta-isbn">cómo distinguir una edición por ISBN</a>
+            o <a href="/libros-agotados-importados-uruguay">cómo funciona un encargo de libro agotado o importado</a>.
+          </p>
+        </aside>
+
         <div class="field field-wide">
           <label for="request-type">¿Qué tipo de búsqueda necesitás?</label>
           <select id="request-type" name="request_type" required>
@@ -335,6 +343,24 @@ const jsonLd = {
     border-top: 0;
     border-radius: 0 0 1.15rem 1.15rem;
     background: #fff;
+  }
+
+  .request-guides {
+    padding: 0.9rem 1rem;
+    border-left: 3px solid var(--salmon);
+    background: #fff7f3;
+    color: var(--ink-2);
+    font-size: 0.78rem;
+    line-height: 1.55;
+  }
+
+  .request-guides strong { color: var(--ink); }
+
+  .request-guides a {
+    color: var(--salmon-hover);
+    font-weight: 800;
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
   }
 
   .field {

--- a/functions/__tests__/seo-ai-quick-wins.test.js
+++ b/functions/__tests__/seo-ai-quick-wins.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { onRequest as renderSitemap, STATIC_SITEMAP_ENTRIES } from '../sitemap-pages.xml.js';
+
+const root = (rel) => fileURLToPath(new URL('../../' + rel, import.meta.url));
+const read = (rel) => readFileSync(root(rel), 'utf8');
+
+test('la portada identifica a Amado Libros y enlaza las páginas de autoridad', () => {
+  const home = read('astro-front/src/pages/index.astro');
+  const guides = read('astro-front/src/components/GuideAccess.astro');
+
+  assert.match(home, /'@type': \['Organization', 'BookStore'\]/);
+  assert.match(home, /'@type': 'WebSite'/);
+  assert.match(home, /jsonLd=\{jsonLd\}/);
+  assert.match(home, /<GuideAccess \/>/);
+  assert.match(guides, /\/como-identificar-edicion-correcta-isbn/);
+  assert.match(guides, /\/libros-agotados-importados-uruguay/);
+  assert.match(guides, /\/quienes-somos/);
+});
+
+test('el formulario de búsqueda ofrece ayuda contextual antes del envío', () => {
+  const page = read('astro-front/src/pages/pedir-libro.astro');
+  assert.match(page, /¿Querés verificar los datos antes de enviar\?/);
+  assert.match(page, /cómo distinguir una edición por ISBN/i);
+  assert.match(page, /cómo funciona un encargo de libro agotado o importado/i);
+});
+
+test('la landing de agotados publica respuesta directa, revisión y entidades conectadas', () => {
+  const page = read('functions/libros-agotados-importados-uruguay.js');
+  assert.match(page, /<strong>Respuesta directa:<\/strong>/);
+  assert.match(page, /Contenido revisado el 12 de agosto de 2026/);
+  assert.match(page, /'@type': 'WebPage'/);
+  assert.match(page, /'@type': 'Service'/);
+  assert.match(page, /'@type': 'BreadcrumbList'/);
+  assert.match(page, /'reviewedBy'/);
+  assert.match(page, /href=\"\/quienes-somos\"/);
+});
+
+test('el sitemap declara lastmod sólo para páginas con revisión significativa conocida', async () => {
+  const home = STATIC_SITEMAP_ENTRIES.find(entry => entry.loc === 'https://www.amadolibros.com/');
+  const guide = STATIC_SITEMAP_ENTRIES.find(entry => entry.loc.endsWith('/como-identificar-edicion-correcta-isbn'));
+  const policies = STATIC_SITEMAP_ENTRIES.find(entry => entry.loc.endsWith('/politicas'));
+
+  assert.equal(home?.lastmod, '2026-08-12');
+  assert.equal(guide?.lastmod, '2026-08-12');
+  assert.equal(policies?.lastmod, undefined);
+
+  const response = await renderSitemap();
+  const xml = await response.text();
+  assert.match(xml, /<loc>https:\/\/www\.amadolibros\.com\/como-identificar-edicion-correcta-isbn<\/loc>\s*<lastmod>2026-08-12<\/lastmod>/);
+  assert.doesNotMatch(xml, /<loc>https:\/\/www\.amadolibros\.com\/politicas<\/loc>\s*<lastmod>/);
+});

--- a/functions/libros-agotados-importados-uruguay.js
+++ b/functions/libros-agotados-importados-uruguay.js
@@ -20,22 +20,67 @@ const PATH = '/libros-agotados-importados-uruguay';
 const TITLE = 'Libros agotados e importados en Uruguay | Amado Libros';
 const DESCRIPTION = 'Buscamos libros agotados, importados y difíciles de conseguir en Europa y otros mercados. Consultá por título, autor, ISBN o foto desde Uruguay.';
 const REQUEST_MESSAGE = 'Hola Amado Libros, busco un libro por encargo. Les paso título, autor, ISBN o una foto de la tapa:';
+const LAST_REVIEWED_ISO = '2026-08-12';
 
 export async function onRequest() {
     const canonical = `${BASE}${PATH}`;
     const requestHref = waHref(REQUEST_MESSAGE);
     const schema = {
         '@context': 'https://schema.org',
-        '@type': 'Service',
-        'name': 'Búsqueda de libros agotados e importados por encargo',
-        'description': DESCRIPTION,
-        'url': canonical,
-        'areaServed': { '@type': 'Country', 'name': 'Uruguay' },
-        'provider': {
-            '@type': 'BookStore',
-            'name': BRAND.name,
-            'url': BASE,
-        },
+        '@graph': [
+            {
+                '@type': ['Organization', 'BookStore'],
+                '@id': `${BASE}/#bookstore`,
+                'name': BRAND.name,
+                'url': `${BASE}/`,
+                'logo': `${BASE}/images/logo-amado.webp`,
+                'telephone': '+59899841325',
+                'email': 'adm@amadolibros.com',
+                'address': {
+                    '@type': 'PostalAddress',
+                    'streetAddress': 'Rincón 608',
+                    'addressLocality': 'Montevideo',
+                    'addressCountry': 'UY',
+                },
+            },
+            {
+                '@type': 'WebPage',
+                '@id': `${canonical}#webpage`,
+                'url': canonical,
+                'name': TITLE,
+                'description': DESCRIPTION,
+                'dateModified': LAST_REVIEWED_ISO,
+                'reviewedBy': { '@id': `${BASE}/#bookstore` },
+                'mainEntity': { '@id': `${canonical}#service` },
+                'inLanguage': 'es-UY',
+            },
+            {
+                '@type': 'Service',
+                '@id': `${canonical}#service`,
+                'name': 'Búsqueda de libros agotados e importados por encargo',
+                'description': DESCRIPTION,
+                'url': canonical,
+                'areaServed': { '@type': 'Country', 'name': 'Uruguay' },
+                'provider': { '@id': `${BASE}/#bookstore` },
+            },
+            {
+                '@type': 'BreadcrumbList',
+                'itemListElement': [
+                    {
+                        '@type': 'ListItem',
+                        'position': 1,
+                        'name': 'Inicio',
+                        'item': `${BASE}/`,
+                    },
+                    {
+                        '@type': 'ListItem',
+                        'position': 2,
+                        'name': 'Libros agotados e importados',
+                        'item': canonical,
+                    },
+                ],
+            },
+        ],
     };
 
     const html = `<!doctype html>
@@ -81,6 +126,7 @@ export async function onRequest() {
     .cta-primary{background:#25d366;color:#102516}
     .cta-secondary{border:1px solid #d2c7bb;background:#f8f5ef}
     .truth{padding:1rem;border-left:4px solid #e49982;background:#fff8f4;color:#6b4b3f;font-size:.9rem}
+    .reviewed{margin-top:.85rem;color:#756a61;font-size:.78rem}.reviewed a{color:#8f4436;font-weight:700;text-underline-offset:.15em}
     .section{padding:2.5rem 0 0}
     h2{font-family:Georgia,"Times New Roman",serif;font-size:clamp(1.45rem,4vw,2rem);line-height:1.2}
     .steps,.types{display:grid;gap:1rem;margin-top:1.25rem}
@@ -118,7 +164,10 @@ export async function onRequest() {
           <a class="cta cta-secondary" href="/catalogo">Buscar en el catálogo</a>
         </div>
       </div>
-      <p class="truth"><strong>Información clara:</strong> un libro agotado no está disponible para entrega inmediata. La posibilidad de conseguirlo, su edición, precio y demora dependen del proveedor y se confirman en cada consulta.</p>
+      <div>
+        <p class="truth"><strong>Respuesta directa:</strong> sí, en muchos casos un libro agotado o fuera de plaza puede conseguirse por encargo desde Uruguay. No podemos asegurar disponibilidad antes de buscar: verificamos título o ISBN, edición, proveedor, precio y plazo para cada consulta.</p>
+        <p class="reviewed">Contenido revisado el 12 de agosto de 2026 por el <a href="/quienes-somos">equipo de Amado Libros</a>.</p>
+      </div>
     </section>
 
     <section class="section">
@@ -129,6 +178,7 @@ export async function onRequest() {
         <article class="card"><span class="step-number">3</span><h3>Vos decidís</h3><p>Te informamos precio, seña y plazo estimado. La gestión empieza únicamente después de tu confirmación.</p></article>
       </div>
       <p class="guide-link">¿No sabés si una publicación corresponde a la que necesitás? Consultá la <a href="/como-identificar-edicion-correcta-isbn">guía para identificar la edición correcta por ISBN</a>.</p>
+      <p class="guide-link">Conocé también <a href="/quienes-somos">quién revisa las búsquedas y cómo verificamos cada edición</a>.</p>
     </section>
 
     <section class="section">

--- a/functions/sitemap-pages.xml.js
+++ b/functions/sitemap-pages.xml.js
@@ -19,6 +19,21 @@ export const STATIC_SITEMAP_PAGES = Object.freeze([
   ...SEO_SPECIALTIES.map(item => `${BASE}${specialtyPath(item.id)}`),
 ]);
 
+const SIGNIFICANT_PAGE_UPDATES = Object.freeze({
+  [`${BASE}/`]: '2026-08-12',
+  [`${BASE}/pedir-libro`]: '2026-08-12',
+  [`${BASE}/como-identificar-edicion-correcta-isbn`]: '2026-08-12',
+  [`${BASE}/libros-agotados-importados-uruguay`]: '2026-08-12',
+  [`${BASE}/quienes-somos`]: '2026-08-12',
+});
+
+export const STATIC_SITEMAP_ENTRIES = Object.freeze(
+  STATIC_SITEMAP_PAGES.map(loc => Object.freeze({
+    loc,
+    ...(SIGNIFICANT_PAGE_UPDATES[loc] ? { lastmod: SIGNIFICANT_PAGE_UPDATES[loc] } : {}),
+  })),
+);
+
 export async function onRequest() {
-  return xmlResponse(urlsetXml(STATIC_SITEMAP_PAGES.map(loc => ({ loc }))));
+  return xmlResponse(urlsetXml(STATIC_SITEMAP_ENTRIES));
 }


### PR DESCRIPTION
## Qué cambia

- publica datos estructurados `BookStore` y `WebSite` en la portada
- agrega un bloque visible de guías y enlaces internos descriptivos
- ayuda a verificar ISBN y encargos antes de enviar el formulario
- convierte la landing de agotados en una respuesta directa, revisada y conectada con `WebPage`, `Service` y breadcrumbs
- declara `lastmod` únicamente en páginas con una actualización significativa comprobable

## Por qué

Refuerza la entidad Amado Libros, la navegabilidad editorial y la capacidad de Google y asistentes con búsqueda para descubrir, comprender y citar contenido útil, sin crear páginas ni metadatos exclusivos para bots.

## Impacto

Mejor descubrimiento de las páginas de autoridad, más contexto antes de una consulta y señales técnicas coherentes para Google, ChatGPT y Gemini.

## Validación

- `node --experimental-sqlite --test` focal: 15/15
- `bash scripts/validate-ci.sh`: suite completa y builds checkout ON/OFF en verde
- `git diff --check`
