### PR TITLE
Normalizar consultas de WhatsApp por contexto

### DIFF
--- a/astro-front/public/whatsapp-messages.js
+++ b/astro-front/public/whatsapp-messages.js
@@ -1,0 +1,49 @@
+(function () {
+  'use strict';
+
+  var NUMBER = '59899841325';
+  var SITE_BASE = 'https://www.amadolibros.com';
+
+  function absolutePage(pathOrUrl) {
+    try {
+      var url = new URL(pathOrUrl || window.location.href, SITE_BASE);
+      url.hash = '';
+      Array.from(url.searchParams.keys()).forEach(function (key) {
+        if (/^(utm_|gclid$|dclid$|gbraid$|wbraid$)/i.test(key)) {
+          url.searchParams.delete(key);
+        }
+      });
+      return url.toString();
+    } catch (_error) {
+      return SITE_BASE + '/';
+    }
+  }
+
+  function build(options) {
+    options = options || {};
+    var lines = [
+      String(options.greeting || 'Hola, encontré Amado Libros y quería hacerles una consulta 😊').trim(),
+      '',
+    ];
+    if (options.motive) lines.push('Motivo: ' + String(options.motive).trim());
+    if (options.book) lines.push('Libro: ' + String(options.book).trim());
+    if (options.author) lines.push('Autor: ' + String(options.author).trim());
+    if (options.situation) lines.push('Situación: ' + String(options.situation).trim());
+    if (options.price) lines.push('Precio publicado: ' + String(options.price).trim());
+    if (options.order) lines.push('Pedido: ' + String(options.order).trim());
+    if (options.page !== false) lines.push('Página: ' + absolutePage(options.page));
+    if (options.closing) lines.push('', String(options.closing).trim());
+    return lines.join('\n');
+  }
+
+  function href(message) {
+    return 'https://wa.me/' + NUMBER + '?text=' + encodeURIComponent(message);
+  }
+
+  window.AmadoWhatsApp = Object.assign({}, window.AmadoWhatsApp, {
+    absolutePage: absolutePage,
+    build: build,
+    href: href,
+    number: NUMBER,
+  });
+})();

--- a/astro-front/src/components/BookCard.astro
+++ b/astro-front/src/components/BookCard.astro
@@ -1,5 +1,9 @@
 ---
 import { responsiveBookCover } from '../lib/cloudflare-images.js';
+import {
+  buildBookWhatsAppMessage,
+  whatsappHref,
+} from '../../../shared/whatsapp-messages.js';
 
 // HOME-COMERCIAL-1: jerarquía de card aprobada — precio principal, cuotas
 // debajo, transferencia como beneficio secundario, envío gratis cuando
@@ -45,8 +49,13 @@ const fichaHref = `/libro/${book.id}/${slugify(book.title)}`;
 
 // Corregido (HOME-COMERCIAL-1): estas cards ya muestran solo libros
 // disponibles — el mensaje no debe preguntar si lo están.
-const waText = `Hola! Me interesa el libro "${book.title}". Tengo una consulta antes de comprar.`;
-const waHref = `https://wa.me/59899841325?text=${encodeURIComponent(waText)}`;
+const waText = buildBookWhatsAppMessage({
+  title: book.title,
+  author: book.author,
+  page: fichaHref,
+  available: true,
+});
+const waHref = whatsappHref(waText);
 
 const fmt = new Intl.NumberFormat('es-UY', {
   style: 'currency', currency: 'UYU', maximumFractionDigits: 0,

--- a/astro-front/src/components/Footer.astro
+++ b/astro-front/src/components/Footer.astro
@@ -1,6 +1,14 @@
 ---
-const WA_HREF =
-  'https://wa.me/59899841325?text=Hola%20Amado%20Libros%2C%20quisiera%20consultar';
+import {
+  buildWhatsAppMessage,
+  whatsappHref,
+} from '../../../shared/whatsapp-messages.js';
+
+const WA_HREF = whatsappHref(buildWhatsAppMessage({
+  motive: 'Consulta general',
+  page: Astro.url.pathname,
+  closing: 'Quisiera hacerles una consulta. ¿Podrían ayudarme? Gracias.',
+}));
 const YEAR = new Date().getFullYear();
 ---
 <footer class="site-footer">

--- a/astro-front/src/components/Header.astro
+++ b/astro-front/src/components/Header.astro
@@ -1,5 +1,9 @@
 ---
 import CartIcon from './CartIcon.astro';
+import {
+  buildWhatsAppMessage,
+  whatsappHref,
+} from '../../../shared/whatsapp-messages.js';
 
 interface Props {
   showSearch?: boolean;
@@ -11,10 +15,19 @@ const {
   showMobileDeliveryBanner = false,
 } = Astro.props;
 
-const WA_HREF =
-  'https://wa.me/59899841325?text=Hola%20Amado%20Libros%2C%20quer%C3%ADa%20consultar';
-const DELIVERY_WA_HREF =
-  'https://wa.me/59899841325?text=Hola%20Amado%20Libros%2C%20quiero%20coordinar%20una%20entrega%20en%202%20horas%20en%20Montevideo';
+const currentPage = Astro.url.pathname;
+const WA_HREF = whatsappHref(buildWhatsAppMessage({
+  motive: 'Consulta general',
+  page: currentPage,
+  closing: 'Quisiera hacerles una consulta. ¿Podrían ayudarme? Gracias.',
+}));
+const DELIVERY_WA_HREF = whatsappHref(buildWhatsAppMessage({
+  greeting: 'Hola, quiero consultar por una entrega de Amado Libros 😊',
+  motive: 'Coordinar una entrega en Montevideo',
+  situation: 'Entrega en aproximadamente 2 horas, sujeta a zona y horario',
+  page: currentPage,
+  closing: 'Quisiera confirmar si pueden entregarme hoy y coordinar el horario. Gracias.',
+}));
 ---
 <header class="site-header">
   <div class:list={['header-inner', { 'without-search': !showSearch }]}>

--- a/astro-front/src/components/SearchOverlay.astro
+++ b/astro-front/src/components/SearchOverlay.astro
@@ -173,12 +173,18 @@
   var input    = document.getElementById('so-input');
   var closeBtn = document.getElementById('so-close');
   var waBtn    = document.getElementById('so-wa-btn');
-  var WA_BASE  = 'https://wa.me/59899841325?text=';
 
   function buildWaUrl(q) {
-    return WA_BASE + encodeURIComponent(
-      'Hola, estoy buscando: "' + q + '". ¿Lo tienen o lo pueden conseguir?'
-    );
+    var wa = window.AmadoWhatsApp;
+    if (!wa) return '#';
+    return wa.href(wa.build({
+      greeting: 'Hola, me interesa este libro que encontré en Amado Libros 😊',
+      motive: 'Consultar disponibilidad y precio',
+      book: q,
+      situation: 'Consulta desde el buscador',
+      page: window.location.href,
+      closing: 'Quisiera saber si lo tienen o si pueden conseguirlo y cuánto demoraría. Gracias.',
+    }));
   }
 
   function openOverlay() {

--- a/astro-front/src/components/WAFloat.astro
+++ b/astro-front/src/components/WAFloat.astro
@@ -1,6 +1,14 @@
 ---
-const WA_HREF =
-  'https://wa.me/59899841325?text=Hola%21%20Quisiera%20consultar%20sobre%20un%20libro';
+import {
+  buildWhatsAppMessage,
+  whatsappHref,
+} from '../../../shared/whatsapp-messages.js';
+
+const WA_HREF = whatsappHref(buildWhatsAppMessage({
+  motive: 'Consulta general',
+  page: Astro.url.pathname,
+  closing: 'Quisiera hacerles una consulta. ¿Podrían ayudarme? Gracias.',
+}));
 ---
 <a
   href={WA_HREF}

--- a/astro-front/src/layouts/BaseLayout.astro
+++ b/astro-front/src/layouts/BaseLayout.astro
@@ -35,6 +35,7 @@ const socialUrl  = canonical || 'https://www.amadolibros.com/';
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v2">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v2">
   <link rel="manifest" href="/site.webmanifest?v2">
+  <script is:inline src="/whatsapp-messages.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="robots" content={indexable ? 'index, follow' : 'noindex, nofollow'}>

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -1704,15 +1704,30 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
           : 'Vendimos todos los ejemplares de “' + item.title + '”. Si querés, lo buscamos para vos.';
         unavailableBox.appendChild(unavailableText);
 
-        var waText = 'Hola, vi que “' + item.title + '”';
         var currentAuthor = validation.author || '';
-        if (currentAuthor) waText += ' de ' + currentAuthor;
-        waText += unsupportedCurrency
-          ? ' está publicada en ' + (validation.currency || 'otra moneda') + '. ¿Me confirman precio y forma de pago?'
-          : ' ya no está disponible. ¿Pueden buscarlo por encargo?';
+        var wa = window.AmadoWhatsApp;
+        var waText = wa
+          ? wa.build({
+              greeting: 'Hola, me interesa este libro que encontré en Amado Libros 😊',
+              motive: unsupportedCurrency
+                ? 'Consultar precio y forma de pago'
+                : 'Consultar disponibilidad y precio',
+              book: item.title,
+              author: currentAuthor,
+              situation: unsupportedCurrency
+                ? 'Precio publicado en ' + (validation.currency || 'otra moneda')
+                : 'Por encargo',
+              page: window.location.href,
+              closing: unsupportedCurrency
+                ? 'Quisiera confirmar el precio en pesos uruguayos y la forma de pago. Gracias.'
+                : 'Quisiera saber si pueden conseguirlo y cuánto demoraría. Gracias.',
+            })
+          : 'Hola, me interesa el libro "' + item.title + '".';
         var waLink = document.createElement('a');
         waLink.className = 'cart-unavailable-wa';
-        waLink.href = 'https://wa.me/' + WHATSAPP_NUMBER + '?text=' + encodeURIComponent(waText);
+        waLink.href = wa
+          ? wa.href(waText)
+          : 'https://wa.me/' + WHATSAPP_NUMBER + '?text=' + encodeURIComponent(waText);
         waLink.target = '_blank';
         waLink.rel = 'noopener noreferrer';
         waLink.textContent = unsupportedCurrency ? 'Consultar precio' : 'Buscarlo por encargo';
@@ -2000,7 +2015,16 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
 
         var subtotal = getSellableSubtotal();
 
-        var lines = ['PEDIDO WEB', '', 'Hola Amado Libros! Quiero hacer este pedido:'];
+        var waContext = window.AmadoWhatsApp;
+        var lines = [
+          'Hola, quiero hacer este pedido en Amado Libros 😊',
+          '',
+          'Motivo: Completar un pedido del carrito',
+          'Situación: Productos seleccionados y datos de entrega prontos',
+          'Página: ' + (waContext ? waContext.absolutePage(window.location.href) : window.location.href),
+          '',
+          'Libros:',
+        ];
         lines.push('');
         for (var i = 0; i < sellableItems.length; i++) {
           var it = sellableItems[i];
@@ -2030,11 +2054,17 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         if (phone) lines.push('WhatsApp/Tel: ' + phone);
         if (email) lines.push('Correo: ' + email);
 
-        var msg = encodeURIComponent(lines.join('\n'));
+        var message = lines.join('\n');
         if (window.AmadoAnalytics) {
           window.AmadoAnalytics.trackWhatsApp({ ctaLocation: 'checkout_order' });
         }
-        window.open('https://wa.me/59899841325?text=' + msg, '_blank', 'noopener,noreferrer');
+        window.open(
+          waContext
+            ? waContext.href(message)
+            : 'https://wa.me/59899841325?text=' + encodeURIComponent(message),
+          '_blank',
+          'noopener,noreferrer'
+        );
       });
     }
 
@@ -2145,11 +2175,16 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       var account = selectedTransferAccount();
       var cart = window.AmadoCart.get();
       var sellableItems = getSellableItems(cart);
+      var waContext = window.AmadoWhatsApp;
       var lines = [
-        'COMPROBANTE DE TRANSFERENCIA',
+        'Hola, ya realicé una transferencia para mi pedido de Amado Libros 😊',
         '',
-        'Hola Amado Libros. Ya realicé la transferencia de mi pedido ' + payment.public_code + '.',
+        'Motivo: Enviar comprobante de transferencia',
+        'Situación: Transferencia realizada',
+        'Pedido: ' + payment.public_code,
+        'Página: ' + (waContext ? waContext.absolutePage(window.location.href) : window.location.href),
         '',
+        'Libros:',
       ];
       for (var i = 0; i < sellableItems.length; i++) {
         lines.push('• ' + sellableItems[i].title + ' (x' + sellableItems[i].quantity + ')');
@@ -2162,7 +2197,9 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       if (buyerName) lines.push('Nombre: ' + buyerName);
       lines.push('');
       lines.push('Adjunto el comprobante en este chat.');
-      return 'https://wa.me/' + WHATSAPP_NUMBER + '?text=' + encodeURIComponent(lines.join('\n'));
+      return waContext
+        ? waContext.href(lines.join('\n'))
+        : 'https://wa.me/' + WHATSAPP_NUMBER + '?text=' + encodeURIComponent(lines.join('\n'));
     }
 
     function renderTransferPayment() {

--- a/astro-front/src/pages/como-identificar-edicion-correcta-isbn.astro
+++ b/astro-front/src/pages/como-identificar-edicion-correcta-isbn.astro
@@ -1,10 +1,18 @@
 ---
 import TrustPageLayout from '../layouts/TrustPageLayout.astro';
+import {
+  buildWhatsAppMessage,
+  whatsappHref,
+} from '../../../shared/whatsapp-messages.js';
 
 const canonical = 'https://www.amadolibros.com/como-identificar-edicion-correcta-isbn';
-const whatsapp = 'https://wa.me/59899841325?text=' + encodeURIComponent(
-  'Hola Amado Libros, quiero verificar la edición correcta de un libro. Les paso el ISBN y los datos que tengo: '
-);
+const whatsapp = whatsappHref(buildWhatsAppMessage({
+  greeting: 'Hola, quiero verificar una edición con Amado Libros 😊',
+  motive: 'Verificar la edición correcta de un libro',
+  situation: 'Tengo el ISBN u otros datos bibliográficos',
+  page: canonical,
+  closing: 'Quisiera pasarles el ISBN y los datos que tengo para confirmar la edición. Gracias.',
+}));
 
 const jsonLd = {
   '@context': 'https://schema.org',

--- a/astro-front/src/pages/contacto.astro
+++ b/astro-front/src/pages/contacto.astro
@@ -1,5 +1,15 @@
 ---
 import TrustPageLayout from '../layouts/TrustPageLayout.astro';
+import {
+  buildWhatsAppMessage,
+  whatsappHref,
+} from '../../../shared/whatsapp-messages.js';
+
+const whatsapp = whatsappHref(buildWhatsAppMessage({
+  motive: 'Consulta general',
+  page: '/contacto',
+  closing: 'Quisiera hacerles una consulta. ¿Podrían ayudarme? Gracias.',
+}));
 ---
 <TrustPageLayout
   title="Contacto y datos comerciales — Amado Libros"
@@ -11,7 +21,7 @@ import TrustPageLayout from '../layouts/TrustPageLayout.astro';
   <ul>
     <li><strong>Actividad:</strong> librería online uruguaya.</li>
     <li><strong>Punto de retiro coordinado:</strong> Rincón 608, Ciudad Vieja, Montevideo, Uruguay. No es un local de venta al público; esperá nuestra confirmación por WhatsApp antes de venir.</li>
-    <li><strong>WhatsApp y teléfono:</strong> <a href="https://wa.me/59899841325">099 841 325</a>.</li>
+    <li><strong>WhatsApp y teléfono:</strong> <a href={whatsapp}>099 841 325</a>.</li>
     <li><strong>Correo:</strong> <a href="mailto:adm@amadolibros.com">adm@amadolibros.com</a>.</li>
   </ul>
 

--- a/astro-front/src/pages/devoluciones.astro
+++ b/astro-front/src/pages/devoluciones.astro
@@ -1,5 +1,16 @@
 ---
 import TrustPageLayout from '../layouts/TrustPageLayout.astro';
+import {
+  buildWhatsAppMessage,
+  whatsappHref,
+} from '../../../shared/whatsapp-messages.js';
+const returnsWhatsApp = whatsappHref(buildWhatsAppMessage({
+  greeting: 'Hola, tengo una consulta sobre una compra de Amado Libros 😊',
+  motive: 'Solicitar una devolución o informar un problema',
+  situation: 'Compra ya realizada',
+  page: '/devoluciones',
+  closing: 'Quisiera pasarles el número de pedido y explicarles lo ocurrido. Gracias.',
+}));
 const returnPolicy = {
   '@context': 'https://schema.org',
   '@type': 'OnlineStore',
@@ -32,7 +43,7 @@ const returnPolicy = {
 
   <h2>Cómo solicitar una devolución</h2>
   <ol>
-    <li>Escribinos a <a href="mailto:adm@amadolibros.com">adm@amadolibros.com</a> o por <a href="https://wa.me/59899841325">WhatsApp al 099 841 325</a>.</li>
+    <li>Escribinos a <a href="mailto:adm@amadolibros.com">adm@amadolibros.com</a> o por <a href={returnsWhatsApp}>WhatsApp al 099 841 325</a>.</li>
     <li>Indicá nombre, número de pedido, producto y motivo de la solicitud.</li>
     <li>Te confirmaremos por escrito la forma de entrega o devolución, y coordinamos con vos el lugar y el horario.</li>
   </ol>

--- a/astro-front/src/pages/envios.astro
+++ b/astro-front/src/pages/envios.astro
@@ -1,5 +1,16 @@
 ---
 import TrustPageLayout from '../layouts/TrustPageLayout.astro';
+import {
+  buildWhatsAppMessage,
+  whatsappHref,
+} from '../../../shared/whatsapp-messages.js';
+const shippingWhatsApp = whatsappHref(buildWhatsAppMessage({
+  greeting: 'Hola, tengo una consulta sobre una entrega de Amado Libros 😊',
+  motive: 'Consultar por una entrega o envío',
+  situation: 'Demora, seguimiento o incidencia con una entrega',
+  page: '/envios',
+  closing: 'Quisiera contarles qué ocurrió para que puedan ayudarme. Gracias.',
+}));
 const shippingDestination = { '@type': 'DefinedRegion', addressCountry: 'UY' };
 const transitTime = {
   '@type': 'ServicePeriod',
@@ -70,7 +81,7 @@ const shippingPolicy = {
   <p>Podés retirar tu pedido en nuestro <strong>pick up a pasos de Plaza Matriz</strong>, de lunes a viernes, de 8 a 17 h. El checkout descuenta $150 por retiro. <strong>Esperá nuestra confirmación por WhatsApp antes de venir:</strong> te avisamos apenas tu pedido esté pronto para retirar, y ahí te pasamos la dirección exacta.</p>
 
   <h2>Demoras o incidencias</h2>
-  <p>Los plazos son estimados. Si un envío presenta una demora o daño visible, contactanos por <a href="https://wa.me/59899841325">WhatsApp al 099 841 325</a> o por <a href="mailto:adm@amadolibros.com">adm@amadolibros.com</a> indicando el número de pedido.</p>
+  <p>Los plazos son estimados. Si un envío presenta una demora o daño visible, contactanos por <a href={shippingWhatsApp}>WhatsApp al 099 841 325</a> o por <a href="mailto:adm@amadolibros.com">adm@amadolibros.com</a> indicando el número de pedido.</p>
 </TrustPageLayout>
 
 <style>

--- a/astro-front/src/pages/pedido.astro
+++ b/astro-front/src/pages/pedido.astro
@@ -3,9 +3,18 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import WAFloat from '../components/WAFloat.astro';
+import {
+  buildWhatsAppMessage,
+  whatsappHref,
+} from '../../../shared/whatsapp-messages.js';
 
-const WA_HREF =
-  'https://wa.me/59899841325?text=Hola%20Amado%20Libros%2C%20quer%C3%ADa%20consultar%20sobre%20mi%20pedido';
+const WA_HREF = whatsappHref(buildWhatsAppMessage({
+  greeting: 'Hola, hice un pedido en Amado Libros y quería consultarles 😊',
+  motive: 'Consultar el estado de mi pedido',
+  situation: 'Estoy revisando la confirmación del pedido',
+  page: '/pedido',
+  closing: '¿Podrían ayudarme a verificarlo? Gracias.',
+}));
 ---
 <BaseLayout
   title="Estado del pedido — Amado Libros"
@@ -27,6 +36,7 @@ const WA_HREF =
       <div class="pedido-ctas">
         <a id="btn-pedido-back" href="/carrito" class="btn-back" hidden>← Volver al carrito</a>
         <a
+          id="btn-pedido-wa"
           href={WA_HREF}
           target="_blank"
           rel="noopener noreferrer"
@@ -52,6 +62,24 @@ const WA_HREF =
       var subEl   = document.getElementById('pedido-sub');
       var codeEl  = document.getElementById('pedido-code');
       var backEl  = document.getElementById('btn-pedido-back');
+      var waEl    = document.getElementById('btn-pedido-wa');
+      var wa      = window.AmadoWhatsApp;
+
+      if (waEl && wa) {
+        var situation = result === 'success'
+          ? 'Pago aprobado'
+          : result === 'failure'
+            ? 'El pago no pudo confirmarse'
+            : 'Pago en proceso de verificación';
+        waEl.href = wa.href(wa.build({
+          greeting: 'Hola, hice un pedido en Amado Libros y quería consultarles 😊',
+          motive: 'Consultar el estado de mi pedido',
+          situation: situation,
+          order: code || '',
+          page: window.location.href,
+          closing: '¿Podrían ayudarme a verificarlo? Gracias.',
+        }));
+      }
 
       // ── Estado inicial según result de MP ──────────────────────────────────
       if (result === 'success' || result === 'pending') {

--- a/astro-front/src/pages/pedir-libro.astro
+++ b/astro-front/src/pages/pedir-libro.astro
@@ -234,11 +234,15 @@ const jsonLd = {
 
     const data = new FormData(form);
     const type = effectiveType();
+    const query = String(data.get('query') || '').trim();
+    const wa = window.AmadoWhatsApp;
     const lines = [
-      'Hola Amado Libros, quiero pedir una búsqueda manual.',
+      'Hola, estoy buscando un libro en Amado Libros y quisiera que me ayudaran 😊',
       '',
-      `Tipo de búsqueda: ${typeLabels[type] || typeLabels.exacto}`,
-      `Busco: ${String(data.get('query') || '').trim()}`,
+      `Motivo: ${typeLabels[type] || typeLabels.exacto}`,
+      `Libro: ${query}`,
+      'Situación: Búsqueda manual por encargo',
+      `Página: ${wa ? wa.absolutePage(window.location.href) : window.location.href}`,
     ];
     const authorIsbn = String(data.get('author_isbn') || '').trim();
     const budget = String(data.get('budget') || '').trim();
@@ -249,14 +253,16 @@ const jsonLd = {
     if (budget) lines.push(`Presupuesto aproximado: $${budget} UYU`);
     if (details) lines.push(`Otros datos: ${details}`);
     if (typeSelect.value === 'tapa') lines.push('Voy a mandar la foto de la tapa en el próximo mensaje.');
-    lines.push('', 'Quedo a la espera de las opciones que encuentren. Gracias.');
+    lines.push('', 'Quisiera saber si pueden conseguirlo, el precio y cuánto demoraría. Gracias.');
 
     window.gtag?.('event', 'book_request_submitted', { request_type: type });
     window.AmadoAnalytics?.trackWhatsApp({
       ctaLocation: 'book_request_form',
       topic: type,
     });
-    window.location.href = `https://wa.me/${WA_NUMBER}?text=${encodeURIComponent(lines.join('\n'))}`;
+    window.location.href = wa
+      ? wa.href(lines.join('\n'))
+      : `https://wa.me/${WA_NUMBER}?text=${encodeURIComponent(lines.join('\n'))}`;
   });
 
   updateContext();

--- a/astro-front/src/pages/quienes-somos.astro
+++ b/astro-front/src/pages/quienes-somos.astro
@@ -1,10 +1,17 @@
 ---
 import TrustPageLayout from '../layouts/TrustPageLayout.astro';
+import {
+  buildWhatsAppMessage,
+  whatsappHref,
+} from '../../../shared/whatsapp-messages.js';
 
 const canonical = 'https://www.amadolibros.com/quienes-somos';
-const whatsapp = 'https://wa.me/59899841325?text=' + encodeURIComponent(
-  'Hola Amado Libros, quiero consultar por un libro. Tengo estos datos: '
-);
+const whatsapp = whatsappHref(buildWhatsAppMessage({
+  motive: 'Consultar por un libro',
+  situation: 'Tengo algunos datos del libro',
+  page: canonical,
+  closing: 'Quisiera contarles qué estoy buscando para que puedan orientarme. Gracias.',
+}));
 
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -139,7 +146,7 @@ const jsonLd = {
     <li><strong>Nombre comercial:</strong> Amado Libros.</li>
     <li><strong>Actividad:</strong> librería online uruguaya.</li>
     <li><strong>Punto de retiro coordinado:</strong> Rincón 608, Ciudad Vieja, Montevideo, Uruguay. No es un local de venta al público; el retiro se realiza después de nuestra confirmación por WhatsApp.</li>
-    <li><strong>WhatsApp y teléfono:</strong> <a href="https://wa.me/59899841325">099 841 325</a>.</li>
+    <li><strong>WhatsApp y teléfono:</strong> <a href={whatsapp}>099 841 325</a>.</li>
     <li><strong>Correo:</strong> <a href="mailto:adm@amadolibros.com">adm@amadolibros.com</a>.</li>
     <li><strong>Información operativa:</strong> <a href="/contacto">contacto y horarios</a>, <a href="/envios">envíos y retiro</a> y <a href="/devoluciones">devoluciones</a>.</li>
   </ul>

--- a/astro-front/src/pages/terminos.astro
+++ b/astro-front/src/pages/terminos.astro
@@ -1,5 +1,16 @@
 ---
 import TrustPageLayout from '../layouts/TrustPageLayout.astro';
+import {
+  buildWhatsAppMessage,
+  whatsappHref,
+} from '../../../shared/whatsapp-messages.js';
+const cancellationWhatsApp = whatsappHref(buildWhatsAppMessage({
+  greeting: 'Hola, necesito consultar por un pedido de Amado Libros 😊',
+  motive: 'Solicitar la cancelación de un pedido',
+  situation: 'Pedido realizado y pendiente de despacho',
+  page: '/terminos',
+  closing: 'Quisiera pasarles el número de pedido para saber si todavía puede cancelarse. Gracias.',
+}));
 ---
 <TrustPageLayout
   title="Términos, pagos y cancelaciones — Amado Libros"
@@ -17,7 +28,7 @@ import TrustPageLayout from '../layouts/TrustPageLayout.astro';
   <p>Los encargos del exterior tienen disponibilidad y plazos estimados sujetos a confirmación del proveedor y del transporte. Antes de iniciar la gestión informamos el precio, la seña requerida y el plazo estimado aplicable a ese pedido.</p>
 
   <h2>Cancelación antes del despacho</h2>
-  <p>Para solicitar la cancelación, escribinos cuanto antes por <a href="https://wa.me/59899841325">WhatsApp</a> o a <a href="mailto:adm@amadolibros.com">adm@amadolibros.com</a> con el número de pedido. Si el pedido todavía no fue despachado o entregado, detendremos la preparación y gestionaremos el reembolso.</p>
+  <p>Para solicitar la cancelación, escribinos cuanto antes por <a href={cancellationWhatsApp}>WhatsApp</a> o a <a href="mailto:adm@amadolibros.com">adm@amadolibros.com</a> con el número de pedido. Si el pedido todavía no fue despachado o entregado, detendremos la preparación y gestionaremos el reembolso.</p>
 
   <h2>Después del despacho</h2>
   <p>Si el pedido ya fue despachado, la solicitud se procesa conforme a la <a href="/devoluciones">política de devoluciones y derecho de retracto</a>. Los gastos de retorno se asignan según el motivo de la devolución y la normativa aplicable.</p>

--- a/functions/__tests__/catalog-display.test.js
+++ b/functions/__tests__/catalog-display.test.js
@@ -3,6 +3,10 @@ import assert from 'node:assert/strict';
 import { onRequest as catalogRequest } from '../catalogo.js';
 import { onRequest as bookRequest } from '../libro/[[path]].js';
 import {
+  buildBookWhatsAppMessage,
+  whatsappHref,
+} from '../../shared/whatsapp-messages.js';
+import {
   CATALOG_URL,
   PAUSED_MANIFEST_URL,
   PRODUCTION_MANIFEST_URL,
@@ -360,10 +364,13 @@ test('la ficha pausada queda noindex, sin precio ni compra directa', async () =>
   // formulario de aviso secundario.
   assert.ok(html.indexOf('Consultar si podemos conseguirlo') < html.indexOf('id="aviso-stock"'));
 
-  const expectedWaMsg = encodeURIComponent(
-    'Hola, me interesa conseguir “Alpha raro”, de Autor Dos. ¿Podrían buscarlo por encargo?'
-  );
-  assert.ok(html.includes(`https://wa.me/59899841325?text=${expectedWaMsg}`));
+  const expectedWaHref = whatsappHref(buildBookWhatsAppMessage({
+    title: 'Alpha raro',
+    author: 'Autor Dos',
+    page: 'https://www.amadolibros.com/libro/MLU2/alpha-raro',
+    available: false,
+  })).replace(/&/g, '&amp;');
+  assert.ok(html.includes(expectedWaHref));
 });
 
 test('CF-R2-2C: schema Book de una ficha pausada no incluye Offer', async () => {

--- a/functions/__tests__/ficha-pricing-cta-order.test.js
+++ b/functions/__tests__/ficha-pricing-cta-order.test.js
@@ -98,8 +98,16 @@ test('5. Mercado Libre no usa el estilo visual principal (sin relleno amarillo d
 
 test('6. El enlace de WhatsApp sigue siendo válido (wa.me + mensaje codificado)', () => {
     const html = renderPage(book({ title: 'Un Libro & Su Título' }), 'un-libro', false, '');
-    assert.match(html, /href="https:\/\/wa\.me\/59899841325\?text=/);
-    assert.match(html, /Hola!%20Me%20interesa/);
+    const match = html.match(/href="https:\/\/wa\.me\/59899841325\?text=([^"]+)"/);
+    assert.ok(match, 'la ficha debe incluir un enlace wa.me con mensaje');
+    const message = decodeURIComponent(match[1]);
+    assert.match(message, /Hola, me interesa este libro que encontré en Amado Libros 😊/);
+    assert.match(message, /Motivo: Consultar disponibilidad y precio/);
+    assert.match(message, /Libro: Un Libro & Su Título/);
+    assert.match(message, /Autor: Autor De Prueba/);
+    assert.match(message, /Situación: Disponible/);
+    assert.match(message, /Página: https:\/\/www\.amadolibros\.com\/libro\/MLU1\/un-libro/);
+    assert.doesNotMatch(message, /Vengo desde la web|Referencia:|Código web:/i);
 });
 
 test('7. El enlace de Mercado Libre sigue siendo válido (permalink real, escapado)', () => {

--- a/functions/__tests__/global-shell-parity.test.js
+++ b/functions/__tests__/global-shell-parity.test.js
@@ -21,6 +21,7 @@ const FOOTER_ASTRO = read('astro-front/src/components/Footer.astro');
 const FICHA        = read('functions/libro/[[path]].js');
 const CATALOGO     = read('functions/catalogo.js');
 const BASE_LAYOUT  = read('astro-front/src/layouts/BaseLayout.astro');
+const WHATSAPP_SHARED = read('shared/whatsapp-messages.js');
 
 // ── 1. Paridad de contenido con Footer.astro ────────────────────────────────
 
@@ -44,7 +45,9 @@ test('3. los datos de contacto coinciden con Footer.astro', () => {
     const flat = FOOTER_ASTRO.replace(/\s+/g, ' ');
     assert.ok(flat.includes(CONTACT.whatsappDisplay), 'teléfono visible');
     assert.ok(FOOTER_ASTRO.includes(CONTACT.email), 'email');
-    assert.ok(FOOTER_ASTRO.includes(CONTACT.whatsappNumber), 'número de WhatsApp');
+    assert.ok(WHATSAPP_SHARED.includes(CONTACT.whatsappNumber), 'número de WhatsApp');
+    assert.match(FOOTER_ASTRO, /whatsappHref\(buildWhatsAppMessage/,
+        'Footer.astro debe usar el generador canónico');
 });
 
 test('4. Footer.astro no incorpora links nuevos sin pasar por brand.js', () => {
@@ -84,7 +87,7 @@ test('6. el copyright es dinámico, no un año fijo', () => {
 
 test('7. la ficha ya no usa el footer mínimo', () => {
     assert.doesNotMatch(FICHA, /<a href="\/">Catálogo<\/a> ·/);
-    assert.match(FICHA, /\$\{footerHtml\(\)\}/);
+    assert.match(FICHA, /\$\{footerHtml\(undefined, canonicalUrl\)\}/);
 });
 
 // ── 3. Favicon ──────────────────────────────────────────────────────────────
@@ -170,7 +173,7 @@ test('15. el logo de la ficha existe, es el webp y tiene alt', () => {
 // ── 5. WhatsApp flotante ────────────────────────────────────────────────────
 
 test('16. la ficha incluye la burbuja flotante con mensaje contextual', () => {
-    assert.match(FICHA, /\$\{waFloatHtml\(`Hola, tengo una consulta sobre \$\{item\.title\}\.`\)\}/);
+    assert.match(FICHA, /\$\{waFloatHtml\(waMessage, canonicalUrl\)\}/);
 });
 
 test('17. el mensaje del flotante viaja codificado', () => {

--- a/functions/__tests__/isbn-guide-authority.test.js
+++ b/functions/__tests__/isbn-guide-authority.test.js
@@ -36,7 +36,8 @@ test('el schema Article declara autor, revisión, fechas y breadcrumb', () => {
 test('la guía convierte y es descubrible desde el sitio completo', () => {
   const path = '/como-identificar-edicion-correcta-isbn';
   assert.match(page, /\/pedir-libro\?tipo=exacto/);
-  assert.match(page, /wa\.me\/59899841325/);
+  assert.match(page, /whatsappHref\(buildWhatsAppMessage/);
+  assert.match(page, /motive: 'Verificar la edición correcta de un libro'/);
   assert.ok(FOOTER_LINKS.some(link => link.href === path));
   assert.ok(STATIC_SITEMAP_PAGES.includes(`https://www.amadolibros.com${path}`));
   assert.match(read('astro-front/src/pages/quienes-somos.astro'), new RegExp(path));

--- a/functions/__tests__/whatsapp-messages.test.js
+++ b/functions/__tests__/whatsapp-messages.test.js
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import {
+  absoluteSitePage,
+  buildBookWhatsAppMessage,
+  buildWhatsAppMessage,
+  whatsappHref,
+} from '../../shared/whatsapp-messages.js';
+
+test('la consulta por encargo usa el copy aprobado y contexto operativo', () => {
+  const message = buildBookWhatsAppMessage({
+    title: 'My Hero Academia 42 Edición Especial Cofre',
+    author: 'Kohei Horikoshi',
+    page: '/libro/MLU63131903/my-hero-academia-42-edicion-especial-cofre',
+    available: false,
+  });
+
+  assert.equal(message, [
+    'Hola, me interesa este libro que encontré en Amado Libros 😊',
+    '',
+    'Motivo: Consultar disponibilidad y precio',
+    'Libro: My Hero Academia 42 Edición Especial Cofre',
+    'Autor: Kohei Horikoshi',
+    'Situación: Por encargo',
+    'Página: https://www.amadolibros.com/libro/MLU63131903/my-hero-academia-42-edicion-especial-cofre',
+    '',
+    'Quisiera saber si pueden conseguirlo y cuánto demoraría. Gracias.',
+  ].join('\n'));
+  assert.doesNotMatch(message, /vengo desde la web|Referencia:|Código web:/i);
+});
+
+test('la consulta disponible cambia situación y cierre sin códigos internos', () => {
+  const message = buildBookWhatsAppMessage({
+    title: 'Libro disponible',
+    author: 'Autora',
+    page: '/libro/MLU1/libro-disponible',
+    available: true,
+  });
+  assert.match(message, /Situación: Disponible en Amado Libros/);
+  assert.match(message, /confirmar si está disponible y cómo sería la entrega/);
+  assert.doesNotMatch(message, /Código web|Referencia:/);
+});
+
+test('la página elimina campañas pero conserva filtros útiles', () => {
+  assert.equal(
+    absoluteSitePage('/catalogo?q=murdoku&utm_source=google&gclid=privado'),
+    'https://www.amadolibros.com/catalogo?q=murdoku',
+  );
+});
+
+test('el href codifica saltos, tildes y emoji de forma segura', () => {
+  const message = buildWhatsAppMessage({
+    motive: 'Consulta general',
+    page: '/contacto',
+    closing: '¿Podrían ayudarme? Gracias.',
+  });
+  const href = whatsappHref(message);
+  assert.match(href, /^https:\/\/wa\.me\/59899841325\?text=/);
+  assert.equal(decodeURIComponent(href.split('?text=')[1]), message);
+});
+
+test('el helper del navegador mantiene el mismo formato visible', () => {
+  const source = readFileSync(new URL('../../astro-front/public/whatsapp-messages.js', import.meta.url), 'utf8');
+  const window = { location: { href: 'https://www.amadolibros.com/catalogo?q=murdoku&utm_source=test' } };
+  vm.runInNewContext(source, { window, URL });
+  const message = window.AmadoWhatsApp.build({
+    motive: 'Búsqueda sin resultados',
+    book: 'Murdoku',
+    situation: 'No apareció en el catálogo',
+    page: window.location.href,
+    closing: 'Quisiera saber si pueden conseguirlo. Gracias.',
+  });
+  assert.match(message, /Motivo: Búsqueda sin resultados/);
+  assert.match(message, /Libro: Murdoku/);
+  assert.match(message, /Página: https:\/\/www\.amadolibros\.com\/catalogo\?q=murdoku/);
+  assert.doesNotMatch(message, /utm_source/);
+});

--- a/functions/_shared/author-page.js
+++ b/functions/_shared/author-page.js
@@ -13,8 +13,10 @@ import {
   CARD_IMAGE_SIZES,
   responsiveImage,
 } from './cloudflare-images.js';
-
-const WA = '59899841325';
+import {
+  buildWhatsAppMessage,
+  whatsappHref,
+} from '../../shared/whatsapp-messages.js';
 
 function escapeHtml(value) {
   return String(value ?? '')
@@ -64,7 +66,15 @@ export function renderAuthorPage(author, items, useCloudflareImages = true) {
   const canonicalUrl = `${BASE}${author.path}`;
   const pageTitle = `Libros de ${author.name} en Uruguay`;
   const metaDescription = `Libros de ${author.name} disponibles en Uruguay: ${author.focus}. Comprá online o consultá por encargos en Amado Libros.`;
-  const waMessage = `Hola, busco un libro de ${author.name}`;
+  const waMessage = buildWhatsAppMessage({
+    greeting: 'Hola, estoy buscando un libro en Amado Libros y quisiera que me ayudaran 😊',
+    motive: 'Consultar por otro libro del autor',
+    book: `Otro título de ${author.name}`,
+    author: author.name,
+    situation: 'Todavía no identifiqué la edición exacta',
+    page: canonicalUrl,
+    closing: 'Quisiera contarles qué título necesito y saber si pueden conseguirlo. Gracias.',
+  });
 
   const itemListElements = items.slice(0, 50).map((item, index) => ({
     '@type': 'ListItem',
@@ -161,10 +171,10 @@ export function renderAuthorPage(author, items, useCloudflareImages = true) {
   </section>
   <p class="count">${items.length} título${items.length === 1 ? '' : 's'} disponible${items.length === 1 ? '' : 's'} ahora</p>
   <section class="grid" aria-label="Libros disponibles de ${escapeHtml(author.name)}">${cards}</section>
-  <a class="wa-cta" href="https://wa.me/${WA}?text=${encodeURIComponent(waMessage)}" target="_blank" rel="noopener noreferrer">Consultar otro título por WhatsApp</a>
+  <a class="wa-cta" href="${escapeHtml(whatsappHref(waMessage))}" target="_blank" rel="noopener noreferrer">Consultar otro título por WhatsApp</a>
 </main>
-${footerHtml()}
-${waFloatHtml(waMessage)}
+${footerHtml(undefined, canonicalUrl)}
+${waFloatHtml(waMessage, canonicalUrl)}
 </body>
 </html>`;
 }

--- a/functions/_shared/brand.js
+++ b/functions/_shared/brand.js
@@ -1,3 +1,8 @@
+import {
+    buildWhatsAppMessage,
+    whatsappHref as buildWhatsAppHref,
+} from '../../shared/whatsapp-messages.js';
+
 /**
  * functions/_shared/brand.js — GLOBAL-SHELL-1
  *
@@ -79,7 +84,7 @@ export const FOOTER_LINKS = [
 
 /** Enlace de WhatsApp con mensaje propio, siempre codificado. */
 export function waHref(message) {
-    return `https://wa.me/${CONTACT.whatsappNumber}?text=${encodeURIComponent(message)}`;
+    return buildWhatsAppHref(message);
 }
 
 const WA_ICON_PATH = 'M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z';
@@ -101,6 +106,7 @@ export function faviconHeadHtml() {
         `<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?${v}">`,
         `<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?${v}">`,
         `<link rel="manifest" href="/site.webmanifest?${v}">`,
+        '<script src="/whatsapp-messages.js"></script>',
         '<script src="/analytics-events.js"></script>',
     ].join('\n  ');
 }
@@ -112,8 +118,13 @@ export function faviconHeadHtml() {
  * [título]"); sin él usa el genérico de la home. Los estilos van embebidos
  * porque las Functions no participan del pipeline de estilos de Astro.
  */
-export function waFloatHtml(message) {
-    const href = waHref(message || '¡Hola! Quisiera consultar sobre un libro');
+export function waFloatHtml(message, page = '/') {
+    const copy = message || buildWhatsAppMessage({
+        motive: 'Consulta general',
+        page,
+        closing: 'Quisiera hacerles una consulta. ¿Podrían ayudarme? Gracias.',
+    });
+    const href = waHref(copy);
     return `<a href="${escapeAttr(href)}" target="_blank" rel="noopener noreferrer" class="wa-float" aria-label="Consultar por WhatsApp">
   <svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="${WA_ICON_PATH}"/></svg>
   <span class="wa-float-label">WhatsApp</span>
@@ -140,11 +151,15 @@ export const WA_FLOAT_STYLES = `
  * Footer completo, con el mismo contenido estructural que Footer.astro:
  * marca, tagline, links institucionales, contacto y copyright dinámico.
  */
-export function footerHtml(year = new Date().getFullYear()) {
+export function footerHtml(year = new Date().getFullYear(), page = '/') {
     const links = FOOTER_LINKS
         .map(l => `<li><a href="${l.href}">${l.label}</a></li>`)
         .join('');
-    const wa = waHref('Hola Amado Libros, quisiera consultar');
+    const wa = waHref(buildWhatsAppMessage({
+        motive: 'Consulta general',
+        page,
+        closing: 'Quisiera hacerles una consulta. ¿Podrían ayudarme? Gracias.',
+    }));
     return `<footer class="site-footer">
   <div class="footer-inner">
     <div class="footer-brand">

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -40,6 +40,11 @@ import { slugify } from './_shared/slug.js';
 // GLOBAL-SHELL-1: mismo favicon que el resto del sitio.
 import { faviconHeadHtml } from './_shared/brand.js';
 import {
+    buildBookWhatsAppMessage,
+    buildWhatsAppMessage,
+    whatsappHref,
+} from '../shared/whatsapp-messages.js';
+import {
     BASE,
     fetchActiveIndex,
     fetchCatalog,
@@ -60,7 +65,6 @@ import {
 } from './_shared/cloudflare-images.js';
 
 const MAX_RESULTS = 48;
-const WA = 'https://wa.me/59899841325';
 const FREE_SHIPPING_THRESHOLD_UYU = 1500;
 
 function escapeHtml(str) {
@@ -393,11 +397,12 @@ const CAT_SELECT_STYLES = `
 // URL de la ficha cuando existe. Nunca se muestra "pausado"/"paused" en el
 // texto visible.
 function buildOrderWaMessage(book, href) {
-    let msg = `Hola, quiero consultar por encargo el libro "${book.title}"`;
-    if (book.author) msg += `, de ${book.author}`;
-    msg += `. Referencia: ${book.id}.`;
-    if (href) msg += ` ${href}`;
-    return msg;
+    return buildBookWhatsAppMessage({
+        title: book.title,
+        author: book.author,
+        page: href,
+        available: false,
+    });
 }
 
 // ── CATALOGO-PAGINACION-1 ────────────────────────────────────────────────────
@@ -704,7 +709,8 @@ export async function onRequest(ctx) {
 
     const cards = limited.map((b, idx) => {
         const slug  = slugify(b.title);
-        const href  = escapeHtml(`${previewBase}/libro/${b.id}/${slug}`);
+        const rawHref = `${previewBase}/libro/${b.id}/${slug}`;
+        const href  = escapeHtml(rawHref);
         const fallbackImage = ctx.env?.APP_ENV === 'production'
             ? bookCoverUrl(b.id)
             : httpsImg(b.pictures?.[0] || b.thumbnail || '');
@@ -728,8 +734,7 @@ export async function onRequest(ctx) {
         const installment = Math.round(price / 12).toLocaleString('es-UY');
         const hasFreeShipping = price >= FREE_SHIPPING_THRESHOLD_UYU;
         const loading  = idx < 8 ? 'eager' : 'lazy';
-        const waHref = `${WA}?text=${encodeURIComponent(`Hola Amado Libros, quiero consultar por encargo: ${b.title}`)}`;
-        const orderWaHref = `${WA}?text=${encodeURIComponent(buildOrderWaMessage(b, href))}`;
+        const orderWaHref = whatsappHref(buildOrderWaMessage(b, rawHref));
         const responsiveAttrs = image.srcset
             ? ` srcset="${escapeHtml(image.srcset)}" sizes="${escapeHtml(image.sizes)}"`
             : '';
@@ -815,7 +820,14 @@ export async function onRequest(ctx) {
       <span>Contanos lo que sabés. Una persona de Amado Libros hace la búsqueda y verifica la edición antes de ofrecerte una opción.</span>
       <div class="manual-request-actions">
         <a class="manual-request-primary" href="/pedir-libro?tipo=sin-resultados&amp;q=${encodeURIComponent(rawQ)}">Pedir que lo busquemos</a>
-        <a class="wa-link" href="${WA}?text=${encodeURIComponent(`Hola Amado Libros, busqué “${rawQ}” y no apareció en el catálogo.`)}" target="_blank" rel="noopener noreferrer">Ir directo a WhatsApp</a>
+        <a class="wa-link" href="${escapeHtml(whatsappHref(buildWhatsAppMessage({
+            greeting: 'Hola, busqué un libro en Amado Libros y quisiera que me ayudaran 😊',
+            motive: 'Búsqueda sin resultados',
+            book: rawQ,
+            situation: 'No apareció en el catálogo',
+            page: url.toString(),
+            closing: 'Quisiera saber si pueden conseguirlo y cuánto demoraría. Gracias.',
+        })))}" target="_blank" rel="noopener noreferrer">Ir directo a WhatsApp</a>
       </div>
     </section>`
         : `<p>Todavía no hay resultados en esta categoría. <a href="/catalogo">Volvé a Todos los libros</a>.</p>`;

--- a/functions/especialidades/[[path]].js
+++ b/functions/especialidades/[[path]].js
@@ -20,6 +20,7 @@ import {
   CARD_IMAGE_SIZES,
   responsiveImage,
 } from '../_shared/cloudflare-images.js';
+import { buildWhatsAppMessage } from '../../shared/whatsapp-messages.js';
 
 function escapeHtml(value) {
   return String(value ?? '')
@@ -90,7 +91,14 @@ export async function onRequest(ctx) {
     .filter(item => isSpecialtyMatch(item, specialty)))
     .slice(0, 24);
   const requestPath = `/pedir-libro?tipo=novedades-tecnicas&q=${encodeURIComponent(`Libros de ${specialty.name}`)}`;
-  const waMessage = `Hola Amado Libros, busco un libro de ${specialty.name}. Estoy en [país y ciudad]. Los datos del libro son:`;
+  const waMessage = buildWhatsAppMessage({
+    greeting: 'Hola, estoy buscando un libro en Amado Libros y quisiera que me ayudaran 😊',
+    motive: 'Buscar un libro por encargo',
+    book: `Libro de ${specialty.name}`,
+    situation: 'Todavía no identifiqué la edición exacta',
+    page: canonical,
+    closing: 'Quisiera contarles qué libro necesito y saber si pueden conseguirlo. Gracias.',
+  });
   const related = SEO_SPECIALTIES.filter(item => item.id !== specialty.id);
 
   const collectionSchema = {
@@ -154,7 +162,7 @@ ${items.length ? `<div class="books-grid">${items.map(item => bookCard(item, isP
 <section class="international"><h2>¿Consultás desde España o Latinoamérica?</h2><p>Podés enviarnos el país, la ciudad y los datos del libro. La venta, el medio de pago y un eventual envío internacional se confirman caso a caso antes de asumir cualquier compromiso. Los precios visibles en el catálogo están expresados en pesos uruguayos.</p><div class="actions"><a class="btn secondary" href="${requestPath}">Enviar país y libro buscado</a></div></section>
 <section class="section"><h2>Cómo funciona la búsqueda</h2><div class="process-grid"><article class="card"><h3>1. Identificamos el libro</h3><p>Usamos título, autor, ISBN, editorial, edición o foto para evitar confusiones.</p></article><article class="card"><h3>2. Verificamos mercados</h3><p>Revisamos disponibilidad real en Uruguay, España, Argentina y otros orígenes pertinentes.</p></article><article class="card"><h3>3. Confirmamos antes de vender</h3><p>Informamos edición, formato, moneda, precio, plazo y destino posible antes de avanzar.</p></article></div></section>
 <section class="section"><h2>Otras especialidades</h2><nav class="links" aria-label="Otras especialidades">${related.map(item => `<a href="${specialtyPath(item.id)}">${escapeHtml(item.name)}</a>`).join('')}</nav></section>
-<section class="closing"><h2>¿Qué libro de ${escapeHtml(specialty.name)} necesitás?</h2><p>Mandanos la referencia y tu país. Una persona de Amado Libros revisa la búsqueda.</p><a class="btn secondary" href="${requestPath}">Pedir que lo busquemos</a></section></main>${footerHtml()}${waFloatHtml(waMessage)}</body></html>`;
+<section class="closing"><h2>¿Qué libro de ${escapeHtml(specialty.name)} necesitás?</h2><p>Mandanos la referencia y tu país. Una persona de Amado Libros revisa la búsqueda.</p><a class="btn secondary" href="${requestPath}">Pedir que lo busquemos</a></section></main>${footerHtml(undefined, canonical)}${waFloatHtml(waMessage, canonical)}</body></html>`;
 
   return new Response(html, {
     headers: { 'content-type': 'text/html;charset=UTF-8', 'cache-control': 'public,max-age=3600' },

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -40,8 +40,11 @@ import {
     waFloatHtml,
     WA_FLOAT_STYLES,
 } from '../_shared/brand.js';
+import {
+    buildBookWhatsAppMessage,
+    whatsappHref,
+} from '../../shared/whatsapp-messages.js';
 
-const WA = '59899841325';
 const FREE_SHIPPING_THRESHOLD_UYU = 1500;
 
 // ---------------------------------------------------------------------------
@@ -127,14 +130,6 @@ function formatDimensions(dimensions) {
     if (isValidDimensionValue(dimensions.weight)) rows.push(`Peso ${dimensions.weight}`);
 
     return rows.length ? rows.join(' · ') : null;
-}
-
-function buildPausedWaMessage(item) {
-    let msg = `Hola, me interesa conseguir “${item.title}”`;
-    if (item.author) msg += `, de ${item.author}`;
-    if (item.isbn) msg += ` (${item.isbn})`;
-    msg += '. ¿Podrían buscarlo por encargo?';
-    return msg;
 }
 
 function detailRow(label, value) {
@@ -422,11 +417,14 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     const descriptionHtml = description
         ? `<div class="book-description"><h2>Descripción</h2><p>${escapeHtml(description)}</p></div>`
         : '';
-    const waMsg         = encodeURIComponent(
-        inStock
-            ? `Hola! Me interesa: ${item.title}`
-            : buildPausedWaMessage(item)
-    );
+    const waMessage = buildBookWhatsAppMessage({
+        title: item.title,
+        author: item.author,
+        page: canonicalUrl,
+        available: inStock,
+        unsupportedCurrency: inStock && !checkoutCurrencySupported,
+    });
+    const waLink = whatsappHref(waMessage);
     const relatedBooksHtml = renderRelatedBooks(relatedBooks, item.author, !isPreview);
     const viewItemAnalytics = {
         dedupeKey: `view_item_${item.id}`,
@@ -598,20 +596,20 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
       >
         <span data-cart-label>🛒 Agregar al carrito</span>
       </button>
-      <a class="btn btn-wa" href="https://wa.me/${WA}?text=${waMsg}" target="_blank" rel="noopener noreferrer">
+      <a class="btn btn-wa" href="${escapeHtml(waLink)}" target="_blank" rel="noopener noreferrer">
         💬 Consultar por WhatsApp
       </a>
       <a class="btn btn-ml" href="${escapeHtml(item.permalink)}" target="_blank" rel="noopener noreferrer">
         Comprar en MercadoLibre
       </a>`
         : inStock
-          ? `<a class="btn btn-wa" href="https://wa.me/${WA}?text=${waMsg}" target="_blank" rel="noopener noreferrer">
+          ? `<a class="btn btn-wa" href="${escapeHtml(waLink)}" target="_blank" rel="noopener noreferrer">
         Consultar precio y forma de pago
       </a>
       <a class="btn btn-ml" href="${escapeHtml(item.permalink)}" target="_blank" rel="noopener noreferrer">
         Comprar en MercadoLibre
       </a>`
-        : `<a class="btn btn-wa" href="https://wa.me/${WA}?text=${waMsg}" target="_blank" rel="noopener noreferrer">
+        : `<a class="btn btn-wa" href="${escapeHtml(waLink)}" target="_blank" rel="noopener noreferrer">
         Consultar si podemos conseguirlo
       </a>
       ${waitlistSiteKey ? `<form class="waitlist-form" id="aviso-stock" novalidate>
@@ -910,8 +908,8 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
   }
 }());<\/script>
 
-${footerHtml()}
-${waFloatHtml(`Hola, tengo una consulta sobre ${item.title}.`)}
+${footerHtml(undefined, canonicalUrl)}
+${waFloatHtml(waMessage, canonicalUrl)}
 
 <script>(function(){
   function updateBadge(n){

--- a/functions/libros-agotados-importados-uruguay.js
+++ b/functions/libros-agotados-importados-uruguay.js
@@ -15,15 +15,22 @@ import {
     waHref,
 } from './_shared/brand.js';
 import { SEO_SPECIALTIES, specialtyPath } from './_shared/seo-specialties.js';
+import { buildWhatsAppMessage } from '../shared/whatsapp-messages.js';
 
 const PATH = '/libros-agotados-importados-uruguay';
 const TITLE = 'Libros agotados e importados en Uruguay | Amado Libros';
 const DESCRIPTION = 'Buscamos libros agotados, importados y difíciles de conseguir en Europa y otros mercados. Consultá por título, autor, ISBN o foto desde Uruguay.';
-const REQUEST_MESSAGE = 'Hola Amado Libros, busco un libro por encargo. Les paso título, autor, ISBN o una foto de la tapa:';
 const LAST_REVIEWED_ISO = '2026-08-12';
 
 export async function onRequest() {
     const canonical = `${BASE}${PATH}`;
+    const REQUEST_MESSAGE = buildWhatsAppMessage({
+        greeting: 'Hola, estoy buscando un libro en Amado Libros y quisiera que me ayudaran 😊',
+        motive: 'Solicitar una búsqueda por encargo',
+        situation: 'Libro agotado, importado o difícil de conseguir',
+        page: canonical,
+        closing: 'Quisiera pasarles el título, autor, ISBN o una foto de la tapa para que puedan buscarlo. Gracias.',
+    });
     const requestHref = waHref(REQUEST_MESSAGE);
     const schema = {
         '@context': 'https://schema.org',
@@ -199,8 +206,8 @@ export async function onRequest() {
       <a class="cta cta-primary" href="${requestHref}" target="_blank" rel="noopener noreferrer">Consultar por WhatsApp</a>
     </section>
   </main>
-  ${footerHtml()}
-  ${waFloatHtml(REQUEST_MESSAGE)}
+  ${footerHtml(undefined, canonical)}
+  ${waFloatHtml(REQUEST_MESSAGE, canonical)}
 </body>
 </html>`;
 

--- a/functions/libros/[[path]].js
+++ b/functions/libros/[[path]].js
@@ -20,6 +20,7 @@ import {
     CARD_IMAGE_SIZES,
     responsiveImage,
 } from '../_shared/cloudflare-images.js';
+import { buildWhatsAppMessage } from '../../shared/whatsapp-messages.js';
 
 const MAX_RESULTS = 48;
 const PAGE_PARAM_RE = /^[1-9][0-9]{0,6}$/;
@@ -273,6 +274,14 @@ function renderPage({ category, categoryUniverseCount, items, isPreview, hasUnex
     const scopeText = Number.isFinite(categoryUniverseCount) && categoryUniverseCount > items.length
         ? `<strong>${items.length} título${items.length === 1 ? '' : 's'} disponible${items.length === 1 ? '' : 's'} ahora.</strong> Los ${categoryUniverseCount} títulos informados en la portada incluyen disponibles y libros que podemos buscar por encargo.`
         : `<strong>${items.length} título${items.length === 1 ? '' : 's'} disponible${items.length === 1 ? '' : 's'} ahora.</strong> También buscamos ediciones agotadas o difíciles de conseguir por encargo.`;
+    const waMessage = buildWhatsAppMessage({
+        greeting: 'Hola, estoy buscando un libro en Amado Libros y quisiera que me ayudaran 😊',
+        motive: 'Consultar por un libro de esta categoría',
+        book: `Libro de ${category.name}`,
+        situation: 'Todavía no identifiqué el título exacto',
+        page: canonical,
+        closing: 'Quisiera contarles qué libro necesito y saber si pueden conseguirlo. Gracias.',
+    });
 
     return `<!doctype html>
 <html lang="es">
@@ -311,8 +320,8 @@ ${headerHtml()}
   ${items.length > 0 ? `<section class="books-grid" aria-label="${escapeHtml(category.h1)}">${cards}</section>${pagination}` : '<p class="empty">No hay títulos disponibles en esta categoría en este momento. Consultanos por WhatsApp y lo buscamos por encargo.</p>'}
   ${categoryNavHtml(category.id)}
 </main>
-${footerHtml()}
-${waFloatHtml(`Hola, busco un libro de ${category.name}.`)}
+${footerHtml(undefined, canonical)}
+${waFloatHtml(waMessage, canonical)}
 <script src="/search-autocomplete.js" defer></script>
 </body>
 </html>`;

--- a/shared/whatsapp-messages.js
+++ b/shared/whatsapp-messages.js
@@ -1,0 +1,89 @@
+export const WHATSAPP_NUMBER = '59899841325';
+export const SITE_BASE = 'https://www.amadolibros.com';
+
+export function absoluteSitePage(pathOrUrl = '/') {
+  try {
+    const url = new URL(String(pathOrUrl || '/'), SITE_BASE);
+    url.hash = '';
+    Array.from(url.searchParams.keys()).forEach((key) => {
+      if (/^(utm_|gclid$|dclid$|gbraid$|wbraid$)/i.test(key)) {
+        url.searchParams.delete(key);
+      }
+    });
+    return url.toString();
+  } catch {
+    return `${SITE_BASE}/`;
+  }
+}
+
+/**
+ * Copy canónico para las consultas que salen del sitio hacia WhatsApp.
+ *
+ * Los rótulos son deliberadamente visibles y humanos: ayudan al equipo a
+ * entender el contexto sin exponer códigos internos ni obligar al cliente a
+ * explicar de nuevo qué estaba viendo.
+ */
+export function buildWhatsAppMessage({
+  greeting = 'Hola, encontré Amado Libros y quería hacerles una consulta 😊',
+  motive,
+  book,
+  author,
+  situation,
+  price,
+  order,
+  page,
+  closing,
+} = {}) {
+  const lines = [String(greeting).trim(), ''];
+
+  if (motive) lines.push(`Motivo: ${String(motive).trim()}`);
+  if (book) lines.push(`Libro: ${String(book).trim()}`);
+  if (author) lines.push(`Autor: ${String(author).trim()}`);
+  if (situation) lines.push(`Situación: ${String(situation).trim()}`);
+  if (price) lines.push(`Precio publicado: ${String(price).trim()}`);
+  if (order) lines.push(`Pedido: ${String(order).trim()}`);
+  if (page) lines.push(`Página: ${absoluteSitePage(page)}`);
+
+  if (closing) lines.push('', String(closing).trim());
+  return lines.join('\n');
+}
+
+export function whatsappHref(message) {
+  return `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponent(message)}`;
+}
+
+export function buildBookWhatsAppMessage({
+  title,
+  author,
+  page,
+  available = false,
+  price,
+  unsupportedCurrency = false,
+} = {}) {
+  const situation = unsupportedCurrency
+    ? 'Precio publicado en otra moneda'
+    : available
+      ? 'Disponible en Amado Libros'
+      : 'Por encargo';
+  const motive = unsupportedCurrency
+    ? 'Consultar precio y forma de pago'
+    : available
+      ? 'Consultar disponibilidad y precio'
+      : 'Consultar disponibilidad y precio';
+  const closing = unsupportedCurrency
+    ? 'Quisiera confirmar el precio en pesos uruguayos y la forma de pago. Gracias.'
+    : available
+      ? 'Quisiera confirmar si está disponible y cómo sería la entrega. Gracias.'
+      : 'Quisiera saber si pueden conseguirlo y cuánto demoraría. Gracias.';
+
+  return buildWhatsAppMessage({
+    greeting: 'Hola, me interesa este libro que encontré en Amado Libros 😊',
+    motive,
+    book: title,
+    author,
+    situation,
+    price,
+    page,
+    closing,
+  });
+}


### PR DESCRIPTION
## Qué cambia

- Unifica las consultas de WhatsApp con mensajes humanos, claros y contextuales.
- En fichas de libros usa el formato aprobado: **Motivo, Libro, Autor, Situación y Página**.
- Adapta el contexto en fichas, tarjetas, búsqueda, pedido manual, carrito, comprobantes, seguimiento, envíos, devoluciones y páginas informativas.
- Elimina del mensaje comercial “vengo desde la web”, “Referencia” y “Código web”.
- Conserva el código público del pedido únicamente en consultas de seguimiento o pago, donde es necesario para identificar la operación.
- Limpia parámetros publicitarios de la URL visible antes de enviarla por WhatsApp.
- Mantiene intacta la medición `whatsapp_click` existente.

## Ejemplo principal

```text
Hola, me interesa este libro que encontré en Amado Libros 😊

Motivo: Consultar disponibilidad y precio
Libro: My Hero Academia 42 Edición Especial Cofre
Autor: Kohei Horikoshi
Situación: Por encargo
Página: https://www.amadolibros.com/libro/MLU63131903/...

Quisiera saber si pueden conseguirlo y cuánto demoraría. Gracias.
```

## Validación local

- 502/502 pruebas de Functions aprobadas.
- `git diff --check` limpio.
- Sintaxis validada en ambos helpers de WhatsApp.
- El build de Astro queda a cargo del CI del PR porque este entorno no tiene instaladas sus dependencias.
