### PR TITLE
Sincronizar secreto de Bing con el Worker

### DIFF
--- a/.github/workflows/deploy-worker-sync.yml
+++ b/.github/workflows/deploy-worker-sync.yml
@@ -61,6 +61,19 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
 
+      - name: Sync Bing Webmaster secret to Worker
+        run: |
+          if [ -z "$BING_WEBMASTER_API_KEY" ]; then
+            echo "ERROR: BING_WEBMASTER_API_KEY no está configurada en production."
+            exit 1
+          fi
+          cd worker-sync
+          printf '%s' "$BING_WEBMASTER_API_KEY" | npx wrangler@3 secret put BING_WEBMASTER_API_KEY
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BING_WEBMASTER_API_KEY: ${{ secrets.BING_WEBMASTER_API_KEY }}
+
       - name: Wait for Worker propagation
         if: ${{ inputs.run_trigger == true }}
         run: |


### PR DESCRIPTION
## Qué cambia

- Agrega al despliegue de `amadolibros-sync` un paso que publica `BING_WEBMASTER_API_KEY` como secreto del Worker.
- Verifica que el secreto exista en el entorno `production` antes de continuar.
- Mantiene la clave fuera del repositorio y de los logs.

## Causa raíz

El informe de Bing de la PR #143 llegó correctamente al Worker, pero el Worker respondió `MISSING_API_KEY`. La clave estaba guardada en GitHub, mientras que el workflow de despliegue sólo sincronizaba `RESEND_API_KEY` hacia Cloudflare.

## Impacto

Después de fusionar, el despliegue del Worker dejará disponible la clave de Bing y permitirá que el informe de solo lectura consulte rendimiento, problemas de rastreo y cuota.

No cambia la web, el catálogo ni activa envíos de URLs a Bing.

## Validación

- Rama creada desde el `main` actual.
- Diff limitado a `.github/workflows/deploy-worker-sync.yml`.
- Un commit, 13 líneas agregadas y ninguna eliminación.
- El workflow falla de forma explícita si el secreto no está disponible en `production`.