### PR TITLE
Priorizar portadas principales durante el backfill de Merchant

### DIFF
--- a/worker-sync/__tests__/cover-mirror.test.js
+++ b/worker-sync/__tests__/cover-mirror.test.js
@@ -164,6 +164,31 @@ test('prioriza faltantes, después URL cambiada y al final revalidaciones vencid
   assert.deepEqual(batch.selected.map(row => row.product_id), ['MLU100001', 'MLU100002', 'MLU100003']);
 });
 
+test('completa portadas principales de distintos libros antes que galerías secundarias', () => {
+  const catalog = {
+    items: [
+      item('MLU100001', {
+        pictures: [
+          'https://http2.mlstatic.com/D_MLU100001_MAIN-O.jpg',
+          'https://http2.mlstatic.com/D_MLU100001_SECOND-O.jpg',
+        ],
+      }),
+      item('MLU100002', {
+        pictures: [
+          'https://http2.mlstatic.com/D_MLU100002_MAIN-O.jpg',
+          'https://http2.mlstatic.com/D_MLU100002_SECOND-O.jpg',
+        ],
+      }),
+    ],
+  };
+
+  const batch = selectCoverBatch(catalog, { schema_version: 1, entries: {} }, { limit: 2 });
+  assert.deepEqual(
+    batch.selected.map(row => `${row.product_id}:${row.position}`),
+    ['MLU100001:0', 'MLU100002:0'],
+  );
+});
+
 test('vuelve a seleccionar una copia reciente de baja resolución al activar Images', () => {
   const now = Date.parse('2026-08-16T12:00:00Z');
   const catalog = { items: [item()] };

--- a/worker-sync/cover-mirror.js
+++ b/worker-sync/cover-mirror.js
@@ -177,6 +177,14 @@ export function selectCoverBatch(catalog, manifest, {
     })
     .filter(candidate => candidate.priority !== null)
     .sort((a, b) => {
+      // Merchant solo necesita la posición 0 para publicar el producto.
+      // Completar galerías enteras por ID antes de pasar al siguiente libro
+      // dejaba miles de ofertas fuera del feed aunque el manifest creciera.
+      // Primero cubrimos una portada principal por producto; después usamos
+      // la capacidad restante para las imágenes secundarias de la galería.
+      const primaryA = a.position === 0;
+      const primaryB = b.position === 0;
+      if (primaryA !== primaryB) return primaryA ? -1 : 1;
       if (a.preferred !== b.preferred) return a.preferred ? -1 : 1;
       if (a.priority !== b.priority) return a.priority - b.priority;
       const validatedA = Date.parse(a.entry?.last_validated_at || '') || 0;


### PR DESCRIPTION
## Problema observado en producción

El manifest R2 siguió creciendo de 3.340 a 3.639 copias válidas, pero el feed continuó en 789 productos seguros y 5.795 pendientes.

La causa no era una detención: el selector ordenaba por producto y copiaba la galería completa de cada libro antes de pasar a la portada principal del siguiente. Eso hace crecer el manifest sin ampliar rápidamente la cobertura de Merchant, que solo necesita la posición 0 para admitir una oferta.

## Corrección

- Prioriza todas las portadas principales (posición 0) antes que las imágenes secundarias.
- Conserva después el backfill de galerías completas: no se pierde esa mejora UX.
- Mantiene la prioridad, revalidación, transformación con Cloudflare Images y escritura atómica existentes.

## Impacto esperado

Una vez desplegado, cada lote de Worker debería habilitar muchos más productos del feed, en vez de consumir el lote completando imágenes secundarias de pocos títulos.

## Validación

- Tests completos de Worker Sync: **106/106 OK**
- Nueva regresión: con dos libros y dos fotos por libro, un lote de dos selecciona ambas portadas principales.
- `git diff --check`: OK