### PR TITLE
Destacar coordinación de entregas en Montevideo

### DIFF
--- a/astro-front/src/components/DeliveryCoordination.astro
+++ b/astro-front/src/components/DeliveryCoordination.astro
@@ -1,0 +1,111 @@
+<section class="delivery-coordination" aria-labelledby="delivery-coordination-title">
+  <div class="delivery-coordination-inner">
+    <div class="delivery-coordination-icon" aria-hidden="true">
+      <svg viewBox="0 0 32 32" fill="none">
+        <path d="M3 19h17V9H3v10Zm17-7h5l4 5v2h-9v-7Z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
+        <circle cx="8" cy="22" r="2.5" stroke="currentColor" stroke-width="1.8"/>
+        <circle cx="24" cy="22" r="2.5" stroke="currentColor" stroke-width="1.8"/>
+      </svg>
+    </div>
+
+    <div class="delivery-coordination-copy">
+      <p class="delivery-coordination-eyebrow">Entregas en Montevideo</p>
+      <h2 id="delivery-coordination-title">El cadete no llega de sorpresa.</h2>
+      <p>
+        Antes de enviar tu pedido, coordinamos contigo la hora o franja en la que podés recibirlo.
+        Si el cadete llega y no estás, no te preocupes: te contactamos para resolver cómo completar la entrega.
+      </p>
+    </div>
+
+    <a href="/envios">Ver cómo funcionan los envíos <span aria-hidden="true">→</span></a>
+  </div>
+</section>
+
+<style>
+  .delivery-coordination {
+    padding: 1rem 1.25rem;
+    background: var(--ink);
+    color: #fff;
+  }
+
+  .delivery-coordination-inner {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.9rem 1rem;
+    align-items: center;
+  }
+
+  .delivery-coordination-icon {
+    width: 48px;
+    height: 48px;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.12);
+    color: var(--salmon);
+  }
+
+  .delivery-coordination-icon svg {
+    width: 30px;
+    height: 30px;
+  }
+
+  .delivery-coordination-copy {
+    min-width: 0;
+  }
+
+  .delivery-coordination-eyebrow {
+    margin: 0 0 0.15rem;
+    color: var(--salmon);
+    font-family: var(--font-ui);
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .delivery-coordination h2 {
+    margin: 0;
+    color: #fff;
+    font-family: var(--font-display);
+    font-size: clamp(1.2rem, 3vw, 1.55rem);
+    line-height: 1.15;
+  }
+
+  .delivery-coordination-copy > p:last-child {
+    margin: 0.4rem 0 0;
+    max-width: 780px;
+    color: rgba(255, 255, 255, 0.86);
+    font-size: 0.9rem;
+    line-height: 1.55;
+  }
+
+  .delivery-coordination a {
+    grid-column: 2;
+    justify-self: start;
+    color: #fff;
+    font-family: var(--font-ui);
+    font-size: 0.875rem;
+    font-weight: 800;
+    text-underline-offset: 0.2em;
+  }
+
+  @media (min-width: 820px) {
+    .delivery-coordination {
+      padding: 1.25rem 2rem;
+    }
+
+    .delivery-coordination-inner {
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      gap: 1.25rem;
+    }
+
+    .delivery-coordination a {
+      grid-column: auto;
+      justify-self: end;
+    }
+  }
+</style>

--- a/astro-front/src/components/ShippingPayments.astro
+++ b/astro-front/src/components/ShippingPayments.astro
@@ -15,10 +15,11 @@
         <h3 class="sp-col-title">Envíos</h3>
         <ul class="sp-list">
           <li>Entrega en 2 horas en Montevideo.*</li>
+          <li>Coordinamos la hora o franja antes de que salga el cadete.</li>
           <li>Envíos a todo Uruguay.</li>
           <li>Envío gratis desde $1.500.</li>
         </ul>
-        <p class="sp-disclaimer">*El plazo depende de la zona y del horario del pedido. Coordinamos la entrega con vos.</p>
+        <p class="sp-disclaimer">*El plazo depende de la zona y del horario del pedido. Si el cadete llega y no estás, te contactamos para resolver cómo completar la entrega.</p>
       </div>
 
       <div class="sp-col">

--- a/astro-front/src/pages/envios.astro
+++ b/astro-front/src/pages/envios.astro
@@ -58,6 +58,9 @@ const shippingPolicy = {
   </ul>
 
   <h2>Montevideo</h2>
+  <aside class="delivery-reassurance">
+    <strong>El cadete no llega de sorpresa.</strong> Antes de enviar tu pedido, coordinamos contigo la hora o franja en la que podés recibirlo. Si al llegar no estás, no te preocupes: te contactamos para resolver cómo completar la entrega.
+  </aside>
   <p>Los productos disponibles pueden entregarse en el día mediante cadetería. La entrega en aproximadamente 2 horas está sujeta a disponibilidad, zona, horario y confirmación por WhatsApp. La fecha y la franja elegidas en el checkout quedan sujetas a confirmación.</p>
 
   <h2>Interior del país</h2>
@@ -69,3 +72,21 @@ const shippingPolicy = {
   <h2>Demoras o incidencias</h2>
   <p>Los plazos son estimados. Si un envío presenta una demora o daño visible, contactanos por <a href="https://wa.me/59899841325">WhatsApp al 099 841 325</a> o por <a href="mailto:adm@amadolibros.com">adm@amadolibros.com</a> indicando el número de pedido.</p>
 </TrustPageLayout>
+
+<style>
+  .delivery-reassurance {
+    margin: 1rem 0;
+    padding: 1rem 1.1rem;
+    border: 1px solid rgba(228, 153, 130, 0.65);
+    border-left: 5px solid var(--salmon);
+    border-radius: var(--r);
+    background: rgba(228, 153, 130, 0.1);
+    color: var(--ink);
+    line-height: 1.6;
+  }
+
+  .delivery-reassurance strong {
+    display: block;
+    margin-bottom: 0.2rem;
+  }
+</style>

--- a/astro-front/src/pages/index.astro
+++ b/astro-front/src/pages/index.astro
@@ -4,6 +4,7 @@
 import BaseLayout          from '../layouts/BaseLayout.astro';
 import Header              from '../components/Header.astro';
 import Hero                from '../components/Hero.astro';
+import DeliveryCoordination from '../components/DeliveryCoordination.astro';
 import BookDiscovery       from '../components/BookDiscovery.astro';
 import GuideAccess         from '../components/GuideAccess.astro';
 import CategoryAccess      from '../components/CategoryAccess.astro';
@@ -70,6 +71,7 @@ const jsonLd = {
   <Header showSearch={false} showMobileDeliveryBanner={true} />
   <main>
     <Hero />
+    <DeliveryCoordination />
     <CategoryAccess />
     <BestsellerSection />
     <BookDiscovery />

--- a/functions/__tests__/delivery-coordination.test.js
+++ b/functions/__tests__/delivery-coordination.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const read = path => readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8');
+
+test('la home destaca la coordinación de la entrega inmediatamente después del hero', () => {
+  const page = read('astro-front/src/pages/index.astro');
+  const component = read('astro-front/src/components/DeliveryCoordination.astro');
+
+  assert.match(page, /import DeliveryCoordination/);
+  assert.ok(page.indexOf('<DeliveryCoordination />') > page.indexOf('<Hero />'));
+  assert.match(component, /El cadete no llega de sorpresa/);
+  assert.match(component, /coordinamos contigo la hora o franja/);
+  assert.match(component, /Si el cadete llega y no estás, no te preocupes/);
+  assert.match(component, /href="\/envios"/);
+});
+
+test('envíos y el bloque comercial repiten la tranquilidad sin prometer reentrega gratuita', () => {
+  const policy = read('astro-front/src/pages/envios.astro');
+  const shipping = read('astro-front/src/components/ShippingPayments.astro');
+  const combined = `${policy}\n${shipping}`;
+
+  assert.match(policy, /class="delivery-reassurance"/);
+  assert.match(policy, /Si al llegar no estás, no te preocupes/);
+  assert.match(shipping, /Coordinamos la hora o franja antes de que salga el cadete/);
+  assert.doesNotMatch(combined, /reentrega gratuita|segunda entrega gratis/i);
+});


### PR DESCRIPTION
## Resultado

Hace visible desde la portada que las entregas en Montevideo se coordinan antes de que salga el cadete y explica qué ocurre si el cliente no está al momento de llegar.

## Cambios

- Nuevo destacado de alto contraste inmediatamente después del hero: **“El cadete no llega de sorpresa”**.
- Aclara que coordinamos la hora o franja de recepción antes de enviar.
- Aclara que, si el cliente no está, lo contactamos para resolver cómo completar la entrega.
- Repite la tranquilidad en el bloque comercial de envíos y en `/envios`.
- Evita prometer una reentrega gratuita o una condición comercial no definida.
- Agrega pruebas de presencia, jerarquía y precisión del texto.

## Impacto

La coordinación deja de estar escondida en letra chica o sólo en el checkout. El comprador la ve en la portada antes de elegir un libro y puede ampliar la información en la política de envíos.

## Validación

- `git diff --check`: verde.
- Prueba específica: 2/2.
- Suite completa de Functions: 484/484.
- El build Astro y los checks de despliegue quedan a cargo de CI, que instala las dependencias del proyecto.