### PR TITLE
Imágenes responsivas con Cloudflare

### DIFF
--- a/astro-front/src/components/BookCard.astro
+++ b/astro-front/src/components/BookCard.astro
@@ -1,4 +1,6 @@
 ---
+import { responsiveBookCover } from '../lib/cloudflare-images.js';
+
 // HOME-COMERCIAL-1: jerarquía de card aprobada — precio principal, cuotas
 // debajo, transferencia como beneficio secundario, envío gratis cuando
 // corresponde, "Agregar al carrito" como acción principal, WhatsApp como
@@ -35,13 +37,9 @@ function slugify(text: string): string {
     .substring(0, 60);
 }
 
-function httpsImg(url: string, suffix: string): string {
-  return (url || '').replace('http://', 'https://').replace('-I.jpg', suffix);
-}
-
-const img = (book.pictures && book.pictures[0])
-  ? httpsImg(book.pictures[0], '-O.jpg')
-  : httpsImg(book.thumbnail, '-V.jpg');
+// La home deja de entregar mlstatic directamente: usa la portada controlada
+// por Amado Libros (R2 primero) y Cloudflare elige el ancho/formato adecuado.
+const cover = responsiveBookCover(book.id);
 
 const fichaHref = `/libro/${book.id}/${slugify(book.title)}`;
 
@@ -61,7 +59,17 @@ const hasFreeShipping = book.price >= FREE_SHIPPING_THRESHOLD;
 
 <article class="bc-card">
   <a href={fichaHref} class="bc-img-link" tabindex="-1" aria-hidden="true">
-    <img src={img} alt="" loading="lazy" decoding="async" class="bc-img" />
+    <img
+      src={cover.src}
+      srcset={cover.srcset}
+      sizes={cover.sizes}
+      alt=""
+      loading="lazy"
+      decoding="async"
+      width="280"
+      height="373"
+      class="bc-img"
+    />
   </a>
 
   <div class="bc-body">
@@ -90,7 +98,7 @@ const hasFreeShipping = book.price >= FREE_SHIPPING_THRESHOLD;
         data-id={book.id}
         data-title={book.title}
         data-price={book.price}
-        data-thumbnail={img}
+        data-thumbnail={cover.src}
         data-max-qty={book.available_quantity}
         aria-label={`Agregar "${book.title}" al carrito`}
       >

--- a/astro-front/src/lib/__tests__/cloudflare-images.test.js
+++ b/astro-front/src/lib/__tests__/cloudflare-images.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  bookCoverUrl,
+  cloudflareImageUrl,
+  responsiveBookCover,
+} from '../cloudflare-images.js';
+
+test('la home usa el proxy propio y tres variantes Cloudflare', () => {
+  const source = bookCoverUrl('MLU987654');
+  const cover = responsiveBookCover('MLU987654');
+  assert.equal(source, 'https://www.amadolibros.com/book-cover/MLU987654/cover.jpg');
+  assert.match(cover.src, /\/cdn-cgi\/image\/.*width=360/);
+  assert.deepEqual(
+    [...cover.srcset.matchAll(/width=(\d+)/g)].map(match => Number(match[1])),
+    [240, 360, 480],
+  );
+  assert.match(cover.srcset, /onerror=redirect/);
+});
+
+test('no anida transformaciones ni admite un ID que no sea MLU', () => {
+  const transformed = cloudflareImageUrl(bookCoverUrl('MLU1'), 240);
+  assert.equal(cloudflareImageUrl(transformed, 480), transformed);
+  assert.equal(bookCoverUrl('MLA1'), '');
+});

--- a/astro-front/src/lib/cloudflare-images.js
+++ b/astro-front/src/lib/cloudflare-images.js
@@ -1,0 +1,30 @@
+const BASE = 'https://www.amadolibros.com';
+const PRODUCT_ID_RE = /^MLU\d+$/;
+
+export function bookCoverUrl(productId) {
+  const id = String(productId || '').toUpperCase();
+  if (!PRODUCT_ID_RE.test(id)) return '';
+  return `${BASE}/book-cover/${encodeURIComponent(id)}/cover.jpg`;
+}
+
+export function cloudflareImageUrl(source, width, quality = 85) {
+  const targetWidth = Number(width);
+  if (!source || !Number.isInteger(targetWidth) || targetWidth <= 0) return String(source || '');
+  const sourceUrl = new URL(source, BASE);
+  if (sourceUrl.origin !== BASE || sourceUrl.pathname.startsWith('/cdn-cgi/image/')) {
+    return String(source);
+  }
+  const options = `format=auto,fit=scale-down,width=${targetWidth},quality=${quality},onerror=redirect`;
+  return `${BASE}/cdn-cgi/image/${options}${sourceUrl.pathname}${sourceUrl.search}`;
+}
+
+export function responsiveBookCover(productId) {
+  const source = bookCoverUrl(productId);
+  const widths = [240, 360, 480];
+  return {
+    source,
+    src: cloudflareImageUrl(source, 360),
+    srcset: widths.map(width => `${cloudflareImageUrl(source, width)} ${width}w`).join(', '),
+    sizes: '(max-width: 639px) calc(50vw - 24px), (max-width: 1023px) calc(33vw - 24px), 280px',
+  };
+}

--- a/functions/__tests__/cloudflare-images.test.js
+++ b/functions/__tests__/cloudflare-images.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  bookCoverUrl,
+  cloudflareImageUrl,
+  responsiveImage,
+} from '../_shared/cloudflare-images.js';
+
+const SOURCE = 'https://www.amadolibros.com/book-cover/MLU123456/cover.jpg';
+
+test('construye una portada primaria controlada y rechaza IDs ajenos', () => {
+  assert.equal(bookCoverUrl('mlu123456'), SOURCE);
+  assert.equal(bookCoverUrl('USD123'), '');
+  assert.equal(bookCoverUrl('../MLU123'), '');
+});
+
+test('genera una transformación segura en la zona productiva', () => {
+  assert.equal(
+    cloudflareImageUrl(SOURCE, { width: 480, quality: 85 }),
+    'https://www.amadolibros.com/cdn-cgi/image/format=auto,fit=scale-down,width=480,quality=85,onerror=redirect/book-cover/MLU123456/cover.jpg',
+  );
+});
+
+test('no transforma hosts externos, previews ni una URL ya transformada', () => {
+  const external = 'https://http2.mlstatic.com/D_TEST-O.jpg';
+  const preview = 'https://preview.example/preview-cover/MLU1/0/hash.jpg';
+  const transformed = cloudflareImageUrl(SOURCE, { width: 480 });
+  assert.equal(cloudflareImageUrl(external, { width: 480 }), external);
+  assert.equal(cloudflareImageUrl(preview, { width: 480 }), preview);
+  assert.equal(cloudflareImageUrl(transformed, { width: 240 }), transformed);
+});
+
+test('srcset ofrece anchos únicos y deja que el navegador elija uno', () => {
+  const image = responsiveImage(SOURCE, {
+    widths: [480, 240, 480, 360],
+    defaultWidth: 360,
+    sizes: '(max-width: 600px) 50vw, 280px',
+  });
+  assert.match(image.src, /width=360/);
+  assert.deepEqual(
+    [...image.srcset.matchAll(/width=(\d+)/g)].map(match => Number(match[1])),
+    [240, 360, 480],
+  );
+  assert.equal(image.sizes, '(max-width: 600px) 50vw, 280px');
+});

--- a/functions/__tests__/preview-cover.test.js
+++ b/functions/__tests__/preview-cover.test.js
@@ -186,3 +186,22 @@ test('Ficha usa la portada R2 sólo como primera imagen y conserva las secundari
   assert.match(html, /https:\/\/http2\.mlstatic\.com\/D_SECOND-O\.jpg/);
   assert.match(html, new RegExp(`data-thumbnail="${previewSrc.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
 });
+
+test('Ficha productiva entrega la portada R2 con srcset de Cloudflare Images', () => {
+  const productionSrc = `https://www.amadolibros.com/preview-cover/${ID}/0/${HASH}.jpg`;
+  const html = renderPage({
+    id: ID,
+    title: 'Libro responsivo',
+    author: 'Autora',
+    price: 1200,
+    status: 'active',
+    available_quantity: 1,
+    condition: 'new',
+    pictures: [SOURCE],
+    thumbnail: '',
+    permalink: 'https://articulo.mercadolibre.com.uy/test',
+  }, 'libro-responsivo', false, '', productionSrc);
+  assert.match(html, /class="cover-main"[^>]+\/cdn-cgi\/image\/format=auto/);
+  assert.match(html, /srcset="[^"]+320w,[^"]+480w,[^"]+768w,[^"]+1024w"/);
+  assert.match(html, /onerror=redirect\/preview-cover\/MLU123456789\/0\//);
+});

--- a/functions/__tests__/seo-author-pages.test.js
+++ b/functions/__tests__/seo-author-pages.test.js
@@ -62,6 +62,8 @@ test('renderiza contenido visible, canonical, schema y enlaces rastreables', () 
   assert.match(html, /"@type":"ItemList"/);
   assert.match(html, /"publisher":\{"@id":"https:\/\/www\.amadolibros\.com\/#bookstore"\}/);
   assert.match(html, /href="\/libro\/MLU9\/libro-mlu9"/);
+  assert.match(html, /\/cdn-cgi\/image\/format=auto[^\"]+\/book-cover\/MLU9\/cover\.jpg/);
+  assert.match(html, /srcset="[^"]+240w,[^"]+360w,[^"]+480w"/);
   assert.match(html, /Quiénes somos y cómo trabajamos/);
 });
 

--- a/functions/__tests__/seo-category-pages.test.js
+++ b/functions/__tests__/seo-category-pages.test.js
@@ -102,6 +102,8 @@ test('la landing filtra productos por la categoría solicitada', async () => {
     assert.doesNotMatch(html, /Libro de prueba Infantil y juvenil/);
     assert.match(html, /<section class="books-grid"/);
     assert.match(html, /href="https:\/\/www\.amadolibros\.com\/libro\/MLU6\//);
+    assert.match(html, /\/cdn-cgi\/image\/format=auto[^\"]+\/book-cover\/MLU6\/cover\.jpg/);
+    assert.match(html, /srcset="[^"]+240w,[^"]+360w,[^"]+480w"/);
     assert.match(html, /<strong>1 título disponible ahora\.<\/strong> Los 791 títulos informados en la portada incluyen disponibles y libros que podemos buscar por encargo\./);
 });
 

--- a/functions/__tests__/seo-specialty-pages.test.js
+++ b/functions/__tests__/seo-specialty-pages.test.js
@@ -80,6 +80,8 @@ test('cada landing muestra catálogo real filtrado y SEO regional verificable', 
     assert.match(html, /eventual envío internacional se confirman caso a caso/);
     assert.doesNotMatch(html, /hreflang/);
     assert.ok(html.includes(expectedItem.title), specialty.id);
+    assert.match(html, /\/cdn-cgi\/image\/format=auto[^\"]+\/book-cover\/MLU\d+\/cover\.jpg/);
+    assert.match(html, /srcset="[^"]+240w,[^"]+360w,[^"]+480w"/);
     assert.doesNotMatch(html, /Cirugía agotada/);
   }
 });

--- a/functions/_shared/author-page.js
+++ b/functions/_shared/author-page.js
@@ -8,6 +8,11 @@ import {
 } from './brand.js';
 import { slugify } from './slug.js';
 import { authorPageById, matchesAuthor } from './seo-authors.js';
+import {
+  bookCoverUrl,
+  CARD_IMAGE_SIZES,
+  responsiveImage,
+} from './cloudflare-images.js';
 
 const WA = '59899841325';
 
@@ -55,7 +60,7 @@ export function selectAuthorBooks(items, author) {
   });
 }
 
-export function renderAuthorPage(author, items) {
+export function renderAuthorPage(author, items, useCloudflareImages = true) {
   const canonicalUrl = `${BASE}${author.path}`;
   const pageTitle = `Libros de ${author.name} en Uruguay`;
   const metaDescription = `Libros de ${author.name} disponibles en Uruguay: ${author.focus}. Comprá online o consultá por encargos en Amado Libros.`;
@@ -99,11 +104,19 @@ export function renderAuthorPage(author, items) {
 
   const cards = items.map(item => {
     const href = `/libro/${encodeURIComponent(item.id)}/${slugify(item.title)}`;
-    const image = coverUrl(item);
+    const source = useCloudflareImages ? bookCoverUrl(item.id) : coverUrl(item);
+    const image = responsiveImage(source, {
+      widths: [240, 360, 480],
+      defaultWidth: 360,
+      sizes: CARD_IMAGE_SIZES,
+    });
     const price = Number(item.price) || 0;
+    const responsiveAttrs = image.srcset
+      ? ` srcset="${escapeHtml(image.srcset)}" sizes="${escapeHtml(image.sizes)}"`
+      : '';
     return `<article class="book-card">
       <a class="cover-link" href="${escapeHtml(href)}">
-        ${image ? `<img src="${escapeHtml(image)}" alt="Portada de ${escapeHtml(item.title)}" loading="lazy" width="180" height="270">` : '<span class="cover-fallback" aria-hidden="true">📚</span>'}
+        ${image.src ? `<img src="${escapeHtml(image.src)}"${responsiveAttrs} alt="Portada de ${escapeHtml(item.title)}" loading="lazy" decoding="async" width="180" height="270">` : '<span class="cover-fallback" aria-hidden="true">📚</span>'}
       </a>
       <div class="book-info">
         <h2><a href="${escapeHtml(href)}">${escapeHtml(item.title)}</a></h2>
@@ -165,7 +178,7 @@ export async function renderAuthorRoute(ctx, authorId) {
     return unavailable('No pudimos cargar el catálogo. Intentá nuevamente en unos minutos.');
   }
   const items = selectAuthorBooks(catalog.items, author);
-  return new Response(renderAuthorPage(author, items), {
+  return new Response(renderAuthorPage(author, items, ctx.env?.APP_ENV === 'production'), {
     headers: {
       'content-type': 'text/html;charset=UTF-8',
       'cache-control': 'public, max-age=3600',

--- a/functions/_shared/cloudflare-images.js
+++ b/functions/_shared/cloudflare-images.js
@@ -1,0 +1,80 @@
+import { BASE } from './catalog.js';
+
+const PRODUCT_ID_RE = /^MLU\d+$/;
+const DEFAULT_WIDTHS = [240, 360, 480];
+
+function positiveInteger(value) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function sameProductionZone(source) {
+  try {
+    const url = new URL(source, BASE);
+    return url.origin === BASE && !url.pathname.startsWith('/cdn-cgi/image/');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Portada primaria controlada por Amado Libros. El endpoint prioriza R2 y
+ * conserva Mercado Libre únicamente como fallback mientras termina el mirror.
+ */
+export function bookCoverUrl(productId) {
+  const id = String(productId || '').toUpperCase();
+  if (!PRODUCT_ID_RE.test(id)) return '';
+  return `${BASE}/book-cover/${encodeURIComponent(id)}/cover.jpg`;
+}
+
+/**
+ * URL de Cloudflare Images para una fuente de la propia zona. No transforma
+ * hosts externos ni previews: esos conservan su URL original para no romper
+ * entornos donde la zona no está habilitada.
+ */
+export function cloudflareImageUrl(source, {
+  width,
+  quality = 85,
+  fit = 'scale-down',
+} = {}) {
+  if (!source || !sameProductionZone(source)) return String(source || '');
+  const targetWidth = positiveInteger(width);
+  if (!targetWidth) return String(source);
+  const targetQuality = Math.min(100, Math.max(1, positiveInteger(quality) || 85));
+  const sourceUrl = new URL(source, BASE);
+  const options = [
+    'format=auto',
+    `fit=${fit}`,
+    `width=${targetWidth}`,
+    `quality=${targetQuality}`,
+    'onerror=redirect',
+  ].join(',');
+  return `${BASE}/cdn-cgi/image/${options}${sourceUrl.pathname}${sourceUrl.search}`;
+}
+
+/**
+ * Devuelve src/srcset/sizes listos para HTML responsivo. Cada ancho produce
+ * una única variante cacheable; el navegador descarga solamente la adecuada.
+ */
+export function responsiveImage(source, {
+  widths = DEFAULT_WIDTHS,
+  defaultWidth,
+  sizes = '100vw',
+  quality = 85,
+  fit = 'scale-down',
+} = {}) {
+  const normalizedWidths = [...new Set(widths.map(positiveInteger).filter(Boolean))]
+    .sort((a, b) => a - b);
+  const fallbackWidth = positiveInteger(defaultWidth) || normalizedWidths.at(-1) || 480;
+  const src = cloudflareImageUrl(source, { width: fallbackWidth, quality, fit });
+  if (!sameProductionZone(source) || normalizedWidths.length === 0) {
+    return { src, srcset: '', sizes: '' };
+  }
+  const srcset = normalizedWidths
+    .map(width => `${cloudflareImageUrl(source, { width, quality, fit })} ${width}w`)
+    .join(', ');
+  return { src, srcset, sizes };
+}
+
+export const CARD_IMAGE_SIZES = '(max-width: 639px) calc(50vw - 24px), (max-width: 1023px) calc(33vw - 24px), 280px';
+export const PRODUCT_IMAGE_SIZES = '(max-width: 759px) calc(100vw - 48px), 360px';

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -53,6 +53,11 @@ import {
     serverTimingValue,
 } from './_shared/perf.js';
 import { previewCoverUrl } from './_shared/preview-cover.js';
+import {
+    bookCoverUrl,
+    CARD_IMAGE_SIZES,
+    responsiveImage,
+} from './_shared/cloudflare-images.js';
 
 const MAX_RESULTS = 48;
 const WA = 'https://wa.me/59899841325';
@@ -700,9 +705,15 @@ export async function onRequest(ctx) {
     const cards = limited.map((b, idx) => {
         const slug  = slugify(b.title);
         const href  = escapeHtml(`${previewBase}/libro/${b.id}/${slug}`);
-        const img   = escapeHtml(
-            r2Covers[idx] || httpsImg(b.pictures?.[0] || b.thumbnail || '')
-        );
+        const fallbackImage = ctx.env?.APP_ENV === 'production'
+            ? bookCoverUrl(b.id)
+            : httpsImg(b.pictures?.[0] || b.thumbnail || '');
+        const image = responsiveImage(r2Covers[idx] || fallbackImage, {
+            widths: [240, 360, 480],
+            defaultWidth: 360,
+            sizes: CARD_IMAGE_SIZES,
+        });
+        const img = escapeHtml(image.src);
         const title = escapeHtml(b.title);
         const author = b.author
             ? `<p class="rc-author">${escapeHtml(b.author)}</p>`
@@ -719,8 +730,11 @@ export async function onRequest(ctx) {
         const loading  = idx < 8 ? 'eager' : 'lazy';
         const waHref = `${WA}?text=${encodeURIComponent(`Hola Amado Libros, quiero consultar por encargo: ${b.title}`)}`;
         const orderWaHref = `${WA}?text=${encodeURIComponent(buildOrderWaMessage(b, href))}`;
+        const responsiveAttrs = image.srcset
+            ? ` srcset="${escapeHtml(image.srcset)}" sizes="${escapeHtml(image.sizes)}"`
+            : '';
         const imgTag = img
-            ? `<img src="${img}" alt="${title}" loading="${loading}" decoding="async">`
+            ? `<img src="${img}"${responsiveAttrs} alt="${title}" loading="${loading}" decoding="async" width="280" height="373">`
             : `<div class="rc-no-img">📚</div>`;
 
         const badge = available

--- a/functions/especialidades/[[path]].js
+++ b/functions/especialidades/[[path]].js
@@ -15,6 +15,11 @@ import {
   SEO_SPECIALTIES,
   specialtyPath,
 } from '../_shared/seo-specialties.js';
+import {
+  bookCoverUrl,
+  CARD_IMAGE_SIZES,
+  responsiveImage,
+} from '../_shared/cloudflare-images.js';
 
 function escapeHtml(value) {
   return String(value ?? '')
@@ -45,14 +50,22 @@ function errorPage() {
   });
 }
 
-function bookCard(item) {
+function bookCard(item, useCloudflareImages) {
   const href = `/libro/${encodeURIComponent(item.id)}/${slugify(item.title)}`;
-  const image = secureImage(item);
+  const source = useCloudflareImages ? bookCoverUrl(item.id) : secureImage(item);
+  const image = responsiveImage(source, {
+    widths: [240, 360, 480],
+    defaultWidth: 360,
+    sizes: CARD_IMAGE_SIZES,
+  });
   const price = Number(item.price || 0);
   const formattedPrice = price > 0 ? price.toLocaleString('es-UY') : '';
+  const responsiveAttrs = image.srcset
+    ? ` srcset="${escapeHtml(image.srcset)}" sizes="${escapeHtml(image.sizes)}"`
+    : '';
   return `<article class="book-card">
-    <a class="cover" href="${href}">${image
-      ? `<img src="${escapeHtml(image)}" alt="${escapeHtml(item.title)}" loading="lazy" width="240" height="360">`
+    <a class="cover" href="${href}">${image.src
+      ? `<img src="${escapeHtml(image.src)}"${responsiveAttrs} alt="${escapeHtml(item.title)}" loading="lazy" decoding="async" width="240" height="360">`
       : '<span aria-hidden="true">Libro sin imagen</span>'}</a>
     <div class="book-info"><p class="stock">Disponible</p><h3><a href="${href}">${escapeHtml(item.title)}</a></h3>
     ${item.author ? `<p class="author">${escapeHtml(item.author)}</p>` : ''}
@@ -136,7 +149,7 @@ export async function onRequest(ctx) {
 <div class="actions"><a class="btn primary" href="${requestPath}">Pedir una búsqueda</a><a class="btn secondary" href="/catalogo?q=${encodeURIComponent(specialty.name)}">Buscar en el catálogo</a></div>
 <p class="truth"><strong>Información verificable:</strong> confirmamos título, autor, ISBN, editorial, edición, idioma, formato, precio y plazo. No prometemos disponibilidad ni presentamos una reimpresión como edición actualizada.</p></section>
 <section class="section"><h2>Libros de ${escapeHtml(specialty.name)} disponibles</h2><p class="section-intro">Estos resultados provienen del catálogo vigente de Amado Libros. Si no aparece la referencia exacta, podés pedir una búsqueda manual.</p>
-${items.length ? `<div class="books-grid">${items.map(bookCard).join('')}</div>` : `<div class="card"><h3>No hay coincidencias disponibles ahora</h3><p>La página sigue sirviendo para solicitar una edición concreta por encargo. Pasanos autor, ISBN, editorial o una foto de la tapa.</p></div>`}</section>
+${items.length ? `<div class="books-grid">${items.map(item => bookCard(item, isProduction)).join('')}</div>` : `<div class="card"><h3>No hay coincidencias disponibles ahora</h3><p>La página sigue sirviendo para solicitar una edición concreta por encargo. Pasanos autor, ISBN, editorial o una foto de la tapa.</p></div>`}</section>
 <section class="section"><h2>Áreas que podemos buscar</h2><div class="topic-grid">${specialty.topics.map(topic => `<article class="card"><h3>${escapeHtml(topic)}</h3><p>Buscamos por referencia bibliográfica y verificamos la edición antes de cotizar.</p></article>`).join('')}</div></section>
 <section class="international"><h2>¿Consultás desde España o Latinoamérica?</h2><p>Podés enviarnos el país, la ciudad y los datos del libro. La venta, el medio de pago y un eventual envío internacional se confirman caso a caso antes de asumir cualquier compromiso. Los precios visibles en el catálogo están expresados en pesos uruguayos.</p><div class="actions"><a class="btn secondary" href="${requestPath}">Enviar país y libro buscado</a></div></section>
 <section class="section"><h2>Cómo funciona la búsqueda</h2><div class="process-grid"><article class="card"><h3>1. Identificamos el libro</h3><p>Usamos título, autor, ISBN, editorial, edición o foto para evitar confusiones.</p></article><article class="card"><h3>2. Verificamos mercados</h3><p>Revisamos disponibilidad real en Uruguay, España, Argentina y otros orígenes pertinentes.</p></article><article class="card"><h3>3. Confirmamos antes de vender</h3><p>Informamos edición, formato, moneda, precio, plazo y destino posible antes de avanzar.</p></article></div></section>

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -18,6 +18,12 @@ import { BASE, fetchCatalog, fetchPausedItem } from '../_shared/catalog.js';
 import { previewCoverUrl as resolvePreviewCoverUrl } from '../_shared/preview-cover.js';
 import { authorPathForName } from '../_shared/seo-authors.js';
 import {
+    bookCoverUrl,
+    cloudflareImageUrl,
+    PRODUCT_IMAGE_SIZES,
+    responsiveImage,
+} from '../_shared/cloudflare-images.js';
+import {
     ensurePerf,
     perfNow,
     perfSummary,
@@ -136,13 +142,30 @@ function detailRow(label, value) {
 function renderGallery(images, safeTitle) {
     if (!images.length) return '';
 
-    const mainImage = images[0];
+    const displayImages = images.map(source => {
+        const main = responsiveImage(source, {
+            widths: [320, 480, 768, 1024],
+            defaultWidth: 480,
+            sizes: PRODUCT_IMAGE_SIZES,
+        });
+        return {
+            src: main.src,
+            srcset: main.srcset,
+            sizes: main.sizes,
+            thumb: cloudflareImageUrl(source, { width: 96, quality: 82 }),
+            lightbox: cloudflareImageUrl(source, { width: 1024, quality: 88 }),
+        };
+    });
+    const mainImage = displayImages[0];
     const multi = images.length > 1;
-    const imagesJson = JSON.stringify(images).replace(/</g, '\\u003c');
+    const imagesJson = JSON.stringify(displayImages).replace(/</g, '\\u003c');
+    const mainResponsiveAttrs = mainImage.srcset
+        ? ` srcset="${escapeHtml(mainImage.srcset)}" sizes="${escapeHtml(mainImage.sizes)}"`
+        : '';
 
     const thumbsHtml = multi
         ? `<div class="thumbs" role="group" aria-label="Más imágenes del libro">
-${images.map((url, i) => `    <button type="button" class="thumb-btn" data-idx="${i}" aria-label="${safeTitle} — imagen ${i + 1}" aria-current="${i === 0 ? 'true' : 'false'}"><img src="${escapeHtml(url)}" alt="${safeTitle} — imagen ${i + 1}" loading="lazy" width="56" height="56"></button>`).join('\n')}
+${displayImages.map((image, i) => `    <button type="button" class="thumb-btn" data-idx="${i}" aria-label="${safeTitle} — imagen ${i + 1}" aria-current="${i === 0 ? 'true' : 'false'}"><img src="${escapeHtml(image.thumb)}" alt="${safeTitle} — imagen ${i + 1}" loading="lazy" decoding="async" width="56" height="56"></button>`).join('\n')}
   </div>`
         : '';
 
@@ -153,13 +176,13 @@ ${images.map((url, i) => `    <button type="button" class="thumb-btn" data-idx="
 
     return `<div class="cover">
   <button type="button" class="cover-btn" id="gMainBtn" data-current-index="0" aria-label="Ampliar imagen de ${safeTitle}">
-    <img class="cover-main" id="gMainImg" src="${escapeHtml(mainImage)}" alt="${safeTitle}" loading="eager" width="260" data-title="${safeTitle}">
+    <img class="cover-main" id="gMainImg" src="${escapeHtml(mainImage.src)}"${mainResponsiveAttrs} alt="${safeTitle}" loading="eager" decoding="async" fetchpriority="high" width="360" height="540" data-title="${safeTitle}">
   </button>
   ${thumbsHtml}
   <div id="glb" class="lb" role="dialog" aria-modal="true" aria-label="Galería de imágenes" tabindex="-1" hidden>
     <div class="lb-inner">
       <button type="button" class="lb-close" id="glbClose" aria-label="Cerrar galería">&#10005;</button>
-      <img class="lb-img" id="glbImg" src="${escapeHtml(mainImage)}" alt="${safeTitle}" loading="eager">
+      <img class="lb-img" id="glbImg" src="${escapeHtml(mainImage.lightbox)}" alt="${safeTitle}" loading="eager" decoding="async">
       <p class="lb-counter" id="glbCounter" aria-live="polite" aria-atomic="true">Imagen 1 de ${images.length}</p>
       <div class="lb-nav">${navBtns}</div>
     </div>
@@ -178,7 +201,14 @@ ${images.map((url, i) => `    <button type="button" class="thumb-btn" data-idx="
 
   function selectThumb(idx){
     cur=idx;
-    mainImg.src=imgs[idx];
+    mainImg.src=imgs[idx].src;
+    if(imgs[idx].srcset){
+      mainImg.srcset=imgs[idx].srcset;
+      mainImg.sizes=imgs[idx].sizes||'';
+    }else{
+      mainImg.removeAttribute('srcset');
+      mainImg.removeAttribute('sizes');
+    }
     mainImg.alt=title+' — imagen '+(idx+1);
     mainBtn.setAttribute('data-current-index',String(idx));
     thumbBtns.forEach(function(b,i){b.setAttribute('aria-current',i===idx?'true':'false');});
@@ -198,7 +228,7 @@ ${images.map((url, i) => `    <button type="button" class="thumb-btn" data-idx="
   }
 
   function updateLb(){
-    lbImg.src=imgs[cur];
+    lbImg.src=imgs[cur].lightbox;
     lbImg.alt=title+' — imagen '+(cur+1);
     if(lbCtr)lbCtr.textContent='Imagen '+(cur+1)+' de '+n;
   }
@@ -275,16 +305,26 @@ export function selectRelatedBooks(catalogItems, item, limit = 4) {
     return related;
 }
 
-function renderRelatedBooks(relatedBooks, author) {
+function renderRelatedBooks(relatedBooks, author, useCloudflareImages = true) {
     if (!Array.isArray(relatedBooks) || relatedBooks.length === 0) return '';
 
     const cards = relatedBooks.map((book) => {
         const title = escapeHtml(book.title);
         const href = `/libro/${encodeURIComponent(book.id)}/${slugify(book.title)}`;
-        const image = normalizeImages(book)[0] || '';
+        const source = useCloudflareImages
+            ? bookCoverUrl(book.id)
+            : normalizeImages(book)[0] || '';
+        const image = responsiveImage(source, {
+            widths: [120, 180, 240],
+            defaultWidth: 180,
+            sizes: '(max-width: 759px) calc(50vw - 40px), 180px',
+        });
+        const responsiveAttrs = image.srcset
+            ? ` srcset="${escapeHtml(image.srcset)}" sizes="${escapeHtml(image.sizes)}"`
+            : '';
         return `<li class="related-book">
       <a class="related-book-link" href="${escapeHtml(href)}">
-        ${image ? `<img class="related-book-cover" src="${escapeHtml(image)}" alt="Portada de ${title}" loading="lazy" width="120" height="180">` : ''}
+        ${image.src ? `<img class="related-book-cover" src="${escapeHtml(image.src)}"${responsiveAttrs} alt="Portada de ${title}" loading="lazy" width="120" height="180" decoding="async">` : ''}
         <span class="related-book-title">${title}</span>
       </a>
     </li>`;
@@ -342,7 +382,15 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     const safeTitle    = escapeHtml(item.title);
     const safeAuthor   = item.author ? escapeHtml(item.author) : null;
     const images       = normalizeImages(item, previewCoverSrc);
+    if (!isPreview && images.length > 0 && !previewCoverSrc) {
+        images[0] = bookCoverUrl(item.id);
+    }
     const img          = images[0] || '';
+    const cartThumbnail = responsiveImage(img, {
+        widths: [240],
+        defaultWidth: 240,
+        sizes: '240px',
+    }).src;
     // Las redes sociales suelen bloquear imágenes servidas directamente por
     // mlstatic. La portada social sale desde nuestro dominio y el proxy valida
     // el MLU antes de obtenerla, para que WhatsApp/Facebook reciban HTTP 200.
@@ -373,7 +421,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
             ? `Hola! Me interesa: ${item.title}`
             : buildPausedWaMessage(item)
     );
-    const relatedBooksHtml = renderRelatedBooks(relatedBooks, item.author);
+    const relatedBooksHtml = renderRelatedBooks(relatedBooks, item.author, !isPreview);
 
     const detailRows = [
         safeAuthor ? detailRow('Autor', item.author) : '',
@@ -519,7 +567,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
         data-id="${escapeHtml(item.id)}"
         data-title="${escapeHtml(item.title)}"
         data-price="${price}"
-        data-thumbnail="${escapeHtml(images[0] || '')}"
+        data-thumbnail="${escapeHtml(cartThumbnail)}"
         data-max-qty="${stockQty}"
       >
         <span data-cart-label>🛒 Agregar al carrito</span>

--- a/functions/libros/[[path]].js
+++ b/functions/libros/[[path]].js
@@ -15,6 +15,11 @@ import {
     WA_FLOAT_STYLES,
 } from '../_shared/brand.js';
 import { findSeoCategory, SEO_CATEGORIES } from '../_shared/seo-categories.js';
+import {
+    bookCoverUrl,
+    CARD_IMAGE_SIZES,
+    responsiveImage,
+} from '../_shared/cloudflare-images.js';
 
 const MAX_RESULTS = 48;
 const PAGE_PARAM_RE = /^[1-9][0-9]{0,6}$/;
@@ -164,15 +169,25 @@ function categoryNavHtml(currentId) {
 
 function cardHtml(item, index, navigationBase) {
     const href = `${navigationBase}/libro/${item.id}/${slugify(item.title)}`;
-    const image = httpsImg(item.pictures?.[0] || item.thumbnail || '');
+    const source = navigationBase === BASE
+        ? bookCoverUrl(item.id)
+        : httpsImg(item.pictures?.[0] || item.thumbnail || '');
+    const image = responsiveImage(source, {
+        widths: [240, 360, 480],
+        defaultWidth: 360,
+        sizes: CARD_IMAGE_SIZES,
+    });
     const title = escapeHtml(item.title);
     const author = item.author ? `<p class="book-author">${escapeHtml(item.author)}</p>` : '';
     const price = Number(item.price) || 0;
     const priceText = price.toLocaleString('es-UY');
     const transferText = Math.round(price * 0.88).toLocaleString('es-UY');
     const installmentText = Math.round(price / 12).toLocaleString('es-UY');
-    const imageHtml = image
-        ? `<img src="${escapeHtml(image)}" alt="Portada de ${title}" loading="${index < 6 ? 'eager' : 'lazy'}" decoding="async">`
+    const responsiveAttrs = image.srcset
+        ? ` srcset="${escapeHtml(image.srcset)}" sizes="${escapeHtml(image.sizes)}"`
+        : '';
+    const imageHtml = image.src
+        ? `<img src="${escapeHtml(image.src)}"${responsiveAttrs} alt="Portada de ${title}" loading="${index < 6 ? 'eager' : 'lazy'}" decoding="async" width="280" height="420">`
         : '<span class="book-placeholder" aria-hidden="true">📚</span>';
 
     return `<article class="book-card">


### PR DESCRIPTION
## Resultado

Conecta las portadas del sitio a las transformaciones de Cloudflare ya habilitadas en `amadolibros.com`.

## Cambios

- Usa como origen estable el proxy propio `/book-cover/...`, que prioriza R2 y evita depender directamente de `mlstatic.com`.
- Añade `srcset` y `sizes` responsivos en portada, catálogo, categorías, especialidades, autores y fichas.
- Genera variantes adecuadas para cada contexto:
  - tarjetas: 240 / 360 / 480 px
  - ficha principal: 320 / 480 / 768 / 1024 px
  - miniaturas y relacionados: tamaños específicos
- Activa `format=auto` para servir AVIF/WebP cuando el navegador lo admite.
- Usa `fit=scale-down` para no deformar ni ampliar artificialmente portadas pequeñas.
- Mantiene las previews sin transformación y conserva estables las URLs del feed y de imágenes sociales.
- Añade cobertura automática para las URLs y el HTML responsivo.

## Evidencia en producción

Prueba con `MLU697960553`:

- origen propio: JPEG, 50.066 bytes
- variante Cloudflare a 360 px: AVIF, 18.783 bytes
- reducción aproximada: 62,5 %
- respuesta confirmada con cabecera `cf-resized`

## Validación

- Pasaron todas las suites de Functions, Astro y API.
- Pasaron los 96 tests del Worker.
- Pasaron los builds con checkout desactivado y activado.
- Se comprobó en el HTML generado la presencia de `/cdn-cgi/image/`, `srcset` y tamaños responsivos.

## Nota de calidad

La transformación optimiza formato, peso y entrega. No inventa detalle que no exista en el archivo original: las portadas de baja resolución necesitan una fuente original mejor para superar realmente 500 × 500.