### PR TITLE
Galerías completas desde Mercado Libre y R2

### DIFF
--- a/astro-front/src/lib/__tests__/cloudflare-images.test.js
+++ b/astro-front/src/lib/__tests__/cloudflare-images.test.js
@@ -11,6 +11,7 @@ test('la home usa el proxy propio y tres variantes Cloudflare', () => {
   const source = bookCoverUrl('MLU987654');
   const cover = responsiveBookCover('MLU987654');
   assert.equal(source, 'https://www.amadolibros.com/book-cover/MLU987654/cover.jpg');
+  assert.equal(bookCoverUrl('MLU987654', 2), 'https://www.amadolibros.com/book-cover/MLU987654/cover-3.jpg');
   assert.match(cover.src, /\/cdn-cgi\/image\/.*width=360/);
   assert.deepEqual(
     [...cover.srcset.matchAll(/width=(\d+)/g)].map(match => Number(match[1])),

--- a/astro-front/src/lib/__tests__/cloudflare-images.test.js
+++ b/astro-front/src/lib/__tests__/cloudflare-images.test.js
@@ -12,6 +12,7 @@ test('la home usa el proxy propio y tres variantes Cloudflare', () => {
   const cover = responsiveBookCover('MLU987654');
   assert.equal(source, 'https://www.amadolibros.com/book-cover/MLU987654/cover.jpg');
   assert.equal(bookCoverUrl('MLU987654', 2), 'https://www.amadolibros.com/book-cover/MLU987654/cover-3.jpg');
+  assert.equal(bookCoverUrl('MLU987654', 15), 'https://www.amadolibros.com/book-cover/MLU987654/cover-16.jpg');
   assert.match(cover.src, /\/cdn-cgi\/image\/.*width=360/);
   assert.deepEqual(
     [...cover.srcset.matchAll(/width=(\d+)/g)].map(match => Number(match[1])),

--- a/astro-front/src/lib/cloudflare-images.js
+++ b/astro-front/src/lib/cloudflare-images.js
@@ -1,10 +1,14 @@
 const BASE = 'https://www.amadolibros.com';
 const PRODUCT_ID_RE = /^MLU\d+$/;
 
-export function bookCoverUrl(productId) {
+export function bookCoverUrl(productId, position = 0) {
   const id = String(productId || '').toUpperCase();
   if (!PRODUCT_ID_RE.test(id)) return '';
-  return `${BASE}/book-cover/${encodeURIComponent(id)}/cover.jpg`;
+  const normalizedPosition = Number.isInteger(position) && position >= 0 && position < 6
+    ? position
+    : 0;
+  const filename = normalizedPosition === 0 ? 'cover.jpg' : `cover-${normalizedPosition + 1}.jpg`;
+  return `${BASE}/book-cover/${encodeURIComponent(id)}/${filename}`;
 }
 
 export function cloudflareImageUrl(source, width, quality = 85) {

--- a/astro-front/src/lib/cloudflare-images.js
+++ b/astro-front/src/lib/cloudflare-images.js
@@ -1,10 +1,11 @@
 const BASE = 'https://www.amadolibros.com';
 const PRODUCT_ID_RE = /^MLU\d+$/;
+const MAX_GALLERY_IMAGES = 16;
 
 export function bookCoverUrl(productId, position = 0) {
   const id = String(productId || '').toUpperCase();
   if (!PRODUCT_ID_RE.test(id)) return '';
-  const normalizedPosition = Number.isInteger(position) && position >= 0 && position < 6
+  const normalizedPosition = Number.isInteger(position) && position >= 0 && position < MAX_GALLERY_IMAGES
     ? position
     : 0;
   const filename = normalizedPosition === 0 ? 'cover.jpg' : `cover-${normalizedPosition + 1}.jpg`;

--- a/functions/__tests__/catalog-dedupe-images.test.js
+++ b/functions/__tests__/catalog-dedupe-images.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { dedupeCatalogResults } from '../catalogo.js';
-import { normalizeImages } from '../libro/[[path]].js';
+import { normalizeImages, renderPage } from '../libro/[[path]].js';
 import { dedupeCategoryResults } from '../libros/[[path]].js';
 
 test('catálogo muestra una sola oferta por mismo ISBN, estado y condición', () => {
@@ -55,6 +55,25 @@ test('la portada primaria convierte miniatura -I en imagen grande -O', () => {
     normalizeImages({ thumbnail: 'http://http2.mlstatic.com/D_PORTADA-I.jpg' }),
     ['https://http2.mlstatic.com/D_PORTADA-O.jpg'],
   );
+});
+
+test('la ficha productiva sirve toda la galería desde Amado Libros', () => {
+  const html = renderPage({
+    id: 'MLU123456',
+    title: 'Libro con galería',
+    status: 'paused',
+    available_quantity: 0,
+    pictures: [
+      'https://http2.mlstatic.com/PORTADA-O.jpg',
+      'https://mlu-s2-p.mlstatic.com/INTERIOR-O.jpg',
+      'https://http2.mlstatic.com/POSTER-O.jpg',
+    ],
+  }, 'libro-con-galeria', false, '');
+
+  assert.match(html, /book-cover\/MLU123456\/cover\.jpg/);
+  assert.match(html, /book-cover\/MLU123456\/cover-2\.jpg/);
+  assert.match(html, /book-cover\/MLU123456\/cover-3\.jpg/);
+  assert.doesNotMatch(html, /mlu-s2-p\.mlstatic\.com/);
 });
 
 test('las landings de categoría tampoco repiten la misma edición', () => {

--- a/functions/__tests__/catalog-dedupe-images.test.js
+++ b/functions/__tests__/catalog-dedupe-images.test.js
@@ -58,22 +58,21 @@ test('la portada primaria convierte miniatura -I en imagen grande -O', () => {
 });
 
 test('la ficha productiva sirve toda la galería desde Amado Libros', () => {
+  const pictures = Array.from({ length: 16 }, (_, index) =>
+    `https://http2.mlstatic.com/GALERIA_${index + 1}-O.jpg`);
   const html = renderPage({
     id: 'MLU123456',
     title: 'Libro con galería',
     status: 'paused',
     available_quantity: 0,
-    pictures: [
-      'https://http2.mlstatic.com/PORTADA-O.jpg',
-      'https://mlu-s2-p.mlstatic.com/INTERIOR-O.jpg',
-      'https://http2.mlstatic.com/POSTER-O.jpg',
-    ],
+    pictures,
   }, 'libro-con-galeria', false, '');
 
   assert.match(html, /book-cover\/MLU123456\/cover\.jpg/);
   assert.match(html, /book-cover\/MLU123456\/cover-2\.jpg/);
   assert.match(html, /book-cover\/MLU123456\/cover-3\.jpg/);
-  assert.doesNotMatch(html, /mlu-s2-p\.mlstatic\.com/);
+  assert.match(html, /book-cover\/MLU123456\/cover-16\.jpg/);
+  assert.doesNotMatch(html, /mlstatic\.com/);
 });
 
 test('las landings de categoría tampoco repiten la misma edición', () => {

--- a/functions/__tests__/catalog-display.test.js
+++ b/functions/__tests__/catalog-display.test.js
@@ -198,7 +198,7 @@ test('COVER-R2 Producción: card y ficha usan el binding productivo', async () =
   const bookHtml = await bookResponse.text();
   assert.match(
     bookHtml,
-    new RegExp(`/preview-cover/MLU1/0/${PREVIEW_COVER_HASH}\\.jpg`),
+    /\/book-cover\/MLU1\/cover\.jpg/,
   );
 });
 

--- a/functions/__tests__/cloudflare-images.test.js
+++ b/functions/__tests__/cloudflare-images.test.js
@@ -16,8 +16,8 @@ test('construye una portada primaria controlada y rechaza IDs ajenos', () => {
     'https://www.amadolibros.com/book-cover/MLU123456/cover-2.jpg',
   );
   assert.equal(
-    bookCoverUrl('MLU123456', 5),
-    'https://www.amadolibros.com/book-cover/MLU123456/cover-6.jpg',
+    bookCoverUrl('MLU123456', 15),
+    'https://www.amadolibros.com/book-cover/MLU123456/cover-16.jpg',
   );
   assert.equal(bookCoverUrl('USD123'), '');
   assert.equal(bookCoverUrl('../MLU123'), '');

--- a/functions/__tests__/cloudflare-images.test.js
+++ b/functions/__tests__/cloudflare-images.test.js
@@ -11,6 +11,14 @@ const SOURCE = 'https://www.amadolibros.com/book-cover/MLU123456/cover.jpg';
 
 test('construye una portada primaria controlada y rechaza IDs ajenos', () => {
   assert.equal(bookCoverUrl('mlu123456'), SOURCE);
+  assert.equal(
+    bookCoverUrl('MLU123456', 1),
+    'https://www.amadolibros.com/book-cover/MLU123456/cover-2.jpg',
+  );
+  assert.equal(
+    bookCoverUrl('MLU123456', 5),
+    'https://www.amadolibros.com/book-cover/MLU123456/cover-6.jpg',
+  );
   assert.equal(bookCoverUrl('USD123'), '');
   assert.equal(bookCoverUrl('../MLU123'), '');
 });

--- a/functions/__tests__/preview-cover.test.js
+++ b/functions/__tests__/preview-cover.test.js
@@ -187,7 +187,7 @@ test('Ficha usa la portada R2 sólo como primera imagen y conserva las secundari
   assert.match(html, new RegExp(`data-thumbnail="${previewSrc.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
 });
 
-test('Ficha productiva entrega la portada R2 con srcset de Cloudflare Images', () => {
+test('Ficha productiva entrega el proxy propio con srcset de Cloudflare Images', () => {
   const productionSrc = `https://www.amadolibros.com/preview-cover/${ID}/0/${HASH}.jpg`;
   const html = renderPage({
     id: ID,
@@ -203,5 +203,5 @@ test('Ficha productiva entrega la portada R2 con srcset de Cloudflare Images', (
   }, 'libro-responsivo', false, '', productionSrc);
   assert.match(html, /class="cover-main"[^>]+\/cdn-cgi\/image\/format=auto/);
   assert.match(html, /srcset="[^"]+320w,[^"]+480w,[^"]+768w,[^"]+1024w"/);
-  assert.match(html, /onerror=redirect\/preview-cover\/MLU123456789\/0\//);
+  assert.match(html, /onerror=redirect\/book-cover\/MLU123456789\/cover\.jpg/);
 });

--- a/functions/__tests__/social-cover-global-autocomplete.test.js
+++ b/functions/__tests__/social-cover-global-autocomplete.test.js
@@ -48,6 +48,42 @@ test('el proxy entrega bytes de imagen con caché pública y admite HEAD', async
   }
 });
 
+test('el proxy sirve posiciones secundarias desde subdominios oficiales de mlstatic', async () => {
+  const originalFetch = globalThis.fetch;
+  const galleryItem = {
+    ...item,
+    pictures: [
+      item.pictures[0],
+      'https://mlu-s2-p.mlstatic.com/D_SECOND-O.jpg',
+    ],
+  };
+  globalThis.caches = { default: { async match() { return null; }, async put() {} } };
+  globalThis.fetch = async input => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url === CATALOG_URL) return Response.json({ items: [galleryItem] });
+    if (url === galleryItem.pictures[1]) {
+      return new Response(new Uint8Array([4, 5, 6]), {
+        headers: { 'content-type': 'image/jpeg' },
+      });
+    }
+    throw new Error(`fetch inesperado: ${url}`);
+  };
+  try {
+    const response = await coverRequest({
+      request: new Request(`https://www.amadolibros.com/book-cover/${item.id}/cover-2.jpg`),
+      params: { path: [item.id, 'cover-2.jpg'] },
+      env: { APP_ENV: 'production' },
+      data: {},
+      waitUntil() {},
+    });
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('x-cover-source'), 'mercadolibre');
+    assert.deepEqual([...new Uint8Array(await response.arrayBuffer())], [4, 5, 6]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('el proxy prioriza la copia R2 y no consulta mlstatic cuando existe', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.caches = { default: { async match() { return null; }, async put() {} } };

--- a/functions/_shared/cloudflare-images.js
+++ b/functions/_shared/cloudflare-images.js
@@ -18,13 +18,17 @@ function sameProductionZone(source) {
 }
 
 /**
- * Portada primaria controlada por Amado Libros. El endpoint prioriza R2 y
+ * Imagen de galería controlada por Amado Libros. El endpoint prioriza R2 y
  * conserva Mercado Libre únicamente como fallback mientras termina el mirror.
  */
-export function bookCoverUrl(productId) {
+export function bookCoverUrl(productId, position = 0) {
   const id = String(productId || '').toUpperCase();
   if (!PRODUCT_ID_RE.test(id)) return '';
-  return `${BASE}/book-cover/${encodeURIComponent(id)}/cover.jpg`;
+  const normalizedPosition = Number.isInteger(position) && position >= 0 && position < 6
+    ? position
+    : 0;
+  const filename = normalizedPosition === 0 ? 'cover.jpg' : `cover-${normalizedPosition + 1}.jpg`;
+  return `${BASE}/book-cover/${encodeURIComponent(id)}/${filename}`;
 }
 
 /**

--- a/functions/_shared/cloudflare-images.js
+++ b/functions/_shared/cloudflare-images.js
@@ -1,6 +1,7 @@
 import { BASE } from './catalog.js';
 
 const PRODUCT_ID_RE = /^MLU\d+$/;
+const MAX_GALLERY_IMAGES = 16;
 const DEFAULT_WIDTHS = [240, 360, 480];
 
 function positiveInteger(value) {
@@ -24,7 +25,7 @@ function sameProductionZone(source) {
 export function bookCoverUrl(productId, position = 0) {
   const id = String(productId || '').toUpperCase();
   if (!PRODUCT_ID_RE.test(id)) return '';
-  const normalizedPosition = Number.isInteger(position) && position >= 0 && position < 6
+  const normalizedPosition = Number.isInteger(position) && position >= 0 && position < MAX_GALLERY_IMAGES
     ? position
     : 0;
   const filename = normalizedPosition === 0 ? 'cover.jpg' : `cover-${normalizedPosition + 1}.jpg`;

--- a/functions/_shared/preview-cover.js
+++ b/functions/_shared/preview-cover.js
@@ -10,7 +10,8 @@ function normalizeSourceUrl(raw) {
     if (typeof raw !== 'string' || raw.trim() === '') return null;
     try {
         const url = new URL(raw.trim());
-        if (url.hostname !== 'http2.mlstatic.com' ||
+        const hostname = url.hostname.toLowerCase();
+        if (!(hostname === 'mlstatic.com' || hostname.endsWith('.mlstatic.com')) ||
             !['http:', 'https:'].includes(url.protocol)) return null;
         url.protocol = 'https:';
         url.hash = '';

--- a/functions/book-cover/[[path]].js
+++ b/functions/book-cover/[[path]].js
@@ -2,7 +2,8 @@ import { fetchCatalog, fetchPausedItem } from '../_shared/catalog.js';
 import { findPreviewCover } from '../_shared/preview-cover.js';
 
 const PRODUCT_ID_RE = /^MLU\d+$/;
-const COVER_FILE_RE = /^cover(?:-([2-6]))?\.jpg$/;
+const COVER_FILE_RE = /^cover(?:-([2-9]|1[0-6]))?\.jpg$/;
+const MAX_GALLERY_IMAGES = 16;
 
 function largeMlImage(raw) {
   if (typeof raw !== 'string' || !raw.trim()) return '';
@@ -25,7 +26,7 @@ export function primaryCoverSource(item) {
 }
 
 export function coverSource(item, position = 0) {
-  if (!Number.isInteger(position) || position < 0 || position > 5) return '';
+  if (!Number.isInteger(position) || position < 0 || position >= MAX_GALLERY_IMAGES) return '';
   const pictures = Array.isArray(item?.pictures)
     ? item.pictures.filter(value => typeof value === 'string')
     : [];

--- a/functions/book-cover/[[path]].js
+++ b/functions/book-cover/[[path]].js
@@ -2,12 +2,15 @@ import { fetchCatalog, fetchPausedItem } from '../_shared/catalog.js';
 import { findPreviewCover } from '../_shared/preview-cover.js';
 
 const PRODUCT_ID_RE = /^MLU\d+$/;
+const COVER_FILE_RE = /^cover(?:-([2-6]))?\.jpg$/;
 
 function largeMlImage(raw) {
   if (typeof raw !== 'string' || !raw.trim()) return '';
   try {
     const url = new URL(raw.trim());
-    if (url.hostname !== 'http2.mlstatic.com' || !['http:', 'https:'].includes(url.protocol)) return '';
+    const hostname = url.hostname.toLowerCase();
+    if (!(hostname === 'mlstatic.com' || hostname.endsWith('.mlstatic.com')) ||
+        !['http:', 'https:'].includes(url.protocol)) return '';
     url.protocol = 'https:';
     url.hash = '';
     url.pathname = url.pathname.replace(/-I\.(jpg|jpeg|png|webp)$/i, '-O.$1');
@@ -18,8 +21,16 @@ function largeMlImage(raw) {
 }
 
 export function primaryCoverSource(item) {
-  const picture = Array.isArray(item?.pictures) ? item.pictures.find(value => typeof value === 'string') : '';
-  return largeMlImage(picture || item?.thumbnail || '');
+  return coverSource(item, 0);
+}
+
+export function coverSource(item, position = 0) {
+  if (!Number.isInteger(position) || position < 0 || position > 5) return '';
+  const pictures = Array.isArray(item?.pictures)
+    ? item.pictures.filter(value => typeof value === 'string')
+    : [];
+  const picture = pictures[position] || (position === 0 ? item?.thumbnail : '');
+  return largeMlImage(picture || '');
 }
 
 function responseHeaders(source, contentType, etag = null) {
@@ -54,12 +65,15 @@ export async function onRequest(ctx) {
   }
   const parts = Array.isArray(ctx.params.path) ? ctx.params.path : [ctx.params.path].filter(Boolean);
   const id = String(parts[0] || '').toUpperCase();
-  if (!PRODUCT_ID_RE.test(id) || parts.length > 2) {
+  const coverMatch = COVER_FILE_RE.exec(String(parts[1] || ''));
+  const position = coverMatch ? Math.max(0, Number(coverMatch[1] || 1) - 1) : -1;
+  if (!PRODUCT_ID_RE.test(id) || parts.length !== 2 || position < 0) {
     return new Response('Not Found', { status: 404, headers: { 'cache-control': 'public,max-age=300' } });
   }
 
   const cache = caches.default;
-  const cacheKey = new Request(new URL(ctx.request.url).origin + `/book-cover/${id}/cover.jpg`);
+  const filename = position === 0 ? 'cover.jpg' : `cover-${position + 1}.jpg`;
+  const cacheKey = new Request(new URL(ctx.request.url).origin + `/book-cover/${id}/${filename}`);
   const cached = await cache.match(cacheKey);
   if (cached) {
     return ctx.request.method === 'HEAD'
@@ -70,8 +84,8 @@ export async function onRequest(ctx) {
   const catalog = await fetchCatalog(ctx);
   let item = Array.isArray(catalog?.items) ? catalog.items.find(candidate => candidate.id === id) : null;
   if (!item && ['preview', 'production'].includes(ctx.env?.APP_ENV)) item = await fetchPausedItem(ctx, id);
-  const source = primaryCoverSource(item);
-  const storedCover = await findPreviewCover(ctx, id, 0, source || null);
+  const source = coverSource(item, position);
+  const storedCover = await findPreviewCover(ctx, id, position, source || null);
   let response = await r2CoverResponse(ctx, storedCover);
 
   if (!response && source) {

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -381,10 +381,10 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     const canonicalUrl = `${BASE}/libro/${item.id}/${slug}`;
     const safeTitle    = escapeHtml(item.title);
     const safeAuthor   = item.author ? escapeHtml(item.author) : null;
-    const images       = normalizeImages(item, previewCoverSrc);
-    if (!isPreview && images.length > 0 && !previewCoverSrc) {
-        images[0] = bookCoverUrl(item.id);
-    }
+    const sourceImages = normalizeImages(item, previewCoverSrc);
+    const images       = isPreview
+        ? sourceImages
+        : sourceImages.map((_, position) => bookCoverUrl(item.id, position));
     const img          = images[0] || '';
     const cartThumbnail = responsiveImage(img, {
         widths: [240],

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -87,7 +87,9 @@ export function normalizeImages(item, previewCoverSrc = '') {
     // `thumbnail` es una versión -I de la primera portada y no una foto
     // adicional. Solo se usa como fallback si ML no entregó pictures[].
     if (pictures.length === 0 && item.thumbnail) pictures.push(httpsImg(item.thumbnail));
-    const normalized = [...new Set(pictures.filter(Boolean))].slice(0, 6);
+    // Mercado Libre suele entregar menos, pero se preserva la galería oficial
+    // completa con una guarda amplia y coherente con el proxy 0..15.
+    const normalized = [...new Set(pictures.filter(Boolean))].slice(0, 16);
     if (previewCoverSrc && normalized.length > 0) normalized[0] = previewCoverSrc;
     if (previewCoverSrc && normalized.length === 0) normalized.push(previewCoverSrc);
     return normalized;

--- a/worker-sync/__tests__/cover-mirror.test.js
+++ b/worker-sync/__tests__/cover-mirror.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   COVER_MANIFEST_KEY,
+  coverCandidates,
   primaryCoverCandidate,
   selectCoverBatch,
   syncCoverMirror,
@@ -91,6 +92,36 @@ test('normaliza miniatura y excluye productos no activos o sin origen ML', () =>
   );
   assert.equal(primaryCoverCandidate(item('MLU123456', { status: 'paused' })), null);
   assert.equal(primaryCoverCandidate(item('MLU123456', { pictures: ['https://example.com/x.jpg'] })), null);
+});
+
+test('genera candidatos para las seis posiciones oficiales de una galería', () => {
+  const candidates = coverCandidates(item('MLU123456', {
+    pictures: [
+      'https://http2.mlstatic.com/D_MAIN-O.jpg',
+      'https://mlu-s2-p.mlstatic.com/D_SECOND-O.jpg',
+    ],
+  }));
+  assert.deepEqual(candidates.map(candidate => candidate.position), [0, 1]);
+  assert.equal(candidates[1].source_url, 'https://mlu-s2-p.mlstatic.com/D_SECOND-O.jpg');
+});
+
+test('copia cada posición de la galería a R2 con entradas independientes', async () => {
+  const bucket = new MockR2();
+  const result = await syncCoverMirror(
+    { COVER_R2: bucket },
+    { items: [item('MLU123456', {
+      pictures: [
+        'https://http2.mlstatic.com/D_MAIN-O.jpg',
+        'https://mlu-s2-p.mlstatic.com/D_SECOND-O.jpg',
+      ],
+    })] },
+    {
+      fetchFn: async () => new Response(pngBytes(), { headers: { 'content-type': 'image/png' } }),
+    },
+  );
+  assert.equal(result.imported, 2);
+  assert.ok(bucket.manifest().entries['MLU123456:0'].current.object_key);
+  assert.ok(bucket.manifest().entries['MLU123456:1'].current.object_key);
 });
 
 test('prioriza faltantes, después URL cambiada y al final revalidaciones vencidas', () => {

--- a/worker-sync/__tests__/cover-mirror.test.js
+++ b/worker-sync/__tests__/cover-mirror.test.js
@@ -94,15 +94,14 @@ test('normaliza miniatura y excluye productos no activos o sin origen ML', () =>
   assert.equal(primaryCoverCandidate(item('MLU123456', { pictures: ['https://example.com/x.jpg'] })), null);
 });
 
-test('genera candidatos para las seis posiciones oficiales de una galería', () => {
+test('genera candidatos para todas las posiciones oficiales de una galería', () => {
   const candidates = coverCandidates(item('MLU123456', {
-    pictures: [
-      'https://http2.mlstatic.com/D_MAIN-O.jpg',
-      'https://mlu-s2-p.mlstatic.com/D_SECOND-O.jpg',
-    ],
+    pictures: Array.from({ length: 18 }, (_, index) =>
+      `https://mlu-s2-p.mlstatic.com/D_GALLERY_${index + 1}-O.jpg`),
   }));
-  assert.deepEqual(candidates.map(candidate => candidate.position), [0, 1]);
-  assert.equal(candidates[1].source_url, 'https://mlu-s2-p.mlstatic.com/D_SECOND-O.jpg');
+  assert.equal(candidates.length, 16);
+  assert.deepEqual(candidates.map(candidate => candidate.position), Array.from({ length: 16 }, (_, index) => index));
+  assert.equal(candidates[15].source_url, 'https://mlu-s2-p.mlstatic.com/D_GALLERY_16-O.jpg');
 });
 
 test('copia cada posición de la galería a R2 con entradas independientes', async () => {

--- a/worker-sync/__tests__/meli-catalog.test.js
+++ b/worker-sync/__tests__/meli-catalog.test.js
@@ -8,6 +8,7 @@ import {
   enrichCatalogDescriptions,
   extractBibliographicDetails,
   extractDimensions,
+  normalizePictures,
   repairKnownTitle,
   sanitizeDescription,
   slimItem,
@@ -566,6 +567,15 @@ test('completa y cachea la galería oficial de catalog_product_id', async () => 
   assert.equal(uncached[0].pictures.length, 2);
   assert.equal(cacheFailure.fetched, 1);
   assert.equal(cacheFailure.cache_write_error, 'R2 temporalmente indisponible');
+});
+
+test('preserva hasta dieciséis imágenes oficiales sin el antiguo corte en seis', () => {
+  const pictures = Array.from({ length: 18 }, (_, index) => ({
+    url: `https://http2.mlstatic.com/D_GALLERY_${index + 1}-O.jpg`,
+  }));
+  const normalized = normalizePictures(pictures);
+  assert.equal(normalized.length, 16);
+  assert.match(normalized.at(-1), /D_GALLERY_16-O\.jpg$/);
 });
 
 test('slimItem conserva identidad de catálogo ML sin inventar señales ausentes', () => {

--- a/worker-sync/__tests__/meli-catalog.test.js
+++ b/worker-sync/__tests__/meli-catalog.test.js
@@ -2,7 +2,9 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   buildCatalog,
+  CATALOG_PRODUCT_GALLERY_CACHE_KEY,
   createDataQualitySummary,
+  enrichCatalogProductPictures,
   enrichCatalogDescriptions,
   extractBibliographicDetails,
   extractDimensions,
@@ -475,6 +477,95 @@ test('descripciones ML usan caché y un cupo incremental sin bloquear faltantes'
     checked: 2, present: 2, pending: 1, refresh_days: 90,
   });
   assert.equal(sanitizeDescription('  Texto\u0000  válido  '), 'Texto válido');
+});
+
+test('completa y cachea la galería oficial de catalog_product_id', async () => {
+  const objects = new Map();
+  const calls = [];
+  const bucket = {
+    async get(key) {
+      const body = objects.get(key);
+      return body == null ? null : { async text() { return body; } };
+    },
+    async put(key, body) { objects.set(key, body); },
+  };
+  const items = [{
+    id: 'MLU100',
+    title: 'Edición especial',
+    status: 'paused',
+    available_quantity: 0,
+    catalog_product_id: 'MLU63131903',
+    start_time: '2026-08-01T00:00:00.000Z',
+    pictures: ['https://http2.mlstatic.com/D_MAIN-O.jpg'],
+  }];
+  const env = {
+    CATALOG_R2: bucket,
+    ML_CATALOG_GALLERY_ENRICH_LIMIT: '1',
+    ML_CATALOG_GALLERY_REFRESH_DAYS: '90',
+    ML_CATALOG_GALLERY_SLEEP_MS: '0',
+    ML_CATALOG_GALLERY_PRIORITY_IDS: 'MLU63131903',
+  };
+
+  const summary = await enrichCatalogProductPictures(items, env, 'token', {
+    now: new Date('2026-08-16T00:00:00.000Z'),
+    mlGetDeps: {
+      fetchFn: async url => {
+        calls.push(String(url));
+        return Response.json({ pictures: [
+          { secure_url: 'https://http2.mlstatic.com/D_MAIN-O.jpg' },
+          { url: 'http://mlu-s2-p.mlstatic.com/D_COFRE-O.jpg' },
+          { url: 'https://http2.mlstatic.com/D_POSTER-O.jpg' },
+        ] });
+      },
+    },
+  });
+
+  assert.equal(calls[0], 'https://api.mercadolibre.com/products/MLU63131903');
+  assert.deepEqual(items[0].pictures, [
+    'https://http2.mlstatic.com/D_MAIN-O.jpg',
+    'https://mlu-s2-p.mlstatic.com/D_COFRE-O.jpg',
+    'https://http2.mlstatic.com/D_POSTER-O.jpg',
+  ]);
+  assert.equal(summary.fetched, 1);
+  assert.equal(summary.multiple_image_galleries, 1);
+  assert.ok(objects.has(CATALOG_PRODUCT_GALLERY_CACHE_KEY));
+
+  const reused = [{
+    ...items[0],
+    pictures: ['https://http2.mlstatic.com/D_MAIN-O.jpg'],
+  }];
+  const second = await enrichCatalogProductPictures(reused, env, 'token', {
+    now: new Date('2026-08-17T00:00:00.000Z'),
+    mlGetDeps: { fetchFn: async () => { throw new Error('no debe consultar ML'); } },
+  });
+  assert.equal(second.reused, 1);
+  assert.equal(second.fetched, 0);
+  assert.equal(reused[0].pictures.length, 3);
+
+  const uncached = [{
+    ...items[0],
+    catalog_product_id: 'MLU63131904',
+    pictures: ['https://http2.mlstatic.com/D_ONLY-O.jpg'],
+  }];
+  const cacheFailure = await enrichCatalogProductPictures(uncached, {
+    ...env,
+    CATALOG_R2: {
+      async get() { return null; },
+      async put() { throw new Error('R2 temporalmente indisponible'); },
+    },
+    ML_CATALOG_GALLERY_PRIORITY_IDS: 'MLU63131904',
+  }, 'token', {
+    now: new Date('2026-08-17T00:00:00.000Z'),
+    mlGetDeps: {
+      fetchFn: async () => Response.json({ pictures: [
+        { url: 'https://http2.mlstatic.com/D_ONLY-O.jpg' },
+        { url: 'https://http2.mlstatic.com/D_SECOND-O.jpg' },
+      ] }),
+    },
+  });
+  assert.equal(uncached[0].pictures.length, 2);
+  assert.equal(cacheFailure.fetched, 1);
+  assert.equal(cacheFailure.cache_write_error, 'R2 temporalmente indisponible');
 });
 
 test('slimItem conserva identidad de catálogo ML sin inventar señales ausentes', () => {

--- a/worker-sync/__tests__/run-sync-no-partial-publish.test.js
+++ b/worker-sync/__tests__/run-sync-no-partial-publish.test.js
@@ -106,6 +106,7 @@ test('runSync conserva el filtro público statuses active', async () => {
   assert.deepEqual(receivedOptions, {
     statuses: ['active'],
     enrichDescriptions: true,
+    enrichCatalogPictures: true,
   });
 });
 

--- a/worker-sync/cover-mirror.js
+++ b/worker-sync/cover-mirror.js
@@ -9,6 +9,7 @@ const ALLOWED_HOST_SUFFIX = '.mlstatic.com';
 const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
 const FETCH_TIMEOUT_MS = 20_000;
 const DEFAULT_CONCURRENCY = 6;
+const MAX_GALLERY_IMAGES = 16;
 const TARGET_SHORT_EDGE = 1024;
 const TRANSFORM_RETRY_MS = 24 * 60 * 60 * 1000;
 
@@ -49,7 +50,7 @@ export function coverCandidates(item, { includePaused = false } = {}) {
     (pictures.length > 0 ? pictures : [item.thumbnail])
       .map(normalizedSource)
       .filter(Boolean),
-  )].slice(0, 6);
+  )].slice(0, MAX_GALLERY_IMAGES);
   return sources.map((sourceUrl, position) => ({
     product_id: id,
     position,

--- a/worker-sync/cover-mirror.js
+++ b/worker-sync/cover-mirror.js
@@ -5,7 +5,7 @@ export const DEFAULT_COVER_BATCH_SIZE = 250;
 export const COVER_REFRESH_MS = 30 * 24 * 60 * 60 * 1000;
 export const COVER_AI_TRANSFORM_VERSION = 1;
 
-const ALLOWED_HOST = 'http2.mlstatic.com';
+const ALLOWED_HOST_SUFFIX = '.mlstatic.com';
 const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
 const FETCH_TIMEOUT_MS = 20_000;
 const DEFAULT_CONCURRENCY = 6;
@@ -20,7 +20,9 @@ function normalizedSource(raw) {
   if (typeof raw !== 'string' || !raw.trim()) return null;
   try {
     const url = new URL(raw.trim());
-    if (!['http:', 'https:'].includes(url.protocol) || url.hostname !== ALLOWED_HOST) return null;
+    const hostname = url.hostname.toLowerCase();
+    if (!['http:', 'https:'].includes(url.protocol) ||
+        !(hostname === 'mlstatic.com' || hostname.endsWith(ALLOWED_HOST_SUFFIX))) return null;
     url.protocol = 'https:';
     url.hash = '';
     url.username = '';
@@ -33,12 +35,27 @@ function normalizedSource(raw) {
 }
 
 export function primaryCoverCandidate(item) {
-  if (!item || item.status !== 'active' || !(Number(item.available_quantity) > 0)) return null;
+  return coverCandidates(item)[0] || null;
+}
+
+export function coverCandidates(item, { includePaused = false } = {}) {
+  const isActive = item?.status === 'active' && Number(item.available_quantity) > 0;
+  const isPaused = includePaused && item?.status === 'paused';
+  if (!isActive && !isPaused) return [];
   const id = String(item.id || '').trim().toUpperCase();
-  if (!/^MLU\d+$/.test(id)) return null;
+  if (!/^MLU\d+$/.test(id)) return [];
   const pictures = Array.isArray(item.pictures) ? item.pictures : [];
-  const sourceUrl = [...pictures, item.thumbnail].map(normalizedSource).find(Boolean);
-  return sourceUrl ? { product_id: id, position: 0, source_url: sourceUrl } : null;
+  const sources = [...new Set(
+    (pictures.length > 0 ? pictures : [item.thumbnail])
+      .map(normalizedSource)
+      .filter(Boolean),
+  )].slice(0, 6);
+  return sources.map((sourceUrl, position) => ({
+    product_id: id,
+    position,
+    source_url: sourceUrl,
+    catalog_product_id: String(item.catalog_product_id || '').trim().toUpperCase() || null,
+  }));
 }
 
 function validManifest(value) {
@@ -80,28 +97,32 @@ export function selectCoverBatch(catalog, manifest, {
   nowMs = Date.now(),
   aiUpscaleEnabled = false,
   aiUpscaleProductIds = null,
+  includePaused = false,
+  priorityCatalogProductIds = null,
 } = {}) {
   const candidates = (Array.isArray(catalog?.items) ? catalog.items : [])
-    .map(primaryCoverCandidate)
-    .filter(Boolean)
+    .flatMap(item => coverCandidates(item, { includePaused }))
     .map(candidate => {
-      const entry = manifest?.entries?.[`${candidate.product_id}:0`] || null;
-      const aiUpscaleEligible = aiUpscaleEnabled &&
+      const entry = manifest?.entries?.[`${candidate.product_id}:${candidate.position}`] || null;
+      const aiUpscaleEligible = candidate.position === 0 && aiUpscaleEnabled &&
         (!aiUpscaleProductIds || aiUpscaleProductIds.has(candidate.product_id));
       return {
         ...candidate,
         entry,
         aiUpscaleEligible,
+        preferred: Boolean(priorityCatalogProductIds?.has(candidate.catalog_product_id)),
         priority: candidatePriority(candidate, entry, nowMs, aiUpscaleEligible),
       };
     })
     .filter(candidate => candidate.priority !== null)
     .sort((a, b) => {
+      if (a.preferred !== b.preferred) return a.preferred ? -1 : 1;
       if (a.priority !== b.priority) return a.priority - b.priority;
       const validatedA = Date.parse(a.entry?.last_validated_at || '') || 0;
       const validatedB = Date.parse(b.entry?.last_validated_at || '') || 0;
       if (validatedA !== validatedB) return validatedA - validatedB;
-      return a.product_id.localeCompare(b.product_id);
+      const productOrder = a.product_id.localeCompare(b.product_id);
+      return productOrder || a.position - b.position;
     });
   return {
     total_candidates: candidates.length,
@@ -202,7 +223,7 @@ async function storeImmutable(bucket, bytes, image, nowIso, metadata = {}) {
   if (!existing) {
     await bucket.put(objectKey, bytes, {
       httpMetadata: { contentType: image.mime, cacheControl: 'public, max-age=31536000, immutable' },
-      customMetadata: { sha256, importedAt: nowIso, sourceHost: ALLOWED_HOST, ...metadata },
+      customMetadata: { sha256, importedAt: nowIso, sourceHost: 'mlstatic.com', ...metadata },
     });
     const stored = await bucket.head(objectKey);
     if (!stored || Number(stored.size) !== bytes.byteLength) {
@@ -295,7 +316,7 @@ async function processCover(bucket, candidate, nowIso, fetchFn, imagesBinding) {
   let finalStored = originalStored;
   let transformInfo = null;
   let transformError = null;
-  const shouldUpscale = candidate.aiUpscaleEligible && Boolean(imagesBinding?.input) &&
+  const shouldUpscale = candidate.position === 0 && candidate.aiUpscaleEligible && Boolean(imagesBinding?.input) &&
     Math.min(source.image.width, source.image.height) < TARGET_SHORT_EDGE;
   if (shouldUpscale) {
     try {
@@ -323,7 +344,7 @@ async function processCover(bucket, candidate, nowIso, fetchFn, imagesBinding) {
   return {
     entry: {
       product_id: candidate.product_id,
-      position: 0,
+      position: candidate.position,
       current: {
         object_key: finalStored.objectKey,
         sha256: finalStored.sha256,
@@ -368,6 +389,7 @@ export async function syncCoverMirror(env, catalog, {
   now = () => new Date(),
   limit = Number(env?.COVER_MIRROR_BATCH_SIZE || DEFAULT_COVER_BATCH_SIZE),
   concurrency = DEFAULT_CONCURRENCY,
+  includePaused = false,
 } = {}) {
   const bucket = env?.COVER_R2;
   if (!bucket || typeof bucket.get !== 'function' || typeof bucket.put !== 'function' || typeof bucket.head !== 'function') {
@@ -377,22 +399,28 @@ export async function syncCoverMirror(env, catalog, {
   const nowIso = nowDate.toISOString();
   const manifest = await readManifest(bucket, nowIso);
   const aiUpscaleEnabled = Boolean(env?.IMAGES && typeof env.IMAGES.input === 'function');
-  // El plan gratuito admite 5.000 transformaciones únicas mensuales. Se
-  // mejora únicamente el mismo universo deduplicado que recibe Merchant;
-  // las demás fichas igualmente conservan su copia original estable en R2.
+  // La mejora generativa se reserva para la portada primaria del mismo
+  // universo deduplicado que recibe Merchant. Las imágenes secundarias se
+  // copian sin alterarlas para no inventar texto ni accesorios del producto.
   const merchantItems = dedupeByGtinAndCondition(
     (Array.isArray(catalog?.items) ? catalog.items : []).filter(isEligibleForFeed),
   );
   const aiUpscaleProductIds = new Set(merchantItems.map(item => String(item.id || '').toUpperCase()));
+  const priorityCatalogProductIds = new Set(String(env?.ML_CATALOG_GALLERY_PRIORITY_IDS || '')
+    .split(',')
+    .map(value => value.trim().toUpperCase())
+    .filter(value => /^MLU\d+$/.test(value)));
   const batch = selectCoverBatch(catalog, manifest, {
     limit,
     nowMs: nowDate.getTime(),
     aiUpscaleEnabled,
     aiUpscaleProductIds,
+    includePaused,
+    priorityCatalogProductIds,
   });
   const nextManifest = { ...manifest, updated_at: nowIso, entries: { ...manifest.entries } };
   const results = await mapWithConcurrency(batch.selected, Math.max(1, Number(concurrency) || 1), async candidate => {
-    const key = `${candidate.product_id}:0`;
+    const key = `${candidate.product_id}:${candidate.position}`;
     try {
       const result = await processCover(
         bucket,
@@ -405,7 +433,7 @@ export async function syncCoverMirror(env, catalog, {
       return { key, status: result.status, quality_status: result.quality_status };
     } catch (error) {
       nextManifest.entries[key] = {
-        ...(candidate.entry || { product_id: candidate.product_id, position: 0, current: null }),
+        ...(candidate.entry || { product_id: candidate.product_id, position: candidate.position, current: null }),
         last_attempted_source_url: candidate.source_url,
         last_error: { at: nowIso, message: String(error?.message || 'Error').slice(0, 240) },
       };
@@ -427,6 +455,7 @@ export async function syncCoverMirror(env, catalog, {
   ).length;
   const qualityPending = aiUpscaleEnabled
     ? Object.values(nextManifest.entries).filter(entry =>
+        Number(entry?.position) === 0 &&
         aiUpscaleProductIds.has(String(entry?.product_id || '').toUpperCase()) && needsAiUpscale(entry)
       ).length
     : null;

--- a/worker-sync/index.js
+++ b/worker-sync/index.js
@@ -239,7 +239,11 @@ async function publishPausedCatalog(env, {
 
   try {
     const accessToken = await getAccessTokenFn(env);
-    const catalog = await buildCatalogFn(env, accessToken);
+    const catalog = await buildCatalogFn(env, accessToken, {
+      // Preview conserva su aislamiento: la caché compartida de galerías y
+      // el mirror R2 se actualizan únicamente desde la publicación real.
+      enrichCatalogPictures: scope === 'production',
+    });
     const summary = summarizeCatalog(catalog);
 
     if (summary.invalid > 0 || summary.duplicate_ids > 0 || summary.paused === 0) {
@@ -297,6 +301,22 @@ async function publishPausedCatalog(env, {
       },
     });
 
+    let coverMirror = null;
+    if (scope === 'production') {
+      try {
+        coverMirror = await syncCoverMirror(env, catalog, {
+          limit: Math.max(20, Number(env.COVER_MIRROR_BATCH_SIZE) || 100),
+          includePaused: true,
+        });
+      } catch (error) {
+        console.warn(`[${errorLabel} catalog] Mirror de galerías pendiente: ${error.message}`);
+        coverMirror = {
+          status: 'error',
+          error: String(error?.message || 'Error').slice(0, 240),
+        };
+      }
+    }
+
     const samplePaused = catalog.items.find(item => item.status === 'paused') || null;
     return {
       status: statusOk,
@@ -321,6 +341,7 @@ async function publishPausedCatalog(env, {
         index_gzip_bytes: artifacts.active_index.gzip_bytes,
       },
       data_quality: catalog.data_quality || null,
+      cover_mirror: coverMirror,
       sample_paused: samplePaused
         ? { id: samplePaused.id, title: samplePaused.title }
         : null,
@@ -449,6 +470,7 @@ export async function runSync(env, options = {}, {
     const catalog = await buildCatalogFn(env, accessToken, {
       statuses: ['active'],
       enrichDescriptions: true,
+      enrichCatalogPictures: true,
     });
 
     // 3. Publicar en R2 (staging → validación → promote)

--- a/worker-sync/meli-catalog.js
+++ b/worker-sync/meli-catalog.js
@@ -35,6 +35,10 @@ const DETAIL_BATCH     = 20;   // ML multi-get soporta hasta 20 ids por request
 const DEFAULT_DESCRIPTION_ENRICH_LIMIT = 100;
 const DEFAULT_DESCRIPTION_REFRESH_DAYS = 90;
 const DEFAULT_DESCRIPTION_SLEEP_MS = 100;
+const DEFAULT_GALLERY_ENRICH_LIMIT = 300;
+const DEFAULT_GALLERY_REFRESH_DAYS = 90;
+const DEFAULT_GALLERY_SLEEP_MS = 75;
+const CATALOG_GALLERY_CACHE_KEY = 'catalog-product-galleries/v1/cache.json';
 const DESCRIPTION_MAX_CHARS = 5000;
 const ML_ATTRIBUTES    =       // campos que necesita slim_item + AUTHOR + enriched fields
   'id,title,price,currency_id,status,available_quantity,thumbnail,pictures,permalink,start_time,attributes,condition,category_id,domain_id,catalog_listing,catalog_product_id';
@@ -77,6 +81,7 @@ export function createSyncRetryBudget(maxWaitMs = ML_SYNC_MAX_RETRY_WAIT_MS) {
 export async function buildCatalog(env, accessToken, {
   statuses = ['active', 'paused'],
   enrichDescriptions = false,
+  enrichCatalogPictures = false,
   retryBudget = createSyncRetryBudget(),
   mlGetDeps = {},
 } = {}) {
@@ -114,6 +119,14 @@ export async function buildCatalog(env, accessToken, {
 
   if (enrichDescriptions) {
     dataQuality.descriptions = await enrichCatalogDescriptions(
+      catalogItems,
+      env,
+      accessToken,
+      { retryBudget, mlGetDeps },
+    );
+  }
+  if (enrichCatalogPictures) {
+    dataQuality.catalog_product_galleries = await enrichCatalogProductPictures(
       catalogItems,
       env,
       accessToken,
@@ -631,10 +644,9 @@ export function extractDimensions(attrs, dataQuality = createDataQualitySummary(
  * Convierte el array pictures de ML a un array de URLs https, máximo 6.
  * Acepta objetos {secure_url, url} o strings directos.
  */
-function normalizePictures(pictures, max = 6) {
+export function normalizePictures(pictures, max = 6) {
   if (!Array.isArray(pictures) || pictures.length === 0) return [];
-  return pictures
-    .slice(0, max)
+  const normalized = pictures
     .map(p => {
       let url = '';
       if (typeof p === 'string') {
@@ -645,7 +657,168 @@ function normalizePictures(pictures, max = 6) {
       return url.replace('http://', 'https://') || null;
     })
     .filter(Boolean);
+  return [...new Set(normalized)].slice(0, Math.max(0, Number(max) || 0));
 }
+
+function freshGalleryEntry(entry, refreshDays, nowMs) {
+  return Array.isArray(entry?.pictures) &&
+    validCheckedAt(entry.checked_at, refreshDays, nowMs);
+}
+
+function galleryPriorityIds(env) {
+  return new Set(String(env?.ML_CATALOG_GALLERY_PRIORITY_IDS || '')
+    .split(',')
+    .map(value => value.trim().toUpperCase())
+    .filter(value => /^MLU\d+$/.test(value)));
+}
+
+async function readCatalogGalleryCache(bucket) {
+  if (!bucket || typeof bucket.get !== 'function') {
+    return { schema_version: 1, updated_at: null, entries: {} };
+  }
+  try {
+    const object = await bucket.get(CATALOG_GALLERY_CACHE_KEY);
+    if (!object) return { schema_version: 1, updated_at: null, entries: {} };
+    const parsed = JSON.parse(await object.text());
+    if (parsed?.schema_version !== 1 || !parsed.entries ||
+        typeof parsed.entries !== 'object' || Array.isArray(parsed.entries)) {
+      throw new Error('esquema inválido');
+    }
+    return parsed;
+  } catch (error) {
+    console.warn(`[Catalog] No se pudo reutilizar la caché de galerías: ${error.message}`);
+    return { schema_version: 1, updated_at: null, entries: {} };
+  }
+}
+
+function mergeOfficialGallery(item, pictures) {
+  const merged = normalizePictures([
+    ...(Array.isArray(item?.pictures) ? item.pictures : []),
+    ...normalizePictures(pictures),
+  ]);
+  if (merged.length > 0) item.pictures = merged;
+}
+
+/**
+ * Las publicaciones de catálogo pueden exponer una sola foto en /items aunque
+ * la página de producto de ML tenga una galería completa. Reutiliza una caché
+ * R2 y consulta incrementalmente /products/:catalog_product_id para completar
+ * hasta seis imágenes oficiales sin sumar miles de requests a cada sync.
+ */
+export async function enrichCatalogProductPictures(items, env, accessToken, {
+  retryBudget = createSyncRetryBudget(),
+  mlGetDeps = {},
+  now = new Date(),
+} = {}) {
+  const limit = Math.max(0, parseInt(
+    env?.ML_CATALOG_GALLERY_ENRICH_LIMIT || String(DEFAULT_GALLERY_ENRICH_LIMIT),
+    10,
+  ) || 0);
+  const refreshDays = Math.max(1, parseInt(
+    env?.ML_CATALOG_GALLERY_REFRESH_DAYS || String(DEFAULT_GALLERY_REFRESH_DAYS),
+    10,
+  ) || DEFAULT_GALLERY_REFRESH_DAYS);
+  const sleepMs = Math.max(0, parseInt(
+    env?.ML_CATALOG_GALLERY_SLEEP_MS || String(DEFAULT_GALLERY_SLEEP_MS),
+    10,
+  ) || 0);
+  const checkedAt = now.toISOString();
+  const cache = await readCatalogGalleryCache(env?.CATALOG_R2);
+  const groups = new Map();
+
+  for (const item of items) {
+    const productId = String(item?.catalog_product_id || '').trim().toUpperCase();
+    if (!/^MLU\d+$/.test(productId)) continue;
+    if (!groups.has(productId)) groups.set(productId, []);
+    groups.get(productId).push(item);
+  }
+
+  const priorityIds = galleryPriorityIds(env);
+  const candidates = [];
+  let reused = 0;
+  for (const [productId, productItems] of groups) {
+    const cached = cache.entries[productId];
+    if (freshGalleryEntry(cached, refreshDays, now.getTime())) {
+      for (const item of productItems) mergeOfficialGallery(item, cached.pictures);
+      reused++;
+      continue;
+    }
+    const newestStart = Math.max(...productItems.map(item => Date.parse(item.start_time || '') || 0));
+    const fewestPictures = Math.min(...productItems.map(item => normalizePictures(item.pictures).length));
+    candidates.push({ productId, productItems, newestStart, fewestPictures });
+  }
+
+  candidates.sort((a, b) => {
+    const priorityA = priorityIds.has(a.productId) ? 1 : 0;
+    const priorityB = priorityIds.has(b.productId) ? 1 : 0;
+    if (priorityA !== priorityB) return priorityB - priorityA;
+    if (a.fewestPictures !== b.fewestPictures) return a.fewestPictures - b.fewestPictures;
+    if (a.newestStart !== b.newestStart) return b.newestStart - a.newestStart;
+    return a.productId.localeCompare(b.productId);
+  });
+
+  let fetched = 0;
+  let failed = 0;
+  let galleriesWithMultipleImages = 0;
+  const selected = candidates.slice(0, limit);
+  for (let index = 0; index < selected.length; index++) {
+    const candidate = selected[index];
+    try {
+      const payload = await mlGet(
+        `https://api.mercadolibre.com/products/${encodeURIComponent(candidate.productId)}`,
+        accessToken,
+        { ...mlGetDeps, retryBudget },
+      );
+      const pictures = normalizePictures(payload?.pictures);
+      cache.entries[candidate.productId] = { pictures, checked_at: checkedAt };
+      for (const item of candidate.productItems) mergeOfficialGallery(item, pictures);
+      if (pictures.length > 1) galleriesWithMultipleImages++;
+      fetched++;
+    } catch (error) {
+      failed++;
+      const stale = cache.entries[candidate.productId];
+      if (Array.isArray(stale?.pictures)) {
+        for (const item of candidate.productItems) mergeOfficialGallery(item, stale.pictures);
+      }
+      console.warn(`[Catalog] Galería ${candidate.productId} pendiente: ${error.message}`);
+    }
+    if (index + 1 < selected.length && sleepMs > 0) {
+      await (mlGetDeps.sleepFn || sleep)(sleepMs);
+    }
+  }
+
+  let cacheWriteError = null;
+  if (fetched > 0 && env?.CATALOG_R2 && typeof env.CATALOG_R2.put === 'function') {
+    try {
+      cache.updated_at = checkedAt;
+      await env.CATALOG_R2.put(CATALOG_GALLERY_CACHE_KEY, JSON.stringify(cache), {
+        httpMetadata: {
+          contentType: 'application/json',
+          cacheControl: 'no-store',
+        },
+      });
+    } catch (error) {
+      // La caché acelera la siguiente corrida, pero nunca debe impedir que el
+      // catálogo enriquecido que ya está en memoria llegue a producción.
+      cacheWriteError = String(error?.message || 'Error').slice(0, 240);
+      console.warn(`[Catalog] No se pudo guardar la caché de galerías: ${cacheWriteError}`);
+    }
+  }
+
+  return {
+    limit,
+    products: groups.size,
+    reused,
+    fetched,
+    failed,
+    multiple_image_galleries: galleriesWithMultipleImages,
+    pending: Math.max(0, candidates.length - fetched),
+    refresh_days: refreshDays,
+    cache_write_error: cacheWriteError,
+  };
+}
+
+export const CATALOG_PRODUCT_GALLERY_CACHE_KEY = CATALOG_GALLERY_CACHE_KEY;
 
 // ─── HTTP helper ──────────────────────────────────────────────────────────────
 

--- a/worker-sync/meli-catalog.js
+++ b/worker-sync/meli-catalog.js
@@ -39,6 +39,7 @@ const DEFAULT_GALLERY_ENRICH_LIMIT = 300;
 const DEFAULT_GALLERY_REFRESH_DAYS = 90;
 const DEFAULT_GALLERY_SLEEP_MS = 75;
 const CATALOG_GALLERY_CACHE_KEY = 'catalog-product-galleries/v1/cache.json';
+const MAX_GALLERY_IMAGES = 16;
 const DESCRIPTION_MAX_CHARS = 5000;
 const ML_ATTRIBUTES    =       // campos que necesita slim_item + AUTHOR + enriched fields
   'id,title,price,currency_id,status,available_quantity,thumbnail,pictures,permalink,start_time,attributes,condition,category_id,domain_id,catalog_listing,catalog_product_id';
@@ -641,10 +642,12 @@ export function extractDimensions(attrs, dataQuality = createDataQualitySummary(
 }
 
 /**
- * Convierte el array pictures de ML a un array de URLs https, máximo 6.
+ * Convierte el array pictures de ML a URLs https. El tope 16 coincide con la
+ * guarda del proxy y evita truncar galerías especiales a las seis fotos que
+ * admitía históricamente la ficha.
  * Acepta objetos {secure_url, url} o strings directos.
  */
-export function normalizePictures(pictures, max = 6) {
+export function normalizePictures(pictures, max = MAX_GALLERY_IMAGES) {
   if (!Array.isArray(pictures) || pictures.length === 0) return [];
   const normalized = pictures
     .map(p => {
@@ -703,7 +706,7 @@ function mergeOfficialGallery(item, pictures) {
  * Las publicaciones de catálogo pueden exponer una sola foto en /items aunque
  * la página de producto de ML tenga una galería completa. Reutiliza una caché
  * R2 y consulta incrementalmente /products/:catalog_product_id para completar
- * hasta seis imágenes oficiales sin sumar miles de requests a cada sync.
+ * hasta dieciséis imágenes oficiales sin sumar miles de requests a cada sync.
  */
 export async function enrichCatalogProductPictures(items, env, accessToken, {
   retryBudget = createSyncRetryBudget(),

--- a/worker-sync/wrangler.toml
+++ b/worker-sync/wrangler.toml
@@ -22,10 +22,17 @@ MIN_ACTIVE_ITEMS = "500"
 ML_DESCRIPTION_ENRICH_LIMIT = "100"
 ML_DESCRIPTION_REFRESH_DAYS = "90"
 ML_DESCRIPTION_SLEEP_MS = "100"
-# Copia incremental de portadas primarias. El cron de 5 minutos completa el
+# Galerías oficiales de productos de catálogo: se cachean en R2 y se
+# completan incrementalmente para no repetir miles de consultas en cada sync.
+# La edición especial de My Hero Academia se prioriza en la primera corrida.
+ML_CATALOG_GALLERY_ENRICH_LIMIT = "300"
+ML_CATALOG_GALLERY_REFRESH_DAYS = "90"
+ML_CATALOG_GALLERY_SLEEP_MS = "75"
+ML_CATALOG_GALLERY_PRIORITY_IDS = "MLU63131903"
+# Copia incremental de portadas y galerías. El cron de 5 minutos completa el
 # primer backfill y luego baja automáticamente a mantenimiento horario para
 # cambios y revalidaciones de copias de más de 30 días.
-COVER_MIRROR_BATCH_SIZE = "20"
+COVER_MIRROR_BATCH_SIZE = "100"
 CANONICAL_ORIGIN = "https://www.amadolibros.com"
 INDEXNOW_ENABLED = "true"
 # Clave pública verificada por el archivo homónimo en astro-front/public.


### PR DESCRIPTION
## Resultado

Completa las galerías de productos de catálogo de Mercado Libre y las sirve íntegramente desde Amado Libros + Cloudflare.

En particular, prioriza `MLU63131903` (My Hero Academia 42 Edición Especial Cofre), cuya publicación individual exponía una sola imagen aunque la ficha de catálogo de Mercado Libre contiene más.

## Qué cambia

- Consulta incrementalmente `/products/:catalog_product_id` y conserva toda la galería oficial, con una guarda amplia de hasta 16 imágenes.
- Elimina el antiguo corte silencioso en 6 fotos.
- Cachea las galerías por 90 días en R2 para no repetir miles de solicitudes.
- Prioriza `MLU63131903` en la primera corrida.
- Publica URLs propias estables desde `cover.jpg` hasta `cover-16.jpg`.
- Copia cada posición de la galería a R2 de forma independiente.
- Incluye publicaciones activas y libros por encargo.
- Mantiene Mercado Libre sólo como fallback mientras completa el mirror.
- Reserva la mejora generativa para la portada primaria; las fotos secundarias se copian sin IA para no alterar accesorios, pósteres, ropa ni texto.
- Mantiene Preview aislado de la caché y del mirror productivos.
- Una caída de la caché de galería no bloquea la publicación del catálogo ya enriquecido.

## Validación

- Sincronizador: 100 pruebas verdes.
- Cloudflare Pages / Functions: 486 pruebas verdes.
- Astro: 29 pruebas verdes.
- API: 255 pruebas verdes.
- Build productivo con checkout OFF: OK.
- Build productivo con checkout ON y Turnstile: OK.
- `git diff --check` y sintaxis JS: OK.

## Fuente oficial

- Producto verificado: https://www.mercadolibre.com.uy/my-hero-academia-42-edicion-especial-cofre-de-kohei-horikoshi-editorial-planeta-comic-2025/p/MLU63131903
- API de productos de catálogo: https://developers.mercadolivre.com.br/buscador-de-produtos
