### PR TITLE
Medición: autenticar GA4 y GSC sin claves JSON

### DIFF
--- a/.github/workflows/ai-measurement-baseline.yml
+++ b/.github/workflows/ai-measurement-baseline.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: ai-measurement-baseline
@@ -57,20 +58,21 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22.12.0'
-      - name: Validate GA4 secrets
+      - name: Validate GA4 secret
         env:
-          GA4_SERVICE_ACCOUNT_JSON: ${{ secrets.GA4_SERVICE_ACCOUNT_JSON }}
           GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
         run: |
-          test -n "$GA4_SERVICE_ACCOUNT_JSON" || { echo "::error::Falta GA4_SERVICE_ACCOUNT_JSON"; exit 1; }
           test -n "$GA4_PROPERTY_ID" || { echo "::error::Falta GA4_PROPERTY_ID"; exit 1; }
       - name: Authenticate with Google Analytics
         id: google_auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.GA4_SERVICE_ACCOUNT_JSON }}
+          project_id: amado-libros-analytics
+          workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
+          service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
           token_format: access_token
           access_token_scopes: https://www.googleapis.com/auth/analytics.readonly
+          create_credentials_file: false
       - name: Extract GA4 reports
         env:
           GA4_ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
@@ -96,18 +98,16 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22.12.0'
-      - name: Validate Search Console secret
-        env:
-          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GA4_SERVICE_ACCOUNT_JSON }}
-        run: |
-          test -n "$GOOGLE_SERVICE_ACCOUNT_JSON" || { echo "::error::Falta GA4_SERVICE_ACCOUNT_JSON"; exit 1; }
       - name: Authenticate with Search Console
         id: google_auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.GA4_SERVICE_ACCOUNT_JSON }}
+          project_id: amado-libros-analytics
+          workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
+          service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
           token_format: access_token
           access_token_scopes: https://www.googleapis.com/auth/webmasters.readonly
+          create_credentials_file: false
       - name: Extract Search Analytics
         env:
           GSC_ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}

--- a/.github/workflows/ga4-export.yml
+++ b/.github/workflows/ga4-export.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: ga4-export
@@ -34,21 +35,22 @@ jobs:
         with:
           node-version: '22.12.0'
 
-      - name: Validate required secrets
+      - name: Validate required secret
         env:
-          GA4_SERVICE_ACCOUNT_JSON: ${{ secrets.GA4_SERVICE_ACCOUNT_JSON }}
           GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
         run: |
-          test -n "$GA4_SERVICE_ACCOUNT_JSON" || { echo "::error::Falta GA4_SERVICE_ACCOUNT_JSON"; exit 1; }
           test -n "$GA4_PROPERTY_ID" || { echo "::error::Falta GA4_PROPERTY_ID"; exit 1; }
 
       - name: Authenticate with Google
         id: google_auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.GA4_SERVICE_ACCOUNT_JSON }}
+          project_id: amado-libros-analytics
+          workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
+          service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
           token_format: access_token
           access_token_scopes: https://www.googleapis.com/auth/analytics.readonly
+          create_credentials_file: false
 
       - name: Extract GA4 reports
         env:

--- a/.github/workflows/gsc-export.yml
+++ b/.github/workflows/gsc-export.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: gsc-export
@@ -38,19 +39,16 @@ jobs:
         with:
           node-version: '22.12.0'
 
-      - name: Validate required secret
-        env:
-          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GA4_SERVICE_ACCOUNT_JSON }}
-        run: |
-          test -n "$GOOGLE_SERVICE_ACCOUNT_JSON" || { echo "::error::Falta GA4_SERVICE_ACCOUNT_JSON (se reutiliza el mismo service account; debe tener acceso de lectura en Search Console)"; exit 1; }
-
       - name: Authenticate with Google
         id: google_auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.GA4_SERVICE_ACCOUNT_JSON }}
+          project_id: amado-libros-analytics
+          workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
+          service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
           token_format: access_token
           access_token_scopes: https://www.googleapis.com/auth/webmasters.readonly
+          create_credentials_file: false
 
       - name: Extract Search Analytics
         env:

--- a/docs/seo/baseline-2026-08-08.md
+++ b/docs/seo/baseline-2026-08-08.md
@@ -134,7 +134,7 @@ Se exportan dos reportes por API:
 
 Workflow: `.github/workflows/gsc-export.yml`.
 
-El workflow reutiliza `GA4_SERVICE_ACCOUNT_JSON` únicamente como credencial Google. Ese service account debe tener permiso de lectura sobre la propiedad de Search Console. La propiedad exacta se pasa por `workflow_dispatch` (`https://www.amadolibros.com/` o `sc-domain:amadolibros.com`, según la propiedad real configurada).
+Los workflows se autentican sin claves persistentes mediante Workload Identity Federation y la cuenta `ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com`. Esa cuenta debe tener permiso de lectura sobre GA4 y sobre la propiedad de Search Console. La propiedad exacta de Search Console se pasa por `workflow_dispatch` (`https://www.amadolibros.com/` o `sc-domain:amadolibros.com`, según la propiedad real configurada).
 
 Salida esperada:
 

--- a/functions/__tests__/google-workload-identity.test.js
+++ b/functions/__tests__/google-workload-identity.test.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const workflowPaths = [
+  '.github/workflows/ga4-export.yml',
+  '.github/workflows/gsc-export.yml',
+  '.github/workflows/ai-measurement-baseline.yml',
+];
+
+const provider =
+  'projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web';
+const serviceAccount =
+  'ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com';
+
+for (const workflowPath of workflowPaths) {
+  test(`${workflowPath} autentica con Workload Identity sin claves persistentes`, () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+
+    assert.match(workflow, /^  id-token: write$/m);
+    assert.match(workflow, /uses: google-github-actions\/auth@v3/);
+    assert.equal(
+      workflow.includes(`workload_identity_provider: ${provider}`),
+      true,
+    );
+    assert.equal(workflow.includes(`service_account: ${serviceAccount}`), true);
+    assert.doesNotMatch(workflow, /GA4_SERVICE_ACCOUNT_JSON/);
+    assert.doesNotMatch(workflow, /credentials_json:/);
+  });
+}


### PR DESCRIPTION
## Qué cambia

- Migra los workflows de GA4 y Search Console a Workload Identity Federation.
- Usa el proveedor `amadolibros-web` y la cuenta técnica `ga4-reporter`.
- Elimina la dependencia de claves JSON persistentes.
- Mantiene únicamente el secreto `GA4_PROPERTY_ID` para identificar la propiedad.
- Agrega una prueba que impide reintroducir `credentials_json` o `GA4_SERVICE_ACCOUNT_JSON`.

## Por qué

La organización bloquea correctamente la creación de claves de cuentas de servicio. La federación permite que GitHub Actions obtenga credenciales temporales y de alcance limitado sin guardar una clave privada en GitHub.

## Impacto

No cambia la web ni despliega contenido. Habilita exportaciones seguras de GA4 y Search Console cuando `ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com` tenga permisos de lectura en ambas propiedades.

## Validación

- `ASTRO_TELEMETRY_DISABLED=1 NPM_CONFIG_CACHE=/tmp/amado-npm-cache bash scripts/validate-ci.sh`
- Suite completa, builds con checkout encendido y apagado: OK.
- `git diff --check`: OK.