### PR TITLE
Completar analítica de comercio y oportunidades CTR

### DIFF
--- a/astro-front/public/analytics-events.js
+++ b/astro-front/public/analytics-events.js
@@ -56,6 +56,89 @@
     return normalized || fallback;
   }
 
+  var ECOMMERCE_EVENTS = new Set([
+    'view_item',
+    'add_to_cart',
+    'view_cart',
+    'begin_checkout',
+    'purchase',
+  ]);
+
+  function positiveNumber(value) {
+    var number = Number(value);
+    return isFinite(number) && number > 0
+      ? Math.round(number * 100) / 100
+      : null;
+  }
+
+  function commerceItem(raw) {
+    if (!raw || typeof raw !== 'object') return null;
+    var itemId = String(raw.item_id || raw.product_id || raw.id || '').trim().slice(0, 100);
+    if (!itemId) return null;
+    var item = {
+      item_id: itemId,
+      item_name: String(raw.item_name || raw.title || 'Libro').trim().slice(0, 200) || 'Libro',
+      item_brand: 'Amado Libros',
+      item_category: 'Libros',
+      quantity: Math.max(1, Math.floor(Number(raw.quantity) || 1)),
+    };
+    var price = positiveNumber(raw.price || raw.unit_price_uyu);
+    if (price !== null) item.price = price;
+    return item;
+  }
+
+  function storageHas(storage, key) {
+    try { return storage.getItem(key) === '1'; } catch (_error) { return false; }
+  }
+
+  function storageSet(storage, key) {
+    try { storage.setItem(key, '1'); } catch (_error) {}
+  }
+
+  function trackCommerce(eventName, options) {
+    options = options || {};
+    if (!ECOMMERCE_EVENTS.has(eventName)) return false;
+
+    var items = (Array.isArray(options.items) ? options.items : [])
+      .map(commerceItem)
+      .filter(Boolean);
+    if (!items.length) return false;
+
+    var params = { currency: 'UYU', items: items };
+    var value = positiveNumber(options.value);
+    if (value === null) {
+      value = items.reduce(function (sum, item) {
+        return sum + (item.price || 0) * item.quantity;
+      }, 0);
+      if (value <= 0) value = null;
+    }
+    if (value !== null) params.value = Math.round(value * 100) / 100;
+
+    var shipping = positiveNumber(options.shipping);
+    if (shipping !== null) params.shipping = shipping;
+
+    var paymentType = safeToken(options.paymentType, '');
+    if (paymentType) params.payment_type = paymentType;
+
+    var dedupeKey = safeToken(options.dedupeKey, '');
+    if (eventName === 'purchase') {
+      var transactionId = String(options.transactionId || '').trim().slice(0, 100);
+      if (!transactionId) return false;
+      params.transaction_id = transactionId;
+      dedupeKey = 'purchase_' + safeToken(transactionId, 'order');
+      if (storageHas(window.localStorage, 'amado_ga4_' + dedupeKey)) return false;
+    } else if (dedupeKey && storageHas(window.sessionStorage, 'amado_ga4_' + dedupeKey)) {
+      return false;
+    }
+
+    window.gtag('event', eventName, params);
+    if (dedupeKey) {
+      var storage = eventName === 'purchase' ? window.localStorage : window.sessionStorage;
+      storageSet(storage, 'amado_ga4_' + dedupeKey);
+    }
+    return true;
+  }
+
   function pageContext() {
     var path = window.location.pathname;
     var productMatch = path.match(/^\/libro\/(MLU\d+)(?:\/|$)/i);
@@ -121,6 +204,7 @@
 
   window.AmadoAnalytics = Object.assign({}, window.AmadoAnalytics, {
     trackWhatsApp: trackWhatsApp,
+    trackCommerce: trackCommerce,
   });
 
   document.addEventListener('click', function (event) {

--- a/astro-front/public/cart.js
+++ b/astro-front/public/cart.js
@@ -276,6 +276,21 @@
     var added = AmadoCart.add(item);
     if (added === false) return; // item inválido, sin feedback
 
+    // GA4 recomendado para Merchant/Ads: se registra únicamente cuando la
+    // cantidad realmente aumentó. `at_max` no es una incorporación nueva.
+    if (added === true && window.AmadoAnalytics &&
+        typeof window.AmadoAnalytics.trackCommerce === 'function') {
+      window.AmadoAnalytics.trackCommerce('add_to_cart', {
+        value: item.price,
+        items: [{
+          item_id: item.id,
+          item_name: item.title,
+          price: item.price,
+          quantity: 1,
+        }],
+      });
+    }
+
     var label = btn.querySelector('[data-cart-label]');
     if (!label) return;
     var orig = label.dataset.origText || label.textContent;

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -1486,6 +1486,36 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       });
     }
 
+    function commerceItems(cart) {
+      return getSellableItems(cart).map(function (item) {
+        return {
+          item_id: item.id,
+          item_name: item.title,
+          price: item.price,
+          quantity: item.quantity,
+        };
+      });
+    }
+
+    function trackCommerce(eventName, order, paymentType, dedupePrefix) {
+      if (!window.AmadoAnalytics ||
+          typeof window.AmadoAnalytics.trackCommerce !== 'function' ||
+          !window.AmadoCart) return;
+      var cart = window.AmadoCart.get();
+      var items = commerceItems(cart);
+      if (!items.length) return;
+      var publicCode = order && order.public_code ? order.public_code : cart.idempotency_key;
+      window.AmadoAnalytics.trackCommerce(eventName, {
+        value: order && order.payable_total_uyu
+          ? order.payable_total_uyu
+          : items.reduce(function (sum, item) { return sum + item.price * item.quantity; }, 0),
+        shipping: order && order.shipping_cost_uyu,
+        paymentType: paymentType,
+        dedupeKey: dedupePrefix + '_' + publicCode,
+        items: items,
+      });
+    }
+
     function syncPaymentAvailability() {
       var cart = window.AmadoCart ? window.AmadoCart.get() : { items: [] };
       var canPay = cartValidationReady && !cartValidationFailed &&
@@ -1553,6 +1583,9 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
 
       renderCart();
       var remaining = getSellableItems(window.AmadoCart.get()).length;
+      if (options && options.initial && remaining > 0) {
+        trackCommerce('view_cart', null, '', 'view_cart');
+      }
       if (data.has_changes) {
         announce(remaining > 0
           ? 'Actualizamos la disponibilidad del carrito. Podés continuar con los libros disponibles.'
@@ -2272,6 +2305,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         try {
           var order = await createTransferOrder();
           if (!order) { resetTransferButton(); return; }
+          trackCommerce('begin_checkout', order, 'bank_transfer', 'begin_checkout_transfer');
           btnTransfer.textContent = 'Cargando cuentas oficiales…';
           transferData = await fetchTransferOptions(order.public_code, transferIdempotencyKey);
           showTransferStep();
@@ -2474,6 +2508,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
             resetPrepareButton();
             return;
           }
+          trackCommerce('begin_checkout', orderData.order, 'mercado_pago', 'begin_checkout_mp');
         } catch (_fetchErr) {
           showCheckoutError('Error de conexión. Verificá tu internet e intentá de nuevo.');
           resetPrepareButton();

--- a/astro-front/src/pages/pedido.astro
+++ b/astro-front/src/pages/pedido.astro
@@ -11,6 +11,7 @@ const WA_HREF =
   title="Estado del pedido — Amado Libros"
   description="Seguimiento de tu pedido en Amado Libros."
   indexable={false}
+  analytics={true}
 >
   <Header />
   <main class="pedido-page">
@@ -80,7 +81,7 @@ const WA_HREF =
 
       var TERMINAL_STATES = { approved: true, rejected: true, cancelled: true, refunded: true };
 
-      function applyFinalState(paymentStatus) {
+      function applyFinalState(paymentStatus, data) {
         if (paymentStatus === 'approved') {
           if (iconEl) iconEl.textContent = '✓';
           if (h1El)   h1El.textContent   = 'Pago confirmado';
@@ -91,6 +92,20 @@ const WA_HREF =
             leadEl.textContent = (data && data.order && data.order.delivery_type === 'pickup')
               ? 'Tu compra quedó confirmada y ya estamos preparando tu pedido. Esperá nuestro mensaje por WhatsApp: te avisaremos apenas esté pronto para retirar.'
               : 'Tu pedido está confirmado. Te contactaremos por WhatsApp para coordinar la entrega.';
+          }
+          // `purchase` se emite únicamente después de que D1 confirma el
+          // pago aprobado. El transaction_id evita duplicados en GA4 y el
+          // helper agrega una segunda guarda local ante recargas.
+          if (data && data.order && Array.isArray(data.items) &&
+              window.AmadoAnalytics &&
+              typeof window.AmadoAnalytics.trackCommerce === 'function') {
+            window.AmadoAnalytics.trackCommerce('purchase', {
+              transactionId: data.order.public_code || code,
+              value: data.order.payable_total_uyu,
+              shipping: data.order.shipping_cost_uyu,
+              paymentType: 'mercado_pago',
+              items: data.items,
+            });
           }
           // Único punto donde se vacía el carrito: recién acá hay
           // confirmación real de pago aprobado, leída de D1 vía
@@ -138,7 +153,7 @@ const WA_HREF =
             var ps = data.payment_status;
             if (ps && TERMINAL_STATES[ps]) {
               stopped = true;
-              applyFinalState(ps);
+              applyFinalState(ps, data);
             } else if (attempts >= MAX_ATTEMPTS) {
               stopped = true;
               onTimeout();

--- a/functions/__tests__/analytics-events.test.js
+++ b/functions/__tests__/analytics-events.test.js
@@ -41,11 +41,20 @@ test('GA4 queda apagado fuera de los dominios productivos', () => {
   assert.match(analytics, /if \(!PRODUCTION_HOSTS\.has\(window\.location\.hostname\)\) return/);
 });
 
-test('mide el carrito noindex sin habilitar Analytics en el estado del pedido', () => {
+test('mide carrito y pedido, ambos noindex, para reconstruir el embudo sin indexarlos', () => {
   assert.match(cart, /indexable=\{false\}[\s\S]*analytics=\{true\}/);
-  assert.match(orderStatus, /indexable=\{false\}/);
-  assert.doesNotMatch(orderStatus, /analytics=\{true\}/);
+  assert.match(orderStatus, /indexable=\{false\}[\s\S]*analytics=\{true\}/);
   assert.match(baseLayout, /analyticsProp !== undefined \? analyticsProp : indexable/);
+});
+
+test('implementa el embudo GA4 recomendado con item_id y compra deduplicada', () => {
+  for (const eventName of ['view_item', 'add_to_cart', 'view_cart', 'begin_checkout', 'purchase']) {
+    assert.match(analytics, new RegExp(`'${eventName}'`));
+  }
+  assert.match(analytics, /item_id:/);
+  assert.match(analytics, /transaction_id/);
+  assert.match(analytics, /currency: 'UYU'/);
+  assert.match(orderStatus, /trackCommerce\('purchase'/);
 });
 
 test('el payload real usa contexto estable y descarta la query sensible', () => {
@@ -83,4 +92,51 @@ test('el payload real usa contexto estable y descarta la query sensible', () => 
   });
   assert.equal(JSON.stringify(params).includes('consulta-privada'), false);
   assert.equal(typeof listeners.click, 'function');
+});
+
+test('trackCommerce normaliza el producto y no duplica purchase al recargar', () => {
+  const values = new Map();
+  const storage = {
+    getItem: key => values.get(key) || null,
+    setItem: (key, value) => values.set(key, value),
+  };
+  const window = {
+    location: {
+      hostname: 'www.amadolibros.com',
+      pathname: '/pedido',
+      href: 'https://www.amadolibros.com/pedido?code=secreto',
+    },
+    dataLayer: [],
+    localStorage: storage,
+    sessionStorage: storage,
+  };
+  const document = {
+    querySelector: () => null,
+    createElement: () => ({}),
+    head: { appendChild: () => {} },
+    addEventListener: () => {},
+  };
+
+  runInNewContext(analytics, {
+    document, window, URL, Set, Date, Object, String, Number, Math, Array, isFinite,
+    encodeURIComponent,
+  });
+  const payload = {
+    transactionId: 'AL-001',
+    value: 1290,
+    shipping: 190,
+    items: [{ product_id: 'MLU123', title: 'Libro', unit_price_uyu: 1100, quantity: 1 }],
+  };
+  assert.equal(window.AmadoAnalytics.trackCommerce('purchase', payload), true);
+  assert.equal(window.AmadoAnalytics.trackCommerce('purchase', payload), false);
+
+  const purchaseEvents = window.dataLayer.filter(
+    entry => Array.from(entry)[0] === 'event' && Array.from(entry)[1] === 'purchase',
+  );
+  assert.equal(purchaseEvents.length, 1);
+  const params = Array.from(purchaseEvents[0])[2];
+  assert.equal(params.transaction_id, 'AL-001');
+  assert.equal(params.currency, 'UYU');
+  assert.equal(params.items[0].item_id, 'MLU123');
+  assert.equal(params.items[0].price, 1100);
 });

--- a/functions/__tests__/checkout-single-step.test.js
+++ b/functions/__tests__/checkout-single-step.test.js
@@ -315,4 +315,19 @@ test('pedido.astro: el vaciado depende del estado real leÃ­do de D1, no del parÃ
   assert.match(pedidoAstro, /fetch\('\/api\/orders\/status'/);
   const pollIdx = pedidoAstro.indexOf("fetch('/api/orders/status'");
   assert.ok(pollIdx > 0);
+  assert.match(pedidoAstro, /applyFinalState\(ps, data\)/);
+});
+
+test('pedido.astro: purchase usa el pedido autenticado y se emite antes de vaciar el carrito', () => {
+  const fnStart = pedidoAstro.indexOf('function applyFinalState');
+  const fnEnd = pedidoAstro.indexOf("paymentStatus === 'rejected'", fnStart);
+  const approved = pedidoAstro.slice(fnStart, fnEnd);
+  assert.match(approved, /trackCommerce\('purchase'/);
+  assert.match(approved, /transactionId: data\.order\.public_code \|\| code/);
+  assert.match(approved, /value: data\.order\.payable_total_uyu/);
+  assert.match(approved, /items: data\.items/);
+  assert.ok(
+    approved.indexOf("trackCommerce('purchase'") < approved.indexOf('AmadoCart.clear()'),
+    'purchase debe registrarse antes de limpiar el carrito',
+  );
 });

--- a/functions/__tests__/seo-product-opportunities.test.js
+++ b/functions/__tests__/seo-product-opportunities.test.js
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { renderPage } from '../libro/[[path]].js';
+import {
+  INDEXABLE_PAUSED_PRODUCT_PATHS,
+  PRODUCT_ID_REDIRECTS,
+  PRODUCT_SEO_OVERRIDES,
+} from '../_shared/seo-products.js';
+import { STATIC_SITEMAP_PAGES } from '../sitemap-pages.xml.js';
+
+function book(overrides = {}) {
+  return {
+    id: 'MLU1', title: 'Libro de prueba', author: 'Autora',
+    price: 1200, currency: 'UYU', status: 'active', available_quantity: 2,
+    condition: 'new', isbn: '9788499809991', publisher: null,
+    pages: null, dimensions: null,
+    thumbnail: 'https://http2.mlstatic.com/D_1-I.jpg', pictures: [],
+    permalink: 'https://articulo.mercadolibre.com.uy/MLU-1',
+    ...overrides,
+  };
+}
+
+test('las once oportunidades GSC tienen title y description curados', () => {
+  assert.equal(Object.keys(PRODUCT_SEO_OVERRIDES).length, 11);
+  for (const [id, override] of Object.entries(PRODUCT_SEO_OVERRIDES)) {
+    assert.match(id, /^MLU\d+$/);
+    assert.ok(override.title.length >= 20 && override.title.length <= 70);
+    assert.ok(override.description.length >= 80 && override.description.length <= 180);
+  }
+});
+
+test('Murdoku conserva indexación aunque esté pausado y muestra intención Uruguay', () => {
+  const html = renderPage(book({
+    id: 'MLU1416777650',
+    title: 'Libro Murdoku 80 Acertijos De Lógica Y Asesinatos De Garand',
+    author: 'Manuel Garand',
+    isbn: '9791387869380',
+    status: 'paused',
+    available_quantity: 0,
+  }), 'libro-murdoku-80-acertijos-de-logica-y-asesinatos-de-garand-', false, '');
+
+  assert.match(html, /<title>Murdoku en Uruguay: 80 acertijos de lógica \| Amado Libros<\/title>/);
+  assert.match(html, /<meta name="robots" content="index, follow">/);
+  assert.match(html, /ISBN 9791387869380/);
+  assert.match(html, /Ver otros libros Murdoku/);
+  assert.doesNotMatch(html, /data-action="add-to-cart"/);
+});
+
+test('una ficha pausada común sigue noindex', () => {
+  const html = renderPage(book({ status: 'paused', available_quantity: 0 }), 'libro-de-prueba', false, '');
+  assert.match(html, /<meta name="robots" content="noindex, follow">/);
+});
+
+test('el duplicado de Murdoku apunta a la URL histórica consolidada', () => {
+  assert.deepEqual(PRODUCT_ID_REDIRECTS.MLU1416777648, {
+    id: 'MLU1416777650',
+    path: '/libro/MLU1416777650/libro-murdoku-80-acertijos-de-logica-y-asesinatos-de-garand-',
+  });
+});
+
+test('la excepción indexable de Murdoku está en sitemap-pages', () => {
+  assert.deepEqual(INDEXABLE_PAUSED_PRODUCT_PATHS, [
+    '/libro/MLU1416777650/libro-murdoku-80-acertijos-de-logica-y-asesinatos-de-garand-',
+  ]);
+  assert.ok(STATIC_SITEMAP_PAGES.includes(
+    'https://www.amadolibros.com/libro/MLU1416777650/libro-murdoku-80-acertijos-de-logica-y-asesinatos-de-garand-',
+  ));
+});

--- a/functions/_shared/seo-products.js
+++ b/functions/_shared/seo-products.js
@@ -66,4 +66,3 @@ export const INDEXABLE_PAUSED_PRODUCT_PATHS = Object.freeze(
     .filter(item => item.indexWhenPaused && item.sitemapPath)
     .map(item => item.sitemapPath),
 );
-

--- a/functions/_shared/seo-products.js
+++ b/functions/_shared/seo-products.js
@@ -1,0 +1,69 @@
+const MURDOKU_CANONICAL_PATH =
+  '/libro/MLU1416777650/libro-murdoku-80-acertijos-de-logica-y-asesinatos-de-garand-';
+
+export const PRODUCT_ID_REDIRECTS = Object.freeze({
+  // Misma edición e ISBN 9791387869380. La URL terminada en 7650 conserva
+  // las señales históricas de GSC; 7648 no debe competir con ella.
+  MLU1416777648: Object.freeze({
+    id: 'MLU1416777650',
+    path: MURDOKU_CANONICAL_PATH,
+  }),
+});
+
+export const PRODUCT_SEO_OVERRIDES = Object.freeze({
+  MLU1416777650: Object.freeze({
+    title: 'Murdoku en Uruguay: 80 acertijos de lógica',
+    description: 'Conseguí Murdoku: 80 acertijos de lógica y asesinatos, de Manuel Garand, en Uruguay. Consultá disponibilidad o pedilo por encargo.',
+    indexWhenPaused: true,
+    sitemapPath: MURDOKU_CANONICAL_PATH,
+    heading: 'Murdoku en Uruguay: verificamos la edición exacta',
+    copy: 'Esta ficha corresponde a Murdoku: 80 acertijos de lógica y asesinatos, de Manuel Garand (ISBN 9791387869380). Si no está disponible, consultanos: verificamos esta edición exacta o la buscamos por encargo, con envíos en Montevideo y todo Uruguay.',
+  }),
+  MLU676002408: Object.freeze({
+    title: 'Mientras dormíamos: El engaño maestro, de Giuseppe Nocera',
+    description: 'Comprá Mientras dormíamos: El engaño maestro, de Giuseppe Nocera Costabile, en Amado Libros. Precio en UYU y envíos a todo Uruguay.',
+  }),
+  MLU633445690: Object.freeze({
+    title: 'Así fue como llegaste: donación de espermatozoides',
+    description: 'Comprá Así fue como llegaste: donación de espermatozoides, de Silvia Jadur y Constanza Duhalde. Envíos a todo Uruguay.',
+  }),
+  MLU646420175: Object.freeze({
+    title: 'Urmah: Los sembradores siderales, de Luis Ángel Loaiza',
+    description: 'Comprá Urmah: Los sembradores siderales, de Luis Ángel Loaiza Ferreira, en Uruguay. Consultá precio, stock y forma de entrega.',
+  }),
+  MLU662039047: Object.freeze({
+    title: 'Jujutsu Kaisen 25, de Gege Akutami',
+    description: 'Comprá Jujutsu Kaisen tomo 25, de Gege Akutami, en Amado Libros. Precio en UYU, cuotas y envíos a todo Uruguay.',
+  }),
+  MLU707743600: Object.freeze({
+    title: 'Colección Grandes Aventuras y Genios: 11 libros',
+    description: 'Comprá la colección Grandes Aventuras y Genios de 11 libros. Consultá disponibilidad, precio en UYU y envíos a todo Uruguay.',
+  }),
+  MLU626854956: Object.freeze({
+    title: 'Amagi, de Sagar Prakash Khatnani: precio en Uruguay',
+    description: 'Comprá Amagi, de Sagar Prakash Khatnani, en Amado Libros. Consultá precio en UYU, disponibilidad y envíos en Uruguay.',
+  }),
+  MLU653980087: Object.freeze({
+    title: '¡Qué misterio! Princesas: dibujos para colorear',
+    description: 'Consultá por ¡Qué misterio! Princesas, libro de dibujos para colorear de Jeremy Mariez. Podemos verificar stock o buscarlo por encargo.',
+  }),
+  MLU1467423248: Object.freeze({
+    title: 'Más astuto que el diablo, de Napoleon Hill',
+    description: 'Comprá Más astuto que el diablo, de Napoleon Hill, en Amado Libros. Precio en UYU, cuotas y envíos a todo Uruguay.',
+  }),
+  MLU889085304: Object.freeze({
+    title: 'Primeros pasos en la clínica psicopedagógica',
+    description: 'Comprá Primeros pasos en la clínica psicopedagógica, de Guillermina Ferra. Consultá precio y envíos en Uruguay.',
+  }),
+  MLU696157645: Object.freeze({
+    title: 'La taza de la mañana: sanación y reflexión diaria',
+    description: 'Comprá La taza de la mañana: sanación y reflexión diaria, de Camille J. Sage. Precio en UYU y envíos a todo Uruguay.',
+  }),
+});
+
+export const INDEXABLE_PAUSED_PRODUCT_PATHS = Object.freeze(
+  Object.values(PRODUCT_SEO_OVERRIDES)
+    .filter(item => item.indexWhenPaused && item.sitemapPath)
+    .map(item => item.sitemapPath),
+);
+

--- a/functions/api/__tests__/order_status.test.js
+++ b/functions/api/__tests__/order_status.test.js
@@ -11,13 +11,16 @@ const PREVIEW_CONFIG = {
   CANONICAL_ORIGIN: 'https://feature.amadolibros-web.pages.dev',
 };
 
-function dbMock({ order = null } = {}) {
+function dbMock({ order = null, items = [] } = {}) {
   return {
     prepare(sql) {
       return {
         bind(..._args) {
           return {
             async first() { return order; },
+            async all() {
+              return { results: sql.includes('FROM order_items') ? items : [] };
+            },
           };
         },
       };
@@ -35,11 +38,13 @@ function makeReq({ method = 'POST', host = ALLOWED_HOST, body = undefined, ct = 
   });
 }
 
-function env(order = { payment_status: 'approved', status: 'paid' }, envPatch = {}) {
-  return { ...PREVIEW_CONFIG, ORDERS_DB: dbMock({ order }), ...envPatch };
+function env(order = { id: 'order-1', public_code: 'AL-001', payment_status: 'approved', status: 'paid' }, envPatch = {}, items = []) {
+  return { ...PREVIEW_CONFIG, ORDERS_DB: dbMock({ order, items }), ...envPatch };
 }
 
-async function call(reqOpts = {}, order = { payment_status: 'approved', status: 'paid' }, envPatch = {}) {
+async function call(reqOpts = {}, order = {
+  id: 'order-1', public_code: 'AL-001', payment_status: 'approved', status: 'paid',
+}, envPatch = {}) {
   const h   = createOrderStatusHandler();
   const req = makeReq(reqOpts);
   const res = await h({ request: req, env: env(order, envPatch) });
@@ -84,7 +89,7 @@ test('os-06: host no permitido → 400', async () => {
   assert.equal(res.status, 400);
 });
 
-test('os-07: respuesta solo expone payment_status y status', async () => {
+test('os-07: respuesta expone solo estado y datos comerciales seguros para GA4', async () => {
   const { res, data } = await call({ body: { public_code: 'AL-001', idempotency_key: 'key-1' } });
   assert.equal(res.status, 200);
   const keys = Object.keys(data);
@@ -94,7 +99,33 @@ test('os-07: respuesta solo expone payment_status y status', async () => {
   assert.ok(!keys.includes('payment_id'));
   assert.ok(!keys.includes('buyer_name'));
   assert.ok(!keys.includes('payable_total_uyu'));
-  assert.equal(keys.length, 2);
+  assert.deepEqual(keys.sort(), ['items', 'order', 'payment_status', 'status']);
+  assert.ok(!Object.hasOwn(data.order, 'id'));
+  assert.ok(!Object.hasOwn(data.order, 'idempotency_key'));
+  assert.ok(!Object.hasOwn(data.order, 'buyer_email'));
+});
+
+test('os-07b: devuelve totales e items autenticados para purchase de GA4', async () => {
+  const order = {
+    id: 'order-1', public_code: 'AL-001', payment_status: 'approved', status: 'paid',
+    delivery_type: 'shipping', products_total_uyu: 1100, pickup_discount_uyu: 0,
+    shipping_cost_uyu: 190, payable_total_uyu: 1290, currency: 'UYU',
+  };
+  const items = [{
+    product_id: 'MLU123', title: 'Libro', quantity: 1,
+    unit_price_uyu: 1100, line_total_uyu: 1100,
+  }];
+  const h = createOrderStatusHandler();
+  const req = makeReq({ body: { public_code: 'AL-001', idempotency_key: 'key-1' } });
+  const res = await h({ request: req, env: env(order, {}, items) });
+  const data = await res.json();
+  assert.equal(res.status, 200);
+  assert.deepEqual(data.order, {
+    public_code: 'AL-001', delivery_type: 'shipping', products_total_uyu: 1100,
+    pickup_discount_uyu: 0, shipping_cost_uyu: 190, payable_total_uyu: 1290,
+    currency: 'UYU',
+  });
+  assert.deepEqual(data.items, items);
 });
 
 test('os-08: Cache-Control: no-store siempre', async () => {

--- a/functions/api/_order_status_handler.js
+++ b/functions/api/_order_status_handler.js
@@ -52,12 +52,44 @@ export function createOrderStatusHandler() {
     if (!db) return json({ error: 'Servicio no disponible.' }, 503);
 
     const order = await db
-      .prepare('SELECT payment_status,status FROM orders WHERE public_code=? AND idempotency_key=?')
+      .prepare(
+        'SELECT id,public_code,payment_status,status,delivery_type,products_total_uyu,' +
+        'pickup_discount_uyu,shipping_cost_uyu,payable_total_uyu,currency ' +
+        'FROM orders WHERE public_code=? AND idempotency_key=?'
+      )
       .bind(publicCode, idempotencyKey)
       .first();
 
     if (!order) return json({ error: 'No encontrado.' }, 404);
 
-    return json({ payment_status: order.payment_status, status: order.status });
+    const itemsResult = await db
+      .prepare(
+        'SELECT product_id,title,quantity,unit_price_uyu,line_total_uyu ' +
+        'FROM order_items WHERE order_id=? ORDER BY created_at,id'
+      )
+      .bind(order.id)
+      .all();
+    const items = Array.isArray(itemsResult?.results) ? itemsResult.results : [];
+
+    return json({
+      payment_status: order.payment_status,
+      status: order.status,
+      order: {
+        public_code: order.public_code,
+        delivery_type: order.delivery_type,
+        products_total_uyu: Number(order.products_total_uyu) || 0,
+        pickup_discount_uyu: Number(order.pickup_discount_uyu) || 0,
+        shipping_cost_uyu: Number(order.shipping_cost_uyu) || 0,
+        payable_total_uyu: Number(order.payable_total_uyu) || 0,
+        currency: order.currency === 'UYU' ? 'UYU' : '',
+      },
+      items: items.map(item => ({
+        product_id: String(item.product_id || ''),
+        title: String(item.title || '').slice(0, 200),
+        quantity: Math.max(1, Math.floor(Number(item.quantity) || 1)),
+        unit_price_uyu: Number(item.unit_price_uyu) || 0,
+        line_total_uyu: Number(item.line_total_uyu) || 0,
+      })),
+    });
   };
 }

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -17,6 +17,7 @@ import { slugify } from '../_shared/slug.js';
 import { BASE, fetchCatalog, fetchPausedItem } from '../_shared/catalog.js';
 import { previewCoverUrl as resolvePreviewCoverUrl } from '../_shared/preview-cover.js';
 import { authorPathForName } from '../_shared/seo-authors.js';
+import { PRODUCT_ID_REDIRECTS, PRODUCT_SEO_OVERRIDES } from '../_shared/seo-products.js';
 import {
     bookCoverUrl,
     cloudflareImageUrl,
@@ -383,6 +384,9 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     const canonicalUrl = `${BASE}/libro/${item.id}/${slug}`;
     const safeTitle    = escapeHtml(item.title);
     const safeAuthor   = item.author ? escapeHtml(item.author) : null;
+    const seoOverride  = PRODUCT_SEO_OVERRIDES[item.id] || null;
+    const documentTitle = escapeHtml(seoOverride?.title || item.title);
+    const indexWhenPaused = seoOverride?.indexWhenPaused === true;
     const sourceImages = normalizeImages(item, previewCoverSrc);
     const images       = isPreview
         ? sourceImages
@@ -424,6 +428,16 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
             : buildPausedWaMessage(item)
     );
     const relatedBooksHtml = renderRelatedBooks(relatedBooks, item.author, !isPreview);
+    const viewItemAnalytics = {
+        dedupeKey: `view_item_${item.id}`,
+        ...(sellableInCheckout ? { value: price } : {}),
+        items: [{
+            item_id: item.id,
+            item_name: item.title,
+            ...(sellableInCheckout ? { price } : {}),
+            quantity: 1,
+        }],
+    };
 
     const detailRows = [
         safeAuthor ? detailRow('Autor', item.author) : '',
@@ -457,13 +471,23 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     </details>`
         : '';
 
-    const metaDesc = sellableInCheckout
+    const defaultMetaDesc = sellableInCheckout
         ? (safeAuthor
             ? `Comprá &quot;${safeTitle}&quot; de ${safeAuthor} en Amado Libros. Transferencia: $${transferPrice} UYU. Envíos a todo Uruguay.`
             : `Comprá &quot;${safeTitle}&quot; en Amado Libros. Transferencia: $${transferPrice} UYU. Envíos a todo Uruguay.`)
         : inStock
           ? `Consultá precio y forma de pago de &quot;${safeTitle}&quot;, publicado en ${escapeHtml(currency)}, en Amado Libros.`
         : `Pedí un aviso cuando &quot;${safeTitle}&quot; vuelva a estar disponible en Amado Libros. También podemos buscarlo por encargo.`;
+    const metaDesc = seoOverride?.description
+        ? escapeHtml(seoOverride.description)
+        : defaultMetaDesc;
+    const seoOpportunityHtml = seoOverride?.heading && seoOverride?.copy
+        ? `<section class="seo-opportunity" aria-labelledby="seo-opportunity-heading">
+      <h2 id="seo-opportunity-heading">${escapeHtml(seoOverride.heading)}</h2>
+      <p>${escapeHtml(seoOverride.copy)}</p>
+      <a href="/catalogo?q=murdoku">Ver otros libros Murdoku</a>
+    </section>`
+        : '';
 
     // JSON-LD — generado con JSON.stringify, nunca concatenación
     const schemaProduct = {
@@ -620,15 +644,15 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>${safeTitle} | Amado Libros</title>
+  <title>${documentTitle} | Amado Libros</title>
   <meta name="description" content="${metaDesc}">
-  <meta name="robots" content="${isPreview || !inStock ? 'noindex, follow' : 'index, follow'}">
+  <meta name="robots" content="${isPreview || (!inStock && !indexWhenPaused) ? 'noindex, follow' : 'index, follow'}">
   <link rel="canonical" href="${canonicalUrl}">
   ${faviconHeadHtml()}
 
   <meta property="og:type"        content="product">
   <meta property="og:url"         content="${canonicalUrl}">
-  <meta property="og:title"       content="${safeTitle} | Amado Libros">
+  <meta property="og:title"       content="${documentTitle} | Amado Libros">
   <meta property="og:description" content="${metaDesc}">
   <meta property="og:image"       content="${escapeHtml(socialImage)}">
   <meta property="og:image:secure_url" content="${escapeHtml(socialImage)}">
@@ -637,7 +661,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
   <meta property="og:site_name"   content="Amado Libros">
 
   <meta name="twitter:card"        content="summary_large_image">
-  <meta name="twitter:title"       content="${safeTitle} | Amado Libros">
+  <meta name="twitter:title"       content="${documentTitle} | Amado Libros">
   <meta name="twitter:description" content="${metaDesc}">
   <meta name="twitter:image"       content="${escapeHtml(socialImage)}">
   <meta name="twitter:image:alt"   content="Portada de ${safeTitle}">
@@ -805,6 +829,11 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     @media(max-width:520px){.waitlist-row{flex-direction:column}.btn-waitlist{width:100%}}
     .shipping{font-size:.82rem;color:#64748b;margin-top:1rem;padding:.75rem 1rem;
               background:white;border:1px solid #e2e8f0;border-radius:.5rem}
+    .seo-opportunity{margin-top:1rem;padding:1rem;background:#fff7ed;
+                     border:1px solid #fdba74;border-radius:.65rem;color:#7c2d12}
+    .seo-opportunity h2{font-size:1rem;line-height:1.35;margin-bottom:.4rem;color:#431407}
+    .seo-opportunity p{font-size:.88rem;margin-bottom:.45rem}
+    .seo-opportunity a{font-size:.85rem;font-weight:700;color:#9a3412}
     .related-books{grid-column:1/-1;border-top:1px solid #e2e8f0;padding-top:1.25rem}
     .related-books h2{font-size:1.05rem;line-height:1.35;color:#0f172a;margin-bottom:.85rem}
     .related-books-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));
@@ -866,6 +895,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
       ${actionHtml}
     </div>
     ${!inStock ? moreDetailsHtml : ''}
+    ${seoOpportunityHtml}
     <p class="shipping">${inStock
       ? '🚚 Entrega en 2 horas en Montevideo · Envíos a todo Uruguay · Envío gratis desde $1.500.'
       : '🌎 Si preferís no esperar, también podemos buscarlo por encargo en el exterior.'
@@ -873,6 +903,12 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
   </div>
   ${relatedBooksHtml}
 </main>
+
+<script>(function(){
+  if(window.AmadoAnalytics&&typeof window.AmadoAnalytics.trackCommerce==='function'){
+    window.AmadoAnalytics.trackCommerce('view_item',${safeJson(viewItemAnalytics)});
+  }
+}());<\/script>
 
 ${footerHtml()}
 ${waFloatHtml(`Hola, tengo una consulta sobre ${item.title}.`)}
@@ -990,6 +1026,15 @@ export async function onRequest(context) {
     // Validar formato ID
     if (!id || !/^MLU\d+$/.test(id)) {
         return notFound();
+    }
+
+    const productRedirect = PRODUCT_ID_REDIRECTS[id];
+    if (productRedirect) {
+        const currentUrl = new URL(context.request.url);
+        const destination = new URL(productRedirect.path, BASE);
+        destination.search = currentUrl.search;
+        destination.searchParams.delete('layout');
+        return Response.redirect(destination.toString(), 301);
     }
 
     // Cargar catálogo (con edge cache)

--- a/functions/sitemap-pages.xml.js
+++ b/functions/sitemap-pages.xml.js
@@ -2,6 +2,7 @@ import { BASE } from './_shared/catalog.js';
 import { urlsetXml, xmlResponse } from './_shared/sitemap.js';
 import { SEO_SPECIALTIES, specialtyPath } from './_shared/seo-specialties.js';
 import { SEO_AUTHORS } from './_shared/seo-authors.js';
+import { INDEXABLE_PAUSED_PRODUCT_PATHS } from './_shared/seo-products.js';
 
 export const STATIC_SITEMAP_PAGES = Object.freeze([
   `${BASE}/`,
@@ -18,6 +19,7 @@ export const STATIC_SITEMAP_PAGES = Object.freeze([
   `${BASE}/contacto`,
   `${BASE}/quienes-somos`,
   ...SEO_SPECIALTIES.map(item => `${BASE}${specialtyPath(item.id)}`),
+  ...INDEXABLE_PAUSED_PRODUCT_PATHS.map(path => `${BASE}${path}`),
 ]);
 
 const SIGNIFICANT_PAGE_UPDATES = Object.freeze({
@@ -27,6 +29,7 @@ const SIGNIFICANT_PAGE_UPDATES = Object.freeze({
   [`${BASE}/libros-agotados-importados-uruguay`]: '2026-08-12',
   [`${BASE}/quienes-somos`]: '2026-08-12',
   ...Object.fromEntries(SEO_AUTHORS.map(author => [`${BASE}${author.path}`, '2026-08-14'])),
+  ...Object.fromEntries(INDEXABLE_PAUSED_PRODUCT_PATHS.map(path => [`${BASE}${path}`, '2026-08-16'])),
 });
 
 export const STATIC_SITEMAP_ENTRIES = Object.freeze(


### PR DESCRIPTION
## Qué resuelve

- Implementa el embudo GA4 recomendado: `view_item`, `add_to_cart`, `view_cart`, `begin_checkout` y `purchase`.
- Usa `item_id` MLU, cantidades, precios UYU, envío y `transaction_id`.
- Emite `purchase` únicamente después de que D1 confirma el pago aprobado y evita duplicados al recargar.
- Corrige el acceso a `data.order.delivery_type` en la confirmación del pedido.
- Optimiza title y meta description de las 11 oportunidades detectadas por GSC.
- Consolida el duplicado de Murdoku en la URL con señales históricas.
- Mantiene Murdoku indexable como excepción de demanda aunque esté pausado, pero sin precio, Offer ni carrito falsos.
- Agrega esa URL al sitemap y contenido útil orientado a “Murdoku Uruguay”.

## Seguridad y exactitud

- El endpoint de estado continúa autenticado por `public_code + idempotency_key`.
- Solo devuelve datos comerciales necesarios; no expone UUID, correo, nombre ni datos de pago.
- Las fichas pausadas comunes continúan en `noindex`.
- Los precios no UYU siguen fuera del checkout y de Merchant.

## Validación

- `git diff --check`: OK
- Tests Functions/API: **737/737 OK**
- Tests dirigidos analítica/SEO/checkout: **93/93 OK**
- El build Astro queda a cargo de CI porque la instalación local de dependencias requiere acceso de red no habilitado en este contenedor.

## Paso externo pendiente

Después del despliegue, importar el evento GA4 `purchase` como conversión en Google Ads y verificarlo en DebugView/Tag Assistant.