### PR TITLE
Fix production R2 deployment false positives

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -307,7 +307,7 @@ jobs:
           for attempt in 1 2 3 4 5 6 7 8; do
             BOOK_CODE="$(curl -sSL --max-time 60 -o /tmp/cover-r2-book.html -w '%{http_code}' \
               "https://www.amadolibros.com/libro/$SAMPLE_ID")"
-            if [ "$BOOK_CODE" = "200" ] && grep -Fq "/preview-cover/$SAMPLE_ID/0/" /tmp/cover-r2-book.html; then
+            if [ "$BOOK_CODE" = "200" ] && grep -Fq "/book-cover/$SAMPLE_ID/cover.jpg" /tmp/cover-r2-book.html; then
               break
             fi
             echo "Ficha R2 productiva todavía propagándose (intento $attempt/8; HTTP $BOOK_CODE)."
@@ -317,16 +317,11 @@ jobs:
             echo "La ficha productiva no respondió 200."
             exit 1
           fi
-          IMAGE_PATH="$(grep -Eo "/preview-cover/$SAMPLE_ID/0/[a-f0-9]{64}\.(jpg|png|webp)" \
-            /tmp/cover-r2-book.html | head -1)"
-          if [ -z "$IMAGE_PATH" ]; then
-            echo "La ficha productiva no contiene una URL R2 inmutable."
-            exit 1
-          fi
+          IMAGE_PATH="/book-cover/$SAMPLE_ID/cover.jpg"
           curl -fsS --max-time 60 -D /tmp/cover-r2-image.headers \
-            "https://www.amadolibros.com$IMAGE_PATH" -o /tmp/cover-r2-image.bin
+            "https://www.amadolibros.com$IMAGE_PATH?smoke=${{ github.sha }}" -o /tmp/cover-r2-image.bin
           tr -d '\r' < /tmp/cover-r2-image.headers | grep -Eqi '^content-type: image/(jpeg|png|webp)$'
-          tr -d '\r' < /tmp/cover-r2-image.headers | grep -Fqi 'x-amado-cover-source: r2-production'
+          tr -d '\r' < /tmp/cover-r2-image.headers | grep -Fqi 'x-cover-source: r2-production'
           test -s /tmp/cover-r2-image.bin
           echo "Portadas R2 productivas: manifest, ficha y bytes OK."
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,7 +95,6 @@ jobs:
           SYNC_SECRET: ${{ secrets.SYNC_SECRET }}
         run: |
           CATALOG_URL="https://pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev/catalog.json"
-          BEFORE=$(curl -sSI "$CATALOG_URL" | tr -d '\r' | grep -Ei '^(etag|content-length|last-modified):' | sort)
           sleep 10
           RESPONSE=$(curl -sS --max-time 900 -w "\nHTTP_STATUS:%{http_code}" \
             -X POST "$PREVIEW_URL/publish-production-catalog" \
@@ -147,13 +146,6 @@ jobs:
               }
             });
           '
-          AFTER=$(curl -sSI "$CATALOG_URL" | tr -d '\r' | grep -Ei '^(etag|content-length|last-modified):' | sort)
-          if [ "$BEFORE" != "$AFTER" ]; then
-            echo "ERROR: las cabeceras de catalog.json cambiaron durante la publicación."
-            echo "ANTES=$BEFORE"
-            echo "DESPUÉS=$AFTER"
-            exit 1
-          fi
 
   deploy:
     name: Deploy

--- a/functions/__tests__/cover-production-config.test.js
+++ b/functions/__tests__/cover-production-config.test.js
@@ -72,3 +72,13 @@ test('deploy productivo exige manifest, ficha y bytes R2 antes de quedar verde',
   assert.match(deploy, /x-cover-source: r2-production/i);
   assert.match(deploy, /steps\.cover_r2_smoke\.outcome/);
 });
+
+test('publicación de catálogo pausado tolera una sincronización legítima concurrente', () => {
+  assert.match(deploy, /grep -q '"production_catalog_modified":false'/);
+  assert.doesNotMatch(deploy, /BEFORE=\$\(curl -sSI "\$CATALOG_URL"/);
+  assert.doesNotMatch(deploy, /AFTER=\$\(curl -sSI "\$CATALOG_URL"/);
+  assert.doesNotMatch(
+    deploy,
+    /las cabeceras de catalog\.json cambiaron durante la publicación/,
+  );
+});

--- a/functions/__tests__/cover-production-config.test.js
+++ b/functions/__tests__/cover-production-config.test.js
@@ -67,7 +67,8 @@ test('deploy productivo exige manifest, ficha y bytes R2 antes de quedar verde',
   assert.match(deploy, /s\.with_valid_copy >= 20/);
   assert.match(deploy, /www\.amadolibros\.com\/libro\/\$SAMPLE_ID/);
   assert.match(deploy, /Ficha R2 productiva todavía propagándose/);
-  assert.match(deploy, /grep -Fq "\/preview-cover\/\$SAMPLE_ID\/0\/"/);
-  assert.match(deploy, /x-amado-cover-source: r2-production/i);
+  assert.match(deploy, /grep -Fq "\/book-cover\/\$SAMPLE_ID\/cover\.jpg"/);
+  assert.match(deploy, /\$IMAGE_PATH\?smoke=\$\{\{ github\.sha \}\}/);
+  assert.match(deploy, /x-cover-source: r2-production/i);
   assert.match(deploy, /steps\.cover_r2_smoke\.outcome/);
 });


### PR DESCRIPTION
## Resultado

Corrige dos falsos fallos del despliegue productivo relacionados con R2, sin debilitar las comprobaciones reales.

## Causa 1: portada productiva

El workflow todavía buscaba la ruta interna antigua `/preview-cover/:id/0/:sha.ext` y la cabecera obsoleta `x-amado-cover-source`. Desde los PR #149 y #150, las fichas productivas publican `/book-cover/:id/cover.jpg` y el proxy informa el origen mediante `x-cover-source`.

## Causa 2: carrera de catálogo

El publicador aislado de catálogos activos/pausados puede coincidir con una sincronización legítima del Worker. La ejecución observada confirmó:

- el Worker renovó `catalog.json` durante la ventana;
- el publicador aislado respondió HTTP 200;
- publicó correctamente sus índices;
- confirmó `production_catalog_modified:false`.

Comparar las cabeceras de `catalog.json` antes y nueve minutos después atribuía incorrectamente al publicador cualquier actualización concurrente.

## Cambios

- Verifica que la ficha contenga `/book-cover/:id/cover.jpg`.
- Solicita la portada con el SHA del despliegue para evitar caché anterior.
- Exige `x-cover-source: r2-production`, MIME de imagen y bytes no vacíos.
- Conserva la validación del manifest y el mínimo de copias R2.
- Mantiene la confirmación explícita `production_catalog_modified:false`.
- Elimina la comparación de cabeceras incompatible con escritores legítimos concurrentes.
- Agrega pruebas de regresión para ambos casos.

## Seguridad conservada

El Worker ya tiene pruebas que verifican que el publicador aislado nunca escribe `catalog.json`; este PR no elimina esa garantía ni modifica el Worker.

## Validación

- Diff limitado a `.github/workflows/deploy.yml` y su test de configuración.
- Prueba real de portada: HTTP 200, `image/jpeg`, `x-cover-source: r2-production` y caché evitada.
- CI completo: verde.
- Deploy y auditoría completa de Preview: verde.