### PR TITLE
Corrige identidad de tienda online y punto de retiro

### DIFF
--- a/astro-front/src/pages/como-identificar-edicion-correcta-isbn.astro
+++ b/astro-front/src/pages/como-identificar-edicion-correcta-isbn.astro
@@ -10,7 +10,7 @@ const jsonLd = {
   '@context': 'https://schema.org',
   '@graph': [
     {
-      '@type': ['Organization', 'BookStore'],
+      '@type': 'OnlineStore',
       '@id': 'https://www.amadolibros.com/#bookstore',
       name: 'Amado Libros',
       url: 'https://www.amadolibros.com/',

--- a/astro-front/src/pages/contacto.astro
+++ b/astro-front/src/pages/contacto.astro
@@ -3,15 +3,14 @@ import TrustPageLayout from '../layouts/TrustPageLayout.astro';
 ---
 <TrustPageLayout
   title="Contacto y datos comerciales — Amado Libros"
-  description="Dirección, WhatsApp, correo y horarios de atención y retiro de Amado Libros en Montevideo, Uruguay."
+  description="Punto de retiro coordinado, WhatsApp, correo y horarios de atención de Amado Libros en Montevideo, Uruguay."
   canonical="https://www.amadolibros.com/contacto"
   heading="Contacto y datos comerciales"
 >
   <h2>Amado Libros</h2>
   <ul>
     <li><strong>Actividad:</strong> librería online uruguaya.</li>
-    <li><strong>Domicilio comercial:</strong> Rincón 608, Ciudad Vieja, Montevideo, Uruguay.</li>
-    <li><strong>Pick up:</strong> a pasos de Plaza Matriz. Te confirmamos la dirección exacta por WhatsApp cuando tu pedido esté pronto para retirar.</li>
+    <li><strong>Punto de retiro coordinado:</strong> Rincón 608, Ciudad Vieja, Montevideo, Uruguay. No es un local de venta al público; esperá nuestra confirmación por WhatsApp antes de venir.</li>
     <li><strong>WhatsApp y teléfono:</strong> <a href="https://wa.me/59899841325">099 841 325</a>.</li>
     <li><strong>Correo:</strong> <a href="mailto:adm@amadolibros.com">adm@amadolibros.com</a>.</li>
   </ul>

--- a/astro-front/src/pages/index.astro
+++ b/astro-front/src/pages/index.astro
@@ -20,7 +20,7 @@ const jsonLd = {
   '@context': 'https://schema.org',
   '@graph': [
     {
-      '@type': ['Organization', 'BookStore'],
+      '@type': 'OnlineStore',
       '@id': 'https://www.amadolibros.com/#bookstore',
       name: 'Amado Libros',
       url: 'https://www.amadolibros.com/',
@@ -33,12 +33,6 @@ const jsonLd = {
         'https://www.mercadolibre.com.uy/tienda/amado-libros-libreria-en-linea',
         'https://www.instagram.com/amadolibros.uy/',
       ],
-      address: {
-        '@type': 'PostalAddress',
-        streetAddress: 'Rincón 608',
-        addressLocality: 'Montevideo',
-        addressCountry: 'UY',
-      },
       areaServed: { '@type': 'Country', name: 'Uruguay' },
       contactPoint: {
         '@type': 'ContactPoint',

--- a/astro-front/src/pages/pedir-libro.astro
+++ b/astro-front/src/pages/pedir-libro.astro
@@ -11,7 +11,7 @@ const jsonLd = {
   serviceType: 'Búsqueda de libros agotados, importados y difíciles de conseguir',
   areaServed: { '@type': 'Country', name: 'Uruguay' },
   provider: {
-    '@type': 'BookStore',
+    '@type': 'OnlineStore',
     name: 'Amado Libros',
     url: 'https://www.amadolibros.com/',
   },

--- a/astro-front/src/pages/politicas.astro
+++ b/astro-front/src/pages/politicas.astro
@@ -27,7 +27,7 @@ import TrustPageLayout from '../layouts/TrustPageLayout.astro';
     </a>
     <a class="policy-link" href="/contacto">
       <strong>Contacto</strong>
-      <span>Dirección, teléfono, correo y horarios.</span>
+      <span>Punto de retiro coordinado, teléfono, correo y horarios.</span>
     </a>
   </div>
 </TrustPageLayout>

--- a/astro-front/src/pages/quienes-somos.astro
+++ b/astro-front/src/pages/quienes-somos.astro
@@ -10,7 +10,7 @@ const jsonLd = {
   '@context': 'https://schema.org',
   '@graph': [
     {
-      '@type': ['Organization', 'BookStore'],
+      '@type': 'OnlineStore',
       '@id': 'https://www.amadolibros.com/#bookstore',
       name: 'Amado Libros',
       url: 'https://www.amadolibros.com/',
@@ -23,12 +23,6 @@ const jsonLd = {
         'https://www.mercadolibre.com.uy/tienda/amado-libros-libreria-en-linea',
         'https://www.instagram.com/amadolibros.uy/',
       ],
-      address: {
-        '@type': 'PostalAddress',
-        streetAddress: 'Rincón 608',
-        addressLocality: 'Montevideo',
-        addressCountry: 'UY',
-      },
       areaServed: {
         '@type': 'Country',
         name: 'Uruguay',
@@ -144,7 +138,7 @@ const jsonLd = {
   <ul>
     <li><strong>Nombre comercial:</strong> Amado Libros.</li>
     <li><strong>Actividad:</strong> librería online uruguaya.</li>
-    <li><strong>Domicilio comercial:</strong> Rincón 608, Ciudad Vieja, Montevideo, Uruguay.</li>
+    <li><strong>Punto de retiro coordinado:</strong> Rincón 608, Ciudad Vieja, Montevideo, Uruguay. No es un local de venta al público; el retiro se realiza después de nuestra confirmación por WhatsApp.</li>
     <li><strong>WhatsApp y teléfono:</strong> <a href="https://wa.me/59899841325">099 841 325</a>.</li>
     <li><strong>Correo:</strong> <a href="mailto:adm@amadolibros.com">adm@amadolibros.com</a>.</li>
     <li><strong>Información operativa:</strong> <a href="/contacto">contacto y horarios</a>, <a href="/envios">envíos y retiro</a> y <a href="/devoluciones">devoluciones</a>.</li>

--- a/functions/__tests__/institutional-authority.test.js
+++ b/functions/__tests__/institutional-authority.test.js
@@ -18,8 +18,8 @@ test('la página institucional publica identidad, método y responsable visibles
   assert.match(page, /12 de agosto de 2026/);
 });
 
-test('la identidad estructurada conecta BookStore, WebSite y AboutPage', () => {
-  assert.match(page, /'@type': \['Organization', 'BookStore'\]/);
+test('la identidad estructurada conecta OnlineStore, WebSite y AboutPage', () => {
+  assert.match(page, /'@type': 'OnlineStore'/);
   assert.match(page, /'@type': 'WebSite'/);
   assert.match(page, /'@type': 'AboutPage'/);
   assert.match(page, /reviewedBy/);

--- a/functions/__tests__/pickup-cx-1.test.js
+++ b/functions/__tests__/pickup-cx-1.test.js
@@ -34,13 +34,12 @@ test('1. ningún archivo público publica la dirección exacta del retiro', () =
     }
 });
 
-test('2. /contacto conserva el domicilio comercial pero no como instrucción de retiro', () => {
+test('2. /contacto presenta Rincón 608 únicamente como punto de retiro coordinado', () => {
     const c = read('astro-front/src/pages/contacto.astro');
-    // El domicilio legal es una obligación distinta y se mantiene.
-    assert.match(c, /Domicilio comercial:<\/strong> Rincón 608/);
-    // Pero ya no se presenta como el lugar al que ir a retirar.
-    assert.doesNotMatch(c, /Dirección y retiro/);
-    assert.match(c, /Pick up:<\/strong> a pasos de Plaza Matriz/);
+    assert.doesNotMatch(c, /Domicilio comercial:<\/strong> Rincón 608/);
+    assert.match(c, /Punto de retiro coordinado:<\/strong> Rincón 608/);
+    assert.match(c, /No es un local de venta al público/);
+    assert.match(c, /confirmación por WhatsApp/);
 });
 
 test('3. el horario público de retiro es único: 8 a 17 h', () => {

--- a/functions/__tests__/seo-ai-quick-wins.test.js
+++ b/functions/__tests__/seo-ai-quick-wins.test.js
@@ -12,7 +12,7 @@ test('la portada identifica a Amado Libros y enlaza las páginas de autoridad', 
   const home = read('astro-front/src/pages/index.astro');
   const guides = read('astro-front/src/components/GuideAccess.astro');
 
-  assert.match(home, /'@type': \['Organization', 'BookStore'\]/);
+  assert.match(home, /'@type': 'OnlineStore'/);
   assert.match(home, /'@type': 'WebSite'/);
   assert.match(home, /jsonLd=\{jsonLd\}/);
   assert.match(home, /<GuideAccess \/>/);

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -851,7 +851,7 @@ export async function onRequest(ctx) {
             'url':        canonicalHref,
             'description': metaDescription,
             'isPartOf':   { '@type': 'WebSite', 'name': 'Amado Libros', 'url': BASE },
-            'publisher':  { '@type': 'BookStore', 'name': 'Amado Libros', 'url': BASE },
+            'publisher':  { '@type': 'OnlineStore', 'name': 'Amado Libros', 'url': BASE },
           })}</script>`
         : '';
 

--- a/functions/especialidades/[[path]].js
+++ b/functions/especialidades/[[path]].js
@@ -88,7 +88,7 @@ export async function onRequest(ctx) {
     url: canonical,
     inLanguage: 'es',
     isPartOf: { '@type': 'WebSite', name: BRAND.name, url: BASE },
-    publisher: { '@type': 'BookStore', name: BRAND.name, url: BASE },
+    publisher: { '@type': 'OnlineStore', name: BRAND.name, url: BASE },
   };
   const itemListSchema = {
     '@context': 'https://schema.org',
@@ -110,7 +110,7 @@ export async function onRequest(ctx) {
     url: canonical,
     areaServed: { '@type': 'Country', name: 'Uruguay' },
     serviceType: 'Búsqueda e importación de libros por encargo',
-    provider: { '@type': 'BookStore', name: BRAND.name, url: BASE },
+    provider: { '@type': 'OnlineStore', name: BRAND.name, url: BASE },
   };
   const breadcrumbSchema = {
     '@context': 'https://schema.org',

--- a/functions/libros-agotados-importados-uruguay.js
+++ b/functions/libros-agotados-importados-uruguay.js
@@ -29,19 +29,13 @@ export async function onRequest() {
         '@context': 'https://schema.org',
         '@graph': [
             {
-                '@type': ['Organization', 'BookStore'],
+                '@type': 'OnlineStore',
                 '@id': `${BASE}/#bookstore`,
                 'name': BRAND.name,
                 'url': `${BASE}/`,
                 'logo': `${BASE}/images/logo-amado.webp`,
                 'telephone': '+59899841325',
                 'email': 'adm@amadolibros.com',
-                'address': {
-                    '@type': 'PostalAddress',
-                    'streetAddress': 'Rincón 608',
-                    'addressLocality': 'Montevideo',
-                    'addressCountry': 'UY',
-                },
             },
             {
                 '@type': 'WebPage',

--- a/functions/libros-maria-montessori-uruguay.js
+++ b/functions/libros-maria-montessori-uruguay.js
@@ -57,7 +57,7 @@ export async function onRequest(ctx) {
         'url':         `${BASE}/libros-maria-montessori-uruguay`,
         'description': 'Selección de libros de María Montessori disponibles en Uruguay. Pedagogía Montessori, educación, infancia y crianza. Envíos a Montevideo y al interior.',
         'isPartOf':    { '@type': 'WebSite', 'name': 'Amado Libros', 'url': BASE },
-        'publisher':   { '@type': 'BookStore', 'name': 'Amado Libros', 'url': BASE },
+        'publisher':   { '@type': 'OnlineStore', 'name': 'Amado Libros', 'url': BASE },
     };
 
     const schemaItemList = {

--- a/functions/libros/[[path]].js
+++ b/functions/libros/[[path]].js
@@ -225,7 +225,7 @@ function renderPage({ category, items, isPreview, hasUnexpectedParameters, navig
         'url': canonical,
         'description': category.description,
         'isPartOf': { '@type': 'WebSite', 'name': BRAND.name, 'url': BASE },
-        'publisher': { '@type': 'BookStore', 'name': BRAND.name, 'url': BASE },
+        'publisher': { '@type': 'OnlineStore', 'name': BRAND.name, 'url': BASE },
         'mainEntity': {
             '@type': 'ItemList',
             'numberOfItems': items.length,

--- a/public/index.html
+++ b/public/index.html
@@ -54,7 +54,7 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": ["BookStore", "Organization"],
+      "@type": "OnlineStore",
       "name": "Amado Libros",
       "url": "https://www.amadolibros.com/",
       "logo": "https://www.amadolibros.com/images/logo-amado.png",


### PR DESCRIPTION
## Resultado

Corrige la información pública y estructurada que podía presentar a Amado Libros como una librería física en Rincón 608.

- Rincón 608 queda definido únicamente como **punto de retiro coordinado**.
- Se aclara que no es un local de venta al público y que hay que esperar confirmación por WhatsApp.
- Se elimina Rincón 608 como domicilio postal de los datos estructurados.
- La entidad comercial pasa de `BookStore` a `OnlineStore` en portada, catálogo, fichas, especialidades y guías.
- Se actualizan las pruebas para impedir que reaparezca “domicilio comercial”.

## Motivo

Merchant Center mantiene bloqueados los productos por una comprobación automática del dominio. El sitio estaba operativo y el dominio estaba verificado y reclamado, pero la web publicaba una señal comercial incorrecta: el punto de retiro aparecía también como domicilio comercial y como dirección de una tienda física.

Este cambio elimina esa contradicción. No garantiza por sí solo la aprobación de Google; después del despliegue corresponde validar la web pública y recién entonces solicitar revisión en Merchant Center.

## Alcance y riesgo

No modifica catálogo, precios, stock, checkout, pagos, envíos ni credenciales. Conserva las mejoras recientes de rendimiento, Psicología y medición porque la rama nació desde el `main` actual.

## Verificación

- transformación validada sobre los archivos del `main` actual;
- 689/689 pruebas locales aprobadas antes de publicar la rama;
- sintaxis de los Functions modificados: correcta;
- el CI limpio de GitHub debe confirmar los builds Astro y la suite completa sobre el `main` actual.