### PR TITLE
Medir conversión de las 3.000 fichas por encargo

### DIFF
--- a/astro-front/public/analytics-events.js
+++ b/astro-front/public/analytics-events.js
@@ -120,6 +120,12 @@
     var paymentType = safeToken(options.paymentType, '');
     if (paymentType) params.payment_type = paymentType;
 
+    var availabilityType = safeToken(
+      options.availabilityType || (eventName === 'view_item' ? productAvailabilityType() : ''),
+      '',
+    );
+    if (availabilityType) params.availability_type = availabilityType;
+
     var dedupeKey = safeToken(options.dedupeKey, '');
     if (eventName === 'purchase') {
       var transactionId = String(options.transactionId || '').trim().slice(0, 100);
@@ -203,6 +209,12 @@
     };
   }
 
+  function productAvailabilityType() {
+    var context = pageContext();
+    if (context.pageType !== 'product') return '';
+    return document.querySelector('.badge.in-stock') ? 'active' : 'by_request';
+  }
+
   function ctaLocation(element) {
     var explicit = element && element.closest('[data-cta-location]');
     if (explicit) return safeToken(explicit.getAttribute('data-cta-location'), 'content');
@@ -238,8 +250,43 @@
     var topic = safeToken(options.topic || context.topic, '');
     if (topic) params.topic = topic;
     if (context.productId) params.product_id = context.productId;
+    var availabilityType = productAvailabilityType();
+    if (availabilityType) params.availability_type = availabilityType;
 
     window.gtag('event', 'whatsapp_click', params);
+  }
+
+  function trackStockWaitlistCreated() {
+    var context = pageContext();
+    if (context.pageType !== 'product' || !context.productId) return false;
+    window.gtag('event', 'stock_waitlist_created', {
+      page_type: 'product',
+      product_id: context.productId,
+      availability_type: 'by_request',
+    });
+    return true;
+  }
+
+  function attachWaitlistSuccessTracking() {
+    if (typeof document.getElementById !== 'function' || typeof window.MutationObserver !== 'function') return;
+    var form = document.getElementById('aviso-stock');
+    var status = document.getElementById('waitlist-status');
+    if (!form || !status) return;
+
+    var emitted = false;
+    var observer = new window.MutationObserver(function () {
+      if (emitted || !status.classList || !status.classList.contains('is-ok')) return;
+      var message = String(status.textContent || '').trim();
+      if (!message || /^Ya teníamos registrado/i.test(message)) return;
+      emitted = trackStockWaitlistCreated();
+    });
+    observer.observe(status, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['class'],
+    });
   }
 
   ensureGoogleTag();
@@ -247,8 +294,15 @@
   window.AmadoAnalytics = Object.assign({}, window.AmadoAnalytics, {
     trackWhatsApp: trackWhatsApp,
     trackCommerce: trackCommerce,
+    trackStockWaitlistCreated: trackStockWaitlistCreated,
     getMeasurementContext: getMeasurementContext,
   });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', attachWaitlistSuccessTracking, { once: true });
+  } else {
+    attachWaitlistSuccessTracking();
+  }
 
   document.addEventListener('click', function (event) {
     var anchor = event.target && event.target.closest

--- a/functions/__tests__/paused-cohort-observability.test.js
+++ b/functions/__tests__/paused-cohort-observability.test.js
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { runInNewContext } from 'node:vm';
+
+const analytics = readFileSync('astro-front/public/analytics-events.js', 'utf8');
+const productPage = readFileSync('functions/libro/[[path]].js', 'utf8');
+
+function storage() {
+  const values = new Map();
+  return {
+    getItem: key => values.get(key) || null,
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+function analyticsRuntime({ inStock }) {
+  const store = storage();
+  const window = {
+    location: {
+      hostname: 'www.amadolibros.com',
+      pathname: '/libro/MLU123/libro-de-prueba',
+      href: 'https://www.amadolibros.com/libro/MLU123/libro-de-prueba',
+    },
+    dataLayer: [],
+    localStorage: store,
+    sessionStorage: store,
+  };
+  const document = {
+    readyState: 'complete',
+    querySelector(selector) {
+      if (selector === '.badge.in-stock') return inStock ? {} : null;
+      return null;
+    },
+    createElement: () => ({}),
+    head: { appendChild: () => {} },
+    addEventListener: () => {},
+  };
+
+  runInNewContext(analytics, {
+    document, window, URL, Set, Date, Object, String, Number, Math, Array, isFinite,
+    encodeURIComponent,
+  });
+  return window;
+}
+
+test('view_item distingue fichas activas de fichas por encargo', () => {
+  for (const [inStock, expected] of [[true, 'active'], [false, 'by_request']]) {
+    const window = analyticsRuntime({ inStock });
+    assert.equal(window.AmadoAnalytics.trackCommerce('view_item', {
+      items: [{ item_id: 'MLU123', item_name: 'Libro de prueba', quantity: 1 }],
+    }), true);
+
+    const event = window.dataLayer.find(entry => {
+      const row = Array.from(entry);
+      return row[0] === 'event' && row[1] === 'view_item';
+    });
+    assert.ok(event, 'debe existir view_item');
+    assert.equal(Array.from(event)[2].availability_type, expected);
+  }
+});
+
+test('whatsapp_click incluye availability_type en fichas sin enviar datos personales', () => {
+  const window = analyticsRuntime({ inStock: false });
+  window.AmadoAnalytics.trackWhatsApp({ ctaLocation: 'primary' });
+
+  const event = Array.from(window.dataLayer.at(-1));
+  assert.equal(event[0], 'event');
+  assert.equal(event[1], 'whatsapp_click');
+  assert.deepEqual({ ...event[2] }, {
+    page_type: 'product',
+    cta_location: 'primary',
+    product_id: 'MLU123',
+    availability_type: 'by_request',
+  });
+  assert.equal(JSON.stringify(event[2]).includes('@'), false);
+});
+
+test('stock_waitlist_created se emite sólo tras un alta nueva confirmada', () => {
+  let mutationCallback = null;
+  const status = {
+    textContent: '',
+    classList: {
+      contains(name) { return name === 'is-ok'; },
+    },
+  };
+  const window = {
+    location: {
+      hostname: 'www.amadolibros.com',
+      pathname: '/libro/MLU456/libro-agotado',
+      href: 'https://www.amadolibros.com/libro/MLU456/libro-agotado',
+    },
+    dataLayer: [],
+    MutationObserver: class {
+      constructor(callback) { mutationCallback = callback; }
+      observe() {}
+    },
+  };
+  const document = {
+    readyState: 'complete',
+    querySelector: () => null,
+    createElement: () => ({}),
+    head: { appendChild: () => {} },
+    addEventListener: () => {},
+    getElementById(id) {
+      if (id === 'aviso-stock') return {};
+      if (id === 'waitlist-status') return status;
+      return null;
+    },
+  };
+
+  runInNewContext(analytics, {
+    document, window, URL, Set, Date, Object, String, Number, Math, Array, isFinite,
+    encodeURIComponent,
+  });
+  assert.equal(typeof mutationCallback, 'function');
+
+  status.textContent = 'Ya teníamos registrado este correo para este libro.';
+  mutationCallback();
+  assert.equal(window.dataLayer.filter(entry => Array.from(entry)[1] === 'stock_waitlist_created').length, 0);
+
+  status.textContent = 'Pronto. Te avisaremos cuando vuelva a estar disponible.';
+  mutationCallback();
+  mutationCallback();
+
+  const events = window.dataLayer.filter(entry => Array.from(entry)[1] === 'stock_waitlist_created');
+  assert.equal(events.length, 1, 'una alta nueva debe contarse una sola vez');
+  assert.deepEqual({ ...Array.from(events[0])[2] }, {
+    page_type: 'product',
+    product_id: 'MLU456',
+    availability_type: 'by_request',
+  });
+});
+
+test('el contrato UI diferencia alta nueva de correo ya registrado', () => {
+  assert.match(productPage, /Ya teníamos registrado este correo para este libro\./);
+  assert.match(productPage, /Pronto\. Te avisaremos cuando vuelva a estar disponible\./);
+  assert.match(analytics, /stock_waitlist_created/);
+  assert.match(analytics, /availability_type/);
+  assert.match(analytics, /\^Ya teníamos registrado/i);
+});


### PR DESCRIPTION
## Objetivo
Convertir la cohorte SEO de 3.000 fichas por encargo en tráfico y demanda medibles antes de ampliar el volumen indexable.

## Alcance de este lote
- GA4 agrega `availability_type=active|by_request` en `view_item` de fichas.
- `whatsapp_click` agrega `availability_type` cuando el clic ocurre en una ficha de producto.
- Nuevo evento `stock_waitlist_created` sólo cuando la UI confirma un alta nueva del aviso de stock.
- El caso `already_registered` no se vuelve a contar como alta.
- No se envían correo, mensaje de WhatsApp ni otros datos personales a GA4.
- Pruebas específicas para activa vs. por encargo, WhatsApp y waitlist.

## Fuera de alcance
- No cambia catálogo, precios, checkout, Merchant, sitemap, canonical ni robots.
- No amplía la cohorte por encima de 3.000.
- No toca producción mientras este PR no sea aprobado y fusionado.
- Segmentación de logs Googlebot/GSC y configuración externa de Search Console quedan como siguiente sublote de observabilidad.

## Riesgo
Bajo. El cambio queda en la capa compartida de analítica cliente y mantiene GA4 apagado fuera de los hosts productivos.
