### PR TITLE
SEO: corregir anomalías GSC y oportunidades CTR

### DIFF
--- a/docs/seo/gsc-fixes-2026-08-16.md
+++ b/docs/seo/gsc-fixes-2026-08-16.md
@@ -1,0 +1,30 @@
+# Correcciones posteriores al informe GSC del 16/8/2026
+
+La corrida `31947454015` inspeccionó 400 fichas de una muestra estratificada. Este cambio usa sus resultados sin extrapolarlos a las 7.110 fichas del sitemap.
+
+## Verificación de las siete anomalías
+
+La producción se volvió a consultar el 16/8/2026 antes de modificar código:
+
+| Hallazgo de la última visita de Google | Cantidad | Estado actual | Acción |
+| --- | ---: | --- | --- |
+| `noindex` | 1 | La ficha `MLU799269208` responde 200, `index, follow` y canónica propia tras volver a tener stock | No crear una redirección falsa; medir el próximo rastreo |
+| Canónica elegida por Google distinta | 2 | Los dos pares siguen activos y coinciden en título e ISBN | 301 a la ficha elegida por Google y exclusión condicional del duplicado en el sitemap |
+| 404 en la última visita de Google | 4 | Las cuatro fichas responden 200, `index, follow` y canónica propia tras volver a estar activas | Mantenerlas y medir el próximo rastreo |
+
+Los pares consolidados son:
+
+- `MLU704333012` → `MLU704333014`, ISBN `9788412027082`.
+- `MLU693866378` → `MLU693700826`, ISBN `9780194316002`.
+
+La consolidación se aplica sólo mientras la ficha destino esté activa y ambas publicaciones conserven el mismo ISBN y slug. Si el catálogo cambia, no se fuerza la redirección.
+
+## Oportunidades de CTR
+
+Se agregaron títulos y descripciones SEO propios para las 11 fichas seleccionadas por el informe, sin cambiar sus títulos comerciales. Murdoku prioriza la intención observada `murdoku uruguay` (244 impresiones).
+
+Murdoku (`MLU1416777650`) y Colorea y descubre el misterio: Princesas (`MLU653980087`) están temporalmente sin stock al momento de esta corrección. Como ya generaron impresiones orgánicas y sus fichas permiten pedir aviso o consultar un encargo, permanecen indexables. Siguen fuera del sitemap de libros activos hasta que vuelva el stock.
+
+## Medición
+
+No se atribuye una mejora de CTR antes de tener datos posteriores al despliegue. La comparación correcta es por URL y consulta después de que Google vuelva a rastrear las fichas, manteniendo separado el cambio de posición del cambio de CTR.

--- a/functions/__tests__/product-seo.test.js
+++ b/functions/__tests__/product-seo.test.js
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  PRODUCT_SEO_IDS,
+  productSeoFor,
+  shouldIndexProduct,
+  verifiedDuplicateCanonicalTarget,
+} from '../_shared/product-seo.js';
+import { renderPage } from '../libro/[[path]].js';
+
+test('las 11 oportunidades GSC tienen snippets editoriales propios', () => {
+  assert.equal(PRODUCT_SEO_IDS.length, 11);
+  assert.equal(productSeoFor('MLU1416777650').title, 'Murdoku en Uruguay: 80 acertijos de lógica');
+
+  const html = renderPage({
+    id: 'MLU1416777650',
+    title: 'Título comercial largo que permanece visible',
+    author: 'Manuel Garand',
+    isbn: '9791387869380',
+    status: 'paused',
+    available_quantity: 0,
+  }, 'titulo-comercial-largo-que-permanece-visible', false, '');
+
+  assert.match(html, /<title>Murdoku en Uruguay: 80 acertijos de lógica \| Amado Libros<\/title>/);
+  assert.match(html, /<h1>Título comercial largo que permanece visible<\/h1>/);
+  assert.match(html, /<meta name="robots" content="index, follow">/);
+  assert.match(html, /Consultá por Murdoku de Manuel Garand en Uruguay/);
+});
+
+test('sólo oportunidades verificadas permanecen indexables sin stock', () => {
+  const paused = id => ({ id, status: 'paused', available_quantity: 0 });
+  assert.equal(shouldIndexProduct(paused('MLU1416777650')), true);
+  assert.equal(shouldIndexProduct(paused('MLU653980087')), true);
+  assert.equal(shouldIndexProduct(paused('MLU676002408')), false);
+  assert.equal(shouldIndexProduct({ id: 'MLU1', status: 'active', available_quantity: 1 }), true);
+  assert.equal(shouldIndexProduct({ id: 'MLU1416777650', status: 'active', available_quantity: 1 }, true), false);
+});
+
+test('consolida sólo duplicados cuyo ISBN, título y destino activo coinciden', () => {
+  const source = {
+    id: 'MLU704333012',
+    title: 'Libro Reflexiones Sobre Vivir En Compasion',
+    isbn: '9788412027082',
+    status: 'active',
+    available_quantity: 2,
+  };
+  const target = {
+    ...source,
+    id: 'MLU704333014',
+    status: 'active',
+    available_quantity: 2,
+  };
+
+  assert.equal(verifiedDuplicateCanonicalTarget(source, [source, target]), target);
+  assert.equal(verifiedDuplicateCanonicalTarget(source, [source, { ...target, isbn: '9780000000000' }]), null);
+  assert.equal(verifiedDuplicateCanonicalTarget(source, [source, { ...target, available_quantity: 0 }]), null);
+});

--- a/functions/__tests__/sitemap-segmentation.test.js
+++ b/functions/__tests__/sitemap-segmentation.test.js
@@ -37,11 +37,14 @@ test('segmento de libros activos excluye pausados, agotados e inválidos', () =>
       { id: 'MLU2', title: 'Libro Dos', status: 'paused', available_quantity: 0 },
       { id: 'MLU3', title: 'Libro Tres', status: 'active', available_quantity: 0 },
       { id: null, title: 'Sin ID', status: 'active', available_quantity: 1 },
+      { id: 'MLU704333012', title: 'Libro Reflexiones Sobre Vivir En Compasion', isbn: '9788412027082', status: 'active', available_quantity: 2 },
+      { id: 'MLU704333014', title: 'Libro Reflexiones Sobre Vivir En Compasion', isbn: '9788412027082', status: 'active', available_quantity: 2 },
     ],
   });
 
   assert.deepEqual(entries, [
     { loc: 'https://www.amadolibros.com/libro/MLU1/libro-uno' },
+    { loc: 'https://www.amadolibros.com/libro/MLU704333014/libro-reflexiones-sobre-vivir-en-compasion' },
   ]);
 });
 

--- a/functions/_shared/product-seo.js
+++ b/functions/_shared/product-seo.js
@@ -1,0 +1,95 @@
+import { slugify } from './slug.js';
+
+/**
+ * Ajustes editoriales respaldados por oportunidades reales de Search Console.
+ * No cambian el título comercial ni los datos del catálogo: sólo el snippet
+ * orgánico de la ficha.
+ */
+const PRODUCT_SEO = new Map([
+  ['MLU1416777650', {
+    title: 'Murdoku en Uruguay: 80 acertijos de lógica',
+    description: 'Consultá por Murdoku de Manuel Garand en Uruguay: stock o encargo, retiro en Montevideo y envíos a todo el país con Amado Libros.',
+    keepIndexedWhenUnavailable: true,
+  }],
+  ['MLU676002408', {
+    title: 'Mientras dormíamos: El engaño maestro',
+    description: 'Mientras dormíamos: El engaño maestro, de Giuseppe Nocera Costabile. Consultá precio, stock y envíos en Uruguay con Amado Libros.',
+  }],
+  ['MLU633445690', {
+    title: 'Así fue como llegaste: donación de esperma',
+    description: 'Así fue como llegaste, de Silvia Jadur y Constanza Duhalde. Consultá precio, stock y envíos en Uruguay con Amado Libros.',
+  }],
+  ['MLU646420175', {
+    title: 'Urmah: Los sembradores siderales',
+    description: 'Urmah: Los sembradores siderales, de Luis Ángel Loaiza Ferreira. Consultá precio, stock y envíos en Uruguay con Amado Libros.',
+  }],
+  ['MLU662039047', {
+    title: 'Jujutsu Kaisen 25 de Gege Akutami',
+    description: 'Jujutsu Kaisen, tomo 25, de Gege Akutami. Verificá edición, idioma, precio, stock y envíos en Uruguay con Amado Libros.',
+  }],
+  ['MLU707743600', {
+    title: 'Colección Grandes Aventuras Genios: 11 libros',
+    description: 'Colección Grandes Aventuras Genios de 11 libros. Consultá precio, stock y envíos a todo Uruguay con Amado Libros.',
+  }],
+  ['MLU626854956', {
+    title: 'Amagi, de Sagar Prakash Khatnani',
+    description: 'Libro Amagi, de Sagar Prakash Khatnani. Consultá precio, stock, retiro en Montevideo y envíos a todo Uruguay con Amado Libros.',
+  }],
+  ['MLU653980087', {
+    title: 'Colorea y descubre el misterio: Princesas',
+    description: 'Colorea y descubre el misterio: Princesas, de Jeremy Mariez. Consultá stock o encargo y envíos a todo Uruguay con Amado Libros.',
+    keepIndexedWhenUnavailable: true,
+  }],
+  ['MLU1467423248', {
+    title: 'Más astuto que el diablo, de Napoleon Hill',
+    description: 'Más astuto que el diablo, de Napoleon Hill. Consultá edición, precio, stock y envíos a todo Uruguay con Amado Libros.',
+  }],
+  ['MLU889085304', {
+    title: 'Primeros pasos en clínica psicopedagógica Vol. 1',
+    description: 'Primeros pasos en la clínica psicopedagógica, volumen 1, de Guillermina Ferra. Consultá precio, stock y envíos con Amado Libros.',
+  }],
+  ['MLU696157645', {
+    title: 'La taza de la mañana, de Camille J. Sage',
+    description: 'La taza de la mañana, de Camille J. Sage. Consultá precio, stock, retiro en Montevideo y envíos a todo Uruguay con Amado Libros.',
+  }],
+]);
+
+/**
+ * Pares de publicaciones comprobados como la misma edición (mismo ISBN,
+ * título y datos comerciales). Google ya eligió la ficha destino como
+ * canónica. La comprobación se repite en runtime para no consolidar dos
+ * ediciones si el catálogo cambia en el futuro.
+ */
+const VERIFIED_DUPLICATE_TARGETS = new Map([
+  ['MLU704333012', 'MLU704333014'],
+  ['MLU693866378', 'MLU693700826'],
+]);
+
+function isbnDigits(value) {
+  return String(value || '').replace(/\D/g, '');
+}
+
+export function productSeoFor(id) {
+  return PRODUCT_SEO.get(String(id || '')) || null;
+}
+
+export function shouldIndexProduct(item, isPreview = false) {
+  if (isPreview) return false;
+  const inStock = item?.status === 'active' && Number(item?.available_quantity) > 0;
+  return inStock || productSeoFor(item?.id)?.keepIndexedWhenUnavailable === true;
+}
+
+export function verifiedDuplicateCanonicalTarget(item, catalogItems = []) {
+  const targetId = VERIFIED_DUPLICATE_TARGETS.get(String(item?.id || ''));
+  if (!targetId || !Array.isArray(catalogItems)) return null;
+
+  const target = catalogItems.find(candidate => candidate?.id === targetId);
+  const sourceIsbn = isbnDigits(item?.isbn);
+  const targetIsbn = isbnDigits(target?.isbn);
+  if (!target || !sourceIsbn || sourceIsbn !== targetIsbn) return null;
+  if (slugify(item?.title) !== slugify(target.title)) return null;
+  if (target.status !== 'active' || Number(target.available_quantity) <= 0) return null;
+  return target;
+}
+
+export const PRODUCT_SEO_IDS = Object.freeze([...PRODUCT_SEO.keys()]);

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -18,6 +18,11 @@ import { BASE, fetchCatalog, fetchPausedItem } from '../_shared/catalog.js';
 import { previewCoverUrl as resolvePreviewCoverUrl } from '../_shared/preview-cover.js';
 import { authorPathForName } from '../_shared/seo-authors.js';
 import {
+    productSeoFor,
+    shouldIndexProduct,
+    verifiedDuplicateCanonicalTarget,
+} from '../_shared/product-seo.js';
+import {
     ensurePerf,
     perfNow,
     perfSummary,
@@ -340,6 +345,8 @@ function notFound() {
 export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverSrc = '', relatedBooks = []) {
     const canonicalUrl = `${BASE}/libro/${item.id}/${slug}`;
     const safeTitle    = escapeHtml(item.title);
+    const seo          = productSeoFor(item.id);
+    const safeSeoTitle = escapeHtml(seo?.title || item.title);
     const safeAuthor   = item.author ? escapeHtml(item.author) : null;
     const images       = normalizeImages(item, previewCoverSrc);
     const img          = images[0] || '';
@@ -404,11 +411,14 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     </details>`
         : '';
 
-    const metaDesc = inStock
+    const metaDesc = seo?.description
+        ? escapeHtml(seo.description)
+        : inStock
         ? (safeAuthor
             ? `Comprá &quot;${safeTitle}&quot; de ${safeAuthor} en Amado Libros. Transferencia: $${transferPrice} UYU. Envíos a todo Uruguay.`
             : `Comprá &quot;${safeTitle}&quot; en Amado Libros. Transferencia: $${transferPrice} UYU. Envíos a todo Uruguay.`)
         : `Pedí un aviso cuando &quot;${safeTitle}&quot; vuelva a estar disponible en Amado Libros. También podemos buscarlo por encargo.`;
+    const robots = shouldIndexProduct(item, isPreview) ? 'index, follow' : 'noindex, follow';
 
     // JSON-LD — generado con JSON.stringify, nunca concatenación
     const schemaProduct = {
@@ -553,15 +563,15 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>${safeTitle} | Amado Libros</title>
+  <title>${safeSeoTitle} | Amado Libros</title>
   <meta name="description" content="${metaDesc}">
-  <meta name="robots" content="${isPreview || !inStock ? 'noindex, follow' : 'index, follow'}">
+  <meta name="robots" content="${robots}">
   <link rel="canonical" href="${canonicalUrl}">
   ${faviconHeadHtml()}
 
   <meta property="og:type"        content="product">
   <meta property="og:url"         content="${canonicalUrl}">
-  <meta property="og:title"       content="${safeTitle} | Amado Libros">
+  <meta property="og:title"       content="${safeSeoTitle} | Amado Libros">
   <meta property="og:description" content="${metaDesc}">
   <meta property="og:image"       content="${escapeHtml(socialImage)}">
   <meta property="og:image:secure_url" content="${escapeHtml(socialImage)}">
@@ -570,7 +580,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
   <meta property="og:site_name"   content="Amado Libros">
 
   <meta name="twitter:card"        content="summary_large_image">
-  <meta name="twitter:title"       content="${safeTitle} | Amado Libros">
+  <meta name="twitter:title"       content="${safeSeoTitle} | Amado Libros">
   <meta name="twitter:description" content="${metaDesc}">
   <meta name="twitter:image"       content="${escapeHtml(socialImage)}">
   <meta name="twitter:image:alt"   content="Portada de ${safeTitle}">
@@ -955,11 +965,22 @@ export async function onRequest(context) {
     }
     if (!item) return notFound();
 
-    const slug = slugify(item.title);
     const isPreview = context.env?.APP_ENV === 'preview';
     const navigationBase = isPreview
         ? new URL(context.request.url).origin
         : BASE;
+
+    const duplicateTarget = verifiedDuplicateCanonicalTarget(item, catalog?.items);
+    if (duplicateTarget) {
+        const currentUrl = new URL(context.request.url);
+        currentUrl.searchParams.delete('layout');
+        return Response.redirect(
+            `${navigationBase}/libro/${duplicateTarget.id}/${slugify(duplicateTarget.title)}${currentUrl.search}`,
+            301,
+        );
+    }
+
+    const slug = slugify(item.title);
 
     // Una sola URL por entidad: slug faltante o incorrecto -> 301 canónico.
     const canonicalRedirect = canonicalProductRedirectUrl({

--- a/functions/sitemap-books-active.xml.js
+++ b/functions/sitemap-books-active.xml.js
@@ -1,11 +1,13 @@
 import { BASE, fetchCatalog } from './_shared/catalog.js';
 import { slugify } from './_shared/slug.js';
 import { urlsetXml, xmlResponse } from './_shared/sitemap.js';
+import { verifiedDuplicateCanonicalTarget } from './_shared/product-seo.js';
 
 export function activeBookSitemapEntries(catalog) {
   if (!catalog || !Array.isArray(catalog.items)) return [];
   return catalog.items
     .filter(item => item?.status === 'active' && Number(item.available_quantity) > 0 && item.id && item.title)
+    .filter(item => !verifiedDuplicateCanonicalTarget(item, catalog.items))
     .map(item => ({ loc: `${BASE}/libro/${item.id}/${slugify(item.title)}` }));
 }
 


### PR DESCRIPTION
## Qué cambia

- consolida con 301 los dos pares duplicados que Google ya eligió bajo otra canónica, sólo mientras coincidan ISBN, título y destino activo;
- excluye condicionalmente esas duplicadas del sitemap activo;
- agrega títulos y descripciones SEO específicos para las 11 oportunidades detectadas por GSC;
- mantiene indexables Murdoku y la ficha de colorear aunque estén temporalmente sin stock, porque ya generan demanda y permiten aviso/encargo;
- documenta que el noindex y los cuatro 404 eran estados históricos: hoy las cinco fichas responden 200, index y canónica propia.

## Por qué

La corrida GSC 31947454015 mostró 7 anomalías y 11 oportunidades de CTR. Murdoku concentró 354 impresiones; la consulta “murdoku uruguay” aportó 244.

## Impacto

Se preservan las URLs válidas que se reactivaron, se consolidan sólo duplicados verificados y se mejora el snippet orgánico sin cambiar títulos comerciales ni datos del catálogo.

## Validación

- suite completa de tests JavaScript: OK;
- tests focalizados SEO/sitemap: 7/7;
- build Astro con checkout OFF: OK;
- build Astro con checkout ON: OK;
- git diff --check: OK.

El intento inicial del validador integrado se cortó únicamente porque npm quiso escribir caché en /root/.npm dentro del entorno. Dependencias y ambos builds se repitieron con caché temporal aislada y pasaron.