### PR TITLE
Separar GSC y Googlebot por cohorte de disponibilidad

### DIFF
--- a/.github/workflows/gsc-export.yml
+++ b/.github/workflows/gsc-export.yml
@@ -8,13 +8,6 @@ on:
       - '.github/workflows/gsc-export.yml'
       - 'scripts/seo/gsc-export.mjs'
       - 'scripts/seo/gsc-analysis.mjs'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/gsc-export.yml'
-      - 'scripts/seo/gsc-export.mjs'
-      - 'scripts/seo/gsc-analysis.mjs'
   schedule:
     - cron: '17 11 * * 1'
   workflow_dispatch:

--- a/.github/workflows/gsc-export.yml
+++ b/.github/workflows/gsc-export.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - '.github/workflows/gsc-export.yml'
+      - 'scripts/seo/gsc-export.mjs'
+      - 'scripts/seo/gsc-analysis.mjs'
   schedule:
     - cron: '17 11 * * 1'
   workflow_dispatch:
@@ -24,7 +26,7 @@ on:
         default: 'sc-domain:amadolibros.com'
         type: string
       inspection_sample_size:
-        description: Cantidad de fichas activas a inspeccionar (máximo 400)
+        description: Cantidad total de fichas activas y por encargo a inspeccionar (máximo 400)
         required: true
         default: 400
         type: number
@@ -92,6 +94,7 @@ jobs:
           GSC_ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
           GSC_OUTPUT_DIR: artifacts/gsc
           GSC_ACTIVE_SITEMAP_URL: https://www.amadolibros.com/sitemap-books-active.xml
+          GSC_PAUSED_SITEMAP_URL: https://www.amadolibros.com/sitemap-books-paused.xml
           GSC_INSPECTION_SAMPLE_SIZE: ${{ inputs.inspection_sample_size || 400 }}
         run: node scripts/seo/gsc-export.mjs
 

--- a/.github/workflows/gsc-export.yml
+++ b/.github/workflows/gsc-export.yml
@@ -8,6 +8,13 @@ on:
       - '.github/workflows/gsc-export.yml'
       - 'scripts/seo/gsc-export.mjs'
       - 'scripts/seo/gsc-analysis.mjs'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/gsc-export.yml'
+      - 'scripts/seo/gsc-export.mjs'
+      - 'scripts/seo/gsc-analysis.mjs'
   schedule:
     - cron: '17 11 * * 1'
   workflow_dispatch:

--- a/.github/workflows/seo-crawl-report.yml
+++ b/.github/workflows/seo-crawl-report.yml
@@ -35,7 +35,7 @@ jobs:
           [[ "$START_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || { echo "start_date inválida"; exit 1; }
           [[ "$END_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || { echo "end_date inválida"; exit 1; }
 
-      - name: Query aggregated D1 rows
+      - name: Query aggregated D1 rows by cohort
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -44,7 +44,7 @@ jobs:
         run: |
           mkdir -p artifacts/seo
           npx wrangler@3.114.17 d1 execute ORDERS_DB --env production --remote --json \
-            --command "SELECT date, pattern, status, verified, ua_googlebot, request_count, bytes_sum, bytes_known_count, duration_ms_sum FROM crawl_stats WHERE date >= '$START_DATE' AND date <= '$END_DATE' ORDER BY date, pattern, status, verified, ua_googlebot" \
+            --command "SELECT date, pattern, segment, status, verified, ua_googlebot, request_count, bytes_sum, bytes_known_count, duration_ms_sum FROM crawl_stats_segmented WHERE date >= '$START_DATE' AND date <= '$END_DATE' ORDER BY date, pattern, segment, status, verified, ua_googlebot" \
             > artifacts/seo/crawl-stats-raw.json
 
       - name: Build useful crawl report
@@ -61,5 +61,6 @@ jobs:
             artifacts/seo/crawl-stats-raw.json
             artifacts/seo/crawl-summary.json
             artifacts/seo/crawl-daily.csv
+            artifacts/seo/crawl-segments.csv
           if-no-files-found: error
           retention-days: 30

--- a/functions/__tests__/cohort-observability.test.js
+++ b/functions/__tests__/cohort-observability.test.js
@@ -6,11 +6,13 @@ import {
   productLookupStateFromContext,
   recordCrawlRequest,
   resetCrawlAnalyticsCachesForTest,
-  shouldCaptureCrawlRequest,
+  resolveProductCrawlSegment,
   classifyCrawlRequest,
 } from '../_shared/crawl-analytics.js';
 
 const BASE = 'https://www.amadolibros.com';
+const BY_REQUEST_ID = 'MLU1416777650';
+const PAUSED_OTHER_ID = 'MLU999999999';
 
 function analyticsRow(page, impressions = 20) {
   return {
@@ -57,14 +59,6 @@ function googleRangesResponse() {
   return new Response(JSON.stringify({
     prefixes: [{ ipv4Prefix: '66.249.64.0/19' }],
   }), { status: 200 });
-}
-
-function pausedSitemap(ids) {
-  const rows = ids.map((id) => `<url><loc>${BASE}/libro/${id}/libro-${id}</loc></url>`).join('');
-  return new Response(
-    `<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${rows}</urlset>`,
-    { status: 200, headers: { 'content-type': 'application/xml' } },
-  );
 }
 
 test('GSC construye una muestra estable 200/200 entre activas y por encargo', async () => {
@@ -139,7 +133,23 @@ test('usa el resultado ya calculado por la ficha para distinguir catálogo activ
   assert.equal(productLookupStateFromContext({ data: {} }), 'unknown');
 });
 
-async function recordSegment({ id, productLookupState, pausedIds }) {
+test('la cohorte versionada clasifica por encargo sin una consulta de red', () => {
+  const byRequest = resolveProductCrawlSegment({
+    request: new Request(`${BASE}/libro/${BY_REQUEST_ID}/libro-en-cohorte`),
+    classification: classifyCrawlRequest(new Request(`${BASE}/libro/${BY_REQUEST_ID}/libro-en-cohorte`)),
+    productLookupState: 'paused',
+  });
+  const pausedOther = resolveProductCrawlSegment({
+    request: new Request(`${BASE}/libro/${PAUSED_OTHER_ID}/libro-fuera-de-cohorte`),
+    classification: classifyCrawlRequest(new Request(`${BASE}/libro/${PAUSED_OTHER_ID}/libro-fuera-de-cohorte`)),
+    productLookupState: 'paused',
+  });
+
+  assert.equal(byRequest, 'by_request');
+  assert.equal(pausedOther, 'paused_other');
+});
+
+async function recordSegment({ id, productLookupState }) {
   resetCrawlAnalyticsCachesForTest();
   const db = fakeDb();
   const env = {
@@ -147,7 +157,7 @@ async function recordSegment({ id, productLookupState, pausedIds }) {
     AMADO_KV: fakeKv({ 'seo:crawl-logs-3:enabled:production': 'true' }),
     ORDERS_DB: db,
   };
-  const sitemapFetches = [];
+  let fetchCount = 0;
   const result = await recordCrawlRequest({
     request: new Request(`${BASE}/libro/${id}/libro-de-prueba`, {
       headers: {
@@ -161,45 +171,39 @@ async function recordSegment({ id, productLookupState, pausedIds }) {
     productLookupState,
   }, {
     nowFn: () => Date.parse('2026-08-17T20:00:00Z'),
-    fetchFn: async (url, options = {}) => {
+    fetchFn: async (url) => {
+      fetchCount += 1;
       if (String(url).includes('common-crawlers.json')) return googleRangesResponse();
-      if (String(url).includes('sitemap-books-paused.xml')) {
-        sitemapFetches.push(options);
-        return pausedSitemap(pausedIds);
-      }
       throw new Error(`Fetch inesperado: ${url}`);
     },
   });
 
   const insert = db.calls.find((call) => /INSERT INTO crawl_stats_segmented/.test(call.sql));
   assert.ok(insert, 'debe persistir la dimensión segmentada');
-  return { result, insert, sitemapFetches };
+  return { result, insert, fetchCount };
 }
 
 test('Googlebot queda separado en active, by_request y paused_other sin guardar URL', async () => {
   const active = await recordSegment({
     id: 'MLU100',
     productLookupState: 'active',
-    pausedIds: ['MLU200'],
   });
   assert.equal(active.result.segment, 'active');
-  assert.equal(active.sitemapFetches.length, 0, 'una activa no necesita consultar el sitemap pausado');
+  assert.equal(active.fetchCount, 1, 'sólo verifica los rangos oficiales de Google');
 
   const byRequest = await recordSegment({
-    id: 'MLU200',
+    id: BY_REQUEST_ID,
     productLookupState: 'paused',
-    pausedIds: ['MLU200'],
   });
   assert.equal(byRequest.result.segment, 'by_request');
-  assert.equal(byRequest.sitemapFetches.length, 1);
-  assert.equal(new Headers(byRequest.sitemapFetches[0].headers).get('x-amado-internal-observability'), '1');
+  assert.equal(byRequest.fetchCount, 1, 'la cohorte no necesita red');
 
   const pausedOther = await recordSegment({
-    id: 'MLU300',
+    id: PAUSED_OTHER_ID,
     productLookupState: 'paused',
-    pausedIds: ['MLU200'],
   });
   assert.equal(pausedOther.result.segment, 'paused_other');
+  assert.equal(pausedOther.fetchCount, 1, 'la cohorte no necesita red');
 
   assert.deepEqual(byRequest.insert.args.slice(0, 6), [
     '2026-08-17', 'libro', 'by_request', 200, 1, 1,
@@ -208,14 +212,7 @@ test('Googlebot queda separado en active, by_request y paused_other sin guardar 
   assert.equal(persisted.includes('/libro/'), false);
   assert.equal(persisted.includes('66.249.66.1'), false);
   assert.equal(persisted.includes('Googlebot'), false);
-});
-
-test('la consulta interna del sitemap no vuelve a entrar al muestreo', () => {
-  const request = new Request(`${BASE}/sitemap-books-paused.xml`, {
-    headers: { 'x-amado-internal-observability': '1' },
-  });
-  const classification = classifyCrawlRequest(request);
-  assert.equal(shouldCaptureCrawlRequest(request, classification, () => 0), false);
+  assert.equal(persisted.includes(BY_REQUEST_ID), false);
 });
 
 test('el reporte agregado entrega KPIs separados por cohorte', async () => {
@@ -246,6 +243,7 @@ test('workflows y migración quedan conectados a las nuevas cohortes', () => {
   const crawlWorkflow = readFileSync('.github/workflows/seo-crawl-report.yml', 'utf8');
   const migration = readFileSync('migrations/0009_crawl_stats_segmented.sql', 'utf8');
   const gscExport = readFileSync('scripts/seo/gsc-export.mjs', 'utf8');
+  const crawlAnalytics = readFileSync('functions/_shared/crawl-analytics.js', 'utf8');
 
   assert.match(gscWorkflow, /GSC_PAUSED_SITEMAP_URL: https:\/\/www\.amadolibros\.com\/sitemap-books-paused\.xml/);
   assert.match(gscWorkflow, /scripts\/seo\/gsc-analysis\.mjs/);
@@ -255,4 +253,6 @@ test('workflows y migración quedan conectados a las nuevas cohortes', () => {
   assert.match(crawlWorkflow, /crawl-segments\.csv/);
   assert.match(migration, /CREATE TABLE IF NOT EXISTS crawl_stats_segmented/);
   assert.match(migration, /historical_unsegmented/);
+  assert.match(crawlAnalytics, /isPausedProductInSeoCohort/);
+  assert.doesNotMatch(crawlAnalytics, /fetchFn\(.*sitemap-books-paused/s);
 });

--- a/functions/__tests__/cohort-observability.test.js
+++ b/functions/__tests__/cohort-observability.test.js
@@ -1,0 +1,258 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import {
+  productLookupStateFromContext,
+  recordCrawlRequest,
+  resetCrawlAnalyticsCachesForTest,
+  shouldCaptureCrawlRequest,
+  classifyCrawlRequest,
+} from '../_shared/crawl-analytics.js';
+
+const BASE = 'https://www.amadolibros.com';
+
+function analyticsRow(page, impressions = 20) {
+  return {
+    keys: [page],
+    clicks: 1,
+    impressions,
+    ctr: 1 / impressions,
+    position: 8,
+  };
+}
+
+function fakeKv(entries = {}) {
+  const map = new Map(Object.entries(entries));
+  return {
+    async get(key) { return map.get(key) ?? null; },
+    async put(key, value) { map.set(key, value); },
+  };
+}
+
+function fakeDb() {
+  const calls = [];
+  return {
+    calls,
+    prepare(sql) {
+      return {
+        async run() {
+          calls.push({ sql, args: [] });
+          return { success: true };
+        },
+        bind(...args) {
+          return {
+            async run() {
+              calls.push({ sql, args });
+              return { success: true };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+function googleRangesResponse() {
+  return new Response(JSON.stringify({
+    prefixes: [{ ipv4Prefix: '66.249.64.0/19' }],
+  }), { status: 200 });
+}
+
+function pausedSitemap(ids) {
+  const rows = ids.map((id) => `<url><loc>${BASE}/libro/${id}/libro-${id}</loc></url>`).join('');
+  return new Response(
+    `<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${rows}</urlset>`,
+    { status: 200, headers: { 'content-type': 'application/xml' } },
+  );
+}
+
+test('GSC construye una muestra estable 200/200 entre activas y por encargo', async () => {
+  const { buildCohortInspectionSample } = await import('../../scripts/seo/gsc-analysis.mjs');
+  const active = Array.from(
+    { length: 300 },
+    (_, index) => `${BASE}/libro/MLU${1000 + index}/activo-${index}`,
+  );
+  const byRequest = Array.from(
+    { length: 300 },
+    (_, index) => `${BASE}/libro/MLU${5000 + index}/encargo-${index}`,
+  );
+  const pageRows = [
+    ...active.slice(0, 80).map((page, index) => analyticsRow(page, 200 - index)),
+    ...byRequest.slice(0, 80).map((page, index) => analyticsRow(page, 160 - index)),
+  ];
+
+  const first = buildCohortInspectionSample({
+    activeSitemapUrls: active,
+    pausedSitemapUrls: byRequest,
+    pageRows,
+    ctrOpportunities: pageRows.slice(0, 20).map((row) => ({ page: row.keys[0] })),
+    size: 400,
+  });
+  const second = buildCohortInspectionSample({
+    activeSitemapUrls: active,
+    pausedSitemapUrls: byRequest,
+    pageRows,
+    size: 400,
+  });
+
+  assert.equal(first.length, 400);
+  assert.equal(first.filter((row) => row.cohort === 'active').length, 200);
+  assert.equal(first.filter((row) => row.cohort === 'by_request').length, 200);
+  assert.equal(new Set(first.map((row) => row.page)).size, 400);
+  assert.ok(first.every((row) => active.includes(row.page) || byRequest.includes(row.page)));
+
+  const stableWithoutPriority = buildCohortInspectionSample({
+    activeSitemapUrls: active,
+    pausedSitemapUrls: byRequest,
+    pageRows,
+    size: 400,
+  });
+  assert.deepEqual(second, stableWithoutPriority);
+});
+
+test('el resumen de inspección conserva resultados separados por cohorte', async () => {
+  const { summarizeInspections } = await import('../../scripts/seo/gsc-analysis.mjs');
+  const summary = summarizeInspections([
+    { cohort: 'active', stratum: 'seen_in_search', verdict: 'PASS', coverageState: 'Submitted and indexed' },
+    { cohort: 'by_request', stratum: 'no_impressions', verdict: 'NEUTRAL', coverageState: 'Crawled - currently not indexed' },
+    { cohort: 'by_request', stratum: 'no_impressions', error: 'HTTP 429' },
+  ]);
+
+  assert.equal(summary.requested, 3);
+  assert.equal(summary.cohorts.active.completed, 1);
+  assert.equal(summary.cohorts.active.verdicts.PASS, 1);
+  assert.equal(summary.cohorts.by_request.requested, 2);
+  assert.equal(summary.cohorts.by_request.errors, 1);
+});
+
+test('usa el resultado ya calculado por la ficha para distinguir catálogo activo y pausado', () => {
+  assert.equal(productLookupStateFromContext({
+    data: { perf: { segments: [{ name: 'active_lookup', found: true }] } },
+  }), 'active');
+  assert.equal(productLookupStateFromContext({
+    data: { perf: { segments: [
+      { name: 'active_lookup', found: false },
+      { name: 'paused_lookup', found: true },
+    ] } },
+  }), 'paused');
+  assert.equal(productLookupStateFromContext({ data: {} }), 'unknown');
+});
+
+async function recordSegment({ id, productLookupState, pausedIds }) {
+  resetCrawlAnalyticsCachesForTest();
+  const db = fakeDb();
+  const env = {
+    APP_ENV: 'production',
+    AMADO_KV: fakeKv({ 'seo:crawl-logs-3:enabled:production': 'true' }),
+    ORDERS_DB: db,
+  };
+  const sitemapFetches = [];
+  const result = await recordCrawlRequest({
+    request: new Request(`${BASE}/libro/${id}/libro-de-prueba`, {
+      headers: {
+        'user-agent': 'Googlebot/2.1',
+        'cf-connecting-ip': '66.249.66.1',
+      },
+    }),
+    response: new Response('ok', { status: 200, headers: { 'content-length': '200' } }),
+    env,
+    durationMs: 12,
+    productLookupState,
+  }, {
+    nowFn: () => Date.parse('2026-08-17T20:00:00Z'),
+    fetchFn: async (url, options = {}) => {
+      if (String(url).includes('common-crawlers.json')) return googleRangesResponse();
+      if (String(url).includes('sitemap-books-paused.xml')) {
+        sitemapFetches.push(options);
+        return pausedSitemap(pausedIds);
+      }
+      throw new Error(`Fetch inesperado: ${url}`);
+    },
+  });
+
+  const insert = db.calls.find((call) => /INSERT INTO crawl_stats_segmented/.test(call.sql));
+  assert.ok(insert, 'debe persistir la dimensión segmentada');
+  return { result, insert, sitemapFetches };
+}
+
+test('Googlebot queda separado en active, by_request y paused_other sin guardar URL', async () => {
+  const active = await recordSegment({
+    id: 'MLU100',
+    productLookupState: 'active',
+    pausedIds: ['MLU200'],
+  });
+  assert.equal(active.result.segment, 'active');
+  assert.equal(active.sitemapFetches.length, 0, 'una activa no necesita consultar el sitemap pausado');
+
+  const byRequest = await recordSegment({
+    id: 'MLU200',
+    productLookupState: 'paused',
+    pausedIds: ['MLU200'],
+  });
+  assert.equal(byRequest.result.segment, 'by_request');
+  assert.equal(byRequest.sitemapFetches.length, 1);
+  assert.equal(new Headers(byRequest.sitemapFetches[0].headers).get('x-amado-internal-observability'), '1');
+
+  const pausedOther = await recordSegment({
+    id: 'MLU300',
+    productLookupState: 'paused',
+    pausedIds: ['MLU200'],
+  });
+  assert.equal(pausedOther.result.segment, 'paused_other');
+
+  assert.deepEqual(byRequest.insert.args.slice(0, 6), [
+    '2026-08-17', 'libro', 'by_request', 200, 1, 1,
+  ]);
+  const persisted = JSON.stringify(byRequest.insert.args);
+  assert.equal(persisted.includes('/libro/'), false);
+  assert.equal(persisted.includes('66.249.66.1'), false);
+  assert.equal(persisted.includes('Googlebot'), false);
+});
+
+test('la consulta interna del sitemap no vuelve a entrar al muestreo', () => {
+  const request = new Request(`${BASE}/sitemap-books-paused.xml`, {
+    headers: { 'x-amado-internal-observability': '1' },
+  });
+  const classification = classifyCrawlRequest(request);
+  assert.equal(shouldCaptureCrawlRequest(request, classification, () => 0), false);
+});
+
+test('el reporte agregado entrega KPIs separados por cohorte', async () => {
+  const { aggregate } = await import('../../scripts/seo/crawl-report.mjs');
+  const { total, daily } = aggregate([
+    {
+      date: '2026-08-17', pattern: 'libro', segment: 'active', status: 200,
+      verified: 1, request_count: 10, duration_ms_sum: 100,
+    },
+    {
+      date: '2026-08-17', pattern: 'libro', segment: 'by_request', status: 200,
+      verified: 1, request_count: 4, duration_ms_sum: 80,
+    },
+    {
+      date: '2026-08-17', pattern: 'libro', segment: 'paused_other', status: 404,
+      verified: 1, request_count: 2, duration_ms_sum: 20,
+    },
+  ]);
+
+  assert.equal(total.bySegment.active.verifiedGooglebotRequests, 10);
+  assert.equal(total.bySegment.by_request.verifiedGooglebotStatus200, 4);
+  assert.equal(total.bySegment.paused_other.verifiedGooglebotNon200, 2);
+  assert.equal(daily[0].bySegment.by_request.averageDurationMs, 20);
+});
+
+test('workflows y migración quedan conectados a las nuevas cohortes', () => {
+  const gscWorkflow = readFileSync('.github/workflows/gsc-export.yml', 'utf8');
+  const crawlWorkflow = readFileSync('.github/workflows/seo-crawl-report.yml', 'utf8');
+  const migration = readFileSync('migrations/0009_crawl_stats_segmented.sql', 'utf8');
+  const gscExport = readFileSync('scripts/seo/gsc-export.mjs', 'utf8');
+
+  assert.match(gscWorkflow, /GSC_PAUSED_SITEMAP_URL: https:\/\/www\.amadolibros\.com\/sitemap-books-paused\.xml/);
+  assert.match(gscWorkflow, /scripts\/seo\/gsc-analysis\.mjs/);
+  assert.match(gscExport, /buildCohortInspectionSample/);
+  assert.match(gscExport, /sitemap-cohorts\.json/);
+  assert.match(crawlWorkflow, /FROM crawl_stats_segmented/);
+  assert.match(crawlWorkflow, /crawl-segments\.csv/);
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS crawl_stats_segmented/);
+  assert.match(migration, /historical_unsegmented/);
+});

--- a/functions/_shared/crawl-analytics.js
+++ b/functions/_shared/crawl-analytics.js
@@ -1,9 +1,12 @@
 const GOOGLE_COMMON_CRAWLERS_URL = 'https://developers.google.com/static/crawling/ipranges/common-crawlers.json';
 const GOOGLE_RANGES_KV_KEY = 'seo:crawl-logs-3:google-common-crawlers:v1';
+const PAUSED_SITEMAP_URL = 'https://www.amadolibros.com/sitemap-books-paused.xml';
+const INTERNAL_OBSERVABILITY_HEADER = 'x-amado-internal-observability';
 const FLAG_PREFIX = 'seo:crawl-logs-3:enabled:';
 const FLAG_CACHE_MS = 60_000;
 const RANGE_FRESH_MS = 24 * 60 * 60 * 1000;
 const ISOLATE_RANGE_CACHE_MS = 60 * 60 * 1000;
+const PAUSED_SITEMAP_CACHE_MS = 5 * 60 * 1000;
 const SAMPLE_RATE = 0.01;
 
 export const USEFUL_CRAWL_RATIO_V1 = Object.freeze({
@@ -26,6 +29,7 @@ const STATIC_USEFUL_PATHS = new Set([
 
 let flagCache = new Map();
 let rangeCache = null;
+let pausedSitemapCache = null;
 let schemaReadyPromise = null;
 
 function appEnv(env) {
@@ -115,6 +119,7 @@ export function classifyCrawlRequest(request) {
 }
 
 export function shouldCaptureCrawlRequest(request, classification, randomFn = Math.random) {
+  if (request.headers.get(INTERNAL_OBSERVABILITY_HEADER) === '1') return false;
   const ua = request.headers.get('user-agent') || '';
   if (classification.pattern === 'asset') return false;
   if (classification.legacy) return true;
@@ -277,6 +282,79 @@ async function verifyGooglebot(request, env, nowMs, fetchFn) {
   return match == null ? -2 : (match ? 1 : 0);
 }
 
+function productIdFromRequest(request) {
+  try {
+    const match = new URL(request.url).pathname.match(/^\/libro\/(MLU\d+)(?:\/|$)/i);
+    return match ? match[1].toUpperCase() : '';
+  } catch {
+    return '';
+  }
+}
+
+function pausedIdsFromSitemap(xml) {
+  const ids = new Set();
+  for (const match of String(xml || '').matchAll(/<loc>\s*([^<]+?)\s*<\/loc>/gi)) {
+    try {
+      const idMatch = new URL(match[1].replaceAll('&amp;', '&')).pathname.match(/^\/libro\/(MLU\d+)(?:\/|$)/i);
+      if (idMatch) ids.add(idMatch[1].toUpperCase());
+    } catch {
+      // Una URL inválida no invalida todo el sitemap; simplemente se omite.
+    }
+  }
+  return ids;
+}
+
+async function loadPausedSitemapIds(nowMs, fetchFn) {
+  if (pausedSitemapCache && pausedSitemapCache.expiresAt > nowMs) {
+    return pausedSitemapCache.ids;
+  }
+  try {
+    const response = await fetchFn(PAUSED_SITEMAP_URL, {
+      headers: {
+        accept: 'application/xml,text/xml',
+        [INTERNAL_OBSERVABILITY_HEADER]: '1',
+      },
+    });
+    if (!response.ok) throw new Error(`sitemap pausado HTTP ${response.status}`);
+    const ids = pausedIdsFromSitemap(await response.text());
+    if (!ids.size) throw new Error('sitemap pausado sin IDs');
+    pausedSitemapCache = { ids, expiresAt: nowMs + PAUSED_SITEMAP_CACHE_MS };
+    return ids;
+  } catch (error) {
+    console.warn('[SEO-CRAWL-LOGS-3] No se pudo clasificar la cohorte pausada:', error?.message || error);
+    return null;
+  }
+}
+
+export function productLookupStateFromContext(context) {
+  const segments = Array.isArray(context?.data?.perf?.segments)
+    ? context.data.perf.segments
+    : [];
+  const activeLookup = segments.find((segment) => segment?.name === 'active_lookup');
+  if (activeLookup?.found === true) return 'active';
+  const pausedLookup = segments.find((segment) => segment?.name === 'paused_lookup');
+  if (pausedLookup?.found === true) return 'paused';
+  return 'unknown';
+}
+
+async function resolveCrawlSegment({
+  request,
+  classification,
+  productLookupState,
+  nowMs,
+  fetchFn,
+}) {
+  if (!classification.pattern.startsWith('libro')) return 'non_product';
+  if (productLookupState === 'active') return 'active';
+  if (productLookupState !== 'paused') return 'unknown_product';
+
+  const productId = productIdFromRequest(request);
+  if (!productId) return 'paused_unknown';
+  const pausedIds = await loadPausedSitemapIds(nowMs, fetchFn);
+  if (!pausedIds) return 'paused_unknown';
+  return pausedIds.has(productId) ? 'by_request' : 'paused_other';
+}
+
 async function ensureSchema(db) {
   if (!db || typeof db.prepare !== 'function') return false;
   if (!schemaReadyPromise) {
@@ -292,6 +370,19 @@ async function ensureSchema(db) {
         bytes_known_count INTEGER NOT NULL DEFAULT 0,
         duration_ms_sum REAL NOT NULL DEFAULT 0,
         PRIMARY KEY (date, pattern, status, verified, ua_googlebot)
+      )`).run();
+      await db.prepare(`CREATE TABLE IF NOT EXISTS crawl_stats_segmented (
+        date TEXT NOT NULL,
+        pattern TEXT NOT NULL,
+        segment TEXT NOT NULL,
+        status INTEGER NOT NULL,
+        verified INTEGER NOT NULL,
+        ua_googlebot INTEGER NOT NULL,
+        request_count INTEGER NOT NULL DEFAULT 0,
+        bytes_sum INTEGER NOT NULL DEFAULT 0,
+        bytes_known_count INTEGER NOT NULL DEFAULT 0,
+        duration_ms_sum REAL NOT NULL DEFAULT 0,
+        PRIMARY KEY (date, pattern, segment, status, verified, ua_googlebot)
       )`).run();
       return true;
     })().catch(error => {
@@ -317,7 +408,13 @@ export function isUsefulRatioDenominator({ classification, verified }) {
   return verified === 1 && classification.contentPage && !DENOMINATOR_EXCLUDED.has(classification.pattern);
 }
 
-export async function recordCrawlRequest({ request, response, env, durationMs = 0 }, deps = {}) {
+export async function recordCrawlRequest({
+  request,
+  response,
+  env,
+  durationMs = 0,
+  productLookupState = 'unknown',
+}, deps = {}) {
   const nowFn = deps.nowFn || Date.now;
   const fetchFn = deps.fetchFn || fetch;
   const randomFn = deps.randomFn || Math.random;
@@ -334,6 +431,13 @@ export async function recordCrawlRequest({ request, response, env, durationMs = 
   const ua = request.headers.get('user-agent') || '';
   const uaGooglebot = isGooglebotUa(ua) ? 1 : 0;
   const verified = await verifyGooglebot(request, env, nowMs, fetchFn);
+  const segment = await resolveCrawlSegment({
+    request,
+    classification,
+    productLookupState,
+    nowMs,
+    fetchFn,
+  });
   const { bytes, known } = knownContentLength(response);
   const date = new Date(nowMs).toISOString().slice(0, 10);
   const safeDuration = Number.isFinite(Number(durationMs)) ? Math.max(0, Number(durationMs)) : 0;
@@ -358,9 +462,30 @@ export async function recordCrawlRequest({ request, response, env, durationMs = 
         safeDuration,
       ).run();
 
+  await env.ORDERS_DB.prepare(`INSERT INTO crawl_stats_segmented
+    (date, pattern, segment, status, verified, ua_googlebot, request_count, bytes_sum, bytes_known_count, duration_ms_sum)
+    VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
+    ON CONFLICT(date, pattern, segment, status, verified, ua_googlebot)
+    DO UPDATE SET
+      request_count = request_count + 1,
+      bytes_sum = bytes_sum + excluded.bytes_sum,
+      bytes_known_count = bytes_known_count + excluded.bytes_known_count,
+      duration_ms_sum = duration_ms_sum + excluded.duration_ms_sum`).bind(
+        date,
+        classification.pattern,
+        segment,
+        response.status,
+        verified,
+        uaGooglebot,
+        bytes,
+        known,
+        safeDuration,
+      ).run();
+
   return {
     recorded: true,
     pattern: classification.pattern,
+    segment,
     verified,
     uaGooglebot,
     usefulNumerator: isUsefulRatioNumerator({ classification, status: response.status, verified }),
@@ -372,13 +497,19 @@ export function scheduleCrawlAnalytics(context, response, durationMs = 0) {
   if (!context || typeof context.waitUntil !== 'function') return;
   if (!context.request || !context.env) return;
   context.waitUntil(
-    recordCrawlRequest({ request: context.request, response, env: context.env, durationMs })
-      .catch(error => console.warn('[SEO-CRAWL-LOGS-3] logging falló:', error?.message || error)),
+    recordCrawlRequest({
+      request: context.request,
+      response,
+      env: context.env,
+      durationMs,
+      productLookupState: productLookupStateFromContext(context),
+    }).catch(error => console.warn('[SEO-CRAWL-LOGS-3] logging falló:', error?.message || error)),
   );
 }
 
 export function resetCrawlAnalyticsCachesForTest() {
   flagCache = new Map();
   rangeCache = null;
+  pausedSitemapCache = null;
   schemaReadyPromise = null;
 }

--- a/functions/_shared/crawl-analytics.js
+++ b/functions/_shared/crawl-analytics.js
@@ -1,12 +1,11 @@
+import { isPausedProductInSeoCohort } from './paused-seo-cohort.js';
+
 const GOOGLE_COMMON_CRAWLERS_URL = 'https://developers.google.com/static/crawling/ipranges/common-crawlers.json';
 const GOOGLE_RANGES_KV_KEY = 'seo:crawl-logs-3:google-common-crawlers:v1';
-const PAUSED_SITEMAP_URL = 'https://www.amadolibros.com/sitemap-books-paused.xml';
-const INTERNAL_OBSERVABILITY_HEADER = 'x-amado-internal-observability';
 const FLAG_PREFIX = 'seo:crawl-logs-3:enabled:';
 const FLAG_CACHE_MS = 60_000;
 const RANGE_FRESH_MS = 24 * 60 * 60 * 1000;
 const ISOLATE_RANGE_CACHE_MS = 60 * 60 * 1000;
-const PAUSED_SITEMAP_CACHE_MS = 5 * 60 * 1000;
 const SAMPLE_RATE = 0.01;
 
 export const USEFUL_CRAWL_RATIO_V1 = Object.freeze({
@@ -29,7 +28,6 @@ const STATIC_USEFUL_PATHS = new Set([
 
 let flagCache = new Map();
 let rangeCache = null;
-let pausedSitemapCache = null;
 let schemaReadyPromise = null;
 
 function appEnv(env) {
@@ -119,7 +117,6 @@ export function classifyCrawlRequest(request) {
 }
 
 export function shouldCaptureCrawlRequest(request, classification, randomFn = Math.random) {
-  if (request.headers.get(INTERNAL_OBSERVABILITY_HEADER) === '1') return false;
   const ua = request.headers.get('user-agent') || '';
   if (classification.pattern === 'asset') return false;
   if (classification.legacy) return true;
@@ -291,41 +288,6 @@ function productIdFromRequest(request) {
   }
 }
 
-function pausedIdsFromSitemap(xml) {
-  const ids = new Set();
-  for (const match of String(xml || '').matchAll(/<loc>\s*([^<]+?)\s*<\/loc>/gi)) {
-    try {
-      const idMatch = new URL(match[1].replaceAll('&amp;', '&')).pathname.match(/^\/libro\/(MLU\d+)(?:\/|$)/i);
-      if (idMatch) ids.add(idMatch[1].toUpperCase());
-    } catch {
-      // Una URL inválida no invalida todo el sitemap; simplemente se omite.
-    }
-  }
-  return ids;
-}
-
-async function loadPausedSitemapIds(nowMs, fetchFn) {
-  if (pausedSitemapCache && pausedSitemapCache.expiresAt > nowMs) {
-    return pausedSitemapCache.ids;
-  }
-  try {
-    const response = await fetchFn(PAUSED_SITEMAP_URL, {
-      headers: {
-        accept: 'application/xml,text/xml',
-        [INTERNAL_OBSERVABILITY_HEADER]: '1',
-      },
-    });
-    if (!response.ok) throw new Error(`sitemap pausado HTTP ${response.status}`);
-    const ids = pausedIdsFromSitemap(await response.text());
-    if (!ids.size) throw new Error('sitemap pausado sin IDs');
-    pausedSitemapCache = { ids, expiresAt: nowMs + PAUSED_SITEMAP_CACHE_MS };
-    return ids;
-  } catch (error) {
-    console.warn('[SEO-CRAWL-LOGS-3] No se pudo clasificar la cohorte pausada:', error?.message || error);
-    return null;
-  }
-}
-
 export function productLookupStateFromContext(context) {
   const segments = Array.isArray(context?.data?.perf?.segments)
     ? context.data.perf.segments
@@ -337,22 +299,14 @@ export function productLookupStateFromContext(context) {
   return 'unknown';
 }
 
-async function resolveCrawlSegment({
-  request,
-  classification,
-  productLookupState,
-  nowMs,
-  fetchFn,
-}) {
+export function resolveProductCrawlSegment({ request, classification, productLookupState }) {
   if (!classification.pattern.startsWith('libro')) return 'non_product';
   if (productLookupState === 'active') return 'active';
   if (productLookupState !== 'paused') return 'unknown_product';
 
   const productId = productIdFromRequest(request);
   if (!productId) return 'paused_unknown';
-  const pausedIds = await loadPausedSitemapIds(nowMs, fetchFn);
-  if (!pausedIds) return 'paused_unknown';
-  return pausedIds.has(productId) ? 'by_request' : 'paused_other';
+  return isPausedProductInSeoCohort(productId) ? 'by_request' : 'paused_other';
 }
 
 async function ensureSchema(db) {
@@ -431,12 +385,10 @@ export async function recordCrawlRequest({
   const ua = request.headers.get('user-agent') || '';
   const uaGooglebot = isGooglebotUa(ua) ? 1 : 0;
   const verified = await verifyGooglebot(request, env, nowMs, fetchFn);
-  const segment = await resolveCrawlSegment({
+  const segment = resolveProductCrawlSegment({
     request,
     classification,
     productLookupState,
-    nowMs,
-    fetchFn,
   });
   const { bytes, known } = knownContentLength(response);
   const date = new Date(nowMs).toISOString().slice(0, 10);
@@ -510,6 +462,5 @@ export function scheduleCrawlAnalytics(context, response, durationMs = 0) {
 export function resetCrawlAnalyticsCachesForTest() {
   flagCache = new Map();
   rangeCache = null;
-  pausedSitemapCache = null;
   schemaReadyPromise = null;
 }

--- a/migrations/0009_crawl_stats_segmented.sql
+++ b/migrations/0009_crawl_stats_segmented.sql
@@ -1,0 +1,48 @@
+-- SEO-CRAWL-COHORT-1
+-- Separa la observabilidad de fichas activas, por encargo y otras pausadas.
+-- Conserva la tabla v1 para continuidad y no guarda IP, user-agent ni URL.
+
+CREATE TABLE IF NOT EXISTS crawl_stats_segmented (
+    date TEXT NOT NULL,
+    pattern TEXT NOT NULL,
+    segment TEXT NOT NULL,
+    status INTEGER NOT NULL,
+    verified INTEGER NOT NULL,
+    ua_googlebot INTEGER NOT NULL,
+    request_count INTEGER NOT NULL DEFAULT 0,
+    bytes_sum INTEGER NOT NULL DEFAULT 0,
+    bytes_known_count INTEGER NOT NULL DEFAULT 0,
+    duration_ms_sum REAL NOT NULL DEFAULT 0,
+    PRIMARY KEY (date, pattern, segment, status, verified, ua_googlebot)
+);
+
+CREATE INDEX IF NOT EXISTS idx_crawl_stats_segmented_date_segment
+    ON crawl_stats_segmented (date, segment);
+
+-- Los datos anteriores no permiten reconstruir disponibilidad sin guardar URL.
+-- Se preservan explícitamente como históricos no segmentados, sin inventar una
+-- clasificación retroactiva.
+INSERT OR IGNORE INTO crawl_stats_segmented (
+    date,
+    pattern,
+    segment,
+    status,
+    verified,
+    ua_googlebot,
+    request_count,
+    bytes_sum,
+    bytes_known_count,
+    duration_ms_sum
+)
+SELECT
+    date,
+    pattern,
+    'historical_unsegmented',
+    status,
+    verified,
+    ua_googlebot,
+    request_count,
+    bytes_sum,
+    bytes_known_count,
+    duration_ms_sum
+FROM crawl_stats;

--- a/scripts/seo/crawl-report.mjs
+++ b/scripts/seo/crawl-report.mjs
@@ -1,12 +1,22 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const INPUT = process.env.CRAWL_REPORT_INPUT || 'artifacts/seo/crawl-stats-raw.json';
 const OUTPUT_DIR = process.env.CRAWL_REPORT_OUTPUT_DIR || 'artifacts/seo';
 const USEFUL_PATTERNS = new Set(['home', 'libro', 'libros', 'catalogo', 'static_page']);
 const EXCLUDED_FROM_DENOMINATOR = new Set(['asset', 'api', 'sitemap', 'robots']);
+const SEGMENT_ORDER = [
+  'active',
+  'by_request',
+  'paused_other',
+  'paused_unknown',
+  'unknown_product',
+  'non_product',
+  'historical_unsegmented',
+];
 
-function rowsFromWrangler(payload) {
+export function rowsFromWrangler(payload) {
   if (Array.isArray(payload)) {
     return payload.flatMap(entry => Array.isArray(entry?.results) ? entry.results : []);
   }
@@ -18,7 +28,40 @@ function number(value) {
   return Number.isFinite(n) ? n : 0;
 }
 
-function aggregate(rows) {
+function emptySegment(segment) {
+  return {
+    segment,
+    requestCount: 0,
+    verifiedGooglebotRequests: 0,
+    verifiedGooglebotStatus200: 0,
+    verifiedGooglebotNon200: 0,
+    durationMsSum: 0,
+    averageDurationMs: null,
+  };
+}
+
+function segmentForRow(row) {
+  const segment = String(row.segment || '').trim();
+  return segment || 'historical_unsegmented';
+}
+
+function finalizeSegment(segment) {
+  segment.averageDurationMs = segment.requestCount
+    ? Number((segment.durationMsSum / segment.requestCount).toFixed(2))
+    : null;
+}
+
+function sortedSegments(bySegment) {
+  return Object.values(bySegment).sort((a, b) => {
+    const aIndex = SEGMENT_ORDER.indexOf(a.segment);
+    const bIndex = SEGMENT_ORDER.indexOf(b.segment);
+    const aRank = aIndex === -1 ? SEGMENT_ORDER.length : aIndex;
+    const bRank = bIndex === -1 ? SEGMENT_ORDER.length : bIndex;
+    return aRank - bRank || a.segment.localeCompare(b.segment);
+  });
+}
+
+export function aggregate(rows) {
   const byDate = new Map();
   for (const row of rows) {
     const date = String(row.date || 'unknown');
@@ -31,6 +74,7 @@ function aggregate(rows) {
         legacyRequests: 0,
         byPattern: {},
         byStatus: {},
+        bySegment: {},
       });
     }
     const day = byDate.get(date);
@@ -38,13 +82,23 @@ function aggregate(rows) {
     const verified = number(row.verified);
     const status = number(row.status);
     const pattern = String(row.pattern || 'other');
+    const segmentName = segmentForRow(row);
 
     day.byPattern[pattern] = (day.byPattern[pattern] || 0) + count;
     day.byStatus[status] = (day.byStatus[status] || 0) + count;
     if (pattern.startsWith('legacy_')) day.legacyRequests += count;
 
+    if (!day.bySegment[segmentName]) day.bySegment[segmentName] = emptySegment(segmentName);
+    const segment = day.bySegment[segmentName];
+    segment.requestCount += count;
+    segment.durationMsSum += number(row.duration_ms_sum);
+
     if (verified === 1) {
       day.verifiedGooglebotRequests += count;
+      segment.verifiedGooglebotRequests += count;
+      if (status === 200) segment.verifiedGooglebotStatus200 += count;
+      else segment.verifiedGooglebotNon200 += count;
+
       const inDenominator = !EXCLUDED_FROM_DENOMINATOR.has(pattern);
       if (inDenominator) day.usefulDenominator += count;
       if (status === 200 && USEFUL_PATTERNS.has(pattern)) day.usefulNumerator += count;
@@ -56,6 +110,7 @@ function aggregate(rows) {
     day.usefulCrawlRatioV1 = day.usefulDenominator
       ? Number((day.usefulNumerator / day.usefulDenominator).toFixed(6))
       : null;
+    for (const segment of Object.values(day.bySegment)) finalizeSegment(segment);
   }
 
   const total = daily.reduce((acc, day) => {
@@ -63,16 +118,32 @@ function aggregate(rows) {
     acc.usefulNumerator += day.usefulNumerator;
     acc.usefulDenominator += day.usefulDenominator;
     acc.legacyRequests += day.legacyRequests;
+    for (const segment of Object.values(day.bySegment)) {
+      if (!acc.bySegment[segment.segment]) acc.bySegment[segment.segment] = emptySegment(segment.segment);
+      const target = acc.bySegment[segment.segment];
+      target.requestCount += segment.requestCount;
+      target.verifiedGooglebotRequests += segment.verifiedGooglebotRequests;
+      target.verifiedGooglebotStatus200 += segment.verifiedGooglebotStatus200;
+      target.verifiedGooglebotNon200 += segment.verifiedGooglebotNon200;
+      target.durationMsSum += segment.durationMsSum;
+    }
     return acc;
-  }, { verifiedGooglebotRequests: 0, usefulNumerator: 0, usefulDenominator: 0, legacyRequests: 0 });
+  }, {
+    verifiedGooglebotRequests: 0,
+    usefulNumerator: 0,
+    usefulDenominator: 0,
+    legacyRequests: 0,
+    bySegment: {},
+  });
   total.usefulCrawlRatioV1 = total.usefulDenominator
     ? Number((total.usefulNumerator / total.usefulDenominator).toFixed(6))
     : null;
+  for (const segment of Object.values(total.bySegment)) finalizeSegment(segment);
 
   return { daily, total };
 }
 
-function csv(daily) {
+function dailyCsv(daily) {
   const lines = ['date,verified_googlebot_requests,useful_numerator,useful_denominator,useful_crawl_ratio_v1,legacy_requests'];
   for (const day of daily) {
     lines.push([
@@ -87,17 +158,45 @@ function csv(daily) {
   return `${lines.join('\n')}\n`;
 }
 
-async function main() {
+function segmentCsv(daily) {
+  const lines = [
+    'date,segment,request_count,verified_googlebot_requests,verified_googlebot_status_200,verified_googlebot_non_200,average_duration_ms',
+  ];
+  for (const day of daily) {
+    for (const segment of sortedSegments(day.bySegment)) {
+      lines.push([
+        day.date,
+        segment.segment,
+        segment.requestCount,
+        segment.verifiedGooglebotRequests,
+        segment.verifiedGooglebotStatus200,
+        segment.verifiedGooglebotNon200,
+        segment.averageDurationMs ?? '',
+      ].join(','));
+    }
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+export async function main() {
   const payload = JSON.parse(await readFile(INPUT, 'utf8'));
   const rows = rowsFromWrangler(payload);
   const { daily, total } = aggregate(rows);
   const report = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     generatedAt: new Date().toISOString(),
     metric: {
       name: 'useful_crawl_ratio_v1',
       numerator: 'verified=1 AND status=200 AND pattern IN (home, libro, libros, catalogo, static_page)',
       denominator: 'verified=1 AND pattern NOT IN (asset, api, sitemap, robots)',
+      productSegments: {
+        active: 'ficha resuelta desde catálogo activo',
+        by_request: 'ficha pausada presente en sitemap-books-paused.xml',
+        paused_other: 'ficha pausada fuera de la cohorte indexable',
+        paused_unknown: 'ficha pausada cuyo sitemap no pudo verificarse',
+        unknown_product: 'ruta de producto sin resolución concluyente',
+        historical_unsegmented: 'datos anteriores a esta instrumentación',
+      },
     },
     rowCount: rows.length,
     total,
@@ -107,12 +206,15 @@ async function main() {
   await mkdir(OUTPUT_DIR, { recursive: true });
   await Promise.all([
     writeFile(path.join(OUTPUT_DIR, 'crawl-summary.json'), `${JSON.stringify(report, null, 2)}\n`),
-    writeFile(path.join(OUTPUT_DIR, 'crawl-daily.csv'), csv(daily)),
+    writeFile(path.join(OUTPUT_DIR, 'crawl-daily.csv'), dailyCsv(daily)),
+    writeFile(path.join(OUTPUT_DIR, 'crawl-segments.csv'), segmentCsv(daily)),
   ]);
   console.log(JSON.stringify(total));
 }
 
-main().catch(error => {
-  console.error(error.stack || error.message);
-  process.exitCode = 1;
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/seo/gsc-analysis.mjs
+++ b/scripts/seo/gsc-analysis.mjs
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 
 const PRODUCT_PATH = '/libro/';
+const MAX_INSPECTION_SAMPLE = 400;
 
 function number(value) {
   const parsed = Number(value);
@@ -22,6 +23,14 @@ function uniqueByPage(rows) {
     seen.add(row.page);
     return true;
   });
+}
+
+function targetSampleSize(value) {
+  return Math.max(1, Math.min(MAX_INSPECTION_SAMPLE, Math.trunc(number(value)) || MAX_INSPECTION_SAMPLE));
+}
+
+function uniqueProductUrls(urls = []) {
+  return [...new Set(urls.filter(isProductUrl))];
 }
 
 export function isProductUrl(url) {
@@ -119,10 +128,10 @@ export function buildInspectionSample({
   sitemapUrls = [],
   pageRows = [],
   ctrOpportunities = [],
-  size = 400,
+  size = MAX_INSPECTION_SAMPLE,
 } = {}) {
-  const targetSize = Math.max(1, Math.min(400, Math.trunc(number(size)) || 400));
-  const activeUrls = [...new Set(sitemapUrls.filter(isProductUrl))];
+  const targetSize = targetSampleSize(size);
+  const activeUrls = uniqueProductUrls(sitemapUrls);
   const activeSet = new Set(activeUrls);
   const normalizedPages = normalizePageRows(pageRows)
     .filter((row) => isProductUrl(row.page) && activeSet.has(row.page));
@@ -166,26 +175,105 @@ export function buildInspectionSample({
   return selected;
 }
 
-export function summarizeInspections(rows = []) {
-  const summary = {
-    requested: rows.length,
+/**
+ * Muestra comparable entre las dos poblaciones comerciales:
+ * - active: libros disponibles;
+ * - by_request: cohorte publicada en sitemap-books-paused.xml.
+ *
+ * La asignación es 50/50 cuando ambas cohortes tienen suficiente volumen. Si
+ * una no llega a su cupo, la otra completa el total. Dentro de cada cohorte se
+ * conserva la selección estable por URL de buildInspectionSample().
+ */
+export function buildCohortInspectionSample({
+  activeSitemapUrls = [],
+  pausedSitemapUrls = [],
+  pageRows = [],
+  ctrOpportunities = [],
+  size = MAX_INSPECTION_SAMPLE,
+} = {}) {
+  const targetSize = targetSampleSize(size);
+  const activeUrls = uniqueProductUrls(activeSitemapUrls);
+  const activeSet = new Set(activeUrls);
+  const pausedUrls = uniqueProductUrls(pausedSitemapUrls).filter((page) => !activeSet.has(page));
+
+  if (!activeUrls.length && !pausedUrls.length) return [];
+
+  let activeTarget = 0;
+  let pausedTarget = 0;
+  if (activeUrls.length && pausedUrls.length) {
+    activeTarget = Math.min(activeUrls.length, Math.floor(targetSize / 2));
+    pausedTarget = Math.min(pausedUrls.length, targetSize - activeTarget);
+  } else if (activeUrls.length) {
+    activeTarget = Math.min(activeUrls.length, targetSize);
+  } else {
+    pausedTarget = Math.min(pausedUrls.length, targetSize);
+  }
+
+  let remaining = targetSize - activeTarget - pausedTarget;
+  if (remaining > 0) {
+    const activeCapacity = activeUrls.length - activeTarget;
+    const activeFill = Math.min(activeCapacity, remaining);
+    activeTarget += activeFill;
+    remaining -= activeFill;
+  }
+  if (remaining > 0) {
+    const pausedCapacity = pausedUrls.length - pausedTarget;
+    const pausedFill = Math.min(pausedCapacity, remaining);
+    pausedTarget += pausedFill;
+  }
+
+  const sampleFor = (urls, cohort, cohortSize) => {
+    if (cohortSize <= 0) return [];
+    return buildInspectionSample({
+      sitemapUrls: urls,
+      pageRows,
+      ctrOpportunities,
+      size: cohortSize,
+    }).map((row) => ({ ...row, cohort }));
+  };
+
+  return [
+    ...sampleFor(activeUrls, 'active', activeTarget),
+    ...sampleFor(pausedUrls, 'by_request', pausedTarget),
+  ];
+}
+
+function emptyInspectionGroup() {
+  return {
+    requested: 0,
     completed: 0,
     errors: 0,
     verdicts: {},
     coverageStates: {},
+  };
+}
+
+function incrementInspectionGroup(group, row) {
+  group.requested += 1;
+  if (row.error) {
+    group.errors += 1;
+    return;
+  }
+  group.completed += 1;
+  const verdict = row.verdict || 'UNKNOWN';
+  const coverageState = row.coverageState || 'UNKNOWN';
+  group.verdicts[verdict] = (group.verdicts[verdict] || 0) + 1;
+  group.coverageStates[coverageState] = (group.coverageStates[coverageState] || 0) + 1;
+}
+
+export function summarizeInspections(rows = []) {
+  const summary = {
+    ...emptyInspectionGroup(),
     strata: {},
+    cohorts: {},
   };
   for (const row of rows) {
     summary.strata[row.stratum] = (summary.strata[row.stratum] || 0) + 1;
-    if (row.error) {
-      summary.errors += 1;
-      continue;
-    }
-    summary.completed += 1;
-    const verdict = row.verdict || 'UNKNOWN';
-    const coverageState = row.coverageState || 'UNKNOWN';
-    summary.verdicts[verdict] = (summary.verdicts[verdict] || 0) + 1;
-    summary.coverageStates[coverageState] = (summary.coverageStates[coverageState] || 0) + 1;
+    incrementInspectionGroup(summary, row);
+
+    const cohort = row.cohort || 'unsegmented';
+    if (!summary.cohorts[cohort]) summary.cohorts[cohort] = emptyInspectionGroup();
+    incrementInspectionGroup(summary.cohorts[cohort], row);
   }
   return summary;
 }

--- a/scripts/seo/gsc-export.mjs
+++ b/scripts/seo/gsc-export.mjs
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import {
-  buildInspectionSample,
+  buildCohortInspectionSample,
   selectCtrOpportunities,
   summarizeInspections,
 } from './gsc-analysis.mjs';
@@ -11,6 +11,8 @@ const URL_INSPECTION_ENDPOINT = 'https://searchconsole.googleapis.com/v1/urlInsp
 const OUTPUT_DIR = process.env.GSC_OUTPUT_DIR || 'artifacts/gsc';
 const ACTIVE_SITEMAP_URL = process.env.GSC_ACTIVE_SITEMAP_URL
   || 'https://www.amadolibros.com/sitemap-books-active.xml';
+const PAUSED_SITEMAP_URL = process.env.GSC_PAUSED_SITEMAP_URL
+  || 'https://www.amadolibros.com/sitemap-books-paused.xml';
 const ROW_LIMIT = 25000;
 const INSPECTION_CONCURRENCY = 8;
 
@@ -74,6 +76,7 @@ function inspectionsToCsv(rows) {
   return rowsToCsv(
     [
       'page',
+      'cohort',
       'stratum',
       'verdict',
       'coverageState',
@@ -169,7 +172,7 @@ async function mapWithConcurrency(items, concurrency, mapper) {
   return results;
 }
 
-async function inspectUrl({ page, stratum }, { siteUrl, accessToken }) {
+async function inspectUrl({ page, stratum, cohort }, { siteUrl, accessToken }) {
   try {
     const response = await fetchWithRetry(URL_INSPECTION_ENDPOINT, {
       method: 'POST',
@@ -182,6 +185,7 @@ async function inspectUrl({ page, stratum }, { siteUrl, accessToken }) {
     const result = response.inspectionResult?.indexStatusResult || {};
     return {
       page,
+      cohort,
       stratum,
       verdict: result.verdict || '',
       coverageState: result.coverageState || '',
@@ -198,6 +202,7 @@ async function inspectUrl({ page, stratum }, { siteUrl, accessToken }) {
   } catch (error) {
     return {
       page,
+      cohort,
       stratum,
       verdict: '',
       coverageState: '',
@@ -214,7 +219,14 @@ async function inspectUrl({ page, stratum }, { siteUrl, accessToken }) {
   }
 }
 
-function reportSummaryMarkdown({ siteUrl, startDate, endDate, ctrReport, inspectionSummary }) {
+function reportSummaryMarkdown({
+  siteUrl,
+  startDate,
+  endDate,
+  ctrReport,
+  inspectionSummary,
+  sitemapCohorts,
+}) {
   const pass = inspectionSummary.verdicts.PASS || 0;
   const lines = [
     '## GSC: indexación y oportunidades CTR',
@@ -224,15 +236,30 @@ function reportSummaryMarkdown({ siteUrl, startDate, endDate, ctrReport, inspect
     `- Fichas con impresiones: ${ctrReport.benchmark.pageCount}`,
     `- CTR agregado de fichas: ${(ctrReport.benchmark.ctr * 100).toFixed(2)}%`,
     `- Oportunidades CTR seleccionadas: ${ctrReport.rows.length}`,
+    `- Sitemap activo: ${sitemapCohorts.activeUrlCount} URLs`,
+    `- Sitemap por encargo: ${sitemapCohorts.byRequestUrlCount} URLs`,
     `- URLs inspeccionadas: ${inspectionSummary.completed}/${inspectionSummary.requested}`,
     `- Veredicto PASS: ${pass}`,
     `- Errores de inspección: ${inspectionSummary.errors}`,
+    '',
+    '### Resultado por cohorte',
+    '',
+    '| Cohorte | Solicitadas | Completadas | PASS | Errores |',
+    '| --- | ---: | ---: | ---: | ---: |',
+  ];
+
+  for (const cohort of ['active', 'by_request']) {
+    const values = inspectionSummary.cohorts[cohort] || {};
+    lines.push(`| ${cohort} | ${values.requested || 0} | ${values.completed || 0} | ${values.verdicts?.PASS || 0} | ${values.errors || 0} |`);
+  }
+
+  lines.push(
     '',
     '### Primeras oportunidades CTR',
     '',
     '| URL | Impresiones | CTR | Posición | Clics potenciales |',
     '| --- | ---: | ---: | ---: | ---: |',
-  ];
+  );
   for (const row of ctrReport.rows.slice(0, 10)) {
     lines.push(`| ${row.page} | ${row.impressions} | ${(row.ctr * 100).toFixed(2)}% | ${row.position.toFixed(1)} | ${row.estimatedMissedClicks.toFixed(1)} |`);
   }
@@ -256,7 +283,7 @@ async function main() {
   await mkdir(OUTPUT_DIR, { recursive: true });
   const extractedAt = new Date().toISOString();
   const manifest = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     siteUrl,
     dateRange: { startDate, endDate },
     extractedAt,
@@ -310,19 +337,50 @@ async function main() {
     csv: 'ctr-opportunities.csv',
   });
 
-  process.stdout.write(`Descargando sitemap activo ${ACTIVE_SITEMAP_URL}... `);
-  const sitemapXml = await fetchWithRetry(ACTIVE_SITEMAP_URL, {}, 4, 'text');
-  const activeUrls = sitemapUrls(sitemapXml);
-  console.log(`${activeUrls.length} URLs.`);
+  process.stdout.write('Descargando sitemaps activo y por encargo... ');
+  const [activeSitemapXml, pausedSitemapXml] = await Promise.all([
+    fetchWithRetry(ACTIVE_SITEMAP_URL, {}, 4, 'text'),
+    fetchWithRetry(PAUSED_SITEMAP_URL, {}, 4, 'text'),
+  ]);
+  const activeUrls = sitemapUrls(activeSitemapXml);
+  const pausedUrls = sitemapUrls(pausedSitemapXml);
+  console.log(`${activeUrls.length} activas; ${pausedUrls.length} por encargo.`);
   if (!activeUrls.length) throw new Error('El sitemap activo no devolvió URLs.');
+  if (!pausedUrls.length) throw new Error('El sitemap por encargo no devolvió URLs.');
 
-  const inspectionSample = buildInspectionSample({
-    sitemapUrls: activeUrls,
+  const activeSet = new Set(activeUrls);
+  const overlap = pausedUrls.filter((page) => activeSet.has(page));
+  if (overlap.length) {
+    throw new Error(`Los sitemaps activo y por encargo se superponen en ${overlap.length} URLs.`);
+  }
+
+  const sitemapCohorts = {
+    schemaVersion: 1,
+    extractedAt,
+    activeSitemapUrl: ACTIVE_SITEMAP_URL,
+    byRequestSitemapUrl: PAUSED_SITEMAP_URL,
+    activeUrlCount: activeUrls.length,
+    byRequestUrlCount: pausedUrls.length,
+    overlapCount: overlap.length,
+  };
+  await writeFile(
+    path.join(OUTPUT_DIR, 'sitemap-cohorts.json'),
+    `${JSON.stringify(sitemapCohorts, null, 2)}\n`,
+  );
+  manifest.reports.push({
+    type: 'sitemap-cohorts',
+    rowCount: activeUrls.length + pausedUrls.length,
+    json: 'sitemap-cohorts.json',
+  });
+
+  const inspectionSample = buildCohortInspectionSample({
+    activeSitemapUrls: activeUrls,
+    pausedSitemapUrls: pausedUrls,
     pageRows: analyticsReports.get('page'),
     ctrOpportunities: ctrReport.rows,
     size: inspectionSampleSize,
   });
-  console.log(`Inspeccionando ${inspectionSample.length} fichas con concurrencia ${INSPECTION_CONCURRENCY}...`);
+  console.log(`Inspeccionando ${inspectionSample.length} fichas activas/por encargo con concurrencia ${INSPECTION_CONCURRENCY}...`);
   const inspections = await mapWithConcurrency(
     inspectionSample,
     INSPECTION_CONCURRENCY,
@@ -330,12 +388,15 @@ async function main() {
   );
   const inspectionSummary = summarizeInspections(inspections);
   const inspectionReport = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     siteUrl,
-    sitemapUrl: ACTIVE_SITEMAP_URL,
+    sitemapUrls: {
+      active: ACTIVE_SITEMAP_URL,
+      byRequest: PAUSED_SITEMAP_URL,
+    },
     extractedAt,
     sampleSize: inspectionSample.length,
-    sampleMethod: 'CTR/alta demanda + vistas en Search + activas sin impresiones; selección estable por URL',
+    sampleMethod: '50/50 activas y por encargo cuando hay volumen; dentro de cada cohorte: CTR/alta demanda + vistas en Search + sin impresiones; selección estable por URL',
     summary: inspectionSummary,
     rows: inspections,
   };
@@ -346,6 +407,7 @@ async function main() {
   manifest.reports.push({
     type: 'url-inspection-sample',
     rowCount: inspections.length,
+    cohorts: inspectionSummary.cohorts,
     json: 'url-inspection-sample.json',
     csv: 'url-inspection-sample.csv',
   });
@@ -356,6 +418,7 @@ async function main() {
     endDate,
     ctrReport,
     inspectionSummary,
+    sitemapCohorts,
   });
   await Promise.all([
     writeFile(path.join(OUTPUT_DIR, 'report-summary.md'), summaryMarkdown),


### PR DESCRIPTION
## Objetivo
Medir si las 3.000 fichas por encargo están siendo descubiertas, rastreadas e indexadas, y compararlas con libros activos antes de ampliar la cohorte.

## Qué cambia

### Search Console
- incorpora `sitemap-books-paused.xml` al export semanal/manual
- construye una muestra estable de hasta 400 fichas
- usa 200 activas + 200 por encargo cuando ambas cohortes tienen volumen suficiente
- evita solapamientos entre sitemaps
- entrega resultados, PASS, cobertura y errores separados por `active` y `by_request`
- agrega `sitemap-cohorts.json` y la columna `cohort` al CSV de inspección

### Googlebot / D1
- conserva la métrica histórica `crawl_stats`
- agrega `crawl_stats_segmented` con migración 0009
- separa `active`, `by_request`, `paused_other`, estados desconocidos y datos históricos no segmentables
- reutiliza el resultado de búsqueda activo/pausado ya calculado por la ficha
- determina `by_request` contra la cohorte de 3.000 versionada en código; no consulta el sitemap ni otro servicio durante la request
- no guarda IP, user-agent, URL, path ni ID de producto
- agrega `crawl-segments.csv` al reporte

## Compatibilidad
- doble escritura: el reporte histórico v1 sigue disponible
- los registros anteriores se conservan como `historical_unsegmented`; no se inventa clasificación retroactiva
- la clasificación ocurre dentro de `waitUntil`, fuera del camino crítico

## Validación real de Search Console

Se ejecutó el export completo en modo de solo lectura sobre `sc-domain:amadolibros.com`, período 2026-07-18 a 2026-08-14:

- autenticación Workload Identity y API: OK
- Search Analytics: 1.573 páginas, 487 consultas y 655 combinaciones página/consulta
- sitemaps actuales: 7.096 activas, 2.998 por encargo, 0 solapamientos
- inspección: 400/400 completadas, 0 errores
- activas: 196/200 PASS e indexadas
- por encargo: 46/200 PASS e indexadas
- por encargo restantes: 76 con `noindex` histórico, 67 descubiertas aún sin indexar, 8 todavía no reconocidas y 3 con 404 histórico

Los 76 estados `noindex` fueron rastreados entre el 1 y el 16 de agosto, antes de publicar la cohorte de 3.000 el 17 de agosto. Los tres 404 corresponden a rastreos de abril-junio. Se toman como baseline histórico pendiente de recrawl, no como una regresión nueva del PR.

## Fuera de alcance
- no cambia indexación, canonical, robots, catálogo, precios, checkout ni Merchant
- no amplía la cohorte más allá de 3.000
- no modifica producción hasta aprobación y merge explícitos

## Riesgo
Bajo. Search Console y los reportes son workflows de solo lectura. La nueva escritura D1 es agregada y compatible con la tabla histórica. La clasificación no incorpora una dependencia de red adicional.