### PR TITLE
SEO: suma Psicología y refuerza la entidad de Amado Libros

### DIFF
--- a/.github/workflows/seo-baseline-audit.yml
+++ b/.github/workflows/seo-baseline-audit.yml
@@ -1,6 +1,8 @@
 name: SEO baseline public audit
 
 on:
+  schedule:
+    - cron: '23 9 * * 1'
   pull_request:
     branches:
       - main
@@ -34,6 +36,7 @@ jobs:
 
       - name: Syntax check
         run: |
+          node --check scripts/seo/catalog-quality-audit.mjs
           node --check scripts/seo/link-graph-audit.mjs
           node --check scripts/seo/duplication-report.mjs
           node --check scripts/seo/gsc-export.mjs
@@ -50,16 +53,25 @@ jobs:
           SEO_OUTPUT_DIR: artifacts/seo
         run: node scripts/seo/duplication-report.mjs
 
+      - name: Run catalog quality audit
+        env:
+          SEO_OUTPUT_DIR: artifacts/seo
+        run: node scripts/seo/catalog-quality-audit.mjs
+
       - name: Validate generated reports
         run: |
           node - <<'NODE'
           const fs = require('fs');
           const link = JSON.parse(fs.readFileSync('artifacts/seo/link-graph-audit-2026-08-08.json', 'utf8'));
           const dup = JSON.parse(fs.readFileSync('artifacts/seo/duplication-report-2026-08-08.json', 'utf8'));
+          const qualityFile = fs.readdirSync('artifacts/seo').find(name => name.startsWith('catalog-quality-audit-'));
+          if (!qualityFile) throw new Error('falta auditoría de calidad del catálogo');
+          const quality = JSON.parse(fs.readFileSync(`artifacts/seo/${qualityFile}`, 'utf8'));
           if (!(link?.totals?.sitemapBooks > 0)) throw new Error('link graph sin sitemapBooks');
           if (!(link?.totals?.linkedBooks >= 0)) throw new Error('link graph sin linkedBooks');
           if (!(dup?.inventory?.activeCatalogItems > 0)) throw new Error('duplication report sin activos');
-          console.log({ link: link.totals, duplicates: dup.summaries, inventory: dup.inventory });
+          if (!(quality?.inventory?.activeWithStock > 0)) throw new Error('quality report sin activos');
+          console.log({ link: link.totals, duplicates: dup.summaries, quality: quality.coverage, inventory: dup.inventory });
           NODE
 
       - name: Upload reproducible baseline

--- a/astro-front/src/pages/index.astro
+++ b/astro-front/src/pages/index.astro
@@ -29,6 +29,10 @@ const jsonLd = {
       description: 'Librería online uruguaya, familiar y atendida por sus dueños. Vende libros disponibles y realiza búsquedas manuales de títulos agotados, importados o difíciles de conseguir.',
       telephone: '+59899841325',
       email: 'adm@amadolibros.com',
+      sameAs: [
+        'https://www.mercadolibre.com.uy/tienda/amado-libros-libreria-en-linea',
+        'https://www.instagram.com/amadolibros.uy/',
+      ],
       address: {
         '@type': 'PostalAddress',
         streetAddress: 'Rincón 608',
@@ -51,6 +55,14 @@ const jsonLd = {
       name: 'Amado Libros',
       publisher: { '@id': 'https://www.amadolibros.com/#bookstore' },
       inLanguage: 'es-UY',
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: {
+          '@type': 'EntryPoint',
+          urlTemplate: 'https://www.amadolibros.com/catalogo?q={search_term_string}',
+        },
+        'query-input': 'required name=search_term_string',
+      },
     },
   ],
 };

--- a/astro-front/src/pages/quienes-somos.astro
+++ b/astro-front/src/pages/quienes-somos.astro
@@ -19,6 +19,10 @@ const jsonLd = {
       description: 'Librería online uruguaya, familiar y atendida por sus dueños. Vende libros disponibles y realiza búsquedas manuales de títulos agotados, importados o difíciles de conseguir.',
       telephone: '+59899841325',
       email: 'adm@amadolibros.com',
+      sameAs: [
+        'https://www.mercadolibre.com.uy/tienda/amado-libros-libreria-en-linea',
+        'https://www.instagram.com/amadolibros.uy/',
+      ],
       address: {
         '@type': 'PostalAddress',
         streetAddress: 'Rincón 608',

--- a/functions/__tests__/institutional-authority.test.js
+++ b/functions/__tests__/institutional-authority.test.js
@@ -24,7 +24,9 @@ test('la identidad estructurada conecta BookStore, WebSite y AboutPage', () => {
   assert.match(page, /'@type': 'AboutPage'/);
   assert.match(page, /reviewedBy/);
   assert.match(page, /Rincón 608/);
-  assert.doesNotMatch(page, /sameAs:/, 'no debe inventar perfiles externos no verificados');
+  assert.match(page, /sameAs:/);
+  assert.match(page, /https:\/\/www\.mercadolibre\.com\.uy\/tienda\/amado-libros-libreria-en-linea/);
+  assert.match(page, /https:\/\/www\.instagram\.com\/amadolibros\.uy\//);
 });
 
 test('la página es descubrible desde el footer global y el sitemap', () => {

--- a/functions/__tests__/seo-entity-discovery.test.js
+++ b/functions/__tests__/seo-entity-discovery.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { onRequest as redirectPsychology } from '../libros-psicologia.js';
+
+const root = (rel) => fileURLToPath(new URL('../../' + rel, import.meta.url));
+const read = (rel) => readFileSync(root(rel), 'utf8');
+
+test('la entidad conecta el sitio con sus perfiles verificables', () => {
+  const home = read('astro-front/src/pages/index.astro');
+  const about = read('astro-front/src/pages/quienes-somos.astro');
+  for (const page of [home, about]) {
+    assert.match(page, /mercadolibre\.com\.uy\/tienda\/amado-libros-libreria-en-linea/);
+    assert.match(page, /instagram\.com\/amadolibros\.uy/);
+  }
+});
+
+test('WebSite declara la búsqueda interna real del catálogo', () => {
+  const home = read('astro-front/src/pages/index.astro');
+  assert.match(home, /'@type': 'SearchAction'/);
+  assert.match(home, /catalogo\?q=\{search_term_string\}/);
+  assert.doesNotMatch(home, /urlTemplate: 'https:\/\/www\.amadolibros\.com\/\?q=/);
+});
+
+test('/libros-psicologia redirige a la landing canónica', async () => {
+  const response = await redirectPsychology();
+  assert.equal(response.status, 301);
+  assert.equal(response.headers.get('location'), 'https://www.amadolibros.com/especialidades/psicologia');
+});

--- a/functions/__tests__/seo-specialty-pages.test.js
+++ b/functions/__tests__/seo-specialty-pages.test.js
@@ -18,6 +18,7 @@ const ITEMS = [
   { id: 'MLU4', title: 'Agricultura: cultivos, suelos y riego', author: 'Autora Agrícola', price: 1800, available_quantity: 1, status: 'active', thumbnail: 'https://img.example/4.jpg' },
   { id: 'MLU5', title: 'Electrotecnia y máquinas eléctricas', author: 'Autor Técnico', isbn: '9780000000002', price: 2700, available_quantity: 1, status: 'active', thumbnail: 'https://img.example/5.jpg' },
   { id: 'MLU7', title: 'Máquinas eléctricas: Electrotecnia', author: 'Autor Técnico', isbn: '9780000000002', price: 2800, available_quantity: 1, status: 'active', thumbnail: 'https://img.example/7.jpg' },
+  { id: 'MLU8', title: 'Manual de psicología clínica y psicodiagnóstico', author: 'Autora Clínica', isbn: '9780000000003', price: 2400, available_quantity: 1, status: 'active', thumbnail: 'https://img.example/8.jpg' },
   { id: 'MLU6', title: 'Cirugía agotada', price: 999, available_quantity: 0, status: 'paused' },
 ];
 
@@ -43,13 +44,13 @@ test.beforeEach(() => {
   };
 });
 
-test('publica cinco especialidades fuertes, diferenciadas y sin páginas por país', () => {
-  assert.equal(SEO_SPECIALTIES.length, 5);
-  assert.equal(new Set(SEO_SPECIALTIES.map(item => item.id)).size, 5);
-  assert.equal(new Set(SEO_SPECIALTIES.map(item => item.title)).size, 5);
-  assert.equal(new Set(SEO_SPECIALTIES.map(item => item.h1)).size, 5);
-  assert.equal(new Set(SEO_SPECIALTIES.map(item => item.description)).size, 5);
-  assert.equal(new Set(SEO_SPECIALTIES.map(item => item.intro)).size, 5);
+test('publica seis especialidades fuertes, diferenciadas y sin páginas por país', () => {
+  assert.equal(SEO_SPECIALTIES.length, 6);
+  assert.equal(new Set(SEO_SPECIALTIES.map(item => item.id)).size, 6);
+  assert.equal(new Set(SEO_SPECIALTIES.map(item => item.title)).size, 6);
+  assert.equal(new Set(SEO_SPECIALTIES.map(item => item.h1)).size, 6);
+  assert.equal(new Set(SEO_SPECIALTIES.map(item => item.description)).size, 6);
+  assert.equal(new Set(SEO_SPECIALTIES.map(item => item.intro)).size, 6);
   for (const item of SEO_SPECIALTIES) {
     assert.ok(item.title.length <= 60, item.id);
     assert.ok(item.description.length >= 135, item.id);
@@ -95,6 +96,9 @@ test('el filtro exige palabras completas y evita coincidencias por fragmentos', 
   assert.equal(isSpecialtyMatch({ title: 'Las experiencias de Tiresias y el hombre griego' }, agriculture), false);
   const medicine = SEO_SPECIALTIES.find(item => item.id === 'medicina');
   assert.equal(isSpecialtyMatch({ title: 'Dosificación de medicamentos en el caballo' }, medicine), false);
+  const psychology = SEO_SPECIALTIES.find(item => item.id === 'psicologia');
+  assert.equal(isSpecialtyMatch({ title: 'Manual de psicología clínica' }, psychology), true);
+  assert.equal(isSpecialtyMatch({ title: 'La psicología del dinero' }, psychology), false);
 });
 
 test('preview, parámetros y slugs no autorizados no crean URLs indexables', async () => {
@@ -109,7 +113,7 @@ test('preview, parámetros y slugs no autorizados no crean URLs indexables', asy
   assert.match(await unknown.text(), /noindex, nofollow/);
 });
 
-test('sitemap y landing de encargos enlazan las cinco especialidades', async () => {
+test('sitemap y landing de encargos enlazan las seis especialidades', async () => {
   const { onRequest: renderPillar } = await import('../libros-agotados-importados-uruguay.js');
   const pillar = await (await renderPillar()).text();
   for (const specialty of SEO_SPECIALTIES) {

--- a/functions/_shared/seo-specialties.js
+++ b/functions/_shared/seo-specialties.js
@@ -63,6 +63,18 @@ export const SEO_SPECIALTIES = Object.freeze([
     topics: ['instalaciones eléctricas', 'circuitos y medidas', 'máquinas eléctricas', 'automatización industrial', 'protecciones y tableros', 'seguridad y normativa'],
     keywords: ['electrotecnia', 'instalaciones electricas', 'maquinas electricas', 'circuitos electricos', 'electricidad industrial', 'automatizacion industrial', 'tableros electricos', 'alta tension'],
   },
+  {
+    id: 'psicologia',
+    name: 'Psicología',
+    title: 'Libros de Psicología para Estudiar y Ejercer | Amado',
+    h1: 'Libros de psicología para estudiantes y profesionales',
+    description: 'Libros de psicología clínica, psicoanálisis, psicoterapia, evaluación y neuropsicología. Catálogo en Uruguay y búsqueda de bibliografía por encargo.',
+    audience: 'estudiantes universitarios, docentes, psicólogos, psicoterapeutas y otros profesionales de la salud mental',
+    intro: 'Reunimos libros de psicología disponibles en Uruguay y buscamos por encargo bibliografía académica y profesional publicada en España, Argentina y otros mercados. Trabajamos con autor, ISBN, editorial, edición y nivel de estudio para distinguir manuales introductorios, textos clínicos y obras especializadas sin recomendar un título solamente por su popularidad.',
+    topics: ['psicología clínica y psicopatología', 'psicoanálisis', 'psicoterapia', 'evaluación y psicodiagnóstico', 'neuropsicología', 'psicología cognitiva y conductual'],
+    keywords: ['psicologia', 'psicologico', 'psicologica', 'psicoanalisis', 'psicoterapia', 'psicopatologia', 'neuropsicologia', 'psicodiagnostico', 'evaluacion psicologica', 'terapia cognitiva'],
+    excludeKeywords: ['psicologia de ventas', 'psicologia del dinero'],
+  },
 ]);
 
 export const SEO_SPECIALTY_IDS = new Set(SEO_SPECIALTIES.map(item => item.id));

--- a/functions/libros-psicologia.js
+++ b/functions/libros-psicologia.js
@@ -1,0 +1,8 @@
+import { BASE } from './_shared/catalog.js';
+import { specialtyPath } from './_shared/seo-specialties.js';
+
+const CANONICAL = `${BASE}${specialtyPath('psicologia')}`;
+
+export async function onRequest() {
+  return Response.redirect(CANONICAL, 301);
+}


### PR DESCRIPTION
## Resultado

- agrega la sexta landing especializada: Psicología, orientada a estudiantes y profesionales;
- declara `SearchAction` sobre la búsqueda real `/catalogo?q=`;
- vincula la entidad Amado Libros con Mercado Libre e Instagram mediante `sameAs`;
- redirige `/libros-psicologia` a la URL canónica;
- programa semanalmente la auditoría SEO e incorpora el control de calidad del catálogo.

## Validación local

- `node --test functions/__tests__/seo-specialty-pages.test.js functions/__tests__/seo-entity-discovery.test.js`: 9/9 verdes.
- comprobación sintáctica de rutas, especialidades y auditoría de catálogo: verde.

## Alcance

No modifica checkout, pagos, credenciales ni infraestructura R2.