### PR TITLE
Medición: auditar indexación y oportunidades CTR

### DIFF
--- a/.github/workflows/gsc-export.yml
+++ b/.github/workflows/gsc-export.yml
@@ -23,6 +23,11 @@ on:
         required: true
         default: 'sc-domain:amadolibros.com'
         type: string
+      inspection_sample_size:
+        description: Cantidad de fichas activas a inspeccionar (máximo 400)
+        required: true
+        default: 400
+        type: number
 
 permissions:
   contents: read
@@ -36,7 +41,7 @@ jobs:
   export:
     name: Extract Search Console data
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -86,9 +91,12 @@ jobs:
         env:
           GSC_ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
           GSC_OUTPUT_DIR: artifacts/gsc
+          GSC_ACTIVE_SITEMAP_URL: https://www.amadolibros.com/sitemap-books-active.xml
+          GSC_INSPECTION_SAMPLE_SIZE: ${{ inputs.inspection_sample_size || 400 }}
         run: node scripts/seo/gsc-export.mjs
 
-      - name: Upload JSON and CSV
+      - name: Upload JSON, CSV and summary
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: gsc-${{ github.run_id }}
@@ -99,10 +107,13 @@ jobs:
       - name: Write run summary
         if: always()
         run: |
-          echo "## GSC export" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f artifacts/gsc/report-summary.md ]; then
+            cat artifacts/gsc/report-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## GSC export incompleto" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "No se generó el resumen; revisar el log de extracción." >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Property: ${GSC_SITE_URL:-not resolved}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Period: ${GSC_START_DATE:-not resolved} to ${GSC_END_DATE:-not resolved}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Reports: page + query" >> "$GITHUB_STEP_SUMMARY"
           echo "- Trigger: ${{ github.event_name }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Deploy: not triggered by this workflow" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Deploy: no se dispara desde este workflow" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/seo/baseline-2026-08-08.md
+++ b/docs/seo/baseline-2026-08-08.md
@@ -127,10 +127,20 @@ Los JSON completos fueron preservados como artifact del workflow `seo-baseline-p
 
 Período baseline fijado: **2026-05-11 a 2026-08-08**, inclusive.
 
-Se exportan dos reportes por API:
+Se exportan tres reportes de rendimiento por API:
 
 - dimensión `page`: clicks, impressions, ctr y position;
 - dimensión `query`: clicks, impressions, ctr y position.
+- dimensiones `page + query`: consultas principales asociadas a cada URL.
+
+El mismo workflow genera además:
+
+- un ranking de hasta 20 fichas con posición 3–15, al menos 10 impresiones y
+  CTR inferior al promedio agregado de las fichas;
+- una muestra estable de hasta 400 fichas activas inspeccionadas con URL
+  Inspection API, separando alta demanda, fichas vistas en Search y fichas
+  activas sin impresiones;
+- un resumen visible en GitHub Actions y los detalles completos en CSV/JSON.
 
 Workflow: `.github/workflows/gsc-export.yml`.
 
@@ -142,6 +152,13 @@ Salida esperada:
 - `search-analytics-page.csv`
 - `search-analytics-query.json`
 - `search-analytics-query.csv`
+- `search-analytics-page-query.json`
+- `search-analytics-page-query.csv`
+- `ctr-opportunities.json`
+- `ctr-opportunities.csv`
+- `url-inspection-sample.json`
+- `url-inspection-sample.csv`
+- `report-summary.md`
 - `manifest.json`
 
 Como el período está fijado, esta extracción puede repetirse después sin perder el baseline histórico. Los JSON que integren el baseline deben copiarse sin transformación a `docs/seo/baseline-2026-08-08/`.

--- a/functions/__tests__/gsc-index-ctr.test.js
+++ b/functions/__tests__/gsc-index-ctr.test.js
@@ -1,0 +1,89 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+
+const PAGE = 'https://www.amadolibros.com/libro/MLU1/libro-uno';
+
+function analyticsRow(page, { clicks, impressions, position }) {
+  return {
+    keys: [page],
+    clicks,
+    impressions,
+    ctr: impressions ? clicks / impressions : 0,
+    position,
+  };
+}
+
+test('prioriza oportunidades CTR con demanda y posición accionable', async () => {
+  const { selectCtrOpportunities } = await import('../../scripts/seo/gsc-analysis.mjs');
+  const pageRows = [
+    analyticsRow(PAGE, { clicks: 0, impressions: 100, position: 8 }),
+    analyticsRow('https://www.amadolibros.com/libro/MLU2/libro-dos', { clicks: 20, impressions: 100, position: 7 }),
+    analyticsRow('https://www.amadolibros.com/libro/MLU3/libro-tres', { clicks: 0, impressions: 9, position: 6 }),
+    analyticsRow('https://www.amadolibros.com/libro/MLU4/libro-cuatro', { clicks: 0, impressions: 100, position: 30 }),
+    analyticsRow('https://www.amadolibros.com/catalogo', { clicks: 0, impressions: 1000, position: 5 }),
+  ];
+  const pageQueryRows = [{
+    keys: [PAGE, 'libro uno uruguay'],
+    clicks: 0,
+    impressions: 80,
+    ctr: 0,
+    position: 8,
+  }];
+
+  const result = selectCtrOpportunities({ pageRows, pageQueryRows });
+
+  assert.equal(result.benchmark.pageCount, 4);
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.rows[0].page, PAGE);
+  assert.equal(result.rows[0].topQueries[0].query, 'libro uno uruguay');
+  assert.ok(Math.abs(result.rows[0].estimatedMissedClicks - (20 / 309) * 100) < 0.000001);
+});
+
+test('arma una muestra estable, sin duplicados y limitada a fichas activas', async () => {
+  const { buildInspectionSample } = await import('../../scripts/seo/gsc-analysis.mjs');
+  const sitemapUrls = Array.from(
+    { length: 500 },
+    (_, index) => `https://www.amadolibros.com/libro/MLU${index + 1}/libro-${index + 1}`,
+  );
+  const pageRows = sitemapUrls.slice(0, 150).map((page, index) => (
+    analyticsRow(page, { clicks: index % 3, impressions: 200 - index, position: 8 })
+  ));
+  const ctrOpportunities = pageRows.slice(0, 20).map((row) => ({ page: row.keys[0] }));
+
+  const first = buildInspectionSample({ sitemapUrls, pageRows, ctrOpportunities, size: 400 });
+  const second = buildInspectionSample({ sitemapUrls, pageRows, ctrOpportunities, size: 400 });
+
+  assert.equal(first.length, 400);
+  assert.deepEqual(first, second);
+  assert.equal(new Set(first.map((row) => row.page)).size, 400);
+  assert.ok(first.some((row) => row.stratum === 'ctr_or_high_demand'));
+  assert.ok(first.some((row) => row.stratum === 'seen_in_search'));
+  assert.ok(first.some((row) => row.stratum === 'no_impressions'));
+  assert.ok(first.every((row) => sitemapUrls.includes(row.page)));
+});
+
+test('resume inspecciones sin confundir errores con verdictos de Google', async () => {
+  const { summarizeInspections } = await import('../../scripts/seo/gsc-analysis.mjs');
+  const summary = summarizeInspections([
+    { stratum: 'seen_in_search', verdict: 'PASS', coverageState: 'Submitted and indexed' },
+    { stratum: 'no_impressions', verdict: 'NEUTRAL', coverageState: 'Crawled - currently not indexed' },
+    { stratum: 'no_impressions', error: 'HTTP 429' },
+  ]);
+
+  assert.equal(summary.requested, 3);
+  assert.equal(summary.completed, 2);
+  assert.equal(summary.errors, 1);
+  assert.equal(summary.verdicts.PASS, 1);
+  assert.equal(summary.coverageStates['Crawled - currently not indexed'], 1);
+});
+
+test('el workflow semanal usa la propiedad correcta, limita la muestra y no despliega', () => {
+  const workflow = readFileSync('.github/workflows/gsc-export.yml', 'utf8');
+
+  assert.match(workflow, /default: 'sc-domain:amadolibros\.com'/);
+  assert.match(workflow, /default: 400/);
+  assert.match(workflow, /GSC_ACTIVE_SITEMAP_URL: https:\/\/www\.amadolibros\.com\/sitemap-books-active\.xml/);
+  assert.match(workflow, /GSC_INSPECTION_SAMPLE_SIZE:/);
+  assert.doesNotMatch(workflow, /wrangler|cloudflare\/pages-action|deploy-pages/);
+});

--- a/scripts/seo/gsc-analysis.mjs
+++ b/scripts/seo/gsc-analysis.mjs
@@ -1,0 +1,191 @@
+import { createHash } from 'node:crypto';
+
+const PRODUCT_PATH = '/libro/';
+
+function number(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function firstKey(row, index = 0) {
+  return row?.keys?.[index] || '';
+}
+
+function stableRank(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function uniqueByPage(rows) {
+  const seen = new Set();
+  return rows.filter((row) => {
+    if (!row.page || seen.has(row.page)) return false;
+    seen.add(row.page);
+    return true;
+  });
+}
+
+export function isProductUrl(url) {
+  try {
+    return new URL(url).pathname.startsWith(PRODUCT_PATH);
+  } catch {
+    return false;
+  }
+}
+
+export function normalizePageRows(rows = []) {
+  return rows.map((row) => ({
+    page: firstKey(row),
+    clicks: number(row.clicks),
+    impressions: number(row.impressions),
+    ctr: number(row.ctr),
+    position: number(row.position),
+  }));
+}
+
+export function summarizeProductPerformance(pageRows = []) {
+  const products = normalizePageRows(pageRows).filter((row) => isProductUrl(row.page));
+  const clicks = products.reduce((sum, row) => sum + row.clicks, 0);
+  const impressions = products.reduce((sum, row) => sum + row.impressions, 0);
+  return {
+    pageCount: products.length,
+    clicks,
+    impressions,
+    ctr: impressions ? clicks / impressions : 0,
+  };
+}
+
+function queriesByPage(pageQueryRows = []) {
+  const grouped = new Map();
+  for (const row of pageQueryRows) {
+    const page = firstKey(row);
+    const query = firstKey(row, 1);
+    if (!page || !query) continue;
+    const values = grouped.get(page) || [];
+    values.push({
+      query,
+      clicks: number(row.clicks),
+      impressions: number(row.impressions),
+      ctr: number(row.ctr),
+      position: number(row.position),
+    });
+    grouped.set(page, values);
+  }
+  for (const values of grouped.values()) {
+    values.sort((a, b) => b.impressions - a.impressions || b.clicks - a.clicks || a.query.localeCompare(b.query));
+  }
+  return grouped;
+}
+
+export function selectCtrOpportunities({
+  pageRows = [],
+  pageQueryRows = [],
+  limit = 20,
+  minImpressions = 10,
+  minPosition = 3,
+  maxPosition = 15,
+} = {}) {
+  const summary = summarizeProductPerformance(pageRows);
+  const queryMap = queriesByPage(pageQueryRows);
+  const rows = normalizePageRows(pageRows)
+    .filter((row) => (
+      isProductUrl(row.page)
+      && row.impressions >= minImpressions
+      && row.position >= minPosition
+      && row.position <= maxPosition
+      && row.ctr < summary.ctr
+    ))
+    .map((row) => ({
+      ...row,
+      benchmarkCtr: summary.ctr,
+      estimatedMissedClicks: Math.max(0, (summary.ctr - row.ctr) * row.impressions),
+      topQueries: (queryMap.get(row.page) || []).slice(0, 5),
+    }))
+    .sort((a, b) => (
+      b.estimatedMissedClicks - a.estimatedMissedClicks
+      || b.impressions - a.impressions
+      || a.position - b.position
+      || a.page.localeCompare(b.page)
+    ))
+    .slice(0, limit);
+
+  return {
+    criteria: { limit, minImpressions, minPosition, maxPosition },
+    benchmark: summary,
+    rows,
+  };
+}
+
+export function buildInspectionSample({
+  sitemapUrls = [],
+  pageRows = [],
+  ctrOpportunities = [],
+  size = 400,
+} = {}) {
+  const targetSize = Math.max(1, Math.min(400, Math.trunc(number(size)) || 400));
+  const activeUrls = [...new Set(sitemapUrls.filter(isProductUrl))];
+  const activeSet = new Set(activeUrls);
+  const normalizedPages = normalizePageRows(pageRows)
+    .filter((row) => isProductUrl(row.page) && activeSet.has(row.page));
+  const pagesWithImpressions = new Set(normalizedPages.map((row) => row.page));
+
+  const priorityCap = Math.min(100, Math.ceil(targetSize * 0.25));
+  const seenCap = Math.min(100, Math.ceil(targetSize * 0.25));
+  const selected = [];
+  const selectedUrls = new Set();
+
+  const add = (page, stratum) => {
+    if (!activeSet.has(page) || selectedUrls.has(page) || selected.length >= targetSize) return false;
+    selected.push({ page, stratum });
+    selectedUrls.add(page);
+    return true;
+  };
+
+  const priority = uniqueByPage([
+    ...ctrOpportunities,
+    ...normalizedPages.slice().sort((a, b) => b.impressions - a.impressions || a.page.localeCompare(b.page)),
+  ]);
+  for (const row of priority.slice(0, priorityCap)) add(row.page, 'ctr_or_high_demand');
+
+  const otherSeen = normalizedPages
+    .filter((row) => !selectedUrls.has(row.page))
+    .sort((a, b) => stableRank(a.page).localeCompare(stableRank(b.page)));
+  for (const row of otherSeen.slice(0, seenCap)) add(row.page, 'seen_in_search');
+
+  const unseen = activeUrls
+    .filter((page) => !pagesWithImpressions.has(page))
+    .sort((a, b) => stableRank(a).localeCompare(stableRank(b)));
+  for (const page of unseen) add(page, 'no_impressions');
+
+  const remainder = activeUrls
+    .filter((page) => !selectedUrls.has(page))
+    .sort((a, b) => stableRank(a).localeCompare(stableRank(b)));
+  for (const page of remainder) {
+    add(page, pagesWithImpressions.has(page) ? 'seen_in_search_fill' : 'no_impressions_fill');
+  }
+
+  return selected;
+}
+
+export function summarizeInspections(rows = []) {
+  const summary = {
+    requested: rows.length,
+    completed: 0,
+    errors: 0,
+    verdicts: {},
+    coverageStates: {},
+    strata: {},
+  };
+  for (const row of rows) {
+    summary.strata[row.stratum] = (summary.strata[row.stratum] || 0) + 1;
+    if (row.error) {
+      summary.errors += 1;
+      continue;
+    }
+    summary.completed += 1;
+    const verdict = row.verdict || 'UNKNOWN';
+    const coverageState = row.coverageState || 'UNKNOWN';
+    summary.verdicts[verdict] = (summary.verdicts[verdict] || 0) + 1;
+    summary.coverageStates[coverageState] = (summary.coverageStates[coverageState] || 0) + 1;
+  }
+  return summary;
+}

--- a/scripts/seo/gsc-export.mjs
+++ b/scripts/seo/gsc-export.mjs
@@ -1,9 +1,18 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import {
+  buildInspectionSample,
+  selectCtrOpportunities,
+  summarizeInspections,
+} from './gsc-analysis.mjs';
 
-const API_ROOT = 'https://www.googleapis.com/webmasters/v3/sites';
+const SEARCH_ANALYTICS_ROOT = 'https://www.googleapis.com/webmasters/v3/sites';
+const URL_INSPECTION_ENDPOINT = 'https://searchconsole.googleapis.com/v1/urlInspection/index:inspect';
 const OUTPUT_DIR = process.env.GSC_OUTPUT_DIR || 'artifacts/gsc';
+const ACTIVE_SITEMAP_URL = process.env.GSC_ACTIVE_SITEMAP_URL
+  || 'https://www.amadolibros.com/sitemap-books-active.xml';
 const ROW_LIMIT = 25000;
+const INSPECTION_CONCURRENCY = 8;
 
 function assertDate(value, label) {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value || '')) throw new Error(`${label} debe usar YYYY-MM-DD.`);
@@ -19,28 +28,90 @@ function csvCell(value) {
   return `"${text.replaceAll('"', '""')}"`;
 }
 
-function toCsv(rows, dimension) {
-  const headers = [dimension, 'clicks', 'impressions', 'ctr', 'position'];
+function rowsToCsv(headers, rows) {
   const lines = [headers.map(csvCell).join(',')];
-  for (const row of rows) {
-    lines.push([
-      row.keys?.[0] ?? '',
-      row.clicks ?? 0,
-      row.impressions ?? 0,
-      row.ctr ?? 0,
-      row.position ?? 0,
-    ].map(csvCell).join(','));
-  }
+  for (const row of rows) lines.push(headers.map((header) => csvCell(row[header])).join(','));
   return `${lines.join('\n')}\n`;
 }
 
-async function fetchWithRetry(url, options, maxAttempts = 4) {
+function analyticsToCsv(rows, dimensions) {
+  const headers = [...dimensions, 'clicks', 'impressions', 'ctr', 'position'];
+  const normalized = rows.map((row) => {
+    const result = {
+      clicks: row.clicks ?? 0,
+      impressions: row.impressions ?? 0,
+      ctr: row.ctr ?? 0,
+      position: row.position ?? 0,
+    };
+    dimensions.forEach((dimension, index) => {
+      result[dimension] = row.keys?.[index] ?? '';
+    });
+    return result;
+  });
+  return rowsToCsv(headers, normalized);
+}
+
+function ctrToCsv(rows) {
+  return rowsToCsv(
+    [
+      'page',
+      'clicks',
+      'impressions',
+      'ctr',
+      'position',
+      'benchmarkCtr',
+      'estimatedMissedClicks',
+      'topQueries',
+    ],
+    rows.map((row) => ({
+      ...row,
+      topQueries: row.topQueries.map((query) => query.query).join(' | '),
+    })),
+  );
+}
+
+function inspectionsToCsv(rows) {
+  return rowsToCsv(
+    [
+      'page',
+      'stratum',
+      'verdict',
+      'coverageState',
+      'indexingState',
+      'robotsTxtState',
+      'pageFetchState',
+      'userCanonical',
+      'googleCanonical',
+      'lastCrawlTime',
+      'error',
+    ],
+    rows,
+  );
+}
+
+function decodeXml(value) {
+  return value
+    .replaceAll('&amp;', '&')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'");
+}
+
+function sitemapUrls(xml) {
+  return [...xml.matchAll(/<loc>\s*([^<]+?)\s*<\/loc>/gi)].map((match) => decodeXml(match[1]));
+}
+
+async function fetchWithRetry(url, options, maxAttempts = 4, parse = 'json') {
   let lastError;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
       const response = await fetch(url, options);
       const body = await response.text();
-      if (response.ok) return body ? JSON.parse(body) : {};
+      if (response.ok) {
+        if (parse === 'text') return body;
+        return body ? JSON.parse(body) : {};
+      }
       const error = new Error(`Search Console API respondió HTTP ${response.status}: ${body}`);
       if (![429, 500, 502, 503, 504].includes(response.status)) throw error;
       lastError = error;
@@ -53,20 +124,20 @@ async function fetchWithRetry(url, options, maxAttempts = 4) {
   throw lastError;
 }
 
-async function queryDimension({ siteUrl, accessToken, startDate, endDate, dimension }) {
+async function queryDimensions({ siteUrl, accessToken, startDate, endDate, dimensions }) {
   const rows = [];
   let startRow = 0;
   while (true) {
     const payload = {
       startDate,
       endDate,
-      dimensions: [dimension],
+      dimensions,
       rowLimit: ROW_LIMIT,
       startRow,
       dataState: 'final',
     };
     const response = await fetchWithRetry(
-      `${API_ROOT}/${encodeURIComponent(siteUrl)}/searchAnalytics/query`,
+      `${SEARCH_ANALYTICS_ROOT}/${encodeURIComponent(siteUrl)}/searchAnalytics/query`,
       {
         method: 'POST',
         headers: {
@@ -84,11 +155,97 @@ async function queryDimension({ siteUrl, accessToken, startDate, endDate, dimens
   return rows;
 }
 
+async function mapWithConcurrency(items, concurrency, mapper) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  async function worker() {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await mapper(items[index], index);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+  return results;
+}
+
+async function inspectUrl({ page, stratum }, { siteUrl, accessToken }) {
+  try {
+    const response = await fetchWithRetry(URL_INSPECTION_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ inspectionUrl: page, siteUrl, languageCode: 'es-419' }),
+    });
+    const result = response.inspectionResult?.indexStatusResult || {};
+    return {
+      page,
+      stratum,
+      verdict: result.verdict || '',
+      coverageState: result.coverageState || '',
+      indexingState: result.indexingState || '',
+      robotsTxtState: result.robotsTxtState || '',
+      pageFetchState: result.pageFetchState || '',
+      userCanonical: result.userCanonical || '',
+      googleCanonical: result.googleCanonical || '',
+      lastCrawlTime: result.lastCrawlTime || '',
+      referringUrls: result.referringUrls || [],
+      sitemap: result.sitemap || [],
+      error: '',
+    };
+  } catch (error) {
+    return {
+      page,
+      stratum,
+      verdict: '',
+      coverageState: '',
+      indexingState: '',
+      robotsTxtState: '',
+      pageFetchState: '',
+      userCanonical: '',
+      googleCanonical: '',
+      lastCrawlTime: '',
+      referringUrls: [],
+      sitemap: [],
+      error: error.message,
+    };
+  }
+}
+
+function reportSummaryMarkdown({ siteUrl, startDate, endDate, ctrReport, inspectionSummary }) {
+  const pass = inspectionSummary.verdicts.PASS || 0;
+  const lines = [
+    '## GSC: indexación y oportunidades CTR',
+    '',
+    `- Propiedad: \`${siteUrl}\``,
+    `- Período: ${startDate} a ${endDate}`,
+    `- Fichas con impresiones: ${ctrReport.benchmark.pageCount}`,
+    `- CTR agregado de fichas: ${(ctrReport.benchmark.ctr * 100).toFixed(2)}%`,
+    `- Oportunidades CTR seleccionadas: ${ctrReport.rows.length}`,
+    `- URLs inspeccionadas: ${inspectionSummary.completed}/${inspectionSummary.requested}`,
+    `- Veredicto PASS: ${pass}`,
+    `- Errores de inspección: ${inspectionSummary.errors}`,
+    '',
+    '### Primeras oportunidades CTR',
+    '',
+    '| URL | Impresiones | CTR | Posición | Clics potenciales |',
+    '| --- | ---: | ---: | ---: | ---: |',
+  ];
+  for (const row of ctrReport.rows.slice(0, 10)) {
+    lines.push(`| ${row.page} | ${row.impressions} | ${(row.ctr * 100).toFixed(2)}% | ${row.position.toFixed(1)} | ${row.estimatedMissedClicks.toFixed(1)} |`);
+  }
+  lines.push('', 'Los CSV y JSON completos quedan en el artefacto de la corrida.', '');
+  return lines.join('\n');
+}
+
 async function main() {
   const accessToken = process.env.GSC_ACCESS_TOKEN;
   const siteUrl = process.env.GSC_SITE_URL;
   const startDate = process.env.GSC_START_DATE;
   const endDate = process.env.GSC_END_DATE;
+  const inspectionSampleSize = Number(process.env.GSC_INSPECTION_SAMPLE_SIZE || 400);
 
   if (!accessToken) throw new Error('Falta GSC_ACCESS_TOKEN.');
   if (!siteUrl) throw new Error('Falta GSC_SITE_URL.');
@@ -105,30 +262,110 @@ async function main() {
     extractedAt,
     reports: [],
   };
+  const analyticsReports = new Map();
 
-  for (const dimension of ['page', 'query']) {
-    process.stdout.write(`Extrayendo GSC por ${dimension}... `);
-    const rows = await queryDimension({ siteUrl, accessToken, startDate, endDate, dimension });
+  for (const dimensions of [['page'], ['query'], ['page', 'query']]) {
+    const label = dimensions.join('-');
+    process.stdout.write(`Extrayendo GSC por ${label}... `);
+    const rows = await queryDimensions({ siteUrl, accessToken, startDate, endDate, dimensions });
     const report = {
       schemaVersion: 1,
       siteUrl,
-      dimension,
+      dimension: dimensions.length === 1 ? dimensions[0] : undefined,
+      dimensions,
       dateRange: { startDate, endDate },
       extractedAt,
       rowCount: rows.length,
       rows,
     };
-    const baseName = `search-analytics-${dimension}`;
+    const baseName = `search-analytics-${label}`;
     await Promise.all([
       writeFile(path.join(OUTPUT_DIR, `${baseName}.json`), `${JSON.stringify(report, null, 2)}\n`),
-      writeFile(path.join(OUTPUT_DIR, `${baseName}.csv`), toCsv(rows, dimension)),
+      writeFile(path.join(OUTPUT_DIR, `${baseName}.csv`), analyticsToCsv(rows, dimensions)),
     ]);
-    manifest.reports.push({ dimension, rowCount: rows.length, json: `${baseName}.json`, csv: `${baseName}.csv` });
+    manifest.reports.push({
+      type: 'search-analytics',
+      dimension: dimensions.length === 1 ? dimensions[0] : undefined,
+      dimensions,
+      rowCount: rows.length,
+      json: `${baseName}.json`,
+      csv: `${baseName}.csv`,
+    });
+    analyticsReports.set(label, rows);
     console.log(`${rows.length} filas.`);
   }
 
-  await writeFile(path.join(OUTPUT_DIR, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  const ctrReport = selectCtrOpportunities({
+    pageRows: analyticsReports.get('page'),
+    pageQueryRows: analyticsReports.get('page-query'),
+  });
+  await Promise.all([
+    writeFile(path.join(OUTPUT_DIR, 'ctr-opportunities.json'), `${JSON.stringify(ctrReport, null, 2)}\n`),
+    writeFile(path.join(OUTPUT_DIR, 'ctr-opportunities.csv'), ctrToCsv(ctrReport.rows)),
+  ]);
+  manifest.reports.push({
+    type: 'ctr-opportunities',
+    rowCount: ctrReport.rows.length,
+    json: 'ctr-opportunities.json',
+    csv: 'ctr-opportunities.csv',
+  });
+
+  process.stdout.write(`Descargando sitemap activo ${ACTIVE_SITEMAP_URL}... `);
+  const sitemapXml = await fetchWithRetry(ACTIVE_SITEMAP_URL, {}, 4, 'text');
+  const activeUrls = sitemapUrls(sitemapXml);
+  console.log(`${activeUrls.length} URLs.`);
+  if (!activeUrls.length) throw new Error('El sitemap activo no devolvió URLs.');
+
+  const inspectionSample = buildInspectionSample({
+    sitemapUrls: activeUrls,
+    pageRows: analyticsReports.get('page'),
+    ctrOpportunities: ctrReport.rows,
+    size: inspectionSampleSize,
+  });
+  console.log(`Inspeccionando ${inspectionSample.length} fichas con concurrencia ${INSPECTION_CONCURRENCY}...`);
+  const inspections = await mapWithConcurrency(
+    inspectionSample,
+    INSPECTION_CONCURRENCY,
+    (sample) => inspectUrl(sample, { siteUrl, accessToken }),
+  );
+  const inspectionSummary = summarizeInspections(inspections);
+  const inspectionReport = {
+    schemaVersion: 1,
+    siteUrl,
+    sitemapUrl: ACTIVE_SITEMAP_URL,
+    extractedAt,
+    sampleSize: inspectionSample.length,
+    sampleMethod: 'CTR/alta demanda + vistas en Search + activas sin impresiones; selección estable por URL',
+    summary: inspectionSummary,
+    rows: inspections,
+  };
+  await Promise.all([
+    writeFile(path.join(OUTPUT_DIR, 'url-inspection-sample.json'), `${JSON.stringify(inspectionReport, null, 2)}\n`),
+    writeFile(path.join(OUTPUT_DIR, 'url-inspection-sample.csv'), inspectionsToCsv(inspections)),
+  ]);
+  manifest.reports.push({
+    type: 'url-inspection-sample',
+    rowCount: inspections.length,
+    json: 'url-inspection-sample.json',
+    csv: 'url-inspection-sample.csv',
+  });
+
+  const summaryMarkdown = reportSummaryMarkdown({
+    siteUrl,
+    startDate,
+    endDate,
+    ctrReport,
+    inspectionSummary,
+  });
+  await Promise.all([
+    writeFile(path.join(OUTPUT_DIR, 'report-summary.md'), summaryMarkdown),
+    writeFile(path.join(OUTPUT_DIR, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`),
+  ]);
+
   console.log(`Extracción terminada en ${OUTPUT_DIR}.`);
+  if (inspectionSummary.completed === 0) {
+    throw new Error('Ninguna URL pudo inspeccionarse; revisar permisos de la cuenta de servicio en Search Console.');
+  }
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Qué cambia

- amplía el informe semanal de Search Console con datos por página, consulta y página+consulta;
- inspecciona una muestra estable de hasta 400 fichas activas del sitemap mediante URL Inspection API;
- separa fichas de alta demanda, fichas ya vistas en Search y fichas activas sin impresiones;
- genera un ranking de hasta 20 oportunidades de CTR con posición 3–15, al menos 10 impresiones y CTR inferior al promedio de producto;
- publica CSV, JSON y un resumen legible como artefactos de GitHub Actions.

## Por qué

El total de páginas indexadas de Search Console no permite saber cuántas corresponden realmente a fichas activas. Este cambio crea una medición recurrente, reproducible y de solo lectura para distinguir indexación real de oportunidad comercial.

La prueba con los datos disponibles encontró 1.484 fichas con impresiones, 3.675 impresiones, 137 clics y un CTR agregado de 3,73%. El ranking detectó oportunidades concretas como Murdoku, Mientras dormíamos y Así fue como llegaste.

## Seguridad y operación

- conserva Workload Identity Federation: no agrega claves JSON;
- usa permisos de solo lectura;
- limita la inspección a 400 URLs por corrida;
- no modifica fichas, sitemap ni producción;
- este workflow no dispara deploy.

## Validación

- 330 tests del repositorio en verde;
- build con checkout OFF en verde;
- build con checkout ON en verde;
- pruebas específicas de selección CTR, muestra determinística, errores de inspección y workflow en verde;
- `git diff --check` en verde.
