### PR TITLE
Performance: cachea el manifest R2 de portadas en el borde

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -266,6 +266,8 @@ jobs:
         run: |
           echo "## Performance controls" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "> Control sintético desde el runner de GitHub; no representa Uruguay ni sustituye RUM de usuarios reales. Comparar rutas dentro del mismo run." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
           echo '| Ruta | Muestra | HTTP | TTFB externo | Total externo | Server-Timing |' >> "$GITHUB_STEP_SUMMARY"
           echo '|---|---:|---:|---:|---:|---|' >> "$GITHUB_STEP_SUMMARY"
           for path in /api/health /catalogo; do

--- a/functions/__tests__/catalog-display.test.js
+++ b/functions/__tests__/catalog-display.test.js
@@ -169,12 +169,13 @@ test('COVER-R2 Preview: card y ficha usan la copia validada del mismo origen', a
   assert.match(timing, /catalog_parse;dur=/);
   assert.match(timing, /active_lookup;dur=/);
   assert.match(timing, /cover_manifest_binding;dur=/);
+  assert.match(timing, /cover_manifest_cache;dur=/);
   assert.match(timing, /cover_manifest_body;dur=/);
   assert.match(timing, /cover_manifest_parse;dur=/);
   assert.match(timing, /cover_resolve;dur=/);
   assert.match(timing, /render;dur=/);
   assert.match(timing, /route_total;dur=/);
-  assert.equal(bookResponse.headers.get('x-cache-status'), 'HIT');
+  assert.equal(bookResponse.headers.get('x-cache-status'), 'MISS');
 });
 
 test('COVER-R2 Producción: card y ficha usan el binding productivo', async () => {

--- a/functions/__tests__/preview-cover.test.js
+++ b/functions/__tests__/preview-cover.test.js
@@ -58,6 +58,10 @@ function ctx({ appEnv = 'preview', coverBucket = bucket(), path = [], method = '
   };
 }
 
+test.beforeEach(() => {
+  delete globalThis.caches;
+});
+
 test('Preview resuelve una URL inmutable del mismo origen y memoiza el manifest', async () => {
   const coverBucket = bucket();
   const context = ctx({ coverBucket });
@@ -72,6 +76,26 @@ test('Producción resuelve la misma URL inmutable desde su binding separado', as
   const coverBucket = bucket();
   const result = await previewCoverUrl(ctx({ appEnv: 'production', coverBucket }), ID, 0, SOURCE);
   assert.equal(result, `https://cover-ui.example/preview-cover/${ID}/0/${HASH}.jpg`);
+  assert.deepEqual(coverBucket.reads, [PREVIEW_COVER_MANIFEST_KEY]);
+});
+
+test('la caché de borde reutiliza el manifest entre requests del mismo entorno', async () => {
+  const store = new Map();
+  globalThis.caches = {
+    default: {
+      async match(request) {
+        const response = store.get(request.url);
+        return response ? response.clone() : null;
+      },
+      async put(request, response) {
+        store.set(request.url, response.clone());
+      },
+    },
+  };
+  const coverBucket = bucket();
+  const first = await previewCoverUrl(ctx({ appEnv: 'production', coverBucket }), ID, 0, SOURCE);
+  const second = await previewCoverUrl(ctx({ appEnv: 'production', coverBucket }), ID, 0, SOURCE);
+  assert.equal(second, first);
   assert.deepEqual(coverBucket.reads, [PREVIEW_COVER_MANIFEST_KEY]);
 });
 

--- a/functions/_shared/preview-cover.js
+++ b/functions/_shared/preview-cover.js
@@ -1,6 +1,8 @@
 import { perfNow, recordPerf } from './perf.js';
 
 const MANIFEST_KEY = 'covers/v1/manifest.json';
+const MANIFEST_EDGE_TTL_SECONDS = 300;
+const MANIFEST_CACHE_PATH = '/__amado-cache/cover-manifest-v1';
 const OBJECT_KEY_RE = /^covers\/v1\/objects\/([a-f0-9]{64})\.(jpg|png|webp)$/;
 const PRODUCT_ID_RE = /^MLU\d+$/;
 
@@ -33,19 +35,60 @@ async function readPreviewManifest(ctx) {
         ctx.data.__coverManifestPromise = (async () => {
             const totalStartedAt = perfNow();
             try {
+                const appEnv = ctx.env.APP_ENV;
+                const edgeCache = globalThis.caches?.default;
+                const cacheKey = new Request(new URL(
+                    `${MANIFEST_CACHE_PATH}?env=${encodeURIComponent(appEnv)}`,
+                    ctx.request.url,
+                ));
+                let body = null;
+                if (edgeCache && typeof edgeCache.match === 'function') {
+                    const cacheStartedAt = perfNow();
+                    const cached = await edgeCache.match(cacheKey);
+                    recordPerf(ctx, 'cover_manifest_cache', cacheStartedAt, {
+                        cache: cached ? 'hit' : 'miss',
+                    });
+                    if (cached) {
+                        const bodyStartedAt = perfNow();
+                        body = await cached.text();
+                        recordPerf(ctx, 'cover_manifest_body', bodyStartedAt, {
+                            bytes: new TextEncoder().encode(body).byteLength,
+                        });
+                    }
+                }
+
+                if (body !== null) {
+                    const parseStartedAt = perfNow();
+                    const parsed = JSON.parse(body);
+                    recordPerf(ctx, 'cover_manifest_parse', parseStartedAt);
+                    return validManifest(parsed) ? parsed : null;
+                }
+
                 const bindingStartedAt = perfNow();
                 const object = await bucket.get(MANIFEST_KEY);
                 recordPerf(ctx, 'cover_manifest_binding', bindingStartedAt);
                 if (!object || typeof object.text !== 'function') return null;
                 const bodyStartedAt = perfNow();
-                const body = await object.text();
+                body = await object.text();
                 recordPerf(ctx, 'cover_manifest_body', bodyStartedAt, {
                     bytes: new TextEncoder().encode(body).byteLength,
                 });
                 const parseStartedAt = perfNow();
                 const parsed = JSON.parse(body);
                 recordPerf(ctx, 'cover_manifest_parse', parseStartedAt);
-                return validManifest(parsed) ? parsed : null;
+                if (!validManifest(parsed)) return null;
+
+                if (edgeCache && typeof edgeCache.put === 'function') {
+                    const put = edgeCache.put(cacheKey, new Response(body, {
+                        headers: {
+                            'content-type': 'application/json; charset=utf-8',
+                            'cache-control': `public, max-age=${MANIFEST_EDGE_TTL_SECONDS}`,
+                        },
+                    }));
+                    if (typeof ctx.waitUntil === 'function') ctx.waitUntil(put);
+                    else await put;
+                }
+                return parsed;
             } catch {
                 return null;
             } finally {


### PR DESCRIPTION
## Resultado esperado

Reduce la ruta caliente de `/catalogo` y las fichas con portada R2, evitando una lectura del binding R2 en cada request.

## Evidencia previa (misma sonda Globalping)

Sonda fija: Montevideo, Antel (AS6057), 10 muestras por ruta.

| Métrica | /api/health | /catalogo |
|---|---:|---:|
| TTFB mediano | 68 ms | 610 ms |
| Total mediano | 102 ms | 644 ms |
| Worker mediano | 0 ms | 345 ms |

Dentro de `/catalogo`, `cover_manifest_binding` tuvo mediana de 261 ms (P95 aproximado 297 ms), mientras categorías tuvieron mediana aproximada de 10 ms.

Medición de control verificable: https://globalping.io?measurement=2qawnU9FtoiJxuPad00020wNG

## Cambio

- Cache API del edge, separada por `APP_ENV`;
- TTL de 300 segundos;
- solo se cachean manifests JSON válidos;
- se conserva la memoización por request;
- `cover_manifest_cache` queda visible en `Server-Timing`;
- el resumen del deploy aclara que el runner de GitHub no representa Uruguay ni sustituye RUM.

## Riesgo acotado

El peor caso de desactualización del manifest es cinco minutos. Las URLs de imagen siguen siendo inmutables por hash y no se modifica ninguna portada ni dato comercial.

## Verificación

- suite completa de Functions: 447/447;
- tests específicos: 36/36;
- sintaxis JS: OK.
