### PR TITLE
SEO: enlazar otros libros del mismo autor en cada ficha

### DIFF
--- a/functions/__tests__/seo-author-links.test.js
+++ b/functions/__tests__/seo-author-links.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { renderPage, selectRelatedBooks } from '../libro/[[path]].js';
+
+function book(id, author, overrides = {}) {
+    return {
+        id,
+        title: `Libro ${id}`,
+        author,
+        price: 1200,
+        status: 'active',
+        available_quantity: 1,
+        condition: 'new',
+        pictures: [`https://http2.mlstatic.com/D_${id}-O.jpg`],
+        permalink: `https://articulo.mercadolibre.com.uy/${id}`,
+        ...overrides,
+    };
+}
+
+test('selecciona hasta cuatro libros activos y con stock del mismo autor', () => {
+    const current = book('MLU1', 'Walter Riso');
+    const catalog = [
+        current,
+        book('MLU2', ' walter   riso '),
+        book('MLU3', 'Walter Riso'),
+        book('MLU4', 'Walter Riso'),
+        book('MLU5', 'Walter Riso'),
+        book('MLU6', 'Walter Riso'),
+        book('MLU7', 'Otro Autor'),
+        book('MLU8', 'Walter Riso', { status: 'paused', available_quantity: 0 }),
+    ];
+
+    assert.deepEqual(
+        selectRelatedBooks(catalog, current).map(item => item.id),
+        ['MLU2', 'MLU3', 'MLU4', 'MLU5'],
+    );
+});
+
+test('no crea enlaces para autores genéricos ni duplica la ficha actual', () => {
+    for (const author of ['Varios autores', 'VV. AA.', 'No aplica', 'Anónimo', null]) {
+        const current = book('MLU1', author);
+        assert.deepEqual(selectRelatedBooks([current, book('MLU2', author)], current), []);
+    }
+});
+
+test('renderiza enlaces SSR canónicos, portadas diferidas y ningún enlace propio', () => {
+    const current = book('MLU1', 'María Montessori', { title: 'Psicogeometría' });
+    const related = [
+        book('MLU2', 'María Montessori', { title: 'La Mente Absorbente Del Niño' }),
+        book('MLU3', 'María Montessori', { title: 'El Niño En La Familia' }),
+    ];
+    const html = renderPage(current, 'psicogeometria', false, '', '', related);
+
+    assert.match(html, /<section class="related-books"/);
+    assert.match(html, /Otros libros de María Montessori/);
+    assert.match(html, /href="\/libro\/MLU2\/la-mente-absorbente-del-nino"/);
+    assert.match(html, /href="\/libro\/MLU3\/el-nino-en-la-familia"/);
+    assert.match(html, /loading="lazy" width="120" height="180"/);
+    assert.doesNotMatch(html, /href="\/libro\/MLU1\//);
+});
+
+test('escapa autor y títulos antes de insertarlos en HTML', () => {
+    const current = book('MLU1', 'Autor <Especial>');
+    const related = [book('MLU2', 'Autor <Especial>', { title: 'Libro & Método' })];
+    const html = renderPage(current, 'libro', false, '', '', related);
+
+    assert.match(html, /Otros libros de Autor &lt;Especial&gt;/);
+    assert.match(html, /Libro &amp; Método/);
+    assert.doesNotMatch(html, /Otros libros de Autor <Especial>/);
+});

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -226,6 +226,75 @@ ${images.map((url, i) => `    <button type="button" class="thumb-btn" data-idx="
 })();<\/script>`;
 }
 
+const GENERIC_AUTHOR_KEYS = new Set([
+    'anónimo',
+    'anonimo',
+    'autor',
+    'autores',
+    'autor no especificado',
+    'no aplica',
+    'n/a',
+    's/a',
+    'sin autor',
+    'varios',
+    'varios autores',
+    'vv aa',
+    'vv. aa.',
+]);
+
+function authorKey(author) {
+    return String(author || '').trim().toLocaleLowerCase('es').replace(/\s+/g, ' ');
+}
+
+/**
+ * SEO-AUTOR: el catálogo activo ya está en memoria cuando se renderiza una
+ * ficha. Reutilizarlo evita otra lectura de R2 y permite crear enlaces HTML
+ * rastreables hacia otros títulos del mismo autor.
+ */
+export function selectRelatedBooks(catalogItems, item, limit = 4) {
+    if (!Array.isArray(catalogItems) || !item) return [];
+
+    const currentAuthor = authorKey(item.author);
+    const requestedLimit = Math.min(4, Math.max(0, Number(limit) || 0));
+    if (!currentAuthor || GENERIC_AUTHOR_KEYS.has(currentAuthor) || requestedLimit === 0) return [];
+
+    const seen = new Set([String(item.id || '')]);
+    const related = [];
+    for (const candidate of catalogItems) {
+        const candidateId = String(candidate?.id || '');
+        if (!candidateId || seen.has(candidateId)) continue;
+        if (!candidate?.title || candidate.status !== 'active') continue;
+        if ((Number(candidate.available_quantity) || 0) <= 0) continue;
+        if (authorKey(candidate.author) !== currentAuthor) continue;
+
+        seen.add(candidateId);
+        related.push(candidate);
+        if (related.length === requestedLimit) break;
+    }
+    return related;
+}
+
+function renderRelatedBooks(relatedBooks, author) {
+    if (!Array.isArray(relatedBooks) || relatedBooks.length === 0) return '';
+
+    const cards = relatedBooks.map((book) => {
+        const title = escapeHtml(book.title);
+        const href = `/libro/${encodeURIComponent(book.id)}/${slugify(book.title)}`;
+        const image = normalizeImages(book)[0] || '';
+        return `<li class="related-book">
+      <a class="related-book-link" href="${escapeHtml(href)}">
+        ${image ? `<img class="related-book-cover" src="${escapeHtml(image)}" alt="Portada de ${title}" loading="lazy" width="120" height="180">` : ''}
+        <span class="related-book-title">${title}</span>
+      </a>
+    </li>`;
+    }).join('\n');
+
+    return `<section class="related-books" aria-labelledby="related-books-title">
+    <h2 id="related-books-title">Otros libros de ${escapeHtml(author)}</h2>
+    <ul class="related-books-grid">${cards}</ul>
+  </section>`;
+}
+
 // ---------------------------------------------------------------------------
 // Respuestas de error
 // ---------------------------------------------------------------------------
@@ -263,7 +332,7 @@ function notFound() {
 // Render HTML completo de la ficha
 // ---------------------------------------------------------------------------
 
-export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverSrc = '') {
+export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverSrc = '', relatedBooks = []) {
     const canonicalUrl = `${BASE}/libro/${item.id}/${slug}`;
     const safeTitle    = escapeHtml(item.title);
     const safeAuthor   = item.author ? escapeHtml(item.author) : null;
@@ -296,6 +365,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
             ? `Hola! Me interesa: ${item.title}`
             : buildPausedWaMessage(item)
     );
+    const relatedBooksHtml = renderRelatedBooks(relatedBooks, item.author);
 
     const detailRows = [
         safeAuthor ? detailRow('Autor', item.author) : '',
@@ -652,6 +722,20 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     @media(max-width:520px){.waitlist-row{flex-direction:column}.btn-waitlist{width:100%}}
     .shipping{font-size:.82rem;color:#64748b;margin-top:1rem;padding:.75rem 1rem;
               background:white;border:1px solid #e2e8f0;border-radius:.5rem}
+    .related-books{grid-column:1/-1;border-top:1px solid #e2e8f0;padding-top:1.25rem}
+    .related-books h2{font-size:1.05rem;line-height:1.35;color:#0f172a;margin-bottom:.85rem}
+    .related-books-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));
+                        gap:.8rem;list-style:none}
+    .related-book{min-width:0}
+    .related-book-link{height:100%;display:flex;flex-direction:column;gap:.55rem;
+                       padding:.65rem;background:#fff;border:1px solid #e2e8f0;
+                       border-radius:.55rem;color:#334155;text-decoration:none}
+    .related-book-link:hover{border-color:#94a3b8;color:#0f172a}
+    .related-book-link:focus-visible{outline:2px solid #3b82f6;outline-offset:2px}
+    .related-book-cover{display:block;width:100%;aspect-ratio:2/3;height:auto;max-height:180px;
+                        object-fit:contain;background:#f8fafc;border-radius:.3rem}
+    .related-book-title{font-size:.82rem;font-weight:700;line-height:1.35}
+    @media(min-width:760px){.related-books-grid{grid-template-columns:repeat(4,minmax(0,1fr))}}
     ${FOOTER_STYLES}
     ${WA_FLOAT_STYLES}
   </style>
@@ -704,6 +788,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
       : '🌎 Si preferís no esperar, también podemos buscarlo por encargo en el exterior.'
     } <a href="/politicas#envios">Ver política de envíos</a>.</p>
   </div>
+  ${relatedBooksHtml}
 </main>
 
 ${footerHtml()}
@@ -886,8 +971,12 @@ export async function onRequest(context) {
         found: Boolean(previewCoverSrc),
     });
 
+    const relatedBooks = activeCatalogAvailable
+        ? selectRelatedBooks(catalog.items, item)
+        : [];
+
     const renderStartedAt = perfNow();
-    const html = renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverSrc || '');
+    const html = renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverSrc || '', relatedBooks);
     recordPerf(context, 'render', renderStartedAt);
 
     const totalDuration = Math.round((perfNow() - requestStartedAt) * 100) / 100;


### PR DESCRIPTION
## Qué cambia

- agrega una sección SSR “Otros libros de [autor]” en las fichas elegibles;
- muestra hasta cuatro libros activos y con stock del mismo autor;
- usa enlaces HTML canónicos, visibles y rastreables;
- excluye autores genéricos, la ficha actual y duplicados;
- carga las portadas relacionadas con `loading="lazy"`;
- reutiliza el catálogo que ya está en memoria, sin nuevas lecturas de R2 ni APIs.

## Por qué

El catálogo actual tiene miles de fichas aisladas que comparten autor. El enlazado interno mejora la navegación del cliente y permite que los rastreadores descubran relaciones entre páginas de producto sin crear contenido artificial.

## Impacto y seguridad

- no modifica títulos, precios, stock, datos estructurados ni checkout;
- no cambia el comportamiento de las fichas sin coincidencias;
- máximo cuatro enlaces por ficha;
- salida escapada antes de insertarse en HTML.

## Validación

- 42 pruebas relevantes aprobadas localmente;
- 0 fallos;
- incluye pruebas para stock, autores genéricos, límite de cuatro, enlaces canónicos, exclusión de la propia ficha y escape HTML.