### PR TITLE
Fortalecer enlaces y breadcrumbs de libros por encargo

### DIFF
--- a/functions/__tests__/order-hub-product-links.test.js
+++ b/functions/__tests__/order-hub-product-links.test.js
@@ -1,0 +1,124 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import {
+  enrichByRequestProductHtml,
+  onRequest,
+} from '../libro/_middleware.js';
+import {
+  ORDER_HUB_PATH,
+  orderHubPageForProductId,
+} from '../_shared/order-hub.js';
+import { PAUSED_SEO_COHORT } from '../_shared/paused-seo-cohort.js';
+
+function productHtml({ preview = false, active = false } = {}) {
+  const breadcrumb = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Inicio', item: 'https://www.amadolibros.com/' },
+      { '@type': 'ListItem', position: 2, name: 'Libro de prueba' },
+    ],
+  };
+  const product = {
+    '@context': 'https://schema.org',
+    '@type': ['Product', 'Book'],
+    name: 'Libro de prueba',
+  };
+  return `<!doctype html><html><head>
+    <meta name="robots" content="${preview ? 'noindex, follow' : 'index, follow'}">
+    <link rel="canonical" href="https://www.amadolibros.com/libro/MLU1/libro-de-prueba">
+    <script type="application/ld+json">${JSON.stringify(product)}</script>
+    <script type="application/ld+json">${JSON.stringify(breadcrumb)}</script>
+    <style>main{display:grid}</style>
+  </head><body>
+    <nav>
+      <a href="/">Inicio</a> ›
+      <span>Libro de prueba</span>
+    </nav>
+    <main>
+      <div class="info">
+        ${active ? '<span class="badge in-stock">✓ En stock</span>' : ''}
+        <div class="order-box"><strong>${active ? 'Precio publicado' : '¿Buscás este libro?'}</strong></div>
+      </div>
+    </main>
+  </body></html>`;
+}
+
+function breadcrumbSchema(html) {
+  for (const match of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    const parsed = JSON.parse(match[1]);
+    if (parsed?.['@type'] === 'BreadcrumbList') return parsed;
+  }
+  return null;
+}
+
+test('resuelve la página exacta del hub sin cargar el índice pausado', () => {
+  assert.equal(orderHubPageForProductId(PAUSED_SEO_COHORT[0].id), 1);
+  assert.equal(orderHubPageForProductId(PAUSED_SEO_COHORT[47].id), 1);
+  assert.equal(orderHubPageForProductId(PAUSED_SEO_COHORT[48].id), 2);
+  assert.equal(orderHubPageForProductId(PAUSED_SEO_COHORT.at(-1).id), 63);
+  assert.equal(orderHubPageForProductId('MLU999999999999'), null);
+});
+
+test('una ficha pausada de la cohorte enlaza al hub, su página exacta y el servicio', () => {
+  const productId = PAUSED_SEO_COHORT[48].id;
+  const html = enrichByRequestProductHtml(productHtml(), productId);
+
+  assert.match(html, /<a href="\/libros-por-encargo">Libros por encargo<\/a> ›/);
+  assert.match(html, /class="order-hub-links"/);
+  assert.match(html, /href="\/libros-por-encargo\?page=2"/);
+  assert.match(html, /Volver a la página 2 donde aparece este título/);
+  assert.match(html, /href="\/libros-agotados-importados-uruguay"/);
+  assert.match(html, /<link rel="canonical" href="https:\/\/www\.amadolibros\.com\/libro\/MLU1\/libro-de-prueba">/);
+  assert.doesNotMatch(html, /"@type":"Offer"|priceCurrency/);
+
+  const schema = breadcrumbSchema(html);
+  assert.ok(schema);
+  assert.deepEqual(schema.itemListElement.map(item => [item.position, item.name]), [
+    [1, 'Inicio'],
+    [2, 'Libros por encargo'],
+    [3, 'Libro de prueba'],
+  ]);
+  assert.equal(schema.itemListElement[1].item, `https://www.amadolibros.com${ORDER_HUB_PATH}`);
+});
+
+test('Preview conserva noindex y los headers mientras muestra la misma navegación HTML', async () => {
+  const productId = PAUSED_SEO_COHORT[48].id;
+  const context = {
+    request: new Request(`https://preview.example.com/libro/${productId}/libro-de-prueba`),
+    next: async () => new Response(productHtml({ preview: true }), {
+      status: 200,
+      headers: {
+        'content-type': 'text/html;charset=UTF-8',
+        'cache-control': 'public, max-age=3600',
+        'server-timing': 'route_total;dur=12',
+      },
+    }),
+  };
+
+  const response = await onRequest(context);
+  const html = await response.text();
+  assert.match(html, /<meta name="robots" content="noindex, follow">/);
+  assert.match(html, /href="\/libros-por-encargo\?page=2"/);
+  assert.match(html, /<a href="\/libros-por-encargo">Libros por encargo<\/a>/);
+  assert.equal(response.headers.get('cache-control'), 'public, max-age=3600');
+  assert.equal(response.headers.get('server-timing'), 'route_total;dur=12');
+});
+
+test('si el título volvió a stock, no se lo etiqueta ni enlaza como por encargo', () => {
+  const productId = PAUSED_SEO_COHORT[48].id;
+  const original = productHtml({ active: true });
+  assert.equal(enrichByRequestProductHtml(original, productId), original);
+});
+
+test('una ficha fuera de la cohorte queda intacta', () => {
+  const original = productHtml();
+  assert.equal(enrichByRequestProductHtml(original, 'MLU999999999999'), original);
+});
+
+test('el middleware no agrega lecturas de catálogo o R2 al camino de la ficha', () => {
+  const source = readFileSync('functions/libro/_middleware.js', 'utf8');
+  assert.doesNotMatch(source, /fetchPausedIndex|fetchPausedItem|fetchCatalog|R2_BASE/);
+});

--- a/functions/_shared/order-hub.js
+++ b/functions/_shared/order-hub.js
@@ -11,6 +11,15 @@ export function orderHubPath(page = 1) {
     : ORDER_HUB_PATH;
 }
 
+export function orderHubPageForProductId(productId) {
+  const normalizedId = String(productId || '').trim().toUpperCase();
+  if (!normalizedId) return null;
+  const cohortIndex = PAUSED_SEO_COHORT.findIndex(entry => entry.id === normalizedId);
+  return cohortIndex >= 0
+    ? Math.floor(cohortIndex / ORDER_HUB_PAGE_SIZE) + 1
+    : null;
+}
+
 export function parseOrderHubPage(rawValue) {
   if (rawValue == null || rawValue === '') {
     return { present: false, valid: true, page: 1 };

--- a/functions/libro/_middleware.js
+++ b/functions/libro/_middleware.js
@@ -1,0 +1,128 @@
+import { BASE } from '../_shared/catalog.js';
+import {
+  ORDER_HUB_PATH,
+  orderHubPageForProductId,
+  orderHubPath,
+} from '../_shared/order-hub.js';
+
+const PRODUCT_PATH_RE = /^\/libro\/(MLU\d+)(?:\/|$)/i;
+const BREADCRUMB_RE = /<nav>\s*<a href="\/">Inicio<\/a>\s*›\s*<span>/;
+const JSON_LD_RE = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
+
+function byRequestStyles() {
+  return `
+    .order-hub-links{grid-column:1/-1;padding:1rem 1.1rem;background:#fff8f4;
+                     border:1px solid #ecd1c6;border-radius:.65rem;color:#4b342b}
+    .order-hub-links h2{font-size:1.05rem;line-height:1.35;color:#18120e;margin-bottom:.35rem}
+    .order-hub-links p{font-size:.86rem;color:#6b4b3f;margin-bottom:.7rem}
+    .order-hub-actions{display:flex;flex-wrap:wrap;gap:.5rem .9rem}
+    .order-hub-actions a{font-size:.84rem;font-weight:750;color:#8f4436;text-decoration:none}
+    .order-hub-actions a:hover{text-decoration:underline}
+    .order-hub-actions a:focus-visible{outline:2px solid #a94e3d;outline-offset:2px}
+  `;
+}
+
+function enrichBreadcrumbSchema(html) {
+  return html.replace(JSON_LD_RE, (full, rawJson) => {
+    let schema;
+    try {
+      schema = JSON.parse(rawJson);
+    } catch {
+      return full;
+    }
+    if (schema?.['@type'] !== 'BreadcrumbList' || !Array.isArray(schema.itemListElement)) {
+      return full;
+    }
+    const current = schema.itemListElement.at(-1) || {};
+    schema.itemListElement = [
+      { '@type': 'ListItem', position: 1, name: 'Inicio', item: `${BASE}/` },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Libros por encargo',
+        item: `${BASE}${ORDER_HUB_PATH}`,
+      },
+      { ...current, position: 3 },
+    ];
+    const serialized = JSON.stringify(schema).replace(/</g, '\\u003c');
+    return `<script type="application/ld+json">${serialized}</script>`;
+  });
+}
+
+export function enrichByRequestProductHtml(html, productId) {
+  const source = String(html || '');
+  const hubPage = orderHubPageForProductId(productId);
+  if (!hubPage || source.includes('class="order-hub-links"')) return source;
+
+  // La cohorte es estática durante el lote SEO, pero un título puede volver a
+  // stock antes de regenerarla. El HTML SSR es la última verdad comercial:
+  // jamás etiquetar como "por encargo" una ficha que ya muestra stock activo.
+  const isPausedPage = source.includes('class="order-box"') &&
+    !source.includes('class="badge in-stock"');
+  if (!isPausedPage) return source;
+
+  let result = source.replace(
+    BREADCRUMB_RE,
+    `<nav>\n  <a href="/">Inicio</a> ›\n  <a href="${ORDER_HUB_PATH}">Libros por encargo</a> ›\n  <span>`,
+  );
+  result = enrichBreadcrumbSchema(result);
+
+  const exactHubPath = orderHubPath(hubPage);
+  const exactLinkLabel = hubPage === 1
+    ? 'Volver a la colección donde aparece este título →'
+    : `Volver a la página ${hubPage} donde aparece este título →`;
+  const rootLink = hubPage > 1
+    ? `<a href="${ORDER_HUB_PATH}">Ver todo el catálogo por encargo</a>`
+    : '';
+  const block = `<section class="order-hub-links" aria-labelledby="order-hub-links-title">
+    <h2 id="order-hub-links-title">Más libros por encargo</h2>
+    <p>Este título forma parte de nuestra colección de libros que podemos buscar y cotizar. La edición, disponibilidad, precio y plazo se confirman antes de aceptar el encargo.</p>
+    <div class="order-hub-actions">
+      <a href="${exactHubPath}">${exactLinkLabel}</a>
+      ${rootLink}
+      <a href="/libros-agotados-importados-uruguay">Cómo funciona la búsqueda por encargo</a>
+    </div>
+  </section>`;
+
+  result = result.replace('</main>', `${block}\n</main>`);
+  result = result.replace('</style>', `${byRequestStyles()}\n  </style>`);
+  return result;
+}
+
+function productIdFromRequest(request) {
+  try {
+    return new URL(request.url).pathname.match(PRODUCT_PATH_RE)?.[1]?.toUpperCase() || null;
+  } catch {
+    return null;
+  }
+}
+
+function responseWithBody(response, body, changed) {
+  const headers = new Headers(response.headers);
+  if (changed) {
+    headers.delete('content-length');
+    headers.delete('etag');
+  }
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export async function onRequest(context) {
+  const productId = productIdFromRequest(context.request);
+  if (!productId || orderHubPageForProductId(productId) == null) {
+    return context.next();
+  }
+
+  const response = await context.next();
+  const contentType = response.headers.get('content-type') || '';
+  if (response.status !== 200 || !contentType.toLowerCase().includes('text/html')) {
+    return response;
+  }
+
+  const html = await response.text();
+  const enriched = enrichByRequestProductHtml(html, productId);
+  return responseWithBody(response, enriched, enriched !== html);
+}


### PR DESCRIPTION
## Objetivo

Fortalecer el rastreo interno de las fichas de la cohorte por encargo sin ampliar la cohorte ni tocar checkout, precios o Merchant.

## Cambios

- agrega breadcrumb HTML `Inicio → Libros por encargo → ficha` sólo cuando el título sigue realmente pausado
- agrega el mismo nodo `Libros por encargo` al `BreadcrumbList` JSON-LD existente
- agrega bloque HTML rastreable `Más libros por encargo`
- enlaza cada ficha a la página exacta del hub donde aparece (`?page=N`) y a la raíz de la colección
- mantiene enlace al servicio informativo de búsqueda por encargo
- calcula la página desde la cohorte estática; no agrega lecturas de R2 ni del catálogo al camino de la ficha
- si un título vuelve a stock antes de regenerar la cohorte, no se lo etiqueta como por encargo
- Preview conserva `noindex`

## Alcance

SEO e interlinking exclusivamente. No modifica disponibilidad, canonical, precios, Offer, carrito, checkout, feed ni Merchant Center.

## Riesgo

Bajo. El middleware está limitado a `/libro/`, sólo procesa IDs de la cohorte por encargo y conserva status/headers de la respuesta SSR.

## Validación añadida

- página exacta del hub para posiciones 1/48/49/final
- breadcrumb visible y JSON-LD
- enlace inverso a la página exacta
- Preview noindex y headers preservados
- exclusión automática si el producto vuelve a stock
- fichas fuera de cohorte intactas
- guarda que prohíbe nuevas lecturas de catálogo/R2 desde el middleware
