### PR TITLE
Performance: completa Server-Timing de catálogo y fichas

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -261,6 +261,32 @@ jobs:
           SMOKE_EXPECT_CHECKOUT: 'enabled'
         run: node scripts/smoke-production.js
 
+      - name: Capture first and repeated production timings
+        id: perf_control
+        run: |
+          echo "## Performance controls" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo '| Ruta | Muestra | HTTP | TTFB externo | Total externo | Server-Timing |' >> "$GITHUB_STEP_SUMMARY"
+          echo '|---|---:|---:|---:|---:|---|' >> "$GITHUB_STEP_SUMMARY"
+          for path in /api/health /catalogo; do
+            # Son dos solicitudes consecutivas desde el mismo runner. La primera
+            # no se etiqueta "cold": Cloudflare no garantiza que el isolate o la
+            # caché de borde estén fríos solo porque sea la primera de este job.
+            for sample in first repeat; do
+              headers="/tmp/perf-${path//\//-}-${sample}.headers"
+              if metrics="$(curl -sS --max-time 60 -o /dev/null -D "$headers" \
+                -w '%{http_code}|%{time_starttransfer}|%{time_total}' \
+                "https://www.amadolibros.com$path")"; then
+                IFS='|' read -r code ttfb total <<< "$metrics"
+                timing="$(tr -d '\r' < "$headers" | sed -n 's/^server-timing:[[:space:]]*//Ip' | tail -1)"
+                timing="${timing//|/\\|}"
+                echo "| \`$path\` | $sample | $code | ${ttfb}s | ${total}s | \`${timing:-ausente}\` |" >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "| \`$path\` | $sample | error | — | — | \`curl falló\` |" >> "$GITHUB_STEP_SUMMARY"
+              fi
+            done
+          done
+
       - name: Verify production R2 covers
         id: cover_r2_smoke
         run: |
@@ -322,5 +348,6 @@ jobs:
           echo "| **home.json** | ${{ steps.home_json.outcome == 'success' && '✅ fresh' || '⚠️ fallback (committed copy)' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **Smoke test** | ${{ steps.smoke.outcome == 'success' && '✅ passed' || steps.smoke.outcome == 'skipped' && '— not run' || '❌ failed' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **R2 covers** | ${{ steps.cover_r2_smoke.outcome == 'success' && '✅ passed' || steps.cover_r2_smoke.outcome == 'skipped' && '— not run' || '❌ failed' }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Performance controls** | ${{ steps.perf_control.outcome == 'success' && '✅ captured' || steps.perf_control.outcome == 'skipped' && '— not run' || '⚠️ unavailable' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **Attempts** | ${{ steps.smoke.outputs.attempts_used || '—' }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **URL** | https://www.amadolibros.com |" >> "$GITHUB_STEP_SUMMARY"

--- a/functions/__tests__/catalog-display.test.js
+++ b/functions/__tests__/catalog-display.test.js
@@ -77,6 +77,9 @@ test.beforeEach(() => {
   globalThis.caches = {
     default: {
       async match(request) {
+        if (request.url.endsWith('/data/active-categories.json')) {
+          return Response.json({ schema_version: 1, categories: [], items: {} });
+        }
         if (request.url === CATALOG_URL) return Response.json(CATALOG);
         if (request.url === PAUSED_MANIFEST_URL) {
           return Response.json({
@@ -162,6 +165,16 @@ test('COVER-R2 Preview: card y ficha usan la copia validada del mismo origen', a
     bookHtml,
     new RegExp(`/preview-cover/MLU1/0/${PREVIEW_COVER_HASH}\\.jpg`),
   );
+  const timing = bookResponse.headers.get('server-timing');
+  assert.match(timing, /catalog_parse;dur=/);
+  assert.match(timing, /active_lookup;dur=/);
+  assert.match(timing, /cover_manifest_binding;dur=/);
+  assert.match(timing, /cover_manifest_body;dur=/);
+  assert.match(timing, /cover_manifest_parse;dur=/);
+  assert.match(timing, /cover_resolve;dur=/);
+  assert.match(timing, /render;dur=/);
+  assert.match(timing, /route_total;dur=/);
+  assert.equal(bookResponse.headers.get('x-cache-status'), 'HIT');
 });
 
 test('COVER-R2 Producción: card y ficha usan el binding productivo', async () => {
@@ -244,6 +257,7 @@ test('la búsqueda Preview usa el índice activo compacto y conserva el precio',
   assert.match(html, /Precio web\/tarjeta:/);
   assert.equal(requests.includes(CATALOG_URL), false);
   assert.match(response.headers.get('server-timing'), /active_index_parse/);
+  assert.match(response.headers.get('server-timing'), /categories_parse/);
   assert.match(response.headers.get('server-timing'), /search;dur=/);
   assert.match(response.headers.get('server-timing'), /render;dur=/);
   assert.match(response.headers.get('server-timing'), /total;dur=/);
@@ -448,6 +462,9 @@ function installProductionCatalogMock() {
     default: {
       async match(request) {
         requestedUrls.push(request.url);
+        if (request.url.endsWith('/data/active-categories.json')) {
+          return Response.json({ schema_version: 1, categories: [], items: {} });
+        }
         if (request.url === CATALOG_URL) {
           return Response.json({ total: 1, items: [PROD_ACTIVE] });
         }

--- a/functions/__tests__/perf-base.test.js
+++ b/functions/__tests__/perf-base.test.js
@@ -71,3 +71,20 @@ test('ASSET-CACHE-1 aplica la misma regla exacta a assets hash en Producción', 
   );
   assert.equal(response.headers.has('x-robots-tag'), false);
 });
+
+test('PERF-BASE mide el worker completo en HTML y API de Producción', async () => {
+  for (const pathname of ['/catalogo', '/api/health']) {
+    const response = await middlewareRequest({
+      request: new Request(`https://www.amadolibros.com${pathname}`),
+      async next() {
+        return new Response('dynamic', {
+          headers: { 'server-timing': 'route_total;dur=12.34' },
+        });
+      },
+    });
+    const timing = response.headers.get('server-timing');
+    assert.match(timing, /route_total;dur=12.34/, pathname);
+    assert.match(timing, /middleware_before;dur=/, pathname);
+    assert.match(timing, /worker_total;dur=/, pathname);
+  }
+});

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -258,5 +258,17 @@ export async function onRequest(context) {
         });
     }
 
-    return finish(await context.next());
+    // Producción también expone el tramo que antes quedaba fuera de los
+    // timers de cada ruta. Así `worker_total` se puede comparar contra el
+    // TTFB externo y `/api/health` funciona como control sin R2 ni SSR.
+    const middlewareBeforeMs = perfNow() - workerStartedAt;
+    const response = await context.next();
+    const newHeaders = new Headers(response.headers);
+    appendServerTiming(newHeaders, 'middleware_before', middlewareBeforeMs);
+    appendServerTiming(newHeaders, 'worker_total', perfNow() - workerStartedAt);
+    return finish(new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: newHeaders,
+    }));
 }

--- a/functions/_shared/preview-cover.js
+++ b/functions/_shared/preview-cover.js
@@ -1,3 +1,5 @@
+import { perfNow, recordPerf } from './perf.js';
+
 const MANIFEST_KEY = 'covers/v1/manifest.json';
 const OBJECT_KEY_RE = /^covers\/v1\/objects\/([a-f0-9]{64})\.(jpg|png|webp)$/;
 const PRODUCT_ID_RE = /^MLU\d+$/;
@@ -29,13 +31,25 @@ async function readPreviewManifest(ctx) {
     if (!ctx.data || typeof ctx.data !== 'object') ctx.data = {};
     if (!ctx.data.__coverManifestPromise) {
         ctx.data.__coverManifestPromise = (async () => {
+            const totalStartedAt = perfNow();
             try {
+                const bindingStartedAt = perfNow();
                 const object = await bucket.get(MANIFEST_KEY);
+                recordPerf(ctx, 'cover_manifest_binding', bindingStartedAt);
                 if (!object || typeof object.text !== 'function') return null;
-                const parsed = JSON.parse(await object.text());
+                const bodyStartedAt = perfNow();
+                const body = await object.text();
+                recordPerf(ctx, 'cover_manifest_body', bodyStartedAt, {
+                    bytes: new TextEncoder().encode(body).byteLength,
+                });
+                const parseStartedAt = perfNow();
+                const parsed = JSON.parse(body);
+                recordPerf(ctx, 'cover_manifest_parse', parseStartedAt);
                 return validManifest(parsed) ? parsed : null;
             } catch {
                 return null;
+            } finally {
+                recordPerf(ctx, 'cover_manifest_total', totalStartedAt);
             }
         })();
     }

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -230,11 +230,18 @@ async function fetchActiveCategories(ctx) {
     // fetchActiveIndex/fetchPausedIndex en _shared/catalog.js.
     try {
         const url = new URL('/data/active-categories.json', ctx.request.url).toString();
+        const readStartedAt = perfNow();
         const cache = caches.default;
         const cacheKey = new Request(url);
+        const cacheStartedAt = perfNow();
         let response = await cache.match(cacheKey);
+        recordPerf(ctx, 'categories_cache', cacheStartedAt, {
+            cache: response ? 'hit' : 'miss',
+        });
         if (!response) {
+            const originStartedAt = perfNow();
             const fetched = await fetch(url);
+            recordPerf(ctx, 'categories_origin', originStartedAt);
             if (!fetched.ok) return null;
             response = new Response(fetched.body, {
                 status: fetched.status,
@@ -247,7 +254,18 @@ async function fetchActiveCategories(ctx) {
                 ctx.waitUntil(cache.put(cacheKey, response.clone()));
             }
         }
-        return await response.json();
+        const bodyStartedAt = perfNow();
+        const body = await response.arrayBuffer();
+        recordPerf(ctx, 'categories_body', bodyStartedAt, {
+            bytes: body.byteLength,
+        });
+        recordPerf(ctx, 'categories_read', readStartedAt, {
+            bytes: body.byteLength,
+        });
+        const parseStartedAt = perfNow();
+        const parsed = JSON.parse(new TextDecoder().decode(body));
+        recordPerf(ctx, 'categories_parse', parseStartedAt);
+        return parsed;
     } catch {
         return null;
     }

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -16,6 +16,13 @@
 import { slugify } from '../_shared/slug.js';
 import { BASE, fetchCatalog, fetchPausedItem } from '../_shared/catalog.js';
 import { previewCoverUrl as resolvePreviewCoverUrl } from '../_shared/preview-cover.js';
+import {
+    ensurePerf,
+    perfNow,
+    perfSummary,
+    recordPerf,
+    serverTimingValue,
+} from '../_shared/perf.js';
 // GLOBAL-SHELL-1: shell global compartido con Astro (marca, favicon, footer
 // y burbuja de WhatsApp). Ver functions/_shared/brand.js.
 import {
@@ -803,6 +810,8 @@ export function canonicalProductRedirectUrl({
 // ---------------------------------------------------------------------------
 
 export async function onRequest(context) {
+    const requestStartedAt = perfNow();
+    ensurePerf(context);
     const pathParts = Array.isArray(context.params.path)
         ? context.params.path
         : [context.params.path].filter(Boolean);
@@ -818,16 +827,24 @@ export async function onRequest(context) {
     // Cargar catálogo (con edge cache)
     const catalog = await fetchCatalog(context);
     const activeCatalogAvailable = catalog && Array.isArray(catalog.items);
+    const activeLookupStartedAt = perfNow();
     let item = activeCatalogAvailable
         ? catalog.items.find(b => b.id === id)
         : null;
+    recordPerf(context, 'active_lookup', activeLookupStartedAt, {
+        found: Boolean(item),
+    });
     // CF-R2-2-BRIDGE: habilitado en Preview y producción — cada uno resuelve
     // contra su propio manifest (fetchPausedItem -> manifestUrlFor en
     // _shared/catalog.js). Si el manifest de ese entorno falta o es
     // inválido, fetchPausedItem devuelve null y el flujo sigue igual que
     // hoy (notFound), sin 500.
     if (!item && ['preview', 'production'].includes(context.env?.APP_ENV)) {
+        const pausedLookupStartedAt = perfNow();
         item = await fetchPausedItem(context, id);
+        recordPerf(context, 'paused_lookup', pausedLookupStartedAt, {
+            found: Boolean(item),
+        });
     }
     if (!item && !activeCatalogAvailable) {
         return new Response('Error al cargar el catálogo. Intentá de nuevo en unos segundos.', {
@@ -861,14 +878,40 @@ export async function onRequest(context) {
 
     const originalImages = normalizeImages(item);
     const coversEnabled = ['preview', 'production'].includes(context.env?.APP_ENV);
+    const coverResolveStartedAt = perfNow();
     const previewCoverSrc = coversEnabled && originalImages[0]
         ? await resolvePreviewCoverUrl(context, item.id, 0, originalImages[0])
         : null;
+    recordPerf(context, 'cover_resolve', coverResolveStartedAt, {
+        found: Boolean(previewCoverSrc),
+    });
 
-    return new Response(renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverSrc || ''), {
+    const renderStartedAt = perfNow();
+    const html = renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverSrc || '');
+    recordPerf(context, 'render', renderStartedAt);
+
+    const totalDuration = Math.round((perfNow() - requestStartedAt) * 100) / 100;
+    const serverTiming = serverTimingValue(context, [{
+        name: 'route_total',
+        duration_ms: totalDuration,
+    }]);
+    const cacheStatus = context.data.perf.cache.miss > 0 ? 'MISS' : 'HIT';
+    console.log(JSON.stringify(perfSummary(context, {
+        event: 'product_page_perf',
+        route: '/libro/:id/:slug',
+        availability: item.status === 'paused' ? 'paused' : 'active',
+        cover_r2: Boolean(previewCoverSrc),
+        total_ms: totalDuration,
+    })));
+
+    return new Response(html, {
         headers: {
             'content-type':  'text/html;charset=UTF-8',
             'cache-control': 'public, max-age=3600',
+            'server-timing': serverTiming,
+            'x-cache-status': cacheStatus,
+            'x-perf-cache-hits': String(context.data.perf.cache.hit),
+            'x-perf-cache-misses': String(context.data.perf.cache.miss),
         },
     });
 }


### PR DESCRIPTION
## Resultado

Completa la observabilidad de rendimiento antes de tocar arquitectura o contratar un plan superior de Cloudflare.

- mide la descarga, lectura y parseo de `active-categories.json`;
- instrumenta fichas `/libro/...`, incluido lookup activo/pausado, portada R2 y render;
- expone `middleware_before` y `worker_total` también en producción;
- conserva los tiempos previos de cada ruta y agrega `route_total`;
- registra dos muestras consecutivas de `/api/health` y `/catalogo` en el resumen de cada deploy, con TTFB externo y `Server-Timing`;
- evita afirmar “cold/warm” cuando Cloudflare no garantiza el estado del isolate.

## Seguridad y alcance

No modifica checkout, pagos, credenciales, catálogo ni reglas de caché. Este lote solo mide y prueba.

## Verificación local

- sintaxis JS: OK;
- suite funcional completa: OK;
- tests específicos de rendimiento/catálogo: OK;
- la reinstalación local de Astro quedó bloqueada por el sandbox de npm al intentar escribir `/root/.npm`; el CI limpio de GitHub ejecutará el build completo antes de fusionar.
