### PR TITLE
Medir el embudo real de transferencia y checkout

### DIFF
--- a/.github/workflows/checkout-funnel-report.yml
+++ b/.github/workflows/checkout-funnel-report.yml
@@ -1,0 +1,118 @@
+name: Checkout funnel daily and manual report
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/checkout-funnel-report.yml'
+      - 'scripts/commerce/checkout-funnel-report.mjs'
+      - 'functions/api/_transfer_options_handler.js'
+  schedule:
+    - cron: '37 11 * * *'
+  workflow_dispatch:
+    inputs:
+      start_date:
+        description: Fecha inicial UTC opcional (YYYY-MM-DD). Vacío = últimos 30 días.
+        required: false
+        type: string
+      end_date:
+        description: Fecha final UTC opcional (YYYY-MM-DD). Vacío = hoy.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: checkout-funnel-report
+  cancel-in-progress: false
+
+jobs:
+  report:
+    name: Build checkout funnel from D1
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Resolve report dates
+        env:
+          INPUT_START_DATE: ${{ inputs.start_date }}
+          INPUT_END_DATE: ${{ inputs.end_date }}
+        run: |
+          if { [ -n "${INPUT_START_DATE:-}" ] && [ -z "${INPUT_END_DATE:-}" ]; } || { [ -z "${INPUT_START_DATE:-}" ] && [ -n "${INPUT_END_DATE:-}" ]; }; then
+            echo "::error::start_date y end_date deben indicarse juntos o dejarse ambos vacíos."
+            exit 1
+          fi
+          if [ -n "${INPUT_START_DATE:-}" ]; then
+            start_date="$INPUT_START_DATE"
+            end_date="$INPUT_END_DATE"
+          else
+            start_date="$(date -u -d '29 days ago' +%F)"
+            end_date="$(date -u +%F)"
+          fi
+          [[ "$start_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || { echo "::error::start_date inválida"; exit 1; }
+          [[ "$end_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || { echo "::error::end_date inválida"; exit 1; }
+          if [[ "$start_date" > "$end_date" ]]; then
+            echo "::error::start_date no puede ser posterior a end_date"
+            exit 1
+          fi
+          {
+            echo "CHECKOUT_FUNNEL_START_DATE=$start_date"
+            echo "CHECKOUT_FUNNEL_END_DATE=$end_date"
+          } >> "$GITHUB_ENV"
+
+      - name: Query aggregated non-PII checkout rows
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          mkdir -p artifacts/commerce
+          npx wrangler@3.114.17 d1 execute ORDERS_DB --env production --remote --json \
+            --command "WITH event_flags AS (SELECT order_id, MAX(CASE WHEN event_type='transfer_payment_info_viewed' THEN 1 ELSE 0 END) AS transfer_prepared, MAX(CASE WHEN event_type='preference_created' THEN 1 ELSE 0 END) AS mp_prepared FROM order_events WHERE event_type IN ('transfer_payment_info_viewed','preference_created') GROUP BY order_id) SELECT substr(o.created_at,1,10) AS date, o.delivery_type, COUNT(*) AS orders_created, COALESCE(SUM(o.payable_total_uyu),0) AS orders_value_uyu, SUM(CASE WHEN COALESCE(f.transfer_prepared,0)=1 OR COALESCE(f.mp_prepared,0)=1 THEN 1 ELSE 0 END) AS payment_selected_count, SUM(COALESCE(f.transfer_prepared,0)) AS transfer_prepared_count, SUM(CASE WHEN COALESCE(f.transfer_prepared,0)=1 THEN MAX(0, CAST(ROUND(o.products_total_uyu * 0.88) AS INTEGER) - o.pickup_discount_uyu + o.shipping_cost_uyu) ELSE 0 END) AS transfer_prepared_value_uyu, SUM(COALESCE(f.mp_prepared,0)) AS mp_prepared_count, SUM(CASE WHEN o.payment_status='approved' THEN 1 ELSE 0 END) AS checkout_approved_count, SUM(CASE WHEN o.payment_status='approved' THEN o.payable_total_uyu ELSE 0 END) AS checkout_approved_value_uyu, SUM(CASE WHEN COALESCE(f.transfer_prepared,0)=1 AND COALESCE(f.mp_prepared,0)=1 THEN 1 ELSE 0 END) AS both_methods_count FROM orders o LEFT JOIN event_flags f ON f.order_id=o.id WHERE substr(o.created_at,1,10) >= '$CHECKOUT_FUNNEL_START_DATE' AND substr(o.created_at,1,10) <= '$CHECKOUT_FUNNEL_END_DATE' GROUP BY substr(o.created_at,1,10), o.delivery_type ORDER BY date, o.delivery_type" \
+            > artifacts/commerce/checkout-funnel-raw.json
+
+      - name: Build funnel report
+        env:
+          CHECKOUT_FUNNEL_INPUT: artifacts/commerce/checkout-funnel-raw.json
+          CHECKOUT_FUNNEL_OUTPUT_DIR: artifacts/commerce
+        run: node scripts/commerce/checkout-funnel-report.mjs
+
+      - name: Validate report outputs
+        run: |
+          test -s artifacts/commerce/checkout-funnel-summary.json
+          test -s artifacts/commerce/checkout-funnel-daily.csv
+          test -s artifacts/commerce/checkout-funnel-delivery.csv
+          test -s artifacts/commerce/report-summary.md
+          node -e "const r=require('./artifacts/commerce/checkout-funnel-summary.json'); if(r.schemaVersion!==1||!r.total) process.exit(1)"
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkout-funnel-${{ env.CHECKOUT_FUNNEL_START_DATE }}-${{ env.CHECKOUT_FUNNEL_END_DATE }}
+          path: artifacts/commerce/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Write run summary
+        if: always()
+        run: |
+          if [ -f artifacts/commerce/report-summary.md ]; then
+            cat artifacts/commerce/report-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Reporte de checkout incompleto" >> "$GITHUB_STEP_SUMMARY"
+            echo "No se generó el resumen; revisar la consulta D1 y el log." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Datos personales: no se consultan ni exportan" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Deploy: no se dispara desde este workflow" >> "$GITHUB_STEP_SUMMARY"

--- a/functions/__tests__/checkout-funnel-report.test.js
+++ b/functions/__tests__/checkout-funnel-report.test.js
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import {
+  aggregate,
+  rowsFromWrangler,
+  summaryMarkdown,
+} from '../../scripts/commerce/checkout-funnel-report.mjs';
+
+function row(patch = {}) {
+  return {
+    date: '2026-08-17',
+    delivery_type: 'pickup',
+    orders_created: 10,
+    orders_value_uyu: 20000,
+    payment_selected_count: 8,
+    transfer_prepared_count: 6,
+    transfer_prepared_value_uyu: 10560,
+    mp_prepared_count: 3,
+    checkout_approved_count: 2,
+    checkout_approved_value_uyu: 4000,
+    both_methods_count: 1,
+    ...patch,
+  };
+}
+
+test('normaliza la respuesta JSON de Wrangler sin exponer filas fuera de results', () => {
+  const rows = rowsFromWrangler([
+    { results: [row()] },
+    { results: [row({ date: '2026-08-18' })] },
+    { success: true },
+  ]);
+  assert.equal(rows.length, 2);
+  assert.equal(rows[1].date, '2026-08-18');
+});
+
+test('agrega el embudo por fecha y entrega con ratios auditables', () => {
+  const result = aggregate([
+    row(),
+    row({
+      delivery_type: 'shipping',
+      orders_created: 5,
+      orders_value_uyu: 7500,
+      payment_selected_count: 4,
+      transfer_prepared_count: 2,
+      transfer_prepared_value_uyu: 2500,
+      mp_prepared_count: 3,
+      checkout_approved_count: 1,
+      checkout_approved_value_uyu: 1500,
+      both_methods_count: 1,
+    }),
+  ]);
+
+  assert.equal(result.total.ordersCreated, 15);
+  assert.equal(result.total.paymentSelected, 12);
+  assert.equal(result.total.transferPrepared, 8);
+  assert.equal(result.total.mercadoPagoPrepared, 6);
+  assert.equal(result.total.checkoutApproved, 3);
+  assert.equal(result.total.bothMethods, 2);
+  assert.equal(result.total.paymentChoiceRate, 0.8);
+  assert.equal(result.total.transferPreparedRate, 0.533333);
+  assert.equal(result.total.checkoutApprovalRate, 0.5);
+  assert.equal(result.daily.length, 1);
+  assert.equal(result.daily[0].ordersCreated, 15);
+  assert.deepEqual(result.delivery.map(item => item.label), ['pickup', 'shipping']);
+});
+
+test('el resumen diferencia transferencia preparada de pago confirmado', () => {
+  const result = aggregate([row()]);
+  const markdown = summaryMarkdown(result, {
+    startDate: '2026-08-01',
+    endDate: '2026-08-17',
+  });
+
+  assert.match(markdown, /Transferencia preparada: 6/);
+  assert.match(markdown, /No equivale a pago confirmado/);
+  assert.match(markdown, /no se inventa un backfill histórico/);
+});
+
+test('el workflow consulta sólo agregados no-PII y usa la señal idempotente', () => {
+  const workflow = readFileSync('.github/workflows/checkout-funnel-report.yml', 'utf8');
+  assert.match(workflow, /transfer_payment_info_viewed/);
+  assert.match(workflow, /GROUP BY substr\(o\.created_at,1,10\), o\.delivery_type/);
+  assert.doesNotMatch(workflow, /buyer_name|buyer_phone|buyer_email|address|public_code/i);
+  assert.match(workflow, /Datos personales: no se consultan ni exportan/);
+});

--- a/functions/api/__tests__/transfer_options.test.js
+++ b/functions/api/__tests__/transfer_options.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   createTransferOptionsHandler,
+  recordTransferPaymentInfoViewed,
   TRANSFER_ACCOUNTS,
 } from '../_transfer_options_handler.js';
 
@@ -62,10 +63,19 @@ function request(body = { public_code: 'AL-260809-TEST', idempotency_key: 'idem-
   });
 }
 
-async function call({ body, order, requestPatch, envPatch, dbOptions, orderEmails } = {}) {
+async function call({
+  body,
+  order,
+  requestPatch,
+  envPatch,
+  dbOptions,
+  orderEmails,
+  recordPaymentInfoViewed,
+} = {}) {
   const handler = createTransferOptionsHandler({
     getNow: () => NOW,
     orderEmails: orderEmails || { sendTransferNotifications: async () => ({}) },
+    recordPaymentInfoViewed: recordPaymentInfoViewed || (async () => ({ recorded: true })),
   });
   const response = await handler({
     request: request(body, requestPatch),
@@ -119,6 +129,72 @@ test('transfer: agenda confirmación al cliente y aviso interno con el total exa
   assert.equal(calls[0].payment.method, 'bank_transfer');
   assert.equal(calls[0].payment.transfer_discount_uyu, 240);
   assert.equal(calls[0].payment.total_uyu, 1610);
+});
+
+test('transfer: registra la señal de embudo con los totales exactos', async () => {
+  const calls = [];
+  const { response } = await call({
+    recordPaymentInfoViewed: async args => { calls.push(args); return { recorded: true }; },
+  });
+  assert.equal(response.status, 200);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].order.id, 'order-uuid');
+  assert.equal(calls[0].payment.method, 'bank_transfer');
+  assert.equal(calls[0].payment.list_total_uyu, 1850);
+  assert.equal(calls[0].payment.transfer_discount_uyu, 240);
+  assert.equal(calls[0].payment.transfer_total_uyu, 1610);
+});
+
+test('transfer: la persistencia es idempotente y no guarda PII ni cuentas', async () => {
+  const statements = [];
+  const db = {
+    prepare(sql) {
+      return {
+        bind(...args) {
+          statements.push({ sql, args });
+          return {
+            async run() {
+              return { meta: { changes: 1 } };
+            },
+          };
+        },
+      };
+    },
+  };
+  const payment = {
+    list_total_uyu: 1850,
+    transfer_discount_uyu: 240,
+    transfer_total_uyu: 1610,
+  };
+
+  const result = await recordTransferPaymentInfoViewed({
+    db,
+    order: openOrder(),
+    payment,
+    now: NOW,
+  });
+
+  assert.equal(result.recorded, true);
+  assert.equal(statements.length, 1);
+  assert.match(statements[0].sql, /INSERT OR IGNORE INTO order_events/);
+  assert.match(statements[0].sql, /transfer_payment_info_viewed/);
+  assert.equal(statements[0].args[0], 'transfer-payment-info:order-uuid');
+  const persisted = JSON.stringify(statements[0].args);
+  assert.equal(persisted.includes('Ana Pérez'), false);
+  assert.equal(persisted.includes('099123456'), false);
+  assert.equal(persisted.includes('ana@example.com'), false);
+  assert.equal(persisted.includes('00065582200001'), false);
+  assert.match(persisted, /bank_transfer/);
+  assert.match(persisted, /1610/);
+});
+
+test('transfer: una falla de observabilidad no bloquea los datos de cobro', async () => {
+  const { response, data } = await call({
+    recordPaymentInfoViewed: async () => { throw new Error('D1 temporal'); },
+  });
+  assert.equal(response.status, 200);
+  assert.equal(data.payment.transfer_total_uyu, 1610);
+  assert.equal(data.accounts.length, 5);
 });
 
 test('transfer: costo de envío no recibe 12% de descuento', async () => {

--- a/functions/api/_transfer_options_handler.js
+++ b/functions/api/_transfer_options_handler.js
@@ -49,9 +49,46 @@ export const TRANSFER_ACCOUNTS = Object.freeze([
   }),
 ]);
 
+/**
+ * Señal de embudo first-party. No confirma un pago: registra únicamente que
+ * una orden autenticada llegó a recibir las opciones de transferencia.
+ *
+ * El id determinista + INSERT OR IGNORE evita duplicar la conversión si el
+ * comprador recarga, vuelve atrás o el navegador reintenta la solicitud.
+ * No se persisten cuentas bancarias ni datos personales del comprador.
+ */
+export async function recordTransferPaymentInfoViewed({ db, order, payment, now }) {
+  if (!db || !order?.id || !(now instanceof Date) || Number.isNaN(now.getTime())) {
+    return { recorded: false, reason: 'invalid_context' };
+  }
+
+  const payload = JSON.stringify({
+    method: 'bank_transfer',
+    delivery_type: order.delivery_type,
+    list_total_uyu: payment.list_total_uyu,
+    transfer_discount_uyu: payment.transfer_discount_uyu,
+    transfer_total_uyu: payment.transfer_total_uyu,
+  });
+  const result = await db.prepare(
+    "INSERT OR IGNORE INTO order_events " +
+    "(id,order_id,event_type,payload_json,created_at) VALUES (?,?,'transfer_payment_info_viewed',?,?)"
+  ).bind(
+    `transfer-payment-info:${order.id}`,
+    order.id,
+    payload,
+    now.toISOString(),
+  ).run();
+
+  return {
+    recorded: Number(result?.meta?.changes) > 0,
+    duplicate: Number(result?.meta?.changes) === 0,
+  };
+}
+
 export function createTransferOptionsHandler({
   getNow = () => new Date(),
   orderEmails = defaultOrderEmailService,
+  recordPaymentInfoViewed = recordTransferPaymentInfoViewed,
 } = {}) {
   return async function onRequest(context) {
     const { request, env } = context;
@@ -144,37 +181,43 @@ export function createTransferOptionsHandler({
 
     const { transferProductsTotal, transferDiscount, transferPayableTotal } =
       calculateTransferTotals({ productsTotal, pickupDiscount, shippingCost });
+    const payment = {
+      method: 'bank_transfer',
+      public_code: order.public_code,
+      currency: order.currency,
+      products_total_uyu: productsTotal,
+      transfer_products_total_uyu: transferProductsTotal,
+      transfer_discount_uyu: transferDiscount,
+      pickup_discount_uyu: pickupDiscount,
+      shipping_cost_uyu: shippingCost,
+      list_total_uyu: payableTotal,
+      transfer_total_uyu: transferPayableTotal,
+      expires_at: order.expires_at,
+    };
 
-    const emailTask = Promise.resolve(orderEmails.sendTransferNotifications({
-      db,
-      env,
-      order,
-      payment: {
-        method: 'bank_transfer',
-        transfer_discount_uyu: transferDiscount,
-        total_uyu: transferPayableTotal,
-      },
-      now,
-    })).catch(error => {
-      console.error('[transfer-options] email task error', safeErrorName(error));
+    // Observabilidad y correos son best-effort. Nunca bloquean ni retrasan la
+    // entrega de los datos de cobro a una orden ya autenticada.
+    const backgroundTask = Promise.all([
+      Promise.resolve().then(() => recordPaymentInfoViewed({ db, order, payment, now })),
+      Promise.resolve().then(() => orderEmails.sendTransferNotifications({
+        db,
+        env,
+        order,
+        payment: {
+          method: payment.method,
+          transfer_discount_uyu: payment.transfer_discount_uyu,
+          total_uyu: payment.transfer_total_uyu,
+        },
+        now,
+      })),
+    ]).catch(error => {
+      console.error('[transfer-options] background task error', safeErrorName(error));
     });
-    if (typeof context.waitUntil === 'function') context.waitUntil(emailTask);
-    else await emailTask;
+    if (typeof context.waitUntil === 'function') context.waitUntil(backgroundTask);
+    else await backgroundTask;
 
     return json({
-      payment: {
-        method: 'bank_transfer',
-        public_code: order.public_code,
-        currency: order.currency,
-        products_total_uyu: productsTotal,
-        transfer_products_total_uyu: transferProductsTotal,
-        transfer_discount_uyu: transferDiscount,
-        pickup_discount_uyu: pickupDiscount,
-        shipping_cost_uyu: shippingCost,
-        list_total_uyu: payableTotal,
-        transfer_total_uyu: transferPayableTotal,
-        expires_at: order.expires_at,
-      },
+      payment,
       accounts: TRANSFER_ACCOUNTS,
     });
   };

--- a/scripts/commerce/checkout-funnel-report.mjs
+++ b/scripts/commerce/checkout-funnel-report.mjs
@@ -1,0 +1,234 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const INPUT = process.env.CHECKOUT_FUNNEL_INPUT || 'artifacts/commerce/checkout-funnel-raw.json';
+const OUTPUT_DIR = process.env.CHECKOUT_FUNNEL_OUTPUT_DIR || 'artifacts/commerce';
+const START_DATE = process.env.CHECKOUT_FUNNEL_START_DATE || '';
+const END_DATE = process.env.CHECKOUT_FUNNEL_END_DATE || '';
+const DELIVERY_ORDER = ['pickup', 'shipping', 'unknown'];
+
+export function rowsFromWrangler(payload) {
+  if (Array.isArray(payload)) {
+    return payload.flatMap(entry => Array.isArray(entry?.results) ? entry.results : []);
+  }
+  if (Array.isArray(payload?.results)) return payload.results;
+  return [];
+}
+
+function number(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function rate(numerator, denominator) {
+  return denominator > 0
+    ? Number((numerator / denominator).toFixed(6))
+    : null;
+}
+
+function emptyBucket(label) {
+  return {
+    label,
+    ordersCreated: 0,
+    ordersValueUyu: 0,
+    paymentSelected: 0,
+    transferPrepared: 0,
+    transferPreparedValueUyu: 0,
+    mercadoPagoPrepared: 0,
+    checkoutApproved: 0,
+    checkoutApprovedValueUyu: 0,
+    bothMethods: 0,
+  };
+}
+
+function addRow(bucket, row) {
+  bucket.ordersCreated += number(row.orders_created);
+  bucket.ordersValueUyu += number(row.orders_value_uyu);
+  bucket.paymentSelected += number(row.payment_selected_count);
+  bucket.transferPrepared += number(row.transfer_prepared_count);
+  bucket.transferPreparedValueUyu += number(row.transfer_prepared_value_uyu);
+  bucket.mercadoPagoPrepared += number(row.mp_prepared_count);
+  bucket.checkoutApproved += number(row.checkout_approved_count);
+  bucket.checkoutApprovedValueUyu += number(row.checkout_approved_value_uyu);
+  bucket.bothMethods += number(row.both_methods_count);
+}
+
+function finalize(bucket) {
+  return {
+    ...bucket,
+    paymentChoiceRate: rate(bucket.paymentSelected, bucket.ordersCreated),
+    transferPreparedRate: rate(bucket.transferPrepared, bucket.ordersCreated),
+    mercadoPagoPreparedRate: rate(bucket.mercadoPagoPrepared, bucket.ordersCreated),
+    checkoutApprovalRate: rate(bucket.checkoutApproved, bucket.mercadoPagoPrepared),
+    checkoutApprovedFromCreatedRate: rate(bucket.checkoutApproved, bucket.ordersCreated),
+    bothMethodsRate: rate(bucket.bothMethods, bucket.ordersCreated),
+    averageCreatedOrderValueUyu: bucket.ordersCreated
+      ? Number((bucket.ordersValueUyu / bucket.ordersCreated).toFixed(2))
+      : null,
+  };
+}
+
+function deliveryKey(value) {
+  return ['pickup', 'shipping'].includes(value) ? value : 'unknown';
+}
+
+export function aggregate(rows = []) {
+  const total = emptyBucket('total');
+  const byDate = new Map();
+  const byDelivery = new Map();
+
+  for (const row of rows) {
+    const date = String(row.date || 'unknown');
+    const delivery = deliveryKey(String(row.delivery_type || 'unknown'));
+
+    if (!byDate.has(date)) byDate.set(date, emptyBucket(date));
+    if (!byDelivery.has(delivery)) byDelivery.set(delivery, emptyBucket(delivery));
+
+    addRow(total, row);
+    addRow(byDate.get(date), row);
+    addRow(byDelivery.get(delivery), row);
+  }
+
+  const daily = [...byDate.values()]
+    .sort((a, b) => a.label.localeCompare(b.label))
+    .map(finalize);
+  const delivery = [...byDelivery.values()]
+    .sort((a, b) => {
+      const aIndex = DELIVERY_ORDER.indexOf(a.label);
+      const bIndex = DELIVERY_ORDER.indexOf(b.label);
+      return aIndex - bIndex || a.label.localeCompare(b.label);
+    })
+    .map(finalize);
+
+  return { total: finalize(total), daily, delivery };
+}
+
+function csvValue(value) {
+  return value == null ? '' : String(value);
+}
+
+function bucketsCsv(buckets, firstColumn) {
+  const header = [
+    firstColumn,
+    'orders_created',
+    'orders_value_uyu',
+    'payment_selected',
+    'payment_choice_rate',
+    'transfer_prepared',
+    'transfer_prepared_rate',
+    'transfer_prepared_value_uyu',
+    'mercado_pago_prepared',
+    'mercado_pago_prepared_rate',
+    'checkout_approved',
+    'checkout_approval_rate',
+    'checkout_approved_from_created_rate',
+    'checkout_approved_value_uyu',
+    'both_methods',
+    'both_methods_rate',
+    'average_created_order_value_uyu',
+  ];
+  const lines = [header.join(',')];
+  for (const bucket of buckets) {
+    lines.push([
+      bucket.label,
+      bucket.ordersCreated,
+      bucket.ordersValueUyu,
+      bucket.paymentSelected,
+      csvValue(bucket.paymentChoiceRate),
+      bucket.transferPrepared,
+      csvValue(bucket.transferPreparedRate),
+      bucket.transferPreparedValueUyu,
+      bucket.mercadoPagoPrepared,
+      csvValue(bucket.mercadoPagoPreparedRate),
+      bucket.checkoutApproved,
+      csvValue(bucket.checkoutApprovalRate),
+      csvValue(bucket.checkoutApprovedFromCreatedRate),
+      bucket.checkoutApprovedValueUyu,
+      bucket.bothMethods,
+      csvValue(bucket.bothMethodsRate),
+      csvValue(bucket.averageCreatedOrderValueUyu),
+    ].join(','));
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function percentage(value) {
+  return value == null ? '—' : `${(value * 100).toFixed(1)}%`;
+}
+
+function money(value) {
+  return `$ ${Math.round(number(value)).toLocaleString('es-UY')}`;
+}
+
+export function summaryMarkdown({ total, delivery }, { startDate = '', endDate = '' } = {}) {
+  const period = startDate && endDate ? `${startDate} a ${endDate}` : 'período solicitado';
+  const lines = [
+    '## Embudo de checkout',
+    '',
+    `- Período UTC: ${period}`,
+    `- Órdenes creadas: ${total.ordersCreated}`,
+    `- Llegaron a elegir un medio: ${total.paymentSelected} (${percentage(total.paymentChoiceRate)})`,
+    `- Transferencia preparada: ${total.transferPrepared} (${percentage(total.transferPreparedRate)})`,
+    `- Mercado Pago preparado: ${total.mercadoPagoPrepared} (${percentage(total.mercadoPagoPreparedRate)})`,
+    `- Pagos aprobados por checkout: ${total.checkoutApproved} (${percentage(total.checkoutApprovedFromCreatedRate)} de las órdenes creadas)`,
+    `- Valor aprobado: ${money(total.checkoutApprovedValueUyu)}`,
+    `- Probaron ambos medios: ${total.bothMethods} (${percentage(total.bothMethodsRate)})`,
+    '',
+    '### Por entrega',
+    '',
+    '| Entrega | Órdenes | Transferencia preparada | Mercado Pago preparado | Aprobadas |',
+    '| --- | ---: | ---: | ---: | ---: |',
+  ];
+  for (const bucket of delivery) {
+    lines.push(`| ${bucket.label} | ${bucket.ordersCreated} | ${bucket.transferPrepared} | ${bucket.mercadoPagoPrepared} | ${bucket.checkoutApproved} |`);
+  }
+  lines.push(
+    '',
+    '> “Transferencia preparada” significa que la orden autenticada recibió los datos de cobro. No equivale a pago confirmado.',
+    '',
+    '> La señal de transferencia empieza a acumularse desde el despliegue de esta instrumentación; no se inventa un backfill histórico.',
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+export async function main() {
+  const payload = JSON.parse(await readFile(INPUT, 'utf8'));
+  const rows = rowsFromWrangler(payload);
+  const result = aggregate(rows);
+  const report = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    period: { startDate: START_DATE || null, endDate: END_DATE || null },
+    definitions: {
+      ordersCreated: 'órdenes persistidas en D1',
+      paymentSelected: 'orden con transferencia preparada o preferencia de Mercado Pago creada',
+      transferPrepared: 'evento idempotente transfer_payment_info_viewed; no confirma el pago',
+      mercadoPagoPrepared: 'evento preference_created',
+      checkoutApproved: 'payment_status=approved; actualmente proviene del webhook validado de Mercado Pago',
+      bothMethods: 'orden que llegó a preparar ambos medios de pago',
+    },
+    sourceRows: rows.length,
+    ...result,
+  };
+
+  await mkdir(OUTPUT_DIR, { recursive: true });
+  await Promise.all([
+    writeFile(path.join(OUTPUT_DIR, 'checkout-funnel-summary.json'), `${JSON.stringify(report, null, 2)}\n`),
+    writeFile(path.join(OUTPUT_DIR, 'checkout-funnel-daily.csv'), bucketsCsv(result.daily, 'date')),
+    writeFile(path.join(OUTPUT_DIR, 'checkout-funnel-delivery.csv'), bucketsCsv(result.delivery, 'delivery_type')),
+    writeFile(
+      path.join(OUTPUT_DIR, 'report-summary.md'),
+      summaryMarkdown(result, { startDate: START_DATE, endDate: END_DATE }),
+    ),
+  ]);
+
+  console.log(JSON.stringify(result.total));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Objetivo

Medir el recorrido real desde una orden creada hasta la elección del medio de pago, separando transferencia, Mercado Pago y pagos aprobados, sin confundir una transferencia preparada con una venta cobrada.

## Qué cambia

### Transferencia
- registra `transfer_payment_info_viewed` cuando una orden autenticada recibe las cuentas de cobro
- usa un ID determinista con `INSERT OR IGNORE`, por lo que recargas y reintentos no duplican la señal
- guarda solamente método, tipo de entrega y totales; no guarda nombre, teléfono, correo, dirección ni cuentas bancarias
- se ejecuta como tarea best-effort: una falla de observabilidad no bloquea el checkout ni los correos

### Reporte operativo
- agrega un workflow diario y manual sobre D1
- por defecto analiza los últimos 30 días
- informa órdenes creadas, elección de medio, transferencia preparada, preferencia de Mercado Pago, pagos aprobados y órdenes que probaron ambos medios
- entrega JSON, CSV diario, CSV por entrega y resumen Markdown
- la consulta es agregada y no exporta filas de clientes ni identificadores de órdenes

## Definiciones

- **Transferencia preparada:** la orden recibió las opciones de cobro. No confirma que el dinero haya llegado.
- **Mercado Pago preparado:** se creó una preferencia de pago.
- **Pago aprobado por checkout:** `payment_status=approved`, actualmente confirmado por el webhook validado de Mercado Pago.
- No se fabrica un backfill histórico de transferencia: la señal empieza a acumularse cuando se despliegue este lote.

## Fuera de alcance

- no cambia precios, descuento del 12 %, cuentas bancarias, stock, catálogo ni textos del checkout
- no marca transferencias como `purchase`
- no modifica GA4 ni Google Ads
- no despliega producción hasta aprobación y merge explícitos

## Validación focalizada previa

- sintaxis del handler: OK
- sintaxis del generador del reporte: OK
- 12 tests de transferencia: OK
- 4 tests del reporte y privacidad: OK
- consulta SQLite del embudo con datos simulados: OK

## Riesgo

Bajo. El único cambio en runtime es una inserción idempotente en `order_events` ejecutada fuera del camino crítico. El reporte es de solo lectura y consulta exclusivamente agregados no-PII.