### PR TITLE
SEO: enriquecer primer lote de 5 libros de psicología

### DIFF
--- a/docs/seo/enrichment-batch-01-psychology.md
+++ b/docs/seo/enrichment-batch-01-psychology.md
@@ -1,0 +1,44 @@
+# SEO — lote 1 de fichas de psicología
+
+Fecha de selección y verificación: 2026-08-14.
+
+## Criterio
+
+Se cruzó el archivo real de ventas de la cuenta principal de Mercado Libre con
+el catálogo público de Amado Libros. El lote prioriza facturación, unidades
+vendidas, disponibilidad actual y utilidad para estudiantes o profesionales de
+psicología. Se excluyeron títulos agotados, productos ajenos a libros y ediciones
+cuyo ISBN no coincidía.
+
+## Libros seleccionados
+
+| Prioridad | MLU | ISBN | Libro | Señal comercial del archivo | Estado al seleccionar |
+| --- | --- | --- | --- | --- | --- |
+| 1 | MLU644161565 | 9781074092290 | Espérame en el arcoíris | 4 ventas; $7.244 netos | Disponible |
+| 2 | MLU678034726 | 9788433031143 | Terapia psicodinámica para la patología de la personalidad | 2 ventas; $6.181 netos | Disponible |
+| 3 | MLU1467827214 | 9788493774301 | Manual de EMDR y procesos de terapia familiar | 1 venta; $3.172 netos | Disponible |
+| 4 | MLU633677061 | 9788449341281 | Diccionario de psicoanálisis | 1 venta; $2.680 netos | Disponible |
+| 5 | MLU1304008698 | 9788433028839 | Psicoterapia centrada en la transferencia | 1 venta; $2.415 netos | Disponible |
+
+## Qué completa este lote
+
+- Autoría completa y editorial verificable.
+- Páginas, formato, año, colección y medidas cuando la edición lo permite.
+- Descripción propia y diferenciada para cada libro.
+- Conservación estricta del título comercial existente.
+- Bloqueo automático si el ISBN de la publicación cambia y pasa a identificar
+  otra edición.
+
+## Fotografías pendientes
+
+Tres publicaciones tienen una sola imagen. Las fotografías adicionales deben
+tomarse del ejemplar real (contraportada, índice e interior) y no se generan ni
+se sustituyen automáticamente.
+
+## Fuentes de verificación bibliográfica
+
+- Desclée De Brouwer: `https://www.edesclee.com/biblioteca-de-psicologia/2355-terapia-psicodinamica-para-la-patologia-de-la-personalidad.html`
+- Desclée De Brouwer: `https://www.edesclee.com/psicologia/2123-psicoterapia-centrada-en-la-transferencia.html`
+- Casa del Libro, ISBN 9788493774301.
+- Casa del Libro, ISBN 9788449341281.
+- Casa del Libro y catálogo ISBN, ISBN 9781074092290.

--- a/worker-sync/__tests__/verified-book-enrichments.test.js
+++ b/worker-sync/__tests__/verified-book-enrichments.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  applyVerifiedBookEnrichments,
+  VERIFIED_BOOK_IDS,
+} from '../verified-book-enrichments.js';
+
+test('enriquece las cinco fichas verificadas sin cambiar sus títulos', () => {
+  const items = VERIFIED_BOOK_IDS.map((id, index) => ({
+    id,
+    title: `Título comercial ${index}`,
+    isbn: null,
+    price: 1000 + index,
+    pictures: [`foto-${index}.jpg`],
+    bibliographic: {},
+    dimensions: {},
+  }));
+
+  const result = applyVerifiedBookEnrichments(items);
+
+  assert.deepEqual(result, { applied: 5, skipped_isbn_mismatch: 0 });
+  assert.deepEqual(items.map(item => item.title), [
+    'Título comercial 0',
+    'Título comercial 1',
+    'Título comercial 2',
+    'Título comercial 3',
+    'Título comercial 4',
+  ]);
+  assert.ok(items.every(item => item.publisher && item.pages && item.description));
+  assert.deepEqual(items[0].pictures, ['foto-0.jpg']);
+  assert.equal(items[1].pages, 672);
+  assert.equal(items[3].author, 'Jean Laplanche y Jean-Bertrand Pontalis');
+});
+
+test('no aplica un dato si el ISBN actual identifica otra edición', () => {
+  const item = {
+    id: 'MLU678034726',
+    title: 'Título intacto',
+    isbn: '9780000000000',
+    publisher: null,
+  };
+
+  const result = applyVerifiedBookEnrichments([item]);
+
+  assert.deepEqual(result, { applied: 0, skipped_isbn_mismatch: 1 });
+  assert.equal(item.title, 'Título intacto');
+  assert.equal(item.publisher, null);
+});

--- a/worker-sync/meli-catalog.js
+++ b/worker-sync/meli-catalog.js
@@ -27,6 +27,8 @@
  *   - MIN_ACTIVE_ITEMS: abortar si R2 quedaría con muy pocos items activos
  */
 
+import { applyVerifiedBookEnrichments } from './verified-book-enrichments.js';
+
 const SCROLL_SLEEP_MS  = 350;  // delay entre páginas de scroll (cortesía ML)
 const DETAIL_SLEEP_MS  = 250;  // delay entre batches de detalles
 const DETAIL_BATCH     = 20;   // ML multi-get soporta hasta 20 ids por request
@@ -118,6 +120,7 @@ export async function buildCatalog(env, accessToken, {
       { retryBudget, mlGetDeps },
     );
   }
+  dataQuality.verified_book_enrichments = applyVerifiedBookEnrichments(catalogItems);
   const activeItems = catalogItems.filter(
     item => item.status === 'active' && Number(item.available_quantity) > 0
   );

--- a/worker-sync/verified-book-enrichments.js
+++ b/worker-sync/verified-book-enrichments.js
@@ -1,0 +1,134 @@
+/**
+ * Datos bibliográficos revisados manualmente para lotes pequeños de fichas.
+ *
+ * Reglas:
+ * - la publicación de ML y el ISBN deben identificar la misma edición;
+ * - nunca se modifica el título comercial;
+ * - las descripciones son redacción propia de Amado Libros;
+ * - las fotos no se sustituyen: deben provenir del ejemplar real.
+ */
+
+const VERIFIED_BOOK_ENRICHMENTS = new Map([
+  ['MLU644161565', {
+    isbn: '9781074092290',
+    author: 'Laura Vidal',
+    publisher: 'Independently published',
+    pages: 128,
+    bibliographic: {
+      language: 'Español',
+      format: 'Tapa blanda',
+      edition: '1.ª edición',
+      publication_year: '2019',
+      genre: 'Duelo y mascotas',
+      subtitle: 'Cómo afrontar el duelo por la pérdida de tu mascota',
+    },
+    dimensions: { width: '14 cm', height: '21 cm' },
+    description: 'Una guía para quienes atraviesan la pérdida de un animal de compañía. Laura Vidal combina experiencias y orientaciones sobre las etapas del duelo, la empatía, la resiliencia y el momento de abrirse a un nuevo vínculo. También ofrece un punto de partida para familias que necesitan acompañar a niños ante la muerte de una mascota.',
+  }],
+  ['MLU678034726', {
+    isbn: '9788433031143',
+    author: 'Eve Caligor, Otto F. Kernberg, John F. Clarkin y Frank E. Yeomans',
+    publisher: 'Desclée De Brouwer',
+    pages: 672,
+    bibliographic: {
+      language: 'Español',
+      format: 'Tapa blanda',
+      publication_year: '2020',
+      genre: 'Psicología clínica',
+      collection: 'Biblioteca de Psicología',
+    },
+    dimensions: { width: '17 cm', height: '24 cm' },
+    description: 'Texto clínico que integra teoría psicodinámica, evaluación y tratamiento de los trastornos de la personalidad. Presenta un marco para comprender el funcionamiento de la personalidad y desarrollar intervenciones aplicables en distintos contextos clínicos, incluida la Psicoterapia Focalizada en la Transferencia ampliada. Está dirigido especialmente a psicólogos, psiquiatras, psicoterapeutas y estudiantes avanzados.',
+  }],
+  ['MLU1467827214', {
+    isbn: '9788493774301',
+    author: 'Francine Shapiro, Florence W. Kaslow y Louise Maxfield',
+    publisher: 'Ediciones Pléyades',
+    pages: 632,
+    bibliographic: {
+      language: 'Español',
+      format: 'Tapa dura',
+      publication_year: '2012',
+      genre: 'Psicología clínica',
+    },
+    description: 'Manual clínico sobre la integración del procesamiento de información de EMDR con perspectivas y técnicas de terapia familiar. Reúne fundamentos, orientación práctica y casos para trabajar con individuos, parejas y familias. Es una obra de consulta para profesionales y estudiantes avanzados que buscan comprender cómo articular ambos enfoques dentro de una formulación terapéutica coherente.',
+  }],
+  ['MLU633677061', {
+    isbn: '9788449341281',
+    author: 'Jean Laplanche y Jean-Bertrand Pontalis',
+    publisher: 'Ediciones Paidós',
+    pages: 592,
+    bibliographic: {
+      language: 'Español',
+      format: 'Tapa blanda',
+      publication_year: '2023',
+      genre: 'Psicoanálisis',
+      collection: 'Psicología, Psiquiatría y Psicoterapia',
+      subtitle: 'Bajo la dirección de Daniel Lagache',
+    },
+    dimensions: { width: '15.5 cm', height: '23.3 cm', weight: '857 g' },
+    description: 'Obra de referencia de Jean Laplanche y Jean-Bertrand Pontalis para estudiar el vocabulario y la evolución conceptual del psicoanálisis. Cada entrada combina definición, historia, estructura y problemas teóricos, con referencias cruzadas y equivalencias terminológicas en varios idiomas. Resulta especialmente útil para estudiantes, docentes y profesionales que necesitan una fuente de consulta sistemática.',
+  }],
+  ['MLU1304008698', {
+    isbn: '9788433028839',
+    author: 'Frank E. Yeomans, John F. Clarkin y Otto F. Kernberg',
+    publisher: 'Desclée De Brouwer',
+    pages: 608,
+    bibliographic: {
+      language: 'Español',
+      format: 'Tapa blanda',
+      edition: '2.ª edición',
+      publication_year: '2016',
+      genre: 'Psicología clínica',
+      collection: 'Biblioteca de Psicología',
+    },
+    dimensions: { width: '15 cm', height: '21 cm' },
+    description: 'Guía clínica de Psicoterapia Centrada en la Transferencia para el abordaje del trastorno límite y otras organizaciones graves de la personalidad. Los autores desarrollan la selección de casos, el encuadre, el análisis de la transferencia y el manejo de crisis mediante ejemplos clínicos. Está orientada a profesionales y estudiantes avanzados de psicología, psiquiatría y psicoterapia.',
+  }],
+]);
+
+function digits(value) {
+  return String(value || '').replace(/\D/g, '');
+}
+
+/**
+ * Aplica el lote solo cuando el ID coincide y el ISBN no contradice la ficha.
+ * Devuelve métricas para que el sync deje evidencia de lo aplicado/omitido.
+ */
+export function applyVerifiedBookEnrichments(items = []) {
+  let applied = 0;
+  let skippedIsbnMismatch = 0;
+
+  for (const item of items) {
+    const enrichment = VERIFIED_BOOK_ENRICHMENTS.get(String(item?.id || ''));
+    if (!enrichment) continue;
+
+    const currentIsbn = digits(item.isbn);
+    const verifiedIsbn = digits(enrichment.isbn);
+    if (currentIsbn && currentIsbn !== verifiedIsbn) {
+      skippedIsbnMismatch++;
+      continue;
+    }
+
+    const originalTitle = item.title;
+    item.isbn = enrichment.isbn;
+    item.author = enrichment.author;
+    item.publisher = enrichment.publisher;
+    item.pages = enrichment.pages;
+    item.bibliographic = {
+      ...(item.bibliographic || {}),
+      ...enrichment.bibliographic,
+    };
+    item.dimensions = {
+      ...(enrichment.dimensions || {}),
+      ...(item.dimensions || {}),
+    };
+    item.description = enrichment.description;
+    item.title = originalTitle;
+    applied++;
+  }
+
+  return { applied, skipped_isbn_mismatch: skippedIsbnMismatch };
+}
+
+export const VERIFIED_BOOK_IDS = Object.freeze([...VERIFIED_BOOK_ENRICHMENTS.keys()]);


### PR DESCRIPTION
## Resultado

Enriquece cinco fichas seleccionadas por ventas reales, disponibilidad actual y afinidad con estudiantes/profesionales de psicología.

- MLU644161565 — Espérame en el arcoíris
- MLU678034726 — Terapia psicodinámica para la patología de la personalidad
- MLU1467827214 — Manual de EMDR y procesos de terapia familiar
- MLU633677061 — Diccionario de psicoanálisis
- MLU1304008698 — Psicoterapia centrada en la transferencia

## Qué cambia

- autoría completa, editorial, páginas, formato, año, colección y medidas verificables;
- una descripción propia y diferenciada para cada ficha;
- el título comercial y las imágenes existentes quedan intactos;
- si el ISBN actual contradice la edición verificada, el enriquecimiento se omite automáticamente;
- deja métricas en data_quality para saber cuántas fichas se aplicaron u omitieron.

## Verificación

- node --test worker-sync/__tests__/verified-book-enrichments.test.js worker-sync/__tests__/meli-catalog.test.js
- 21 pruebas aprobadas localmente.

## Fuera de alcance

Las fotos adicionales deben tomarse del ejemplar real. No se generan imágenes ni se alteran títulos.