### PR TITLE
Crear hub indexable para libros por encargo

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -84,11 +84,28 @@ jobs:
           COMMERCE_FAIL_ON_CRITICAL: 'true'
         run: node scripts/commerce/full-commerce-audit.mjs
 
+      - name: Audit by-request hub link graph
+        env:
+          SEO_BASE_URL: ${{ steps.deploy.outputs.preview_url }}
+          SEO_EXPECT_INDEXABLE: 'false'
+          SEO_OUTPUT_DIR: artifacts/seo-order-hub-preview
+          SEO_CONCURRENCY: '8'
+        run: node scripts/seo/order-hub-live-audit.mjs
+
       - name: Upload Preview report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: commerce-preview-pr-${{ github.event.pull_request.number }}
           path: artifacts/commerce-preview/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload by-request SEO report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: order-hub-seo-preview-pr-${{ github.event.pull_request.number }}
+          path: artifacts/seo-order-hub-preview/
           if-no-files-found: error
           retention-days: 30

--- a/astro-front/src/components/OrderHubAccess.astro
+++ b/astro-front/src/components/OrderHubAccess.astro
@@ -1,0 +1,30 @@
+<section class="order-hub-access" aria-labelledby="order-hub-title">
+  <div class="order-hub-copy">
+    <p class="order-hub-eyebrow">Libros por encargo</p>
+    <h2 id="order-hub-title">Explorá títulos que podemos buscar y cotizar</h2>
+    <p>
+      Reunimos ediciones agotadas, importadas o difíciles de conseguir en una
+      colección navegable. La disponibilidad, el precio y el plazo se confirman
+      antes de iniciar cualquier encargo.
+    </p>
+  </div>
+  <a class="order-hub-link" href="/libros-por-encargo">
+    Ver libros por encargo <span aria-hidden="true">→</span>
+  </a>
+</section>
+
+<style>
+  .order-hub-access{
+    max-width:1180px;margin:1.25rem auto;padding:1.25rem;
+    display:flex;flex-direction:column;align-items:flex-start;gap:1rem;
+    background:#fff8f4;border:1px solid #ead5ca;border-radius:1rem;color:#18120e;
+  }
+  .order-hub-copy{max-width:760px}
+  .order-hub-eyebrow{margin:0 0 .3rem;color:#a94e3d;font-size:.75rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase}
+  h2{margin:0;font-family:Georgia,"Times New Roman",serif;font-size:clamp(1.35rem,4vw,1.9rem);line-height:1.2}
+  .order-hub-copy>p:last-child{margin:.55rem 0 0;color:#574d45;line-height:1.6}
+  .order-hub-link{display:inline-flex;min-height:46px;align-items:center;gap:.4rem;padding:.7rem 1rem;background:#18120e;color:#fff;border-radius:.65rem;text-decoration:none;font-weight:800}
+  .order-hub-link:hover{background:#342820}
+  .order-hub-link:focus-visible{outline:3px solid #e49982;outline-offset:3px}
+  @media(min-width:760px){.order-hub-access{flex-direction:row;align-items:center;justify-content:space-between;padding:1.5rem 1.75rem}.order-hub-link{flex:0 0 auto}}
+</style>

--- a/astro-front/src/pages/index.astro
+++ b/astro-front/src/pages/index.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 // Lote 2-B — home con sección Novedades renderizada en build desde public/home.json.
 // Sin catálogo completo, sin GA4, sin lógica de negocio. noindex activo.
 import BaseLayout          from '../layouts/BaseLayout.astro';
@@ -8,6 +8,7 @@ import DeliveryCoordination from '../components/DeliveryCoordination.astro';
 import BookDiscovery       from '../components/BookDiscovery.astro';
 import GuideAccess         from '../components/GuideAccess.astro';
 import CategoryAccess      from '../components/CategoryAccess.astro';
+import OrderHubAccess      from '../components/OrderHubAccess.astro';
 import BestsellerSection   from '../components/BestsellerSection.astro';
 import Footer              from '../components/Footer.astro';
 import WAFloat             from '../components/WAFloat.astro';
@@ -73,6 +74,7 @@ const jsonLd = {
     <Hero />
     <DeliveryCoordination />
     <CategoryAccess />
+    <OrderHubAccess />
     <BestsellerSection />
     <BookDiscovery />
     <GuideAccess />

--- a/functions/__tests__/order-hub-seo.test.js
+++ b/functions/__tests__/order-hub-seo.test.js
@@ -1,0 +1,187 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import { createOrderHubHandler } from '../libros-por-encargo.js';
+import { pageSitemapEntries, STATIC_SITEMAP_PAGES } from '../sitemap-pages.xml.js';
+import {
+  ORDER_HUB_PAGE_SIZE,
+  orderHubBooks,
+  orderHubPageCount,
+  orderHubPaginationEntries,
+  orderHubPath,
+  parseOrderHubPage,
+} from '../_shared/order-hub.js';
+import { PAUSED_SEO_COHORT } from '../_shared/paused-seo-cohort.js';
+
+function pausedIndex(count = 120) {
+  return {
+    items: PAUSED_SEO_COHORT.slice(0, count).map((entry, index) => ({
+      id: entry.id,
+      title: `Libro por encargo ${String(index + 1).padStart(3, '0')}`,
+      author: `Autor ${index + 1}`,
+      isbn: entry.isbn,
+      thumbnail: `https://example.com/${entry.id}.jpg`,
+      status: 'paused',
+    })),
+  };
+}
+
+function context(path, appEnv = 'production', userAgent = 'Mozilla/5.0') {
+  return {
+    request: new Request(`https://www.amadolibros.com${path}`, {
+      headers: { 'user-agent': userAgent },
+    }),
+    env: { APP_ENV: appEnv },
+  };
+}
+
+function uniqueBookIds(html) {
+  return new Set(
+    [...html.matchAll(/href="\/libro\/(MLU\d+)\/[^\"]+"/g)].map(match => match[1]),
+  );
+}
+
+test('la cohorte del hub conserva orden estable y excluye activos o no aprobados', () => {
+  const approved = PAUSED_SEO_COHORT.slice(0, 3);
+  const index = {
+    items: [
+      { id: approved[1].id, title: 'Segundo', status: 'paused' },
+      { id: approved[0].id, title: 'Primero', status: 'paused' },
+      { id: approved[2].id, title: 'Activo', status: 'active' },
+      { id: 'MLU999999999', title: 'Fuera de cohorte', status: 'paused' },
+    ],
+  };
+
+  assert.deepEqual(orderHubBooks(index).map(book => book.id), [approved[0].id, approved[1].id]);
+  assert.equal(ORDER_HUB_PAGE_SIZE, 48);
+  assert.equal(orderHubPageCount(97), 3);
+  assert.equal(orderHubPath(1), '/libros-por-encargo');
+  assert.equal(orderHubPath(3), '/libros-por-encargo?page=3');
+});
+
+test('el parser normaliza sólo page=1 y rechaza páginas ambiguas', () => {
+  assert.deepEqual(parseOrderHubPage(null), { present: false, valid: true, page: 1 });
+  assert.deepEqual(parseOrderHubPage('1'), { present: true, valid: true, page: 1 });
+  assert.deepEqual(parseOrderHubPage('02'), { present: true, valid: false, page: null });
+  assert.deepEqual(parseOrderHubPage('0'), { present: true, valid: false, page: null });
+  assert.deepEqual(parseOrderHubPage('dos'), { present: true, valid: false, page: null });
+});
+
+test('producción entrega 48 fichas directas, canonical propio y sin Offer inventado', async () => {
+  const handler = createOrderHubHandler({ fetchPaused: async () => pausedIndex(120) });
+  const response = await handler(context('/libros-por-encargo'));
+  const html = await response.text();
+
+  assert.equal(response.status, 200);
+  assert.match(html, /<meta name="robots" content="index, follow">/);
+  assert.match(html, /<link rel="canonical" href="https:\/\/www\.amadolibros\.com\/libros-por-encargo">/);
+  assert.equal(uniqueBookIds(html).size, 48);
+  assert.match(html, /href="\/libros-por-encargo\?page=2"/);
+  assert.match(html, /href="\/libros-por-encargo\?page=3"/);
+  assert.doesNotMatch(html, /"@type":"Offer"|priceCurrency|itemCondition/);
+  assert.match(html, /Edición, disponibilidad, precio y plazo a confirmar/);
+});
+
+test('cada página paginada tiene canonical, prev, next y su propio lote estable', async () => {
+  const handler = createOrderHubHandler({ fetchPaused: async () => pausedIndex(120) });
+  const response = await handler(context('/libros-por-encargo?page=2'));
+  const html = await response.text();
+
+  assert.equal(response.status, 200);
+  assert.match(html, /Página 2 de 3/);
+  assert.match(html, /rel="prev" href="https:\/\/www\.amadolibros\.com\/libros-por-encargo"/);
+  assert.match(html, /rel="next" href="https:\/\/www\.amadolibros\.com\/libros-por-encargo\?page=3"/);
+  assert.match(html, /rel="canonical" href="https:\/\/www\.amadolibros\.com\/libros-por-encargo\?page=2"/);
+  const ids = uniqueBookIds(html);
+  assert.equal(ids.size, 48);
+  assert.ok(ids.has(PAUSED_SEO_COHORT[48].id));
+  assert.ok(ids.has(PAUSED_SEO_COHORT[95].id));
+  assert.ok(!ids.has(PAUSED_SEO_COHORT[0].id));
+});
+
+test('page=1 redirige y páginas inválidas o fuera de rango devuelven 404 noindex', async () => {
+  const handler = createOrderHubHandler({ fetchPaused: async () => pausedIndex(60) });
+  const normalized = await handler(context('/libros-por-encargo?page=1'));
+  assert.equal(normalized.status, 301);
+  assert.equal(normalized.headers.get('location'), 'https://www.amadolibros.com/libros-por-encargo');
+
+  for (const path of ['/libros-por-encargo?page=0', '/libros-por-encargo?page=abc', '/libros-por-encargo?page=3']) {
+    const response = await handler(context(path));
+    const html = await response.text();
+    assert.equal(response.status, 404, path);
+    assert.match(response.headers.get('x-robots-tag'), /noindex, nofollow/);
+    assert.match(html, /<meta name="robots" content="noindex, nofollow">/);
+  }
+});
+
+test('Preview es noindex y entrega exactamente los mismos enlaces a mobile y desktop', async () => {
+  const index = pausedIndex(70);
+  const handler = createOrderHubHandler({ fetchPaused: async () => index });
+  const desktop = await handler(context('/libros-por-encargo', 'preview', 'Mozilla/5.0 desktop'));
+  const mobile = await handler(context('/libros-por-encargo', 'preview', 'Mozilla/5.0 Mobile Safari'));
+  const desktopHtml = await desktop.text();
+  const mobileHtml = await mobile.text();
+
+  assert.match(desktopHtml, /<meta name="robots" content="noindex, nofollow">/);
+  assert.deepEqual([...uniqueBookIds(mobileHtml)], [...uniqueBookIds(desktopHtml)]);
+  assert.equal(uniqueBookIds(desktopHtml).size, 48);
+});
+
+test('si el catálogo pausado falla, el hub devuelve 503 y nunca una página indexable vacía', async () => {
+  const handler = createOrderHubHandler({ fetchPaused: async () => null });
+  const response = await handler(context('/libros-por-encargo'));
+  const html = await response.text();
+
+  assert.equal(response.status, 503);
+  assert.equal(response.headers.get('retry-after'), '60');
+  assert.match(response.headers.get('x-robots-tag'), /noindex/);
+  assert.match(html, /catálogo por encargo está actualizándose/);
+});
+
+test('el sitemap dinámico sólo agrega páginas 2+ y usa el mismo tamaño de página', () => {
+  const entries = orderHubPaginationEntries(pausedIndex(120), 'https://www.amadolibros.com');
+  assert.deepEqual(entries, [
+    { loc: 'https://www.amadolibros.com/libros-por-encargo?page=2' },
+    { loc: 'https://www.amadolibros.com/libros-por-encargo?page=3' },
+  ]);
+});
+
+test('la cohorte completa queda cubierta una sola vez en un máximo de 63 páginas', () => {
+  const books = orderHubBooks(pausedIndex(PAUSED_SEO_COHORT.length));
+  const seen = new Set();
+
+  assert.equal(books.length, PAUSED_SEO_COHORT.length);
+  assert.equal(orderHubPageCount(books), 63);
+  for (let page = 1; page <= orderHubPageCount(books); page += 1) {
+    for (const book of books.slice((page - 1) * ORDER_HUB_PAGE_SIZE, page * ORDER_HUB_PAGE_SIZE)) {
+      assert.equal(seen.has(book.id), false, `duplicado ${book.id}`);
+      seen.add(book.id);
+    }
+  }
+  assert.equal(seen.size, PAUSED_SEO_COHORT.length);
+});
+
+test('sitemap-pages publica la raíz y sólo las páginas vigentes 2..N', async () => {
+  const entries = await pageSitemapEntries({}, { loadPausedIndex: async () => pausedIndex(120) });
+  const locs = entries.map(entry => entry.loc);
+
+  assert.ok(STATIC_SITEMAP_PAGES.includes('https://www.amadolibros.com/libros-por-encargo'));
+  assert.ok(locs.includes('https://www.amadolibros.com/libros-por-encargo'));
+  assert.ok(locs.includes('https://www.amadolibros.com/libros-por-encargo?page=2'));
+  assert.ok(locs.includes('https://www.amadolibros.com/libros-por-encargo?page=3'));
+  assert.ok(!locs.includes('https://www.amadolibros.com/libros-por-encargo?page=4'));
+});
+
+test('la home enlaza el hub de forma visible y el hub mantiene la landing informativa', () => {
+  const home = readFileSync('astro-front/src/pages/index.astro', 'utf8');
+  const access = readFileSync('astro-front/src/components/OrderHubAccess.astro', 'utf8');
+  const hub = readFileSync('functions/libros-por-encargo.js', 'utf8');
+
+  assert.match(home, /import OrderHubAccess/);
+  assert.match(home, /<OrderHubAccess \/>/);
+  assert.match(access, /href="\/libros-por-encargo"/);
+  assert.match(access, /disponibilidad, el precio y el plazo se confirman/i);
+  assert.match(hub, /href="\/libros-agotados-importados-uruguay"/);
+  assert.doesNotMatch(access, /priceCurrency|"@type":\s*"Offer"/);
+});

--- a/functions/_shared/order-hub.js
+++ b/functions/_shared/order-hub.js
@@ -1,0 +1,67 @@
+import { PAUSED_SEO_COHORT } from './paused-seo-cohort.js';
+import { slugify } from './slug.js';
+
+export const ORDER_HUB_PATH = '/libros-por-encargo';
+export const ORDER_HUB_PAGE_SIZE = 48;
+
+export function orderHubPath(page = 1) {
+  const normalized = Number(page);
+  return Number.isInteger(normalized) && normalized > 1
+    ? `${ORDER_HUB_PATH}?page=${normalized}`
+    : ORDER_HUB_PATH;
+}
+
+export function parseOrderHubPage(rawValue) {
+  if (rawValue == null || rawValue === '') {
+    return { present: false, valid: true, page: 1 };
+  }
+  const value = String(rawValue).trim();
+  if (!/^[1-9]\d*$/.test(value)) {
+    return { present: true, valid: false, page: null };
+  }
+  const page = Number(value);
+  if (!Number.isSafeInteger(page)) {
+    return { present: true, valid: false, page: null };
+  }
+  return { present: true, valid: true, page };
+}
+
+export function orderHubBooks(pausedIndex) {
+  const pausedItems = Array.isArray(pausedIndex?.items) ? pausedIndex.items : [];
+  const byId = new Map(pausedItems.map(item => [String(item?.id || '').toUpperCase(), item]));
+
+  return PAUSED_SEO_COHORT
+    .map(entry => byId.get(entry.id))
+    .filter(item => item?.status === 'paused' && item.id && item.title)
+    .map(item => Object.freeze({
+      id: String(item.id).toUpperCase(),
+      title: String(item.title),
+      author: item.author ? String(item.author) : '',
+      isbn: item.isbn ? String(item.isbn) : '',
+      thumbnail: item.thumbnail ? String(item.thumbnail) : '',
+      slug: slugify(item.title),
+    }));
+}
+
+export function orderHubPageCount(booksOrCount) {
+  const count = Array.isArray(booksOrCount)
+    ? booksOrCount.length
+    : Math.max(0, Number(booksOrCount) || 0);
+  return Math.max(1, Math.ceil(count / ORDER_HUB_PAGE_SIZE));
+}
+
+export function orderHubPageSlice(books, page) {
+  const pageNumber = Number(page);
+  if (!Array.isArray(books) || !Number.isInteger(pageNumber) || pageNumber < 1) return [];
+  const start = (pageNumber - 1) * ORDER_HUB_PAGE_SIZE;
+  return books.slice(start, start + ORDER_HUB_PAGE_SIZE);
+}
+
+export function orderHubPaginationEntries(pausedIndex, baseUrl) {
+  const books = orderHubBooks(pausedIndex);
+  const totalPages = orderHubPageCount(books);
+  const base = String(baseUrl || '').replace(/\/$/, '');
+  return Array.from({ length: Math.max(0, totalPages - 1) }, (_, index) => ({
+    loc: `${base}${orderHubPath(index + 2)}`,
+  }));
+}

--- a/functions/libros-por-encargo.js
+++ b/functions/libros-por-encargo.js
@@ -1,0 +1,147 @@
+import { BASE, fetchPausedIndex } from './_shared/catalog.js';
+import {
+  BRAND, faviconHeadHtml, footerHtml, FOOTER_STYLES,
+  waFloatHtml, WA_FLOAT_STYLES,
+} from './_shared/brand.js';
+import { bookCoverUrl, CARD_IMAGE_SIZES, responsiveImage } from './_shared/cloudflare-images.js';
+import {
+  ORDER_HUB_PAGE_SIZE, ORDER_HUB_PATH, orderHubBooks, orderHubPageCount,
+  orderHubPageSlice, orderHubPath, parseOrderHubPage,
+} from './_shared/order-hub.js';
+import { buildWhatsAppMessage } from '../shared/whatsapp-messages.js';
+
+const TITLE = 'Libros por encargo en Uruguay | Amado Libros';
+const DESCRIPTION = 'Explorá libros agotados, importados y difíciles de conseguir que Amado Libros puede buscar y cotizar por encargo desde Uruguay.';
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+function noindexPage({ status, heading, message, retryAfter = '' }) {
+  const headers = {
+    'Content-Type': 'text/html;charset=UTF-8',
+    'Cache-Control': status === 503 ? 'no-store' : 'public, max-age=300',
+    'X-Robots-Tag': 'noindex, nofollow',
+  };
+  if (retryAfter) headers['Retry-After'] = retryAfter;
+  return new Response(`<!doctype html><html lang="es"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex, nofollow"><title>${escapeHtml(heading)} | Amado Libros</title>${faviconHeadHtml()}</head><body style="font-family:system-ui,sans-serif;max-width:680px;margin:4rem auto;padding:1rem;line-height:1.6"><main><h1>${escapeHtml(heading)}</h1><p>${escapeHtml(message)}</p><p><a href="${ORDER_HUB_PATH}">Volver a libros por encargo</a></p></main></body></html>`, { status, headers });
+}
+
+function pageIndexHtml(totalPages, currentPage) {
+  return `<nav class="page-index" aria-label="Todas las páginas de libros por encargo">${Array.from({ length: totalPages }, (_, index) => {
+    const page = index + 1;
+    return page === currentPage
+      ? `<span class="page-number is-current" aria-current="page">${page}</span>`
+      : `<a class="page-number" href="${orderHubPath(page)}" aria-label="Ir a la página ${page}">${page}</a>`;
+  }).join('')}</nav>`;
+}
+
+function pagerHtml(totalPages, currentPage) {
+  const previous = currentPage > 1
+    ? `<a class="pager-link" href="${orderHubPath(currentPage - 1)}" rel="prev">← Anterior</a>`
+    : '<span class="pager-link is-disabled" aria-disabled="true">← Anterior</span>';
+  const next = currentPage < totalPages
+    ? `<a class="pager-link" href="${orderHubPath(currentPage + 1)}" rel="next">Siguiente →</a>`
+    : '<span class="pager-link is-disabled" aria-disabled="true">Siguiente →</span>';
+  return `<nav class="pager" aria-label="Paginación de libros por encargo">${previous}<span>Página ${currentPage} de ${totalPages}</span>${next}</nav>`;
+}
+
+function cardHtml(book, position) {
+  const href = `/libro/${encodeURIComponent(book.id)}/${book.slug}`;
+  const image = responsiveImage(bookCoverUrl(book.id), {
+    widths: [240, 360, 480], defaultWidth: 360, sizes: CARD_IMAGE_SIZES,
+  });
+  const responsive = image.srcset
+    ? ` srcset="${escapeHtml(image.srcset)}" sizes="${escapeHtml(image.sizes)}"`
+    : '';
+  return `<article class="book-card">
+    <a class="book-cover-link" href="${href}" aria-label="Ver ficha de ${escapeHtml(book.title)}"><img src="${escapeHtml(image.src)}"${responsive} alt="Portada de ${escapeHtml(book.title)}" loading="${position < 8 ? 'eager' : 'lazy'}" decoding="async" width="280" height="420"></a>
+    <div class="book-body"><span class="order-badge">Por encargo</span><h2><a href="${href}">${escapeHtml(book.title)}</a></h2>
+      ${book.author ? `<p class="book-author">${escapeHtml(book.author)}</p>` : ''}
+      ${book.isbn ? `<p class="book-isbn">ISBN ${escapeHtml(book.isbn)}</p>` : ''}
+      <p class="order-note">Edición, disponibilidad, precio y plazo a confirmar.</p><a class="book-cta" href="${href}">Ver ficha y consultar →</a>
+    </div>
+  </article>`;
+}
+
+function renderPage({ books, pageBooks, currentPage, totalPages, indexable }) {
+  const offset = (currentPage - 1) * ORDER_HUB_PAGE_SIZE;
+  const canonicalPath = orderHubPath(currentPage);
+  const canonicalUrl = `${BASE}${canonicalPath}`;
+  const pageTitle = currentPage === 1 ? TITLE : `Libros por encargo en Uruguay — Página ${currentPage} | Amado Libros`;
+  const pageDescription = currentPage === 1 ? DESCRIPTION : `Página ${currentPage} de libros agotados, importados y difíciles de conseguir que Amado Libros puede buscar por encargo desde Uruguay.`;
+  const schema = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'CollectionPage', '@id': `${canonicalUrl}#webpage`, url: canonicalUrl,
+        name: pageTitle, description: pageDescription, inLanguage: 'es-UY',
+        mainEntity: { '@id': `${canonicalUrl}#item-list` },
+      },
+      {
+        '@type': 'ItemList', '@id': `${canonicalUrl}#item-list`,
+        name: currentPage === 1 ? 'Libros por encargo' : `Libros por encargo — página ${currentPage}`,
+        numberOfItems: pageBooks.length,
+        itemListElement: pageBooks.map((book, index) => ({
+          '@type': 'ListItem', position: offset + index + 1,
+          url: `${BASE}/libro/${book.id}/${book.slug}`, name: book.title,
+        })),
+      },
+      {
+        '@type': 'BreadcrumbList', itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Inicio', item: `${BASE}/` },
+          { '@type': 'ListItem', position: 2, name: 'Libros por encargo', item: `${BASE}${ORDER_HUB_PATH}` },
+          ...(currentPage > 1 ? [{ '@type': 'ListItem', position: 3, name: `Página ${currentPage}`, item: canonicalUrl }] : []),
+        ],
+      },
+    ],
+  };
+  const message = buildWhatsAppMessage({
+    motive: 'Consulta por un libro por encargo', page: canonicalUrl,
+    closing: 'Quisiera consultar por uno de los títulos del catálogo por encargo. Gracias.',
+  });
+  const pager = pagerHtml(totalPages, currentPage);
+  const rangeFrom = offset + 1;
+  const rangeTo = offset + pageBooks.length;
+  const styles = `
+    *{box-sizing:border-box;margin:0;padding:0}body{font-family:Inter,system-ui,-apple-system,"Segoe UI",sans-serif;background:#f8f5ef;color:#18120e;line-height:1.6}a{color:inherit}.site-header{background:#18120e;color:#fff}.header-inner{max-width:1180px;margin:auto;padding:.75rem 1rem;display:flex;align-items:center;justify-content:space-between;gap:1rem}.brand-link{display:flex;align-items:center;gap:.7rem;text-decoration:none;font-weight:800}.brand-link img{width:48px;height:48px;object-fit:contain;background:#fff;border-radius:50%}.header-links{display:flex;gap:.5rem;font-size:.82rem}.header-links a{padding:.55rem .7rem;text-decoration:none}.crumbs{max-width:1180px;margin:auto;padding:.85rem 1rem;color:#6b6157;font-size:.84rem}.crumbs a,.book-cta{color:#8f4436;text-decoration:none}main{max-width:1180px;margin:auto;padding:0 1rem 3rem}.hero{padding:clamp(1.35rem,4vw,2.5rem);background:#fff;border:1px solid #e2dbd0;border-radius:1rem}.eyebrow{color:#a94e3d;font-size:.75rem;font-weight:800;letter-spacing:.09em;text-transform:uppercase}h1{max-width:24ch;margin-top:.45rem;font-family:Georgia,"Times New Roman",serif;font-size:clamp(1.9rem,6vw,3rem);line-height:1.08}.lead{max-width:76ch;margin-top:.85rem;color:#574d45}.truth{margin-top:1rem;padding:.85rem 1rem;border-left:4px solid #e49982;background:#fff8f4;color:#6b4b3f;font-size:.9rem}.collection-meta{display:flex;flex-wrap:wrap;justify-content:space-between;gap:.7rem;margin:1.25rem 0 .8rem;color:#6b6157;font-size:.86rem}.book-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.75rem}.book-card{display:flex;flex-direction:column;background:#fff;border:1px solid #e2dbd0;border-radius:.8rem;overflow:hidden}.book-cover-link{display:block;aspect-ratio:2/3;background:#f3efe8;overflow:hidden}.book-cover-link img{width:100%;height:100%;object-fit:contain}.book-body{display:flex;flex:1;flex-direction:column;align-items:flex-start;padding:.8rem;gap:.38rem}.order-badge{padding:.2rem .52rem;border-radius:999px;background:#fff1e8;color:#8f4436;font-size:.68rem;font-weight:800;text-transform:uppercase}.book-body h2{font-size:.92rem;line-height:1.3}.book-body h2 a{text-decoration:none}.book-author{font-size:.8rem;color:#574d45}.book-isbn,.order-note{font-size:.74rem;color:#756a61}.book-cta{margin-top:auto;padding-top:.45rem;font-size:.8rem;font-weight:800}.pager{display:grid;grid-template-columns:1fr auto 1fr;align-items:center;gap:.6rem;margin:1.25rem 0;padding:.8rem;background:#fff;border:1px solid #e2dbd0;border-radius:.75rem;text-align:center;font-size:.84rem}.pager-link{min-height:44px;display:flex;align-items:center;padding:.55rem .7rem;text-decoration:none;font-weight:800}.pager-link:last-child{justify-content:flex-end}.pager-link.is-disabled{color:#a39a91}.page-index{display:flex;flex-wrap:wrap;gap:.35rem;margin-top:1rem;padding:1rem;background:#fff;border:1px solid #e2dbd0;border-radius:.75rem}.page-number{min-width:38px;min-height:38px;display:inline-flex;align-items:center;justify-content:center;border:1px solid #d8d1c7;border-radius:.45rem;text-decoration:none;font-size:.78rem;font-weight:700}.page-number.is-current{background:#18120e;color:#fff}.service-link{margin-top:1.25rem;padding:1rem;background:#18120e;color:#fff;border-radius:.75rem}.service-link p{color:#ffffffb8;font-size:.88rem}.service-link a{display:inline-flex;margin-top:.65rem;font-weight:800}@media(min-width:640px){.book-grid{grid-template-columns:repeat(3,minmax(0,1fr));gap:1rem}.book-body{padding:1rem}}@media(min-width:980px){.book-grid{grid-template-columns:repeat(4,minmax(0,1fr))}}@media(max-width:560px){.header-links a:last-child{display:none}.pager{grid-template-columns:1fr 1fr}.pager>span{grid-column:1/-1;grid-row:1}.pager-link{grid-row:2}.page-index{max-height:12rem;overflow:auto}}
+    ${FOOTER_STYLES}${WA_FLOAT_STYLES}`;
+
+  return `<!doctype html><html lang="es"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escapeHtml(pageTitle)}</title><meta name="description" content="${escapeHtml(pageDescription)}"><meta name="robots" content="${indexable ? 'index, follow' : 'noindex, nofollow'}"><link rel="canonical" href="${canonicalUrl}">${currentPage > 1 ? `<link rel="prev" href="${BASE}${orderHubPath(currentPage - 1)}">` : ''}${currentPage < totalPages ? `<link rel="next" href="${BASE}${orderHubPath(currentPage + 1)}">` : ''}${faviconHeadHtml()}<script type="application/ld+json">${JSON.stringify(schema).replace(/</g, '\\u003c')}</script><style>${styles}</style></head><body>
+    <header class="site-header"><div class="header-inner"><a class="brand-link" href="/"><img src="${BRAND.logo}" alt="${BRAND.logoAlt}" width="48" height="48"><span>Amado Libros</span></a><nav class="header-links" aria-label="Navegación principal"><a href="/catalogo">Catálogo</a><a href="/pedir-libro">Pedir un libro</a></nav></div></header>
+    <nav class="crumbs" aria-label="Migas de pan"><a href="/">Inicio</a> › ${currentPage > 1 ? `<a href="${ORDER_HUB_PATH}">Libros por encargo</a> › Página ${currentPage}` : 'Libros por encargo'}</nav>
+    <main><section class="hero"><p class="eyebrow">Catálogo rastreable de títulos difíciles de conseguir</p><h1>${currentPage === 1 ? 'Libros que podemos buscar por encargo' : `Libros por encargo — página ${currentPage}`}</h1><p class="lead">${currentPage === 1 ? 'Esta colección reúne títulos que hoy no están en stock local, pero que podemos buscar y cotizar en proveedores del exterior. Cada ficha corresponde a una edición identificada por título, autor o ISBN.' : `Continuá explorando los libros ${rangeFrom} a ${rangeTo} de la colección por encargo.`}</p><p class="truth"><strong>Importante:</strong> aparecer en esta colección no garantiza stock ni precio. Verificamos edición, proveedor, costo y plazo antes de aceptar un encargo.</p></section>
+      <div class="collection-meta"><p><strong>${books.length.toLocaleString('es-UY')}</strong> títulos seleccionados</p><p>Mostrando ${rangeFrom}–${rangeTo} · ${ORDER_HUB_PAGE_SIZE} por página</p></div>${pager}
+      <section class="book-grid" aria-label="Libros por encargo de la página ${currentPage}">${pageBooks.map(cardHtml).join('\n')}</section>${pager}
+      <section aria-labelledby="all-pages-title"><h2 id="all-pages-title" style="font-size:1rem;margin-top:1.35rem">Ir directamente a otra página</h2>${pageIndexHtml(totalPages, currentPage)}</section>
+      <aside class="service-link"><h2 style="font-size:1rem">¿No aparece el título que buscás?</h2><p>También hacemos búsquedas manuales por título, autor, ISBN o foto de la tapa.</p><a href="/libros-agotados-importados-uruguay">Conocer el servicio de búsqueda por encargo →</a></aside>
+    </main>${footerHtml(undefined, canonicalUrl)}${waFloatHtml(message, canonicalUrl)}</body></html>`;
+}
+
+export function createOrderHubHandler({ fetchPaused = fetchPausedIndex } = {}) {
+  return async function onRequest(ctx) {
+    const url = new URL(ctx.request.url);
+    const parsed = parseOrderHubPage(url.searchParams.get('page'));
+    if (!parsed.valid) return noindexPage({ status: 404, heading: 'Página no encontrada', message: 'La página de libros por encargo que buscás no existe.' });
+    if (parsed.present && parsed.page === 1) return Response.redirect(new URL(ORDER_HUB_PATH, url.origin).toString(), 301);
+
+    let pausedIndex;
+    try { pausedIndex = await fetchPaused(ctx); } catch { pausedIndex = null; }
+    const books = orderHubBooks(pausedIndex);
+    if (!Array.isArray(pausedIndex?.items) || books.length === 0) {
+      return noindexPage({ status: 503, heading: 'El catálogo por encargo está actualizándose', message: 'Probá nuevamente en unos minutos.', retryAfter: '60' });
+    }
+
+    const totalPages = orderHubPageCount(books);
+    if (parsed.page > totalPages) return noindexPage({ status: 404, heading: 'Página no encontrada', message: 'La página de libros por encargo que buscás no existe.' });
+    const html = renderPage({
+      books, pageBooks: orderHubPageSlice(books, parsed.page), currentPage: parsed.page,
+      totalPages, indexable: ctx.env?.APP_ENV === 'production',
+    });
+    return new Response(html, { headers: { 'Content-Type': 'text/html;charset=UTF-8', 'Cache-Control': 'public, max-age=300' } });
+  };
+}
+
+export const onRequest = createOrderHubHandler();

--- a/functions/sitemap-pages.xml.js
+++ b/functions/sitemap-pages.xml.js
@@ -1,7 +1,8 @@
-import { BASE } from './_shared/catalog.js';
+import { BASE, fetchPausedIndex } from './_shared/catalog.js';
 import { urlsetXml, xmlResponse } from './_shared/sitemap.js';
 import { SEO_SPECIALTIES, specialtyPath } from './_shared/seo-specialties.js';
 import { SEO_AUTHORS } from './_shared/seo-authors.js';
+import { orderHubPaginationEntries } from './_shared/order-hub.js';
 
 export const STATIC_SITEMAP_PAGES = Object.freeze([
   `${BASE}/`,
@@ -9,6 +10,7 @@ export const STATIC_SITEMAP_PAGES = Object.freeze([
   `${BASE}/pedir-libro`,
   `${BASE}/como-identificar-edicion-correcta-isbn`,
   `${BASE}/libros-agotados-importados-uruguay`,
+  `${BASE}/libros-por-encargo`,
   ...SEO_AUTHORS.map(author => `${BASE}${author.path}`),
   `${BASE}/politicas`,
   `${BASE}/envios`,
@@ -25,6 +27,7 @@ const SIGNIFICANT_PAGE_UPDATES = Object.freeze({
   [`${BASE}/pedir-libro`]: '2026-08-12',
   [`${BASE}/como-identificar-edicion-correcta-isbn`]: '2026-08-12',
   [`${BASE}/libros-agotados-importados-uruguay`]: '2026-08-12',
+  [`${BASE}/libros-por-encargo`]: '2026-08-17',
   [`${BASE}/quienes-somos`]: '2026-08-12',
   ...Object.fromEntries(SEO_AUTHORS.map(author => [`${BASE}${author.path}`, '2026-08-14'])),
 });
@@ -36,6 +39,22 @@ export const STATIC_SITEMAP_ENTRIES = Object.freeze(
   })),
 );
 
-export async function onRequest() {
-  return xmlResponse(urlsetXml(STATIC_SITEMAP_ENTRIES));
+export async function pageSitemapEntries(ctx, { loadPausedIndex = fetchPausedIndex } = {}) {
+  let paginatedOrderHubEntries = [];
+  try {
+    const pausedIndex = await loadPausedIndex(ctx);
+    paginatedOrderHubEntries = orderHubPaginationEntries(pausedIndex, BASE);
+  } catch {
+    // El sitemap institucional sigue disponible aunque R2 tenga una caída
+    // temporal. La raíz del hub queda publicada y las páginas 2+ vuelven en
+    // el siguiente request cuando el índice pausado se recupere.
+  }
+  return [
+    ...STATIC_SITEMAP_ENTRIES,
+    ...paginatedOrderHubEntries,
+  ];
+}
+
+export async function onRequest(ctx) {
+  return xmlResponse(urlsetXml(await pageSitemapEntries(ctx)));
 }

--- a/scripts/seo/order-hub-live-audit.mjs
+++ b/scripts/seo/order-hub-live-audit.mjs
@@ -1,0 +1,231 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const BASE_URL = (process.env.SEO_BASE_URL || 'https://www.amadolibros.com').replace(/\/$/, '');
+const PRODUCTION_ORIGIN = 'https://www.amadolibros.com';
+const EXPECT_INDEXABLE = process.env.SEO_EXPECT_INDEXABLE !== 'false';
+const OUTPUT_DIR = process.env.SEO_OUTPUT_DIR || 'artifacts/seo-order-hub';
+const PAGE_SIZE = 48;
+const CONCURRENCY = Math.max(1, Math.min(12, Number(process.env.SEO_CONCURRENCY) || 8));
+
+function decodeHtml(value) {
+  return String(value || '')
+    .replaceAll('&amp;', '&').replaceAll('&quot;', '"').replaceAll('&#39;', "'")
+    .replaceAll('&lt;', '<').replaceAll('&gt;', '>');
+}
+
+function sitemapLocs(xml) {
+  return [...xml.matchAll(/<loc>([\s\S]*?)<\/loc>/gi)]
+    .map(match => decodeHtml(match[1].trim()));
+}
+
+function bookId(value) {
+  try {
+    const url = new URL(value, BASE_URL);
+    return url.pathname.match(/^\/libro\/(MLU\d+)(?:\/|$)/i)?.[1]?.toUpperCase() || null;
+  } catch {
+    return null;
+  }
+}
+
+function hrefs(html) {
+  return [...html.matchAll(/\bhref\s*=\s*(?:"([^"]*)"|'([^']*)')/gi)]
+    .map(match => decodeHtml(match[1] ?? match[2] ?? ''))
+    .filter(Boolean);
+}
+
+function uniqueBookIds(html) {
+  return new Set(hrefs(html).map(bookId).filter(Boolean));
+}
+
+function pageLinks(html) {
+  const pages = new Set([1]);
+  for (const href of hrefs(html)) {
+    try {
+      const url = new URL(href, BASE_URL);
+      if (url.pathname !== '/libros-por-encargo') continue;
+      const raw = url.searchParams.get('page');
+      if (!raw) {
+        pages.add(1);
+        continue;
+      }
+      if (/^[1-9]\d*$/.test(raw)) pages.add(Number(raw));
+    } catch {
+      // Otra validación comprueba la cobertura completa.
+    }
+  }
+  return pages;
+}
+
+function canonical(html) {
+  return decodeHtml(html.match(/<link\s+rel="canonical"\s+href="([^"]+)"/i)?.[1] || '');
+}
+
+function robots(html) {
+  return String(html.match(/<meta\s+name="robots"\s+content="([^"]+)"/i)?.[1] || '').toLowerCase();
+}
+
+async function fetchHtml(pathname, userAgent = 'AmadoLibros-OrderHub-Audit/1.0') {
+  const url = new URL(pathname, BASE_URL).toString();
+  const response = await fetch(url, {
+    redirect: 'follow',
+    headers: { 'user-agent': userAgent },
+    signal: AbortSignal.timeout(45_000),
+  });
+  return {
+    url,
+    status: response.status,
+    headers: Object.fromEntries(response.headers.entries()),
+    html: await response.text(),
+  };
+}
+
+async function mapConcurrent(values, mapper) {
+  const results = new Array(values.length);
+  let cursor = 0;
+  async function worker() {
+    while (cursor < values.length) {
+      const index = cursor++;
+      results[index] = await mapper(values[index], index);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, values.length) }, worker));
+  return results;
+}
+
+function setDifference(left, right) {
+  return [...left].filter(value => !right.has(value)).sort();
+}
+
+async function main() {
+  const failures = [];
+  const pausedSitemapResponse = await fetch(`${BASE_URL}/sitemap-books-paused.xml`, {
+    headers: { 'user-agent': 'AmadoLibros-OrderHub-Audit/1.0' },
+    signal: AbortSignal.timeout(45_000),
+  });
+  if (!pausedSitemapResponse.ok) {
+    throw new Error(`sitemap-books-paused.xml respondió HTTP ${pausedSitemapResponse.status}`);
+  }
+  const sitemapIds = new Set(
+    sitemapLocs(await pausedSitemapResponse.text()).map(bookId).filter(Boolean),
+  );
+  if (sitemapIds.size === 0) failures.push('El sitemap pausado no contiene fichas.');
+
+  const expectedPages = Math.max(1, Math.ceil(sitemapIds.size / PAGE_SIZE));
+  const rootDesktop = await fetchHtml('/libros-por-encargo', 'Mozilla/5.0 desktop AmadoAudit');
+  const rootMobile = await fetchHtml('/libros-por-encargo', 'Mozilla/5.0 Mobile Safari AmadoAudit');
+  if (rootDesktop.status !== 200) failures.push(`El hub respondió HTTP ${rootDesktop.status}.`);
+  if (rootMobile.status !== 200) failures.push(`El hub mobile respondió HTTP ${rootMobile.status}.`);
+
+  const desktopBooks = uniqueBookIds(rootDesktop.html);
+  const mobileBooks = uniqueBookIds(rootMobile.html);
+  const desktopPages = pageLinks(rootDesktop.html);
+  const mobilePages = pageLinks(rootMobile.html);
+  if (setDifference(desktopBooks, mobileBooks).length || setDifference(mobileBooks, desktopBooks).length) {
+    failures.push('Mobile y desktop no entregan las mismas fichas en el HTML SSR.');
+  }
+  if (setDifference(desktopPages, mobilePages).length || setDifference(mobilePages, desktopPages).length) {
+    failures.push('Mobile y desktop no entregan los mismos enlaces de paginación.');
+  }
+  for (let page = 1; page <= expectedPages; page += 1) {
+    if (!desktopPages.has(page)) failures.push(`La portada del hub no enlaza la página ${page}.`);
+  }
+
+  const pageNumbers = Array.from({ length: expectedPages }, (_, index) => index + 1);
+  const pages = await mapConcurrent(pageNumbers, async page => {
+    const pathname = page === 1 ? '/libros-por-encargo' : `/libros-por-encargo?page=${page}`;
+    const result = page === 1 ? rootDesktop : await fetchHtml(pathname);
+    const ids = uniqueBookIds(result.html);
+    const expectedCanonical = `${PRODUCTION_ORIGIN}${pathname}`;
+    const metaRobots = robots(result.html);
+    const xRobots = String(result.headers['x-robots-tag'] || '').toLowerCase();
+    const expectedItems = page < expectedPages
+      ? PAGE_SIZE
+      : Math.max(1, sitemapIds.size - ((expectedPages - 1) * PAGE_SIZE));
+
+    if (result.status !== 200) failures.push(`${pathname} respondió HTTP ${result.status}.`);
+    if (canonical(result.html) !== expectedCanonical) {
+      failures.push(`${pathname} canonicalizó a ${canonical(result.html) || 'vacío'}.`);
+    }
+    if (ids.size !== expectedItems) {
+      failures.push(`${pathname} enlaza ${ids.size} fichas únicas; se esperaban ${expectedItems}.`);
+    }
+    if (/"@type"\s*:\s*"Offer"|"offers"\s*:|priceCurrency/.test(result.html)) {
+      failures.push(`${pathname} publica una oferta o precio para libros por encargo.`);
+    }
+    if (EXPECT_INDEXABLE) {
+      if (!metaRobots.includes('index') || metaRobots.includes('noindex')) {
+        failures.push(`${pathname} no está marcado index, follow en producción.`);
+      }
+      if (xRobots.includes('noindex')) failures.push(`${pathname} recibe X-Robots-Tag noindex en producción.`);
+    } else {
+      if (!metaRobots.includes('noindex')) failures.push(`${pathname} no tiene meta noindex en Preview.`);
+      if (!xRobots.includes('noindex')) failures.push(`${pathname} no tiene X-Robots-Tag noindex en Preview.`);
+    }
+
+    return {
+      page, pathname, status: result.status, canonical: canonical(result.html),
+      robots: metaRobots, xRobotsTag: xRobots, uniqueBookLinks: ids.size, ids: [...ids],
+    };
+  });
+
+  const allIds = new Set();
+  const duplicateIds = new Set();
+  for (const page of pages) {
+    for (const id of page.ids) {
+      if (allIds.has(id)) duplicateIds.add(id);
+      allIds.add(id);
+    }
+  }
+  const missingFromHub = setDifference(sitemapIds, allIds);
+  const outsideSitemap = setDifference(allIds, sitemapIds);
+  if (duplicateIds.size) failures.push(`${duplicateIds.size} fichas aparecen en más de una página del hub.`);
+  if (missingFromHub.length) failures.push(`${missingFromHub.length} fichas del sitemap pausado no tienen enlace desde el hub.`);
+  if (outsideSitemap.length) failures.push(`${outsideSitemap.length} fichas del hub no pertenecen al sitemap pausado.`);
+
+  const invalidPage = await fetchHtml(`/libros-por-encargo?page=${expectedPages + 1}`);
+  if (invalidPage.status !== 404) failures.push('Una página fuera de rango no devuelve 404.');
+  if (!robots(invalidPage.html).includes('noindex')) failures.push('La página fuera de rango no declara noindex.');
+
+  const report = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    baseUrl: BASE_URL,
+    expectIndexable: EXPECT_INDEXABLE,
+    pageSize: PAGE_SIZE,
+    sitemapBooks: sitemapIds.size,
+    expectedPages,
+    pagesAudited: pages.length,
+    linkedBooks: allIds.size,
+    missingFromHub,
+    outsideSitemap,
+    duplicateIds: [...duplicateIds].sort(),
+    mobileParity: {
+      books: desktopBooks.size === mobileBooks.size && setDifference(desktopBooks, mobileBooks).length === 0,
+      pages: desktopPages.size === mobilePages.size && setDifference(desktopPages, mobilePages).length === 0,
+    },
+    invalidPageStatus: invalidPage.status,
+    failures,
+    pages: pages.map(({ ids, ...page }) => page),
+  };
+
+  await mkdir(OUTPUT_DIR, { recursive: true });
+  const outputPath = path.join(OUTPUT_DIR, 'order-hub-live-audit.json');
+  await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+  console.log(JSON.stringify({
+    sitemapBooks: report.sitemapBooks,
+    pages: report.pagesAudited,
+    linkedBooks: report.linkedBooks,
+    failures: report.failures.length,
+  }));
+  console.log(`Escrito: ${outputPath}`);
+
+  if (failures.length) {
+    throw new Error(`Auditoría del hub falló: ${failures.join(' | ')}`);
+  }
+}
+
+main().catch(error => {
+  console.error(error.stack || error.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Objetivo

Dar a Google y a los compradores una ruta HTML estable y navegable hacia toda la cohorte SEO de libros por encargo, sin depender únicamente del sitemap ni de búsquedas internas.

## Qué cambia

### Hub SSR indexable
- crea `/libros-por-encargo`
- usa únicamente la intersección entre la cohorte SEO aprobada y los títulos que continúan pausados
- muestra 48 fichas por página en orden estable
- enlaza todas las páginas desde la portada del hub mediante `<a href>` reales
- cada página tiene título, descripción y canonical propios
- `?page=1` redirige a la raíz
- páginas inválidas o fuera de rango responden 404 + `noindex`
- si el índice pausado no está disponible, responde 503 + `Retry-After`; nunca publica una colección indexable vacía

### Enlazado interno
- agrega un bloque visible y contextual en la home con enlace directo al hub
- el hub enlaza la landing informativa de búsqueda manual
- recorrido máximo: Home → hub → página paginada → ficha
- mobile y desktop reciben exactamente los mismos enlaces en el HTML SSR

### Sitemap
- mantiene los cuatro segmentos actuales
- agrega la raíz del hub a `sitemap-pages.xml`
- agrega únicamente las páginas 2..N que existen según la cohorte pausada vigente
- no inventa `priority`, `changefreq` ni fechas de modificación para páginas dinámicas

### Seguridad comercial y SEO
- no publica precio, stock, plazo ni `Offer` para libros por encargo
- Preview continúa `noindex, nofollow`
- Producción será `index, follow` sólo después de un merge aprobado
- no cambia catálogo, checkout, Merchant, ficha de producto ni la cohorte de 3.000

### Auditoría automática nueva
El workflow de Preview recorre el hub completo y falla si:
- falta una ficha del sitemap pausado
- aparece una ficha fuera del sitemap
- una ficha se repite entre páginas
- falta alguna página en la navegación
- canonical o robots son incorrectos
- mobile y desktop difieren
- aparece un precio u `Offer`
- una página fuera de rango no responde 404

## Validación local focalizada
- sintaxis JS/MJS: OK
- 11 tests específicos del hub: OK
- simulación del auditor live sobre 120 títulos y 3 páginas: 120/120 enlazados, 0 faltantes, 0 duplicados, 0 fallas

## Riesgo

Bajo a medio. Se incorpora una ruta SSR y páginas dinámicas al sitemap, pero el lote queda aislado, con fallos cerrados, Preview protegida y auditoría completa antes de cualquier merge a producción.