### PR TITLE
SEO: integrar Bing Webmaster API en modo solo lectura

### DIFF
--- a/worker-sync/__tests__/bing-webmaster.test.js
+++ b/worker-sync/__tests__/bing-webmaster.test.js
@@ -1,0 +1,182 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import {
+  BING_WEBMASTER_API_BASE,
+  BING_WEBMASTER_READ_METHODS,
+  BING_WEBMASTER_SITE_URL,
+  buildBingWebmasterUrl,
+  fetchBingWebmasterMethod,
+  getBingWebmasterReadOnlySummary,
+} from '../bing-webmaster.js';
+
+const API_KEY = 'bing-test-key';
+
+function jsonResponse(value, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+test('construye únicamente URLs REST/JSON para la propiedad canónica con www', () => {
+  const url = buildBingWebmasterUrl('GetQueryStats', API_KEY);
+
+  assert.equal(url.origin + url.pathname, BING_WEBMASTER_API_BASE + '/GetQueryStats');
+  assert.equal(url.searchParams.get('siteUrl'), BING_WEBMASTER_SITE_URL);
+  assert.equal(url.searchParams.get('apikey'), API_KEY);
+  assert.doesNotMatch(url.pathname, /\/pox\/|\/soap\//);
+});
+
+test('rechaza métodos de escritura y no llama a la red sin secret', async () => {
+  assert.throws(
+    () => buildBingWebmasterUrl('SubmitUrlBatch', API_KEY),
+    /Método de Bing no permitido/,
+  );
+
+  let calls = 0;
+  await assert.rejects(
+    () => fetchBingWebmasterMethod('GetCrawlIssues', {}, {
+      fetchFn: async () => {
+        calls++;
+        return jsonResponse({ d: [] });
+      },
+    }),
+    error => error.code === 'MISSING_API_KEY',
+  );
+  assert.equal(calls, 0);
+});
+
+test('consulta por GET y desenvuelve el campo d del protocolo JSON', async () => {
+  let captured;
+  const data = await fetchBingWebmasterMethod(
+    'GetUrlSubmissionQuota',
+    { BING_WEBMASTER_API_KEY: API_KEY },
+    {
+      fetchFn: async (url, options) => {
+        captured = { url, options };
+        return jsonResponse({
+          d: {
+            __type: 'UrlSubmissionQuota:#Microsoft.Bing.Webmaster.Api',
+            DailyQuota: 5,
+            MonthlyQuota: 24,
+          },
+        });
+      },
+    },
+  );
+
+  assert.equal(captured.options.method, 'GET');
+  assert.equal(new URL(captured.url).searchParams.get('siteUrl'), BING_WEBMASTER_SITE_URL);
+  assert.equal(data.DailyQuota, 5);
+  assert.equal(data.MonthlyQuota, 24);
+});
+
+test('convierte el ErrorCode documentado de Bing en un error controlado', async () => {
+  await assert.rejects(
+    () => fetchBingWebmasterMethod(
+      'GetQueryStats',
+      { BING_WEBMASTER_API_KEY: API_KEY },
+      {
+        fetchFn: async () => jsonResponse({
+          ErrorCode: 3,
+          Message: 'InvalidApiKey',
+        }),
+      },
+    ),
+    error => error.code === 'BING_3' && /InvalidApiKey/.test(error.message),
+  );
+});
+
+test('el resumen llama exactamente los tres métodos de lectura y normaliza resultados', async () => {
+  const calls = [];
+  const fetchFn = async (rawUrl, options) => {
+    const url = new URL(rawUrl);
+    const method = url.pathname.split('/').at(-1);
+    calls.push({ method, options, siteUrl: url.searchParams.get('siteUrl') });
+
+    if (method === 'GetQueryStats') {
+      return jsonResponse({
+        d: [{
+          Query: 'libros de psicología uruguay',
+          Date: '/Date(1786665600000)/',
+          Impressions: 12,
+          Clicks: 3,
+          AvgImpressionPosition: 8,
+          AvgClickPosition: 6,
+        }],
+      });
+    }
+    if (method === 'GetCrawlIssues') {
+      return jsonResponse({
+        d: [{
+          Url: 'https://www.amadolibros.com/libro/MLU1/libro',
+          HttpCode: 404,
+          Issues: 1,
+          InLinks: 4,
+        }],
+      });
+    }
+    return jsonResponse({ d: { DailyQuota: 5, MonthlyQuota: 24 } });
+  };
+
+  const result = await getBingWebmasterReadOnlySummary(
+    { BING_WEBMASTER_API_KEY: API_KEY },
+    { fetchFn },
+  );
+
+  assert.equal(result.status, 'ok');
+  assert.equal(result.read_only, true);
+  assert.equal(result.site_url, BING_WEBMASTER_SITE_URL);
+  assert.deepEqual(
+    calls.map(call => call.method).sort(),
+    [...BING_WEBMASTER_READ_METHODS].sort(),
+  );
+  assert.ok(calls.every(call => call.options.method === 'GET'));
+  assert.ok(calls.every(call => call.siteUrl === BING_WEBMASTER_SITE_URL));
+  assert.equal(result.query_performance.totals.impressions, 12);
+  assert.equal(result.query_performance.totals.clicks, 3);
+  assert.equal(result.crawl_issues.by_http_code['404'], 1);
+  assert.equal(result.url_submission_quota.daily_quota, 5);
+  assert.equal(result.url_submission_quota.submissions_enabled, false);
+  assert.equal(result.limitations.replaces_keyword_research, false);
+  assert.equal(result.limitations.replaces_full_site_scan, false);
+  assert.equal(result.limitations.submit_url_batch_enabled, false);
+  assert.doesNotMatch(JSON.stringify(result), new RegExp(API_KEY));
+});
+
+test('una falla parcial queda visible sin ocultar los otros datos', async () => {
+  const fetchFn = async rawUrl => {
+    const method = new URL(rawUrl).pathname.split('/').at(-1);
+    if (method === 'GetCrawlIssues') {
+      return jsonResponse({ ErrorCode: 3, Message: 'InvalidApiKey' });
+    }
+    if (method === 'GetQueryStats') return jsonResponse({ d: [] });
+    return jsonResponse({ d: { DailyQuota: 2, MonthlyQuota: 9 } });
+  };
+
+  const result = await getBingWebmasterReadOnlySummary(
+    { BING_WEBMASTER_API_KEY: API_KEY },
+    { fetchFn },
+  );
+
+  assert.equal(result.status, 'partial');
+  assert.equal(result.crawl_issues.status, 'error');
+  assert.equal(result.crawl_issues.error.code, 'BING_3');
+  assert.equal(result.query_performance.status, 'ok');
+  assert.equal(result.url_submission_quota.status, 'ok');
+});
+
+test('la configuración declara la API key únicamente como secret', () => {
+  const root = fileURLToPath(new URL('../', import.meta.url));
+  const wrangler = readFileSync(root + '/wrangler.toml', 'utf8');
+  const source = readFileSync(root + '/index.js', 'utf8');
+
+  assert.match(wrangler, /BING_WEBMASTER_API_KEY\s+—\s+secret de la API/);
+  assert.doesNotMatch(wrangler, /BING_WEBMASTER_API_KEY\s*=\s*['"]/);
+  assert.match(source, /GET \/bing-webmaster\/summary/);
+  assert.match(source, /getBingWebmasterReadOnlySummary\(env\)/);
+  assert.doesNotMatch(source, /SubmitUrlBatch/);
+});

--- a/worker-sync/bing-webmaster.js
+++ b/worker-sync/bing-webmaster.js
@@ -1,0 +1,227 @@
+/**
+ * Cliente de solo lectura para Bing Webmaster Tools.
+ *
+ * Usa exclusivamente el protocolo REST/JSON. La API key se lee del secret
+ * BING_WEBMASTER_API_KEY y nunca se registra ni se devuelve al cliente.
+ * La propiedad queda fijada al dominio canónico verificado.
+ */
+
+export const BING_WEBMASTER_API_BASE =
+  'https://ssl.bing.com/webmaster/api.svc/json';
+export const BING_WEBMASTER_SITE_URL = 'https://www.amadolibros.com';
+export const BING_WEBMASTER_READ_METHODS = Object.freeze([
+  'GetCrawlIssues',
+  'GetQueryStats',
+  'GetUrlSubmissionQuota',
+]);
+
+const MAX_QUERY_ROWS = 100;
+const MAX_CRAWL_ISSUES = 200;
+
+export class BingWebmasterApiError extends Error {
+  constructor(message, {
+    code = 'BING_API_ERROR',
+    httpStatus = null,
+  } = {}) {
+    super(message);
+    this.name = 'BingWebmasterApiError';
+    this.code = code;
+    this.httpStatus = httpStatus;
+  }
+}
+
+export function buildBingWebmasterUrl(method, apiKey) {
+  if (!BING_WEBMASTER_READ_METHODS.includes(method)) {
+    throw new BingWebmasterApiError('Método de Bing no permitido.', {
+      code: 'METHOD_NOT_ALLOWED',
+    });
+  }
+  if (!apiKey || !String(apiKey).trim()) {
+    throw new BingWebmasterApiError('BING_WEBMASTER_API_KEY no está configurada.', {
+      code: 'MISSING_API_KEY',
+    });
+  }
+
+  const url = new URL(BING_WEBMASTER_API_BASE + '/' + method);
+  url.searchParams.set('apikey', String(apiKey).trim());
+  url.searchParams.set('siteUrl', BING_WEBMASTER_SITE_URL);
+  return url;
+}
+
+export async function fetchBingWebmasterMethod(method, env, {
+  fetchFn = fetch,
+  signal,
+} = {}) {
+  const apiKey = env?.BING_WEBMASTER_API_KEY;
+  const url = buildBingWebmasterUrl(method, apiKey);
+
+  let response;
+  try {
+    response = await fetchFn(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal,
+    });
+  } catch (error) {
+    throw new BingWebmasterApiError(
+      'No se pudo conectar con Bing Webmaster Tools.',
+      { code: 'NETWORK_ERROR' },
+    );
+  }
+
+  let payload;
+  try {
+    const text = await response.text();
+    payload = text ? JSON.parse(text) : null;
+  } catch {
+    throw new BingWebmasterApiError(
+      'Bing devolvió una respuesta que no es JSON válido.',
+      {
+        code: 'INVALID_JSON',
+        httpStatus: response.status,
+      },
+    );
+  }
+
+  const apiError = payload?.ErrorCode != null
+    ? payload
+    : payload?.d?.ErrorCode != null
+      ? payload.d
+      : null;
+
+  if (!response.ok || apiError) {
+    const code = apiError?.ErrorCode != null
+      ? 'BING_' + apiError.ErrorCode
+      : 'HTTP_' + response.status;
+    const message = apiError?.Message
+      ? 'Bing rechazó la consulta: ' + String(apiError.Message).slice(0, 240)
+      : 'Bing respondió con HTTP ' + response.status + '.';
+    throw new BingWebmasterApiError(message, {
+      code,
+      httpStatus: response.status,
+    });
+  }
+
+  return payload?.d ?? payload;
+}
+
+function bingDateToIso(value) {
+  const match = String(value || '').match(/^\/Date\((-?\d+)(?:[+-]\d+)?\)\/$/);
+  if (!match) return value || null;
+  const date = new Date(Number(match[1]));
+  return Number.isNaN(date.getTime()) ? value : date.toISOString();
+}
+
+function countBy(rows, key) {
+  const counts = {};
+  for (const row of rows) {
+    const value = row?.[key] ?? 'unknown';
+    counts[String(value)] = (counts[String(value)] || 0) + 1;
+  }
+  return counts;
+}
+
+function normalizeQueryStats(value) {
+  const rows = Array.isArray(value) ? value : [];
+  const sorted = [...rows].sort((a, b) =>
+    Number(b?.Impressions || 0) - Number(a?.Impressions || 0)
+    || Number(b?.Clicks || 0) - Number(a?.Clicks || 0)
+  );
+  return {
+    total_rows: rows.length,
+    totals: {
+      impressions: rows.reduce((sum, row) => sum + Number(row?.Impressions || 0), 0),
+      clicks: rows.reduce((sum, row) => sum + Number(row?.Clicks || 0), 0),
+    },
+    rows: sorted.slice(0, MAX_QUERY_ROWS).map(row => ({
+      query: String(row?.Query || ''),
+      date: bingDateToIso(row?.Date),
+      impressions: Number(row?.Impressions || 0),
+      clicks: Number(row?.Clicks || 0),
+      average_impression_position: finiteOrNull(row?.AvgImpressionPosition),
+      average_click_position: finiteOrNull(row?.AvgClickPosition),
+    })),
+    truncated: rows.length > MAX_QUERY_ROWS,
+    documented_update_frequency: 'weekly',
+  };
+}
+
+function normalizeCrawlIssues(value) {
+  const rows = Array.isArray(value) ? value : [];
+  return {
+    total: rows.length,
+    by_http_code: countBy(rows, 'HttpCode'),
+    by_issue_code: countBy(rows, 'Issues'),
+    rows: rows.slice(0, MAX_CRAWL_ISSUES).map(row => ({
+      url: String(row?.Url || ''),
+      http_code: finiteOrNull(row?.HttpCode),
+      issue_code: finiteOrNull(row?.Issues),
+      inlinks: finiteOrNull(row?.InLinks),
+    })),
+    truncated: rows.length > MAX_CRAWL_ISSUES,
+    limitation: 'No reemplaza el Site Scan SEO completo de Bing.',
+  };
+}
+
+function normalizeQuota(value) {
+  return {
+    daily_quota: finiteOrNull(value?.DailyQuota),
+    monthly_quota: finiteOrNull(value?.MonthlyQuota),
+    informational_only: true,
+    submissions_enabled: false,
+  };
+}
+
+function finiteOrNull(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function publicError(error) {
+  return {
+    code: error?.code || 'BING_API_ERROR',
+    message: String(error?.message || 'Error consultando Bing.').slice(0, 300),
+    http_status: Number.isInteger(error?.httpStatus) ? error.httpStatus : null,
+  };
+}
+
+export async function getBingWebmasterReadOnlySummary(env, {
+  fetchFn = fetch,
+} = {}) {
+  const methods = BING_WEBMASTER_READ_METHODS;
+  const results = await Promise.allSettled(
+    methods.map(method => fetchBingWebmasterMethod(method, env, { fetchFn })),
+  );
+  const byMethod = Object.fromEntries(
+    methods.map((method, index) => [method, results[index]]),
+  );
+  const fulfilled = results.filter(result => result.status === 'fulfilled').length;
+  const status = fulfilled === results.length
+    ? 'ok'
+    : fulfilled > 0
+      ? 'partial'
+      : 'error';
+
+  const valueOrError = (method, normalize) => {
+    const result = byMethod[method];
+    return result.status === 'fulfilled'
+      ? { status: 'ok', ...normalize(result.value) }
+      : { status: 'error', error: publicError(result.reason) };
+  };
+
+  return {
+    status,
+    checked_at: new Date().toISOString(),
+    site_url: BING_WEBMASTER_SITE_URL,
+    protocol: 'rest-json',
+    read_only: true,
+    query_performance: valueOrError('GetQueryStats', normalizeQueryStats),
+    crawl_issues: valueOrError('GetCrawlIssues', normalizeCrawlIssues),
+    url_submission_quota: valueOrError('GetUrlSubmissionQuota', normalizeQuota),
+    limitations: {
+      replaces_keyword_research: false,
+      replaces_full_site_scan: false,
+      submit_url_batch_enabled: false,
+    },
+  };
+}

--- a/worker-sync/index.js
+++ b/worker-sync/index.js
@@ -8,6 +8,8 @@
  *   fetch(request)   — POST /trigger con header Authorization: Bearer <SYNC_SECRET>
  *                      para disparar sync manualmente.
  *                    — GET /status con el mismo header para auditar KV + R2.
+ *                    — GET /bing-webmaster/summary consulta Bing Webmaster
+ *                      en modo solo lectura con el mismo header.
  *                    — POST /measure descarga y mide sin escribir R2 ni estado de sync.
  *                    — POST /publish-preview-catalog escribe únicamente el catálogo
  *                      separado de STOCK-1 (prefijo stock1-preview/*) cuando la
@@ -49,6 +51,7 @@ import { publishToR2    } from './r2-publish.js';
 import { notifyHealthcheck } from './healthcheck.js';
 import { processStockWaitlist } from './stock-waitlist-notifier.js';
 import { readPreviousPublicCatalog, submitIndexNow } from './indexnow.js';
+import { getBingWebmasterReadOnlySummary } from './bing-webmaster.js';
 import {
   addCompressedIndexes,
   buildManifest,
@@ -87,6 +90,11 @@ export default {
       return json(await readStatus(env));
     }
 
+    if (request.method === 'GET' && url.pathname === '/bing-webmaster/summary') {
+      const result = await getBingWebmasterReadOnlySummary(env);
+      return json(result, result.status === 'error' ? 502 : 200);
+    }
+
     if (request.method === 'POST' && url.pathname === '/measure') {
       const result = await runMeasure(env);
       return json(result, result.status === 'measured' ? 200 : 500);
@@ -109,7 +117,7 @@ export default {
     }
 
     if (request.method !== 'POST' || url.pathname !== '/trigger') {
-      return json({ error: 'Not found. Use POST /measure, POST /trigger or GET /status.' }, 404);
+      return json({ error: 'Not found. Use POST /measure, POST /trigger, GET /status or GET /bing-webmaster/summary.' }, 404);
     }
 
     const mode = url.searchParams.get('mode') || 'async';

--- a/worker-sync/wrangler.toml
+++ b/worker-sync/wrangler.toml
@@ -50,6 +50,7 @@ database_id = "6dc8dc3a-2d4f-4045-b428-14323c7b0bcd"
 
 # ── Secrets a configurar via `wrangler secret put` ───────────────────────────
 # CLIENT_SECRET  — secreto OAuth de la app MercadoLibre
-# SYNC_SECRET    — token para el trigger manual POST /trigger
+# SYNC_SECRET    — token para rutas internas, incluido GET /bing-webmaster/summary
+# BING_WEBMASTER_API_KEY — secret de la API de Bing Webmaster Tools (solo lectura)
 # RESEND_API_KEY — envío automático al cliente cuando vuelve el stock
 # (No hay env REFRESH_TOKEN — el token rotativo vive en KV: auth:refresh_token)


### PR DESCRIPTION
## Qué incorpora

- Cliente exclusivo para `/api.svc/json/`.
- Propiedad fija: `https://www.amadolibros.com`.
- Endpoint interno protegido: `GET /bing-webmaster/summary`.
- Consultas permitidas:
  - `GetQueryStats`
  - `GetCrawlIssues`
  - `GetUrlSubmissionQuota`
- Resumen normalizado, sin devolver ni registrar la API key.
- Resultado parcial cuando Bing falla en un método sin ocultar los otros dos.
- Pruebas de protocolo, allowlist, errores, cuota y ausencia de escrituras.

## Seguridad

La credencial se lee exclusivamente desde el secret Cloudflare `BING_WEBMASTER_API_KEY`. La ruta exige además el mismo `Authorization: Bearer <SYNC_SECRET>` que protege las operaciones internas del Worker.

No se implementa `SubmitUrlBatch`, no se modifica IndexNow y no hay ningún POST a Bing.

## Corrección de alcance

La documentación oficial indica que:

- `GetCrawlIssues` informa problemas de rastreo por URL, pero no sustituye todo el Site Scan SEO.
- `GetQueryStats` devuelve rendimiento de consultas y se actualiza semanalmente; no sustituye investigación de demanda.

La respuesta del endpoint declara explícitamente ambas limitaciones.

## Validación esperada

CI debe ejecutar sintaxis, suite completa y builds de Astro con checkout apagado y encendido. La prueba real contra Bing queda bloqueada hasta cargar el secret en el Worker.