### PR TITLE
Auditar Merchant Center por API en modo solo lectura

### DIFF
--- a/.github/workflows/merchant-readonly-audit.yml
+++ b/.github/workflows/merchant-readonly-audit.yml
@@ -1,0 +1,104 @@
+name: Merchant Center read-only diagnostics
+
+on:
+  push:
+    branches:
+      - agent/merchant-readonly-diagnostics
+    paths:
+      - '.github/workflows/merchant-readonly-audit.yml'
+      - 'scripts/commerce/merchant-readonly-audit.mjs'
+      - 'functions/__tests__/merchant-readonly-audit.test.js'
+  pull_request:
+    paths:
+      - '.github/workflows/merchant-readonly-audit.yml'
+      - 'scripts/commerce/merchant-readonly-audit.mjs'
+      - 'functions/__tests__/merchant-readonly-audit.test.js'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: merchant-readonly-diagnostics-${{ github.event_name }}
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Inspect Merchant account without writes
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Validate audit code and read-only contract
+        run: |
+          node --check scripts/commerce/merchant-readonly-audit.mjs
+          node --test functions/__tests__/merchant-readonly-audit.test.js
+
+      - name: Authenticate with Google through Workload Identity
+        id: google_auth
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: amado-libros-analytics
+          workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
+          service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/content
+          create_credentials_file: false
+
+      - name: Run Merchant API audit
+        id: merchant_audit
+        continue-on-error: true
+        env:
+          MERCHANT_ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
+          MERCHANT_ACCOUNT_ID: '5330457716'
+          MERCHANT_PUBLIC_FEED_URL: https://www.amadolibros.com/feed.xml
+          MERCHANT_OUTPUT_DIR: artifacts/merchant
+        run: node scripts/commerce/merchant-readonly-audit.mjs
+
+      - name: Validate generated report
+        if: steps.merchant_audit.outcome == 'success'
+        run: |
+          test -s artifacts/merchant/merchant-readonly-report.json
+          test -s artifacts/merchant/report-summary.md
+          node -e "const r=require('./artifacts/merchant/merchant-readonly-report.json'); if(r.schemaVersion!==1||r.accountId!=='5330457716') process.exit(1)"
+
+      - name: Upload Merchant audit
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: merchant-readonly-${{ github.run_id }}
+          path: artifacts/merchant/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Write run summary
+        if: always()
+        run: |
+          if [ -f artifacts/merchant/report-summary.md ]; then
+            cat artifacts/merchant/report-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## Merchant Center — auditoría incompleta' >> "$GITHUB_STEP_SUMMARY"
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo 'No se generó el reporte. Revisar autenticación Workload Identity, API Merchant habilitada y acceso de la cuenta de servicio a Merchant Center.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Cuenta: 5330457716' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Modo: solo lectura; llamadas Merchant API exclusivamente GET' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Deploy: no se ejecuta' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if API audit did not complete
+        if: steps.merchant_audit.outcome != 'success'
+        run: |
+          echo 'La auditoría no pudo completar los endpoints principales de Merchant API.'
+          exit 1
+
+# Ready-for-review: revalida todos los checks requeridos antes del merge.

--- a/functions/__tests__/merchant-readonly-audit.test.js
+++ b/functions/__tests__/merchant-readonly-audit.test.js
@@ -1,0 +1,126 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import {
+  aggregateDynamicRemarketingUy,
+  buildDiagnosis,
+  countFeedItems,
+  summarizeDataSource,
+  summarizeProducts,
+} from '../../scripts/commerce/merchant-readonly-audit.mjs';
+
+test('cuenta únicamente ofertas item del feed', () => {
+  assert.equal(countFeedItems('<rss><channel><item></item><item data-x="1"></item></channel></rss>'), 2);
+  assert.equal(countFeedItems('<rss><channel></channel></rss>'), 0);
+});
+
+test('resume fuentes sin exponer credenciales o parámetros secretos', () => {
+  const row = summarizeDataSource({
+    name: 'accounts/533/dataSources/12',
+    dataSourceId: '12',
+    displayName: 'Feed Amado',
+    input: 'FILE',
+    primaryProductDataSource: {},
+    fileInput: {
+      fileInputType: 'FETCH',
+      fetchSettings: {
+        fetchUri: 'https://usuario:clave@example.com/feed.xml?token=secreto',
+        frequency: 'DAILY',
+        timeOfDay: { hours: 5, minutes: 0 },
+      },
+    },
+  });
+
+  assert.equal(row.type, 'primaryProductDataSource');
+  assert.equal(row.fetchUri, 'https://example.com/feed.xml');
+  assert.equal(JSON.stringify(row).includes('clave'), false);
+  assert.equal(JSON.stringify(row).includes('secreto'), false);
+  assert.equal(JSON.stringify(row).includes('usuario'), false);
+});
+
+test('agrega el destino Dynamic remarketing para Uruguay', () => {
+  const result = aggregateDynamicRemarketingUy([
+    {
+      reportingContext: 'DISPLAY_ADS',
+      country: 'UY',
+      stats: { activeCount: '2981', pendingCount: '14', disapprovedCount: '669', expiringCount: '120' },
+      itemLevelIssues: [{ code: 'expiration_date', severity: 'DISAPPROVED', productCount: '120' }],
+    },
+    {
+      reportingContext: 'SHOPPING_ADS',
+      country: 'UY',
+      stats: { activeCount: '10' },
+    },
+  ]);
+
+  assert.equal(result.rows, 1);
+  assert.equal(result.active, 2981);
+  assert.equal(result.pending, 14);
+  assert.equal(result.disapproved, 669);
+  assert.equal(result.expiring, 120);
+  assert.equal(result.issueCounts.get('expiration_date').productCount, 120);
+});
+
+test('clasifica productos procesados por estado, fuente y vencimiento', () => {
+  const now = new Date('2026-08-18T12:00:00.000Z');
+  const products = [
+    {
+      dataSource: 'accounts/533/dataSources/1',
+      productStatus: {
+        googleExpirationDate: '2026-08-20T12:00:00.000Z',
+        lastUpdateDate: '2026-08-17T01:00:00.000Z',
+        destinationStatuses: [{ reportingContext: 'DISPLAY_ADS', approvedCountries: ['UY'] }],
+        itemLevelIssues: [],
+      },
+    },
+    {
+      dataSource: 'accounts/533/dataSources/2',
+      productStatus: {
+        googleExpirationDate: '2026-08-28T12:00:00.000Z',
+        lastUpdateDate: '2026-08-16T01:00:00.000Z',
+        destinationStatuses: [{ reportingContext: 'DISPLAY_ADS', disapprovedCountries: ['UY'] }],
+        itemLevelIssues: [{
+          code: 'image_too_small',
+          severity: 'DISAPPROVED',
+          reportingContext: 'DISPLAY_ADS',
+          applicableCountries: ['UY'],
+        }],
+      },
+    },
+  ];
+
+  const result = summarizeProducts(products, now);
+  assert.equal(result.processed, 2);
+  assert.equal(result.dynamicRemarketingUy.active, 1);
+  assert.equal(result.dynamicRemarketingUy.disapproved, 1);
+  assert.equal(result.expiringWithin3Days, 1);
+  assert.equal(result.byDataSource.length, 2);
+  assert.equal(result.topIssues[0].code, 'image_too_small');
+});
+
+test('el diagnóstico diferencia hechos de hipótesis', () => {
+  const diagnosis = buildDiagnosis({
+    alert: { previousActive: 3745, currentActive: 2981 },
+    feedCount: 3664,
+    dataSources: [
+      { type: 'primaryProductDataSource' },
+      { type: 'primaryProductDataSource' },
+    ],
+    accountIssues: [],
+    aggregate: { active: 2981, pending: 0, disapproved: 683, expiring: 100 },
+    products: { processed: 3664, dynamicRemarketingUy: { active: 2981 }, expiringWithin3Days: 100 },
+  });
+
+  assert.ok(diagnosis.facts.some(row => row.includes('3745')));
+  assert.ok(diagnosis.hypotheses.some(row => row.text.includes('683 ofertas')));
+  assert.ok(diagnosis.hypotheses.some(row => row.text.includes('2 fuentes primarias')));
+});
+
+test('la implementación no contiene llamadas de escritura a Merchant API', () => {
+  const source = readFileSync('scripts/commerce/merchant-readonly-audit.mjs', 'utf8');
+  assert.doesNotMatch(source, /method\s*:\s*['"](?:POST|PATCH|PUT|DELETE)['"]/i);
+  assert.doesNotMatch(source, /productInputs:insert|:fetch|triggeraction/i);
+  assert.match(source, /merchantapi\.googleapis\.com/);
+  assert.doesNotMatch(source, /\/v1beta\//);
+});

--- a/scripts/commerce/merchant-readonly-audit.mjs
+++ b/scripts/commerce/merchant-readonly-audit.mjs
@@ -1,0 +1,548 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const API_ROOT = 'https://merchantapi.googleapis.com';
+const DEFAULT_ACCOUNT_ID = '5330457716';
+const DEFAULT_FEED_URL = 'https://www.amadolibros.com/feed.xml';
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function asText(value) {
+  return String(value ?? '').trim();
+}
+
+function asNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function upper(value) {
+  return asText(value).toUpperCase();
+}
+
+function isDynamicRemarketing(value) {
+  const normalized = upper(value);
+  return normalized.includes('DYNAMIC') || normalized.includes('REMARKETING') || normalized === 'DISPLAY_ADS';
+}
+
+function isUy(value) {
+  return upper(value) === 'UY';
+}
+
+function safeFetchUri(value) {
+  const raw = asText(value);
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return '[configured]';
+  }
+}
+
+export function countFeedItems(xml) {
+  return [...String(xml || '').matchAll(/<item(?:\s|>)/gi)].length;
+}
+
+export function summarizeDataSource(source = {}) {
+  const typeKeys = [
+    'primaryProductDataSource',
+    'supplementalProductDataSource',
+    'localInventoryDataSource',
+    'regionalInventoryDataSource',
+    'promotionDataSource',
+    'productReviewDataSource',
+    'merchantReviewDataSource',
+  ];
+  const type = typeKeys.find(key => source[key] != null) || 'unknown';
+  const fileInput = source.fileInput || {};
+  const fetchSettings = fileInput.fetchSettings || source.fetchSettings || {};
+  const timeOfDay = fetchSettings.timeOfDay || {};
+
+  return {
+    name: asText(source.name) || null,
+    dataSourceId: asText(source.dataSourceId) || null,
+    displayName: asText(source.displayName) || '(sin nombre)',
+    input: asText(source.input) || null,
+    type,
+    fileInputType: asText(fileInput.fileInputType || fileInput.inputType) || null,
+    fetchUri: safeFetchUri(fetchSettings.fetchUri || fileInput.fetchUri),
+    frequency: asText(fetchSettings.frequency) || null,
+    dayOfWeek: asText(fetchSettings.dayOfWeek) || null,
+    dayOfMonth: fetchSettings.dayOfMonth ?? null,
+    timeOfDay: Object.keys(timeOfDay).length
+      ? {
+          hours: timeOfDay.hours ?? null,
+          minutes: timeOfDay.minutes ?? null,
+          seconds: timeOfDay.seconds ?? null,
+        }
+      : null,
+  };
+}
+
+export function summarizeAccountIssue(issue = {}) {
+  const impacted = Array.isArray(issue.impactedDestinations)
+    ? issue.impactedDestinations
+    : Array.isArray(issue.impacts)
+      ? issue.impacts
+      : [];
+  return {
+    name: asText(issue.name) || null,
+    title: asText(issue.title) || asText(issue.description) || '(sin título)',
+    severity: asText(issue.severity) || null,
+    detail: asText(issue.detail) || null,
+    documentationUri: asText(issue.documentationUri || issue.documentation) || null,
+    impactedDestinations: impacted.map(row => ({
+      reportingContext: asText(row.reportingContext) || null,
+      impacts: Array.isArray(row.impacts)
+        ? row.impacts.map(impact => ({
+            regionCode: asText(impact.regionCode) || null,
+            severity: asText(impact.severity) || null,
+          }))
+        : [],
+    })),
+  };
+}
+
+export function aggregateDynamicRemarketingUy(rows = []) {
+  const matching = rows.filter(row => isUy(row?.country) && isDynamicRemarketing(row?.reportingContext));
+  return matching.reduce((summary, row) => {
+    const stats = row.stats || {};
+    summary.rows += 1;
+    summary.contexts.push(asText(row.reportingContext));
+    summary.active += asNumber(stats.activeCount);
+    summary.pending += asNumber(stats.pendingCount);
+    summary.disapproved += asNumber(stats.disapprovedCount);
+    summary.expiring += asNumber(stats.expiringCount);
+    for (const issue of Array.isArray(row.itemLevelIssues) ? row.itemLevelIssues : []) {
+      const key = asText(issue.code) || '(sin código)';
+      const current = summary.issueCounts.get(key) || {
+        code: key,
+        severity: asText(issue.severity) || null,
+        resolution: asText(issue.resolution) || null,
+        attribute: asText(issue.attribute) || null,
+        description: asText(issue.description) || null,
+        detail: asText(issue.detail) || null,
+        documentationUri: asText(issue.documentationUri) || null,
+        productCount: 0,
+      };
+      current.productCount += asNumber(issue.productCount);
+      summary.issueCounts.set(key, current);
+    }
+    return summary;
+  }, {
+    rows: 0,
+    contexts: [],
+    active: 0,
+    pending: 0,
+    disapproved: 0,
+    expiring: 0,
+    issueCounts: new Map(),
+  });
+}
+
+function finalizeAggregate(summary) {
+  return {
+    rows: summary.rows,
+    contexts: [...new Set(summary.contexts.filter(Boolean))],
+    active: summary.active,
+    pending: summary.pending,
+    disapproved: summary.disapproved,
+    expiring: summary.expiring,
+    topIssues: [...summary.issueCounts.values()]
+      .sort((a, b) => b.productCount - a.productCount || a.code.localeCompare(b.code))
+      .slice(0, 30),
+  };
+}
+
+function productDestinationState(product, country = 'UY') {
+  const rows = Array.isArray(product?.productStatus?.destinationStatuses)
+    ? product.productStatus.destinationStatuses.filter(row => isDynamicRemarketing(row.reportingContext))
+    : [];
+  const approved = rows.some(row => (row.approvedCountries || []).some(isUy));
+  const pending = rows.some(row => (row.pendingCountries || []).some(isUy));
+  const disapproved = rows.some(row => (row.disapprovedCountries || []).some(isUy));
+  if (approved) return 'active';
+  if (pending) return 'pending';
+  if (disapproved) return 'disapproved';
+  return rows.length ? 'other_country' : 'missing_context';
+}
+
+export function summarizeProducts(products = [], now = new Date()) {
+  const nowMs = now.getTime();
+  const issueCounts = new Map();
+  const bySource = new Map();
+  const destination = {
+    active: 0,
+    pending: 0,
+    disapproved: 0,
+    other_country: 0,
+    missing_context: 0,
+  };
+  let archived = 0;
+  let expiringWithin3Days = 0;
+  let expiringWithin7Days = 0;
+  let alreadyExpired = 0;
+  let oldestUpdate = null;
+  let newestUpdate = null;
+
+  for (const product of products) {
+    const source = asText(product.dataSource) || '(sin fuente)';
+    bySource.set(source, (bySource.get(source) || 0) + 1);
+    if (product.archived === true) archived += 1;
+
+    const state = productDestinationState(product);
+    destination[state] += 1;
+
+    const status = product.productStatus || {};
+    const expirationMs = Date.parse(status.googleExpirationDate || '');
+    if (Number.isFinite(expirationMs)) {
+      const distance = expirationMs - nowMs;
+      if (distance < 0) alreadyExpired += 1;
+      else {
+        if (distance <= 3 * DAY_MS) expiringWithin3Days += 1;
+        if (distance <= 7 * DAY_MS) expiringWithin7Days += 1;
+      }
+    }
+
+    const updateMs = Date.parse(status.lastUpdateDate || '');
+    if (Number.isFinite(updateMs)) {
+      if (oldestUpdate == null || updateMs < oldestUpdate) oldestUpdate = updateMs;
+      if (newestUpdate == null || updateMs > newestUpdate) newestUpdate = updateMs;
+    }
+
+    for (const issue of Array.isArray(status.itemLevelIssues) ? status.itemLevelIssues : []) {
+      const countries = Array.isArray(issue.applicableCountries) ? issue.applicableCountries : [];
+      if (!isDynamicRemarketing(issue.reportingContext)) continue;
+      if (countries.length && !countries.some(isUy)) continue;
+      const key = asText(issue.code) || '(sin código)';
+      const current = issueCounts.get(key) || {
+        code: key,
+        severity: asText(issue.severity) || null,
+        resolution: asText(issue.resolution) || null,
+        attribute: asText(issue.attribute) || null,
+        description: asText(issue.description) || null,
+        detail: asText(issue.detail) || null,
+        documentation: asText(issue.documentation) || null,
+        products: 0,
+      };
+      current.products += 1;
+      issueCounts.set(key, current);
+    }
+  }
+
+  return {
+    processed: products.length,
+    archived,
+    dynamicRemarketingUy: destination,
+    expiringWithin3Days,
+    expiringWithin7Days,
+    alreadyExpired,
+    oldestUpdateDate: oldestUpdate == null ? null : new Date(oldestUpdate).toISOString(),
+    newestUpdateDate: newestUpdate == null ? null : new Date(newestUpdate).toISOString(),
+    byDataSource: [...bySource.entries()]
+      .map(([dataSource, count]) => ({ dataSource, count }))
+      .sort((a, b) => b.count - a.count || a.dataSource.localeCompare(b.dataSource)),
+    topIssues: [...issueCounts.values()]
+      .sort((a, b) => b.products - a.products || a.code.localeCompare(b.code))
+      .slice(0, 30),
+  };
+}
+
+export function buildDiagnosis({ alert, feedCount, dataSources, accountIssues, aggregate, products }) {
+  const facts = [];
+  const hypotheses = [];
+  const active = aggregate?.active || products?.dynamicRemarketingUy?.active || 0;
+  const primarySources = dataSources.filter(row => row.type === 'primaryProductDataSource');
+
+  facts.push(`El correo informó una caída de ${alert.previousActive} a ${alert.currentActive} artículos activos para Dynamic remarketing en UY.`);
+  if (feedCount != null) facts.push(`El feed público contiene ${feedCount} ofertas en esta lectura.`);
+  if (products) facts.push(`Merchant devolvió ${products.processed} productos procesados.`);
+  if (active) facts.push(`La API informó ${active} productos activos para Dynamic remarketing en UY.`);
+  if (aggregate?.pending) facts.push(`${aggregate.pending} productos están pendientes para ese destino.`);
+  if (aggregate?.disapproved) facts.push(`${aggregate.disapproved} productos están rechazados para ese destino.`);
+  if (aggregate?.expiring || products?.expiringWithin3Days) {
+    facts.push(`${aggregate?.expiring || products?.expiringWithin3Days} productos aparecen próximos a vencer.`);
+  }
+  if (accountIssues.length) facts.push(`Hay ${accountIssues.length} problemas de cuenta devueltos por la API.`);
+
+  if (feedCount != null && active && feedCount > active) {
+    hypotheses.push({
+      confidence: 'high',
+      text: `Hay ${feedCount - active} ofertas en el feed que no están activas para Dynamic remarketing UY; la causa debe localizarse en procesamiento, vencimiento, reglas o rechazos de Merchant.`,
+    });
+  }
+  if (feedCount != null && alert.previousActive > feedCount) {
+    hypotheses.push({
+      confidence: 'medium',
+      text: `La cifra anterior de activos superaba al feed actual por ${alert.previousActive - feedCount}; esto es compatible con productos antiguos o una fuente adicional que luego vencieron o dejaron de servir.`,
+    });
+  }
+  if (primarySources.length > 1) {
+    hypotheses.push({
+      confidence: 'high',
+      text: `Merchant tiene ${primarySources.length} fuentes primarias; hay que revisar si una fuente vieja o automática está duplicando o caducando productos.`,
+    });
+  }
+  if (products?.expiringWithin3Days > 0) {
+    hypotheses.push({
+      confidence: 'high',
+      text: `${products.expiringWithin3Days} productos procesados vencen dentro de 3 días y pueden explicar parte de la alerta.`,
+    });
+  }
+
+  return { facts, hypotheses };
+}
+
+async function requestJson(url, accessToken) {
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/json',
+    },
+    signal: AbortSignal.timeout(60_000),
+  });
+  const raw = await response.text();
+  let data = null;
+  try { data = raw ? JSON.parse(raw) : {}; } catch {}
+  if (!response.ok) {
+    const error = new Error(data?.error?.message || `HTTP ${response.status}`);
+    error.status = response.status;
+    error.apiStatus = data?.error?.status || null;
+    error.details = Array.isArray(data?.error?.details)
+      ? data.error.details.map(row => ({
+          type: row?.['@type'] || null,
+          reason: row?.reason || row?.metadata?.service || null,
+        }))
+      : [];
+    throw error;
+  }
+  return data || {};
+}
+
+async function listAll({ endpoint, arrayField, pageSize, accessToken }) {
+  const rows = [];
+  let pageToken = '';
+  for (let page = 0; page < 30; page += 1) {
+    const url = new URL(endpoint);
+    url.searchParams.set('pageSize', String(pageSize));
+    if (pageToken) url.searchParams.set('pageToken', pageToken);
+    const data = await requestJson(url, accessToken);
+    if (Array.isArray(data[arrayField])) rows.push(...data[arrayField]);
+    pageToken = asText(data.nextPageToken);
+    if (!pageToken) return rows;
+  }
+  throw new Error(`Paginación excedió 30 páginas para ${arrayField}`);
+}
+
+function endpointError(error) {
+  return {
+    message: asText(error?.message) || 'Error desconocido',
+    httpStatus: Number(error?.status) || null,
+    apiStatus: asText(error?.apiStatus) || null,
+    details: Array.isArray(error?.details) ? error.details : [],
+  };
+}
+
+async function runEndpoint(name, fn) {
+  try {
+    return { name, ok: true, data: await fn(), error: null };
+  } catch (error) {
+    return { name, ok: false, data: null, error: endpointError(error) };
+  }
+}
+
+function markdownEscape(value) {
+  return asText(value).replaceAll('|', '\\|').replaceAll('\n', ' ');
+}
+
+function reportMarkdown(report) {
+  const lines = [
+    '# Merchant Center — auditoría de solo lectura',
+    '',
+    `- Cuenta: ${report.accountId}`,
+    `- Generado: ${report.generatedAt}`,
+    `- Feed público: ${report.publicFeed.ok ? `${report.publicFeed.items} ofertas` : `error: ${report.publicFeed.error}`}`,
+    '',
+    '## Alerta recibida',
+    '',
+    `Dynamic remarketing UY: ${report.alert.previousActive} → ${report.alert.currentActive} (${report.alert.dropPercent}% de descenso; ${report.alert.dropCount} artículos).`,
+    '',
+  ];
+
+  if (report.dynamicRemarketingUy) {
+    const row = report.dynamicRemarketingUy;
+    lines.push(
+      '## Estado API — Dynamic remarketing UY',
+      '',
+      '| Activos | Pendientes | Rechazados | Próximos a vencer |',
+      '| ---: | ---: | ---: | ---: |',
+      `| ${row.active} | ${row.pending} | ${row.disapproved} | ${row.expiring} |`,
+      '',
+    );
+  }
+
+  if (report.products) {
+    const product = report.products;
+    lines.push(
+      '## Productos procesados',
+      '',
+      `- Total procesado: ${product.processed}`,
+      `- Vencen en 3 días: ${product.expiringWithin3Days}`,
+      `- Vencen en 7 días: ${product.expiringWithin7Days}`,
+      `- Archivados: ${product.archived}`,
+      '',
+    );
+  }
+
+  lines.push('## Fuentes de datos', '', '| Fuente | Tipo | Entrada | Frecuencia | URI segura |', '| --- | --- | --- | --- | --- |');
+  if (!report.dataSources.length) lines.push('| — | — | — | — | — |');
+  for (const source of report.dataSources) {
+    lines.push(`| ${markdownEscape(source.displayName)} | ${source.type} | ${source.input || '—'} | ${source.frequency || '—'} | ${markdownEscape(source.fetchUri || '—')} |`);
+  }
+  lines.push('', '## Diagnóstico', '');
+  for (const fact of report.diagnosis.facts) lines.push(`- Hecho: ${fact}`);
+  for (const hypothesis of report.diagnosis.hypotheses) lines.push(`- Hipótesis ${hypothesis.confidence}: ${hypothesis.text}`);
+
+  lines.push('', '## Problemas principales', '', '| Código | Severidad | Productos | Descripción |', '| --- | --- | ---: | --- |');
+  const issues = report.dynamicRemarketingUy?.topIssues?.length
+    ? report.dynamicRemarketingUy.topIssues
+    : report.products?.topIssues || [];
+  if (!issues.length) lines.push('| — | — | 0 | Sin problemas devueltos para este destino |');
+  for (const issue of issues.slice(0, 20)) {
+    lines.push(`| ${markdownEscape(issue.code)} | ${issue.severity || '—'} | ${issue.productCount ?? issue.products ?? 0} | ${markdownEscape(issue.description || issue.detail || '—')} |`);
+  }
+
+  lines.push('', '## Endpoints', '');
+  for (const endpoint of report.endpoints) {
+    lines.push(`- ${endpoint.name}: ${endpoint.ok ? 'OK' : `ERROR ${endpoint.error?.httpStatus || ''} ${endpoint.error?.apiStatus || ''} — ${endpoint.error?.message || ''}`}`);
+  }
+  lines.push('', '> Esta auditoría no modifica, recupera, crea ni elimina productos o fuentes. Todas las llamadas a Merchant API son GET.');
+  return `${lines.join('\n')}\n`;
+}
+
+export async function main() {
+  const accessToken = asText(process.env.MERCHANT_ACCESS_TOKEN);
+  const accountId = asText(process.env.MERCHANT_ACCOUNT_ID) || DEFAULT_ACCOUNT_ID;
+  const outputDir = asText(process.env.MERCHANT_OUTPUT_DIR) || 'artifacts/merchant';
+  const feedUrl = asText(process.env.MERCHANT_PUBLIC_FEED_URL) || DEFAULT_FEED_URL;
+  if (!accessToken) throw new Error('Falta MERCHANT_ACCESS_TOKEN.');
+  if (!/^\d+$/.test(accountId)) throw new Error('MERCHANT_ACCOUNT_ID inválido.');
+
+  const parent = `accounts/${accountId}`;
+  const endpoints = [];
+  endpoints.push(await runEndpoint('accountIssues', () => listAll({
+    endpoint: `${API_ROOT}/accounts/v1/${parent}/issues?languageCode=es-419&timeZone=America%2FMontevideo`,
+    arrayField: 'accountIssues',
+    pageSize: 100,
+    accessToken,
+  })));
+  endpoints.push(await runEndpoint('dataSources', () => listAll({
+    endpoint: `${API_ROOT}/datasources/v1/${parent}/dataSources`,
+    arrayField: 'dataSources',
+    pageSize: 1000,
+    accessToken,
+  })));
+  endpoints.push(await runEndpoint('aggregateProductStatuses', () => listAll({
+    endpoint: `${API_ROOT}/issueresolution/v1/${parent}/aggregateProductStatuses`,
+    arrayField: 'aggregateProductStatuses',
+    pageSize: 250,
+    accessToken,
+  })));
+  endpoints.push(await runEndpoint('products', () => listAll({
+    endpoint: `${API_ROOT}/products/v1/${parent}/products`,
+    arrayField: 'products',
+    pageSize: 1000,
+    accessToken,
+  })));
+
+  const byName = Object.fromEntries(endpoints.map(row => [row.name, row]));
+  const publicFeed = await (async () => {
+    try {
+      const response = await fetch(feedUrl, { signal: AbortSignal.timeout(60_000) });
+      const xml = await response.text();
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return { ok: true, url: feedUrl, items: countFeedItems(xml), bytes: Buffer.byteLength(xml) };
+    } catch (error) {
+      return { ok: false, url: feedUrl, items: null, bytes: null, error: asText(error?.message) };
+    }
+  })();
+
+  const dataSources = (byName.dataSources.data || []).map(summarizeDataSource);
+  const accountIssues = (byName.accountIssues.data || []).map(summarizeAccountIssue);
+  const aggregate = finalizeAggregate(aggregateDynamicRemarketingUy(byName.aggregateProductStatuses.data || []));
+  const products = byName.products.ok ? summarizeProducts(byName.products.data || [], new Date()) : null;
+  const alert = {
+    observedAt: '2026-08-17T00:20:00-03:00',
+    previousActive: 3745,
+    currentActive: 2981,
+    dropCount: 764,
+    dropPercent: 20,
+    reportingContext: 'Dynamic remarketing',
+    country: 'UY',
+  };
+  const dynamicRemarketingUy = aggregate.rows ? aggregate : products
+    ? {
+        rows: 0,
+        contexts: [],
+        active: products.dynamicRemarketingUy.active,
+        pending: products.dynamicRemarketingUy.pending,
+        disapproved: products.dynamicRemarketingUy.disapproved,
+        expiring: products.expiringWithin3Days,
+        topIssues: products.topIssues,
+      }
+    : null;
+
+  const report = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    accountId,
+    alert,
+    publicFeed,
+    endpoints: endpoints.map(row => ({ name: row.name, ok: row.ok, error: row.error })),
+    dataSources,
+    accountIssues,
+    aggregateStatuses: byName.aggregateProductStatuses.ok ? byName.aggregateProductStatuses.data : null,
+    dynamicRemarketingUy,
+    products,
+    diagnosis: buildDiagnosis({
+      alert,
+      feedCount: publicFeed.ok ? publicFeed.items : null,
+      dataSources,
+      accountIssues,
+      aggregate: dynamicRemarketingUy,
+      products,
+    }),
+  };
+
+  await mkdir(outputDir, { recursive: true });
+  await Promise.all([
+    writeFile(path.join(outputDir, 'merchant-readonly-report.json'), `${JSON.stringify(report, null, 2)}\n`),
+    writeFile(path.join(outputDir, 'report-summary.md'), reportMarkdown(report)),
+    writeFile(path.join(outputDir, 'account-issues.json'), `${JSON.stringify(accountIssues, null, 2)}\n`),
+    writeFile(path.join(outputDir, 'data-sources.json'), `${JSON.stringify(dataSources, null, 2)}\n`),
+  ]);
+
+  console.log(JSON.stringify({
+    accountId,
+    publicFeedItems: publicFeed.items,
+    dynamicRemarketingUy,
+    processedProducts: products?.processed ?? null,
+    endpointFailures: endpoints.filter(row => !row.ok).map(row => row.name),
+  }));
+
+  if (!byName.aggregateProductStatuses.ok && !byName.products.ok) {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Objetivo

Diagnosticar la alerta de Merchant Center del 17 de agosto de 2026 —caída de artículos activos para Dynamic remarketing UY de 3.745 a 2.981— sin modificar productos, fuentes ni configuración.

## Alcance

- autentica mediante Workload Identity existente de Google Cloud
- solicita únicamente el alcance `https://www.googleapis.com/auth/content`
- ejecuta exclusivamente llamadas HTTP GET
- consulta problemas de cuenta
- consulta fuentes de datos y su programación
- consulta estados agregados por destino y país
- enumera productos procesados para medir vigencia, fuente, rechazos y vencimiento
- compara el resultado con el `/feed.xml` público
- genera informe JSON y resumen Markdown como artefactos de GitHub Actions

## Guardas

- no crea, actualiza, elimina ni recupera manualmente fuentes
- no llama `productInputs:insert`, `dataSources:fetch` ni `triggeraction`
- no despliega el sitio
- no guarda credenciales, usuarios de fuente ni parámetros sensibles de URLs
- si Merchant API está deshabilitada o la cuenta de servicio no tiene acceso, falla explícitamente y conserva la evidencia disponible

## Hipótesis a comprobar

1. productos próximos a vencer o caducados
2. productos rechazados o pendientes para Dynamic remarketing UY
3. fuente antigua o automática coexistiendo con `/feed.xml`
4. brecha entre ofertas del feed y productos procesados/activos
5. problema de cuenta que impide servir artículos

## Fuera de alcance

- no corrige todavía el feed
- no modifica Merchant Center
- no mezcla este diagnóstico con el cambio comercial del beneficio de retiro
