### PR TITLE
Permite lastmod fiable en sitemap estático

### DIFF
--- a/functions/__tests__/smoke-sitemap-index.test.js
+++ b/functions/__tests__/smoke-sitemap-index.test.js
@@ -42,7 +42,7 @@ test('pages exige todas las páginas estáticas relevantes', () => {
     '/', '/catalogo', '/pedir-libro', '/libros-maria-montessori-uruguay', '/politicas', '/envios',
     '/devoluciones', '/terminos', '/privacidad', '/contacto',
   ];
-  const valid = xml(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${pages.map(path => `<url>${loc(`${BASE}${path}`)}</url>`).join('')}</urlset>`);
+  const valid = xml(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${pages.map((path, index) => `<url>${loc(`${BASE}${path}`)}${index === 0 ? '<lastmod>2026-08-12</lastmod>' : ''}</url>`).join('')}</urlset>`);
   assert.deepEqual(analyzeSitemapBody(valid, 'sitemap-pages'), { ok: true });
 
   const missing = valid.replace(`<url>${loc(`${BASE}/privacidad`)}</url>`, '');
@@ -58,9 +58,17 @@ test('categorías y libros activos deben ser urlsets no vacíos y del espacio co
   assert.deepEqual(analyzeSitemapBody(books, 'sitemap-books-active'), { ok: true });
 });
 
-test('rechaza señales SEO ficticias reintroducidas en sitemaps', () => {
+test('rechaza priority y changefreq ficticios reintroducidos en sitemaps', () => {
   const body = xml(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url>${loc(`${BASE}/libros/literatura`)}<priority>1.0</priority></url></urlset>`);
   const result = analyzeSitemapBody(body, 'sitemap-categories');
   assert.equal(result.ok, false);
-  assert.match(result.reason, /priority|changefreq|lastmod/);
+  assert.match(result.reason, /priority|changefreq/);
+});
+
+test('lastmod exige fecha válida y queda limitado a páginas con revisión fiable', () => {
+  const invalidDate = xml(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url>${loc(`${BASE}/`)}<lastmod>2026-02-31</lastmod></url></urlset>`);
+  const categoryDate = xml(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url>${loc(`${BASE}/libros/literatura`)}<lastmod>2026-08-12</lastmod></url></urlset>`);
+
+  assert.match(analyzeSitemapBody(invalidDate, 'sitemap-pages').reason, /invalid lastmod/);
+  assert.match(analyzeSitemapBody(categoryDate, 'sitemap-categories').reason, /reliable static-page revision/);
 });

--- a/scripts/smoke-production.js
+++ b/scripts/smoke-production.js
@@ -234,12 +234,30 @@ function sitemapLocs(body) {
   return [...String(body || '').matchAll(/<loc>([^<]+)<\/loc>/g)].map(match => match[1]);
 }
 
+function sitemapLastmods(body) {
+  return [...String(body || '').matchAll(/<lastmod>([^<]+)<\/lastmod>/gi)].map(match => match[1]);
+}
+
+function isValidSitemapDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const date = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}
+
 function analyzeSitemapBody(body, kind) {
   if (typeof body !== 'string' || !body.startsWith('<?xml')) {
     return { ok: false, reason: 'invalid XML declaration' };
   }
-  if (/<(?:priority|changefreq|lastmod)>/i.test(body)) {
-    return { ok: false, reason: 'sitemap reintroduced priority/changefreq/lastmod' };
+  if (/<(?:priority|changefreq)>/i.test(body)) {
+    return { ok: false, reason: 'sitemap reintroduced priority/changefreq' };
+  }
+
+  const lastmods = sitemapLastmods(body);
+  if (lastmods.length > 0 && kind !== 'sitemap-pages') {
+    return { ok: false, reason: 'lastmod requires a reliable static-page revision date' };
+  }
+  if (lastmods.some(value => !isValidSitemapDate(value))) {
+    return { ok: false, reason: 'sitemap contains invalid lastmod date' };
   }
 
   const locs = sitemapLocs(body);


### PR DESCRIPTION
## Qué corrige

El smoke de Producción rechazaba cualquier `<lastmod>`, aunque la fecha proviniera de una revisión significativa real de una página estática.

## Cambio

- permite `lastmod` únicamente en `sitemap-pages.xml`
- exige fechas `YYYY-MM-DD` calendáricamente válidas
- sigue rechazando `lastmod` en categorías y libros sin fecha fiable
- sigue rechazando `priority` y `changefreq`

## Evidencia

- pruebas focales: 15/15
- smoke contra Producción: 13/13 rutas en el primer intento
- el deploy anterior publicó correctamente; su único fallo fue la regla obsoleta del smoke
