### PR TITLE
CLOUDFLARE-COMMERCE-HARDENING

### DIFF
--- a/functions/__tests__/cover-preview-ui-config.test.js
+++ b/functions/__tests__/cover-preview-ui-config.test.js
@@ -44,7 +44,7 @@ test('workflow prueba 20 copias, card, ficha, bytes y 404 productivo sin secret 
   assert.doesNotMatch(workflow, /COVER_PILOT_SECRET|SYNC_SECRET/);
 });
 
-test('COVER_R2 sólo es referenciado por los tres módulos runtime de lectura de portadas', () => {
+test('COVER_R2 sólo es referenciado por los cuatro módulos runtime de lectura de portadas', () => {
   const references = runtimeJsFiles(path.join(ROOT, 'functions'))
     .filter(file => readFileSync(file, 'utf8').includes('COVER_R2'))
     .map(file => path.relative(ROOT, file).replaceAll(path.sep, '/'))
@@ -53,6 +53,7 @@ test('COVER_R2 sólo es referenciado por los tres módulos runtime de lectura de
   assert.deepEqual(references, [
     'functions/_shared/preview-cover.js',
     'functions/book-cover/[[path]].js',
+    'functions/feed.xml.js',
     'functions/preview-cover/[[path]].js',
   ]);
 });
@@ -61,6 +62,7 @@ test('módulos COVER_R2 sólo leen con get; no escriben, borran ni enumeran', ()
   const sources = [
     'functions/_shared/preview-cover.js',
     'functions/book-cover/[[path]].js',
+    'functions/feed.xml.js',
     'functions/preview-cover/[[path]].js',
   ].map(file => readFileSync(path.join(ROOT, file), 'utf8')).join('\n');
 

--- a/functions/__tests__/feed-gtin-and-coverage.test.js
+++ b/functions/__tests__/feed-gtin-and-coverage.test.js
@@ -18,6 +18,7 @@ import {
     normalizePublisherForDescription,
     buildFeedDescription,
     merchantImageLink,
+    filterItemsWithReadyPrimaryCover,
     truncateMerchantText,
     renderFeedItem,
     pickRepresentativeItem,
@@ -31,7 +32,7 @@ function book(overrides = {}) {
         status: 'active', available_quantity: 1, condition: 'new',
         thumbnail: 'http://http2.mlstatic.com/D_1-I.jpg',
         permalink: 'https://articulo.mercadolibre.com.uy/MLU-1',
-        isbn: null, publisher: null,
+        isbn: null, publisher: null, currency: 'UYU', domain_id: 'MLU-BOOKS',
         ...overrides,
     };
 }
@@ -177,6 +178,11 @@ test('10. ISBN inválido (checksum incorrecto) nunca se publica como GTIN', () =
     assert.equal(result.hadValue, true);
 });
 
+test('10b. Un EAN-13 válido que no usa prefijo 978/979 no se confunde con ISBN', () => {
+    assert.equal(isValidIsbn13('4006381333931'), false);
+    assert.equal(normalizeIsbnToGtin('4006381333931').valid, false);
+});
+
 test('11. Producto con GTIN válido no lleva <g:identifier_exists>no</g:identifier_exists>', () => {
     const xml = renderFeedItem(book({ id: 'MLU1', isbn: '9788499809991' }));
     assert.doesNotMatch(xml, /identifier_exists/);
@@ -259,15 +265,25 @@ test('17b. La imagen Merchant siempre queda bajo dominio propio', () => {
     assert.equal(merchantImageLink(book({ id: 'otro' })), '');
 });
 
-test('17c. Excluye moneda explícita distinta de UYU sin apagar el catálogo legado', () => {
+test('17c. Exige moneda UYU explícita y no infiere precios ambiguos', () => {
     assert.equal(isEligibleForFeed(book({ currency: 'UYU' })), true);
-    assert.equal(isEligibleForFeed(book({ currency: null })), true);
+    assert.equal(isEligibleForFeed(book({ currency: null })), false);
     assert.equal(isEligibleForFeed(book({ currency: 'USD' })), false);
+    assert.throws(() => renderFeedItem(book({ currency: null })), /Moneda no publicable/);
 });
 
-test('17d. Un dominio no-libro es autoritativo y un legado necesita evidencia bibliográfica', () => {
+test('17d. Clasifica libros con señales fuertes sin aceptar una señal legado aislada', () => {
     assert.equal(isBookProduct(book({ domain_id: 'MLU-BOOKS' })), true);
-    assert.equal(isBookProduct(book({ domain_id: 'MLU-COMPUTER_COMPONENTS', isbn: '9788499809991' })), false);
+    assert.equal(isBookProduct(book({
+        domain_id: 'MLU-BOOKS_AND_MAGAZINES', isbn: null, author: null, pages: null,
+    })), true);
+    assert.equal(isBookProduct(book({ domain_id: 'MLU-COMPUTER_COMPONENTS', isbn: '9788499809991' })), true);
+    assert.equal(isBookProduct(book({
+        domain_id: 'MLU-COMPUTER_COMPONENTS', isbn: '9788499809991', author: null,
+        pages: null, bibliographic: null,
+    })), false);
+    assert.equal(isBookProduct(book({ domain_id: null, isbn: null, author: 'Una autora', pages: null })), false);
+    assert.equal(isBookProduct(book({ domain_id: null, isbn: null, author: 'Una autora', pages: 240 })), true);
     const ssd = book({
         title: 'Disco Sólido SSD Kingston', domain_id: null,
         author: null, isbn: null, pages: null, bibliographic: null,
@@ -276,7 +292,35 @@ test('17d. Un dominio no-libro es autoritativo y un legado necesita evidencia bi
     assert.equal(isEligibleForFeed(ssd), false);
 });
 
-test('17e. Título Merchant nunca supera 150 caracteres y corta por palabra', () => {
+test('17e. Producción publica sólo portadas primarias válidas y vigentes en R2', () => {
+    const ready = book({ id: 'MLU123456', thumbnail: 'http://http2.mlstatic.com/D_READY-I.jpg' });
+    const stale = book({ id: 'MLU123457', thumbnail: 'https://http2.mlstatic.com/D_NEW-I.jpg' });
+    const missing = book({ id: 'MLU123458', thumbnail: 'https://http2.mlstatic.com/D_MISSING-I.jpg' });
+    const sha = 'a'.repeat(64);
+    const manifest = {
+        schema_version: 1,
+        entries: {
+            'MLU123456:0': {
+                current: {
+                    object_key: `covers/v1/objects/${sha}.jpg`, sha256: sha,
+                    mime: 'image/jpeg', source_url: 'https://http2.mlstatic.com/D_READY-O.jpg',
+                },
+            },
+            'MLU123457:0': {
+                current: {
+                    object_key: `covers/v1/objects/${sha}.jpg`, sha256: sha,
+                    mime: 'image/jpeg', source_url: 'https://http2.mlstatic.com/D_OLD-O.jpg',
+                },
+            },
+        },
+    };
+    assert.deepEqual(
+        filterItemsWithReadyPrimaryCover([ready, stale, missing], manifest).map(item => item.id),
+        ['MLU123456'],
+    );
+});
+
+test('17f. Título Merchant nunca supera 150 caracteres y corta por palabra', () => {
     const title = Array.from({ length: 40 }, () => 'palabra').join(' ');
     const clipped = truncateMerchantText(title, 150);
     assert.ok(clipped.length <= 150);

--- a/functions/__tests__/ficha-pricing-cta-order.test.js
+++ b/functions/__tests__/ficha-pricing-cta-order.test.js
@@ -127,7 +127,8 @@ test('9. Ficha sin stock ("por encargo"): no hay precio web/tarjeta ni botón de
 test('9b. Moneda no-UYU se informa sin conversión inventada y queda fuera del carrito', () => {
     const html = renderPage(book({ price: 285, currency: 'USD' }), 'producto-en-usd', false, '');
     assert.match(html, /Precio publicado: USD 285/);
-    assert.match(html, /"priceCurrency":"USD"/);
+    assert.doesNotMatch(html, /"priceCurrency":"USD"/);
+    assert.doesNotMatch(html, /"offers":/);
     assert.doesNotMatch(html, /data-action="add-to-cart"/);
     assert.doesNotMatch(html, /Precio web\/tarjeta/);
     assert.match(html, /Consultar precio y forma de pago/);

--- a/functions/__tests__/full-commerce-audit.test.js
+++ b/functions/__tests__/full-commerce-audit.test.js
@@ -46,7 +46,9 @@ test('detecta precio cruzado, imagen externa y producto no-libro', () => {
     image: 'https://http2.mlstatic.com/D_X-O.jpg',
     price: '25650 UYU',
   }));
-  const result = auditFeed({ items: [catalogItem({ domain_id: 'MLU-COMPUTER_COMPONENTS' })] }, rows);
+  const result = auditFeed({ items: [catalogItem({
+    domain_id: 'MLU-COMPUTER_COMPONENTS', isbn: null, author: null, pages: null,
+  })] }, rows);
   const codes = result.issues.map(row => row.code);
   assert.ok(codes.includes('FEED_NON_BOOK'));
   assert.ok(codes.includes('FEED_PRICE_MISMATCH'));

--- a/functions/feed.xml.js
+++ b/functions/feed.xml.js
@@ -58,6 +58,8 @@ import { fetchCatalog } from './_shared/catalog.js';
 
 const CANONICAL_BASE_URL = "https://www.amadolibros.com";
 const SITE_TITLE = "Amado Libros";
+const COVER_MANIFEST_KEY = 'covers/v1/manifest.json';
+const COVER_OBJECT_KEY_RE = /^covers\/v1\/objects\/([a-f0-9]{64})\.(jpg|png|webp)$/;
 
 export async function onRequest(context) {
     try {
@@ -74,7 +76,12 @@ export async function onRequest(context) {
         // ficha válida + moneda UYU + evidencia bibliográfica. El catálogo
         // web puede seguir mostrando antigüedades u otros productos; el feed
         // de Amado Libros se mantiene deliberadamente limitado a libros.
-        const eligibleItems = items.filter(isEligibleForFeed);
+        const commerciallyEligibleItems = items.filter(isEligibleForFeed);
+        const coverManifest = await readMerchantCoverManifest(context);
+        const eligibleItems = coverManifest
+            ? filterItemsWithReadyPrimaryCover(commerciallyEligibleItems, coverManifest)
+            : commerciallyEligibleItems;
+        const pendingCovers = commerciallyEligibleItems.length - eligibleItems.length;
 
         // Deduplicación controlada: una sola oferta por GTIN+condition (ver
         // comentario de cabecera). Los ítems sin GTIN válido pasan todos,
@@ -107,7 +114,8 @@ export async function onRequest(context) {
         return new Response(feed, {
             headers: {
                 "content-type": "application/xml;charset=UTF-8",
-                "cache-control": "public, max-age=21600", // Cache 6 horas
+                "cache-control": `public, max-age=${pendingCovers > 0 ? 300 : 21600}`,
+                "x-amado-feed-cover-pending": String(pendingCovers),
             },
         });
 
@@ -137,32 +145,36 @@ export function isEligibleForFeed(item) {
     if (!(Number(item.available_quantity) > 0)) return false;
     if (!(Number(item.price) > 0)) return false;
     const currency = String(item.currency || item.currency_id || '').trim().toUpperCase();
-    // Catálogos anteriores a FULL-COMMERCE-AUDIT no conservan currency_id.
-    // Se tolera temporalmente el vacío para no apagar el feed durante el
-    // despliegue coordinado; una moneda explícita distinta de UYU se excluye.
-    if (currency && currency !== 'UYU') return false;
+    // No se infiere moneda: un precio sin currency_id es ambiguo y Merchant
+    // no debe recibirlo como UYU por defecto.
+    if (currency !== 'UYU') return false;
     if (!isBookProduct(item)) return false;
     return true;
 }
 
 /**
  * Merchant no debe recibir un SSD, un candelabro u otra antigüedad como si
- * fuera un libro. Cuando ML ya informa domain_id, ese dato es autoritativo.
- * Para el catálogo legado sin domain_id se exige evidencia bibliográfica
- * fuerte; el título o publisher no bastan porque pueden ser engañosos.
+ * fuera un libro. El dominio BOOKS es una señal suficiente; un dominio de
+ * otra familia no invalida por sí solo un ISBN de libro acompañado por otra
+ * señal bibliográfica. Sin dominio se exige ISBN o dos señales independientes.
  */
 export function isBookProduct(item) {
     const domain = String(item?.domain_id || '').trim().toUpperCase();
-    if (domain) return domain.endsWith('-BOOKS');
-
-    if (normalizeIsbnToGtin(item?.isbn).valid) return true;
-    if (String(item?.author || '').trim()) return true;
-    if (Number(item?.pages) > 0) return true;
     const bibliographic = item?.bibliographic;
-    return Boolean(
+    const hasBibliographic = Boolean(
         bibliographic && typeof bibliographic === 'object' &&
         Object.values(bibliographic).some(value => String(value || '').trim())
     );
+    const hasIsbn = normalizeIsbnToGtin(item?.isbn).valid;
+    const supportingSignals = [
+        Boolean(String(item?.author || '').trim()),
+        Number(item?.pages) > 0,
+        hasBibliographic,
+    ].filter(Boolean).length;
+
+    if (/(?:^|[-_])BOOKS(?:$|[-_])/.test(domain)) return true;
+    if (domain) return hasIsbn && supportingSignals >= 1;
+    return hasIsbn || supportingSignals >= 2;
 }
 
 // ---------------------------------------------------------------------------
@@ -183,9 +195,9 @@ export function cleanIsbnRaw(raw) {
         .replace(/[\s-]+/g, '');
 }
 
-/** Valida el dígito de control de un ISBN-13 (o EAN-13 de libro). */
+/** Valida un ISBN-13 real: prefijo Bookland 978/979 y dígito de control. */
 export function isValidIsbn13(digits) {
-    if (!/^\d{13}$/.test(digits)) return false;
+    if (!/^(978|979)\d{10}$/.test(digits)) return false;
     let sum = 0;
     for (let i = 0; i < 12; i++) sum += Number(digits[i]) * (i % 2 === 0 ? 1 : 3);
     const check = (10 - (sum % 10)) % 10;
@@ -347,13 +359,72 @@ export function merchantImageLink(item) {
         : '';
 }
 
+function primaryMerchantSource(item) {
+    const pictures = Array.isArray(item?.pictures) ? item.pictures : [];
+    const raw = pictures[0] || item?.thumbnail;
+    if (typeof raw !== 'string' || !raw.trim()) return '';
+    try {
+        const url = new URL(raw.trim());
+        const hostname = url.hostname.toLowerCase();
+        if (!['http:', 'https:'].includes(url.protocol) ||
+            !(hostname === 'mlstatic.com' || hostname.endsWith('.mlstatic.com'))) return '';
+        url.protocol = 'https:';
+        url.hash = '';
+        url.username = '';
+        url.password = '';
+        url.pathname = url.pathname.replace(/-I\.(jpg|jpeg|png|webp)$/i, '-O.$1');
+        return url.toString();
+    } catch {
+        return '';
+    }
+}
+
+function readyPrimaryCover(entry, sourceUrl) {
+    const current = entry?.current;
+    const match = COVER_OBJECT_KEY_RE.exec(String(current?.object_key || ''));
+    if (!match || current.sha256 !== match[1]) return false;
+    const expectedMime = `image/${match[2] === 'jpg' ? 'jpeg' : match[2]}`;
+    return current.mime === expectedMime && current.source_url === sourceUrl;
+}
+
+export function filterItemsWithReadyPrimaryCover(items, manifest) {
+    if (!manifest || manifest.schema_version !== 1 || !manifest.entries ||
+        typeof manifest.entries !== 'object' || Array.isArray(manifest.entries)) {
+        throw new Error('Manifest de portadas no válido para Merchant.');
+    }
+    return items.filter(item => {
+        const id = String(item?.id || '').trim().toUpperCase();
+        const sourceUrl = primaryMerchantSource(item);
+        return Boolean(sourceUrl && readyPrimaryCover(manifest.entries[`${id}:0`], sourceUrl));
+    });
+}
+
+async function readMerchantCoverManifest(context) {
+    if (context?.env?.APP_ENV !== 'production') return null;
+    const bucket = context?.env?.COVER_R2;
+    if (!bucket || typeof bucket.get !== 'function') {
+        throw new Error('COVER_R2 no está disponible en producción; se conserva el feed anterior.');
+    }
+    const object = await bucket.get(COVER_MANIFEST_KEY);
+    if (!object || typeof object.text !== 'function') {
+        throw new Error('Manifest de portadas no disponible; se conserva el feed anterior.');
+    }
+    const manifest = JSON.parse(await object.text());
+    if (!manifest || manifest.schema_version !== 1 || !manifest.entries ||
+        typeof manifest.entries !== 'object' || Array.isArray(manifest.entries)) {
+        throw new Error('Manifest de portadas inválido; se conserva el feed anterior.');
+    }
+    return manifest;
+}
+
 // ---------------------------------------------------------------------------
 // Render de un <item>
 // ---------------------------------------------------------------------------
 
 export function renderFeedItem(item) {
     const stock = Number(item.available_quantity) || 0;
-    const currency = String(item.currency || item.currency_id || 'UYU').toUpperCase();
+    const currency = String(item.currency || item.currency_id || '').trim().toUpperCase();
+    if (currency !== 'UYU') throw new Error(`Moneda no publicable en Merchant para ${item.id || 'item sin id'}.`);
     const cond = item.condition ?? 'used';
     const availability = stock > 0 ? 'in stock' : 'out of stock';
     const price = `${item.price} ${currency}`;

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -474,7 +474,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
         'description': description || (item.author ? `${item.title} — ${item.author}` : item.title),
         'sku':      item.id,
     };
-    if (inStock) {
+    if (sellableInCheckout) {
         schemaProduct.offers = {
             '@type':        'Offer',
             'url':          canonicalUrl,

--- a/worker-sync/__tests__/cover-mirror.test.js
+++ b/worker-sync/__tests__/cover-mirror.test.js
@@ -25,20 +25,40 @@ function pngBytes(width = 600, height = 900, salt = 0) {
 class MockR2 {
   constructor(manifest = null) {
     this.objects = new Map();
-    if (manifest) this.objects.set(COVER_MANIFEST_KEY, new TextEncoder().encode(JSON.stringify(manifest)));
+    this.versions = new Map();
+    this.conflictManifestOnce = null;
+    if (manifest) this.write(COVER_MANIFEST_KEY, new TextEncoder().encode(JSON.stringify(manifest)));
+  }
+  etag(key) {
+    return `etag-${this.versions.get(key) || 0}`;
+  }
+  write(key, bytes) {
+    this.objects.set(key, bytes.slice());
+    this.versions.set(key, (this.versions.get(key) || 0) + 1);
   }
   async get(key) {
     const bytes = this.objects.get(key);
     if (!bytes) return null;
-    return { body: bytes, text: async () => new TextDecoder().decode(bytes) };
+    return { body: bytes, etag: this.etag(key), text: async () => new TextDecoder().decode(bytes) };
   }
   async head(key) {
     const bytes = this.objects.get(key);
     return bytes ? { size: bytes.byteLength } : null;
   }
-  async put(key, body) {
+  async put(key, body, options = {}) {
+    if (key === COVER_MANIFEST_KEY && this.conflictManifestOnce) {
+      const manifest = this.conflictManifestOnce(this.objects.has(key) ? this.manifest() : null);
+      this.conflictManifestOnce = null;
+      this.write(key, new TextEncoder().encode(JSON.stringify(manifest)));
+      return null;
+    }
+    const current = this.objects.has(key) ? this.etag(key) : null;
+    const onlyIf = options.onlyIf || null;
+    if (onlyIf?.etagMatches && onlyIf.etagMatches !== current) return null;
+    if (onlyIf?.etagDoesNotMatch === '*' && current) return null;
     const bytes = typeof body === 'string' ? new TextEncoder().encode(body) : new Uint8Array(body);
-    this.objects.set(key, bytes.slice());
+    this.write(key, bytes);
+    return { etag: this.etag(key) };
   }
   manifest() {
     return JSON.parse(new TextDecoder().decode(this.objects.get(COVER_MANIFEST_KEY)));
@@ -269,5 +289,90 @@ test('una descarga fallida conserva la última copia y registra el error', async
   assert.equal(result.pending, 1);
   const entry = bucket.manifest().entries['MLU123456:0'];
   assert.equal(entry.current.object_key, 'covers/v1/objects/old.jpg');
+  assert.match(entry.last_error.message, /HTTP 403/);
+});
+
+test('reintenta el put condicional y fusiona entradas de dos corridas concurrentes', async () => {
+  const bucket = new MockR2();
+  bucket.conflictManifestOnce = () => ({
+    schema_version: 1,
+    updated_at: '2026-08-16T11:59:59.000Z',
+    entries: {
+      'MLU999999:0': {
+        product_id: 'MLU999999', position: 0,
+        current: {
+          object_key: `covers/v1/objects/${'b'.repeat(64)}.jpg`,
+          sha256: 'b'.repeat(64), mime: 'image/jpeg',
+          source_url: 'https://http2.mlstatic.com/D_CONCURRENT-O.jpg',
+        },
+        last_validated_at: '2026-08-16T11:59:59.000Z',
+      },
+    },
+  });
+
+  const result = await syncCoverMirror(
+    { COVER_R2: bucket },
+    { items: [item()] },
+    {
+      now: () => new Date('2026-08-16T12:00:00.000Z'),
+      fetchFn: async () => new Response(pngBytes(), { headers: { 'content-type': 'image/png' } }),
+    },
+  );
+
+  assert.equal(result.manifest_retries, 1);
+  assert.ok(bucket.manifest().entries['MLU123456:0'].current.object_key);
+  assert.equal(
+    bucket.manifest().entries['MLU999999:0'].current.object_key,
+    `covers/v1/objects/${'b'.repeat(64)}.jpg`,
+  );
+});
+
+test('un intento fallido concurrente no pisa una copia válida más nueva', async () => {
+  const previous = {
+    schema_version: 1,
+    updated_at: '2026-08-01T00:00:00.000Z',
+    entries: {
+      'MLU123456:0': {
+        product_id: 'MLU123456', position: 0,
+        current: {
+          object_key: `covers/v1/objects/${'a'.repeat(64)}.jpg`,
+          sha256: 'a'.repeat(64), mime: 'image/jpeg',
+          source_url: 'https://http2.mlstatic.com/D_OLD-O.jpg',
+        },
+        last_validated_at: '2026-08-01T00:00:00.000Z',
+      },
+    },
+  };
+  const bucket = new MockR2(previous);
+  bucket.conflictManifestOnce = manifest => ({
+    ...manifest,
+    updated_at: '2026-08-16T12:00:01.000Z',
+    entries: {
+      ...manifest.entries,
+      'MLU123456:0': {
+        ...manifest.entries['MLU123456:0'],
+        current: {
+          object_key: `covers/v1/objects/${'c'.repeat(64)}.jpg`,
+          sha256: 'c'.repeat(64), mime: 'image/jpeg',
+          source_url: item().pictures[0],
+        },
+        last_validated_at: '2026-08-16T12:00:01.000Z',
+      },
+    },
+  });
+
+  const result = await syncCoverMirror(
+    { COVER_R2: bucket },
+    { items: [item()] },
+    {
+      now: () => new Date('2026-08-16T12:00:00.000Z'),
+      fetchFn: async () => new Response('bloqueado', { status: 403 }),
+      limit: 1,
+    },
+  );
+
+  assert.equal(result.manifest_retries, 1);
+  const entry = bucket.manifest().entries['MLU123456:0'];
+  assert.equal(entry.current.object_key, `covers/v1/objects/${'c'.repeat(64)}.jpg`);
   assert.match(entry.last_error.message, /HTTP 403/);
 });

--- a/worker-sync/__tests__/run-sync-no-partial-publish.test.js
+++ b/worker-sync/__tests__/run-sync-no-partial-publish.test.js
@@ -1,6 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { runSync } from '../index.js';
+import {
+  configuredCoverMirrorBatchSize,
+  runCoverMirror,
+  runSync,
+} from '../index.js';
 import { buildCatalog } from '../meli-catalog.js';
 
 function fakeEnv({ putThrows = false } = {}) {
@@ -223,4 +227,72 @@ test('si falla publishToR2 el resultado final conserva ese error', async () => {
 
   assert.equal(result.status, 'error');
   assert.equal(result.error, 'R2 no publicó');
+});
+
+test('el lote del cron respeta COVER_MIRROR_BATCH_SIZE y sus límites seguros', () => {
+  assert.equal(configuredCoverMirrorBatchSize({ COVER_MIRROR_BATCH_SIZE: '100' }), 100);
+  assert.equal(configuredCoverMirrorBatchSize({ COVER_MIRROR_BATCH_SIZE: '5000' }), 1000);
+  assert.equal(configuredCoverMirrorBatchSize({ COVER_MIRROR_BATCH_SIZE: 'no-numero' }), 250);
+});
+
+test('runSync invalida el backfill viejo y persiste el resultado del catálogo nuevo', async () => {
+  const { env, puts, deletes } = fakeEnv();
+  env.COVER_R2 = {};
+  const catalog = {
+    total: 1,
+    updated_at: '2026-08-16T12:00:00.000Z',
+    items: [itemForSync()],
+  };
+  const result = await runSync(env, { source: 'manual-await' }, {
+    getAccessTokenFn: async () => 'token',
+    buildCatalogFn: async () => catalog,
+    publishToR2Fn: async () => {},
+    readPreviousPublicCatalogFn: async () => ({ items: [] }),
+    submitIndexNowFn: async () => ({ status: 'disabled' }),
+    processStockWaitlistFn: async () => ({ status: 'ok' }),
+    syncCoverMirrorFn: async () => ({ status: 'completed', attempted: 1, failed: 0, pending: 0, valid_copies: 1 }),
+    notifyHealthcheckFn: noHealthcheck,
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.ok(deletes.includes('cover-mirror:backfill_complete'));
+  const marker = puts.find(entry => entry.key === 'cover-mirror:backfill_complete');
+  assert.equal(JSON.parse(marker.value).catalog_version, catalog.updated_at);
+  assert.ok(puts.some(entry => entry.key === 'cover-mirror:last_result'));
+});
+
+test('el cron sólo salta mantenimiento cuando la marca coincide con el catálogo actual', async () => {
+  const store = new Map();
+  const catalog = { updated_at: '2026-08-16T12:00:00.000Z', items: [] };
+  const env = {
+    CATALOG_R2: {
+      async get() { return { async text() { return JSON.stringify(catalog); } }; },
+    },
+    AMADO_KV: {
+      async get(key) { return store.get(key) || null; },
+      async put(key, value) { store.set(key, value); },
+      async delete(key) { store.delete(key); },
+    },
+  };
+  store.set('cover-mirror:backfill_complete', JSON.stringify({
+    completed: true,
+    catalog_version: catalog.updated_at,
+  }));
+  let calls = 0;
+  const syncCoverMirrorFn = async () => {
+    calls++;
+    return { status: 'completed', pending: 0 };
+  };
+
+  const skipped = await runCoverMirror(env, { maintenanceMinute: 25 }, { syncCoverMirrorFn });
+  assert.equal(skipped.status, 'skipped');
+  assert.equal(calls, 0);
+
+  store.set('cover-mirror:backfill_complete', JSON.stringify({
+    completed: true,
+    catalog_version: '2026-08-15T00:00:00.000Z',
+  }));
+  const executed = await runCoverMirror(env, { maintenanceMinute: 25 }, { syncCoverMirrorFn });
+  assert.equal(executed.status, 'completed');
+  assert.equal(calls, 1);
 });

--- a/worker-sync/cover-mirror.js
+++ b/worker-sync/cover-mirror.js
@@ -12,6 +12,7 @@ const DEFAULT_CONCURRENCY = 6;
 const MAX_GALLERY_IMAGES = 16;
 const TARGET_SHORT_EDGE = 1024;
 const TRANSFORM_RETRY_MS = 24 * 60 * 60 * 1000;
+const MANIFEST_WRITE_ATTEMPTS = 4;
 
 function emptyManifest(nowIso) {
   return { schema_version: 1, updated_at: nowIso, entries: {} };
@@ -64,12 +65,71 @@ function validManifest(value) {
     typeof value.entries === 'object' && !Array.isArray(value.entries);
 }
 
-async function readManifest(bucket, nowIso) {
+async function readManifestState(bucket, nowIso) {
   const object = await bucket.get(COVER_MANIFEST_KEY);
-  if (!object) return emptyManifest(nowIso);
+  if (!object) return { manifest: emptyManifest(nowIso), etag: null };
   const parsed = JSON.parse(await object.text());
   if (!validManifest(parsed)) throw new Error('Manifest de portadas R2 inválido.');
-  return parsed;
+  const etag = String(object.etag || object.httpEtag || '').replace(/^"|"$/g, '');
+  if (!etag) throw new Error('Manifest de portadas R2 sin ETag; no se puede actualizar de forma atómica.');
+  return { manifest: parsed, etag };
+}
+
+function timestamp(value) {
+  const parsed = Date.parse(value || '');
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function mergeProcessedEntry(freshEntry, processed) {
+  const localEntry = processed.entry;
+  if (!freshEntry) return localEntry;
+
+  if (processed.status !== 'failed') {
+    // Si otra ejecución ya validó la misma entrada mientras esta corrida
+    // procesaba sus bytes, nunca hacemos retroceder el puntero `current`.
+    return timestamp(localEntry?.last_validated_at) > timestamp(freshEntry?.last_validated_at)
+      ? localEntry
+      : freshEntry;
+  }
+
+  // Un error sólo agrega diagnóstico. La última copia válida leída tras
+  // el conflicto gana siempre, incluso si el intento fallido partió de un
+  // manifest más viejo.
+  const merged = { ...freshEntry };
+  if (timestamp(localEntry?.last_error?.at) > timestamp(freshEntry?.last_error?.at)) {
+    merged.last_attempted_source_url = localEntry.last_attempted_source_url;
+    merged.last_error = localEntry.last_error;
+  }
+  return merged;
+}
+
+async function writeManifestAtomically(bucket, initialState, processedEntries, nowIso) {
+  let state = initialState;
+  for (let attempt = 0; attempt < MANIFEST_WRITE_ATTEMPTS; attempt++) {
+    const nextManifest = {
+      ...state.manifest,
+      updated_at: timestamp(nowIso) > timestamp(state.manifest.updated_at)
+        ? nowIso
+        : state.manifest.updated_at,
+      entries: { ...state.manifest.entries },
+    };
+    for (const [key, processed] of processedEntries) {
+      nextManifest.entries[key] = mergeProcessedEntry(nextManifest.entries[key], processed);
+    }
+
+    const onlyIf = state.etag
+      ? { etagMatches: state.etag }
+      : { etagDoesNotMatch: '*' };
+    const result = await bucket.put(COVER_MANIFEST_KEY, JSON.stringify(nextManifest), {
+      onlyIf,
+      httpMetadata: { contentType: 'application/json', cacheControl: 'no-store' },
+    });
+    // R2 devuelve null cuando la precondición falla. `undefined` sigue siendo
+    // un éxito válido para mocks/implementaciones compatibles con put().
+    if (result !== null) return { manifest: nextManifest, retries: attempt };
+    state = await readManifestState(bucket, nowIso);
+  }
+  throw new Error(`Conflicto persistente al publicar ${COVER_MANIFEST_KEY}.`);
 }
 
 function needsAiUpscale(entry) {
@@ -398,7 +458,8 @@ export async function syncCoverMirror(env, catalog, {
   }
   const nowDate = now();
   const nowIso = nowDate.toISOString();
-  const manifest = await readManifest(bucket, nowIso);
+  const manifestState = await readManifestState(bucket, nowIso);
+  const manifest = manifestState.manifest;
   const aiUpscaleEnabled = Boolean(env?.IMAGES && typeof env.IMAGES.input === 'function');
   // La mejora generativa se reserva para la portada primaria del mismo
   // universo deduplicado que recibe Merchant. Las imágenes secundarias se
@@ -419,7 +480,7 @@ export async function syncCoverMirror(env, catalog, {
     includePaused,
     priorityCatalogProductIds,
   });
-  const nextManifest = { ...manifest, updated_at: nowIso, entries: { ...manifest.entries } };
+  const processedEntries = new Map();
   const results = await mapWithConcurrency(batch.selected, Math.max(1, Number(concurrency) || 1), async candidate => {
     const key = `${candidate.product_id}:${candidate.position}`;
     try {
@@ -430,32 +491,35 @@ export async function syncCoverMirror(env, catalog, {
         fetchFn,
         candidate.aiUpscaleEligible ? env?.IMAGES : null,
       );
-      nextManifest.entries[key] = result.entry;
+      processedEntries.set(key, { entry: result.entry, status: result.status });
       return { key, status: result.status, quality_status: result.quality_status };
     } catch (error) {
-      nextManifest.entries[key] = {
+      const entry = {
         ...(candidate.entry || { product_id: candidate.product_id, position: candidate.position, current: null }),
         last_attempted_source_url: candidate.source_url,
         last_error: { at: nowIso, message: String(error?.message || 'Error').slice(0, 240) },
       };
+      processedEntries.set(key, { entry, status: 'failed' });
       return { key, status: 'failed', error: String(error?.message || 'Error').slice(0, 160) };
     }
   });
+  let finalManifest = manifest;
+  let manifestRetries = 0;
   if (batch.selected.length > 0) {
-    await bucket.put(COVER_MANIFEST_KEY, JSON.stringify(nextManifest), {
-      httpMetadata: { contentType: 'application/json', cacheControl: 'no-store' },
-    });
+    const written = await writeManifestAtomically(bucket, manifestState, processedEntries, nowIso);
+    finalManifest = written.manifest;
+    manifestRetries = written.retries;
   }
-  const validCopies = Object.values(nextManifest.entries).filter(entry => entry?.current?.object_key).length;
+  const validCopies = Object.values(finalManifest.entries).filter(entry => entry?.current?.object_key).length;
   const imported = results.filter(result => ['imported', 'revalidated'].includes(result.status)).length;
   const failed = results.filter(result => result.status === 'failed').length;
-  const aiUpscaled = Object.values(nextManifest.entries).filter(entry =>
+  const aiUpscaled = Object.values(finalManifest.entries).filter(entry =>
     entry?.current?.transform?.kind === 'cloudflare-ai-upscale' &&
     Number(entry.current.transform.version) === COVER_AI_TRANSFORM_VERSION &&
     Math.min(Number(entry.current.width) || 0, Number(entry.current.height) || 0) >= TARGET_SHORT_EDGE
   ).length;
   const qualityPending = aiUpscaleEnabled
-    ? Object.values(nextManifest.entries).filter(entry =>
+    ? Object.values(finalManifest.entries).filter(entry =>
         Number(entry?.position) === 0 &&
         aiUpscaleProductIds.has(String(entry?.product_id || '').toUpperCase()) && needsAiUpscale(entry)
       ).length
@@ -472,6 +536,7 @@ export async function syncCoverMirror(env, catalog, {
     valid_copies: validCopies,
     ai_upscaled: aiUpscaled,
     quality_pending: qualityPending,
+    manifest_retries: manifestRetries,
     results,
   };
 }

--- a/worker-sync/index.js
+++ b/worker-sync/index.js
@@ -73,10 +73,11 @@ export default {
     if (event?.cron === '*/5 * * * *') {
       // Backfill autónomo: cada 5 minutos hasta cubrir todo. Una vez completo,
       // baja solo a una ejecución por hora para revalidar el ciclo de 30 días.
-      const complete = await kvGet(env, 'cover-mirror:backfill_complete');
       const minute = new Date().getUTCMinutes();
-      if (complete === 'true' && minute !== 0) return;
-      ctx.waitUntil(runCoverMirror(env, { limit: 20 }));
+      ctx.waitUntil(runCoverMirror(env, {
+        limit: configuredCoverMirrorBatchSize(env),
+        maintenanceMinute: minute,
+      }));
       return;
     }
     ctx.waitUntil(runSync(env, { source: 'cron' }));
@@ -492,7 +493,12 @@ export async function runSync(env, options = {}, {
     // catálogo ya publicado, pero queda visible en el resultado del sync.
     let coverMirror;
     try {
+      // Un catálogo nuevo invalida cualquier marca de backfill anterior. La
+      // marca versionada también protege contra una corrida vieja que termine
+      // después y vuelva a escribir su propio estado.
+      if (env?.COVER_R2) await kvDelete(env, 'cover-mirror:backfill_complete');
       coverMirror = await syncCoverMirrorFn(env, catalog);
+      await persistCoverMirrorState(env, coverMirror, catalog);
     } catch (error) {
       console.error(`[Cover mirror] Error: ${error?.message || 'Error'}`);
       coverMirror = { status: 'error', error: String(error?.message || 'Error').slice(0, 200) };
@@ -572,29 +578,67 @@ export async function runSync(env, options = {}, {
   }
 }
 
-export async function runCoverMirror(env, { limit = 250 } = {}, {
+export function configuredCoverMirrorBatchSize(env) {
+  const parsed = Number(env?.COVER_MIRROR_BATCH_SIZE || 250);
+  return Math.min(1000, Math.max(1, Number.isFinite(parsed) ? parsed : 250));
+}
+
+function catalogBackfillVersion(catalog) {
+  return String(catalog?.updated_at || catalog?.last_full_sync || '').trim() || null;
+}
+
+function parseBackfillMarker(value) {
+  if (!value) return null;
+  if (value === 'true') return { completed: true, catalog_version: null };
+  try {
+    const parsed = JSON.parse(value);
+    return parsed?.completed === true ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function persistCoverMirrorState(env, result, catalog) {
+  const catalogVersion = catalogBackfillVersion(catalog);
+  await kvPut(env, 'cover-mirror:last_result', JSON.stringify({
+    at: new Date().toISOString(),
+    status: result.status,
+    catalog_version: catalogVersion,
+    attempted: result.attempted ?? null,
+    failed: result.failed ?? null,
+    pending: result.pending ?? null,
+    valid_copies: result.valid_copies ?? null,
+    ai_upscaled: result.ai_upscaled ?? null,
+    quality_pending: result.quality_pending ?? null,
+    manifest_retries: result.manifest_retries ?? null,
+  }));
+  if (result.status === 'completed' && result.pending === 0) {
+    await kvPut(env, 'cover-mirror:backfill_complete', JSON.stringify({
+      completed: true,
+      catalog_version: catalogVersion,
+      at: new Date().toISOString(),
+    }));
+  } else if (result.status === 'completed') {
+    await kvDelete(env, 'cover-mirror:backfill_complete');
+  }
+}
+
+export async function runCoverMirror(env, { limit = 250, maintenanceMinute = null } = {}, {
   syncCoverMirrorFn = syncCoverMirror,
 } = {}) {
   try {
     const object = await env?.CATALOG_R2?.get?.('catalog.json');
     if (!object) return { status: 'error', error: 'catalog.json no disponible.' };
     const catalog = JSON.parse(await object.text());
-    const result = await syncCoverMirrorFn(env, catalog, { limit });
-    await kvPut(env, 'cover-mirror:last_result', JSON.stringify({
-      at: new Date().toISOString(),
-      status: result.status,
-      attempted: result.attempted ?? null,
-      failed: result.failed ?? null,
-      pending: result.pending ?? null,
-      valid_copies: result.valid_copies ?? null,
-      ai_upscaled: result.ai_upscaled ?? null,
-      quality_pending: result.quality_pending ?? null,
-    }));
-    if (result.status === 'completed' && result.pending === 0) {
-      await kvPut(env, 'cover-mirror:backfill_complete', 'true');
-    } else if (result.status === 'completed') {
-      await kvDelete(env, 'cover-mirror:backfill_complete');
+    if (maintenanceMinute !== null && Number(maintenanceMinute) !== 0) {
+      const marker = parseBackfillMarker(await kvGet(env, 'cover-mirror:backfill_complete'));
+      const currentVersion = catalogBackfillVersion(catalog);
+      if (marker?.catalog_version && marker.catalog_version === currentVersion) {
+        return { status: 'skipped', reason: 'hourly-maintenance', catalog_version: currentVersion };
+      }
     }
+    const result = await syncCoverMirrorFn(env, catalog, { limit });
+    await persistCoverMirrorState(env, result, catalog);
     return result;
   } catch (error) {
     return { status: 'error', error: String(error?.message || 'Error').slice(0, 240) };
@@ -626,6 +670,7 @@ async function readStatus(env) {
     readBucketHead(env?.COVER_R2, 'covers/v1/manifest.json'),
   ]);
 
+  const parsedCoverMirrorComplete = parseBackfillMarker(coverMirrorComplete);
   return {
     status: 'ok',
     checked_at: new Date().toISOString(),
@@ -640,7 +685,8 @@ async function readStatus(env) {
     },
     cover_mirror: {
       last_result: parseJsonOrValue(coverMirrorResult),
-      backfill_complete: coverMirrorComplete === 'true',
+      backfill_complete: parsedCoverMirrorComplete?.completed === true,
+      backfill_catalog_version: parsedCoverMirrorComplete?.catalog_version || null,
     },
     r2: {
       meta,


### PR DESCRIPTION
## Resultado

Resuelve el HIGH y los cinco MEDIUM de la revisión adversarial del PR #148 sin mezclar cambios del PR #151.

## Cambios

- Publica el manifest de portadas R2 con ETag/CAS, reintentos y fusión de entradas concurrentes.
- Conserva siempre la última copia válida si una descarga falla o una corrida vieja pierde la carrera.
- Usa el lote configurado del cron y versiona el estado de backfill por catálogo para evitar marcas obsoletas.
- Exige moneda UYU explícita; ya no infiere UYU cuando falta currency.
- Endurece la identificación de libros: ISBN Bookland 978/979, dominios BOOKS variantes y señales bibliográficas combinadas.
- Emite schema.org Offer únicamente para productos realmente vendibles en el checkout UYU.
- En producción, el feed Merchant sólo publica una ficha cuando su portada primaria vigente ya está validada en R2; si el manifest no está disponible, responde con error en vez de sustituir el feed por datos inseguros.
- Expone el conteo de portadas pendientes en `x-amado-feed-cover-pending` y reduce temporalmente el TTL mientras haya backfill.

## Validación

- Suite completa de Worker: 105 tests.
- Suite completa de Pages Functions: 484 tests.
- Suite completa de API/checkout: 243 tests.
- Pruebas nuevas de carrera CAS, retención de copia válida, backfill versionado, moneda/clasificación, Offer no-UYU y gating de imágenes.
- Build Astro con checkout OFF: OK.
- Build Astro con checkout ON + Turnstile de Producción: OK.
- `git diff --check`: OK.

## Rollout

El PR no activa descuentos automáticos ni modifica fuentes de Merchant Center. Primero estabiliza la fuente, los precios y las imágenes bajo dominio propio.