### PR TITLE
SEO: enriquecer 31 ISBN con demanda y datos verificados

### DIFF
--- a/worker-sync/__tests__/verified-book-enrichments.test.js
+++ b/worker-sync/__tests__/verified-book-enrichments.test.js
@@ -5,6 +5,19 @@ import {
   VERIFIED_BOOK_IDS,
 } from '../verified-book-enrichments.js';
 
+const EMPTY_DEMAND_METRICS = {
+  matched_items: 0,
+  applied_items: 0,
+  applied_fields: {
+    isbn: 0,
+    publisher: 0,
+    pages: 0,
+    publication_year: 0,
+  },
+  skipped_isbn_mismatch: 0,
+  preserved_existing_fields: 0,
+};
+
 test('enriquece las cinco fichas verificadas sin cambiar sus títulos', () => {
   const items = VERIFIED_BOOK_IDS.map((id, index) => ({
     id,
@@ -18,7 +31,11 @@ test('enriquece las cinco fichas verificadas sin cambiar sus títulos', () => {
 
   const result = applyVerifiedBookEnrichments(items);
 
-  assert.deepEqual(result, { applied: 5, skipped_isbn_mismatch: 0 });
+  assert.deepEqual(result, {
+    applied: 5,
+    skipped_isbn_mismatch: 0,
+    demand_bibliography: EMPTY_DEMAND_METRICS,
+  });
   assert.deepEqual(items.map(item => item.title), [
     'Título comercial 0',
     'Título comercial 1',
@@ -42,7 +59,54 @@ test('no aplica un dato si el ISBN actual identifica otra edición', () => {
 
   const result = applyVerifiedBookEnrichments([item]);
 
-  assert.deepEqual(result, { applied: 0, skipped_isbn_mismatch: 1 });
+  assert.deepEqual(result, {
+    applied: 0,
+    skipped_isbn_mismatch: 1,
+    demand_bibliography: EMPTY_DEMAND_METRICS,
+  });
   assert.equal(item.title, 'Título intacto');
   assert.equal(item.publisher, null);
+});
+
+test('integra el lote parcial de demanda después de los enriquecimientos manuales', () => {
+  const item = {
+    id: 'MLU704191572',
+    title: 'Título comercial intacto',
+    author: 'Autor existente',
+    isbn: '9788417880521',
+    publisher: null,
+    pages: null,
+    bibliographic: { format: 'Tapa blanda' },
+    description: 'Descripción existente',
+    price: 1500,
+    pictures: ['foto.jpg'],
+  };
+
+  const result = applyVerifiedBookEnrichments([item]);
+
+  assert.deepEqual(result, {
+    applied: 0,
+    skipped_isbn_mismatch: 0,
+    demand_bibliography: {
+      matched_items: 1,
+      applied_items: 1,
+      applied_fields: {
+        isbn: 0,
+        publisher: 1,
+        pages: 1,
+        publication_year: 1,
+      },
+      skipped_isbn_mismatch: 0,
+      preserved_existing_fields: 0,
+    },
+  });
+  assert.equal(item.title, 'Título comercial intacto');
+  assert.equal(item.author, 'Autor existente');
+  assert.equal(item.publisher, 'Almuzara');
+  assert.equal(item.pages, 232);
+  assert.equal(item.bibliographic.format, 'Tapa blanda');
+  assert.equal(item.bibliographic.publication_year, '2021');
+  assert.equal(item.description, 'Descripción existente');
+  assert.equal(item.price, 1500);
+  assert.deepEqual(item.pictures, ['foto.jpg']);
 });

--- a/worker-sync/__tests__/verified-demand-bibliography.test.js
+++ b/worker-sync/__tests__/verified-demand-bibliography.test.js
@@ -1,0 +1,168 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  applyVerifiedDemandBibliography,
+  VERIFIED_DEMAND_BOOK_IDS,
+} from '../verified-demand-bibliography.js';
+
+test('completa sólo campos confirmados en las 31 fichas sin tocar contenido comercial', () => {
+  assert.equal(VERIFIED_DEMAND_BOOK_IDS.length, 31);
+  assert.equal(new Set(VERIFIED_DEMAND_BOOK_IDS).size, 31);
+
+  const items = VERIFIED_DEMAND_BOOK_IDS.map((id, index) => ({
+    id,
+    title: `Título comercial ${index}`,
+    author: `Autor existente ${index}`,
+    isbn: null,
+    publisher: null,
+    pages: null,
+    bibliographic: {
+      format: 'Tapa dura existente',
+      edition: 'Edición existente',
+    },
+    description: `Descripción existente ${index}`,
+    price: 1000 + index,
+    available_quantity: index,
+    pictures: [`foto-${index}.jpg`],
+  }));
+
+  const result = applyVerifiedDemandBibliography(items);
+
+  assert.deepEqual(result, {
+    matched_items: 31,
+    applied_items: 31,
+    applied_fields: {
+      isbn: 31,
+      publisher: 6,
+      pages: 11,
+      publication_year: 26,
+    },
+    skipped_isbn_mismatch: 0,
+    preserved_existing_fields: 0,
+  });
+
+  assert.ok(items.every((item, index) => item.title === `Título comercial ${index}`));
+  assert.ok(items.every((item, index) => item.author === `Autor existente ${index}`));
+  assert.ok(items.every((item, index) => item.description === `Descripción existente ${index}`));
+  assert.ok(items.every((item, index) => item.price === 1000 + index));
+  assert.ok(items.every((item, index) => item.available_quantity === index));
+  assert.ok(items.every((item, index) => item.pictures[0] === `foto-${index}.jpg`));
+  assert.ok(items.every(item => item.bibliographic.format === 'Tapa dura existente'));
+  assert.ok(items.every(item => item.bibliographic.edition === 'Edición existente'));
+
+  const almuzara = items.find(item => item.id === 'MLU704191572');
+  assert.equal(almuzara.isbn, '9788417880521');
+  assert.equal(almuzara.publisher, 'Almuzara');
+  assert.equal(almuzara.pages, 232);
+  assert.equal(almuzara.bibliographic.publication_year, '2021');
+
+  const pagesOnly = items.find(item => item.id === 'MLU644929173');
+  assert.equal(pagesOnly.pages, 320);
+  assert.equal(pagesOnly.bibliographic.publication_year, undefined);
+
+  const publisherOnly = items.find(item => item.id === 'MLU656702417');
+  assert.equal(publisherOnly.publisher, 'Debolsillo');
+  assert.equal(publisherOnly.pages, null);
+  assert.equal(publisherOnly.bibliographic.publication_year, undefined);
+});
+
+test('conserva datos reales existentes y sólo reemplaza publishers placeholder', () => {
+  const existing = {
+    id: 'MLU704191572',
+    title: 'Título intacto',
+    isbn: '9788417880521',
+    publisher: 'Editorial ya cargada',
+    pages: 999,
+    bibliographic: {
+      publication_year: '1999',
+      format: 'Tapa blanda',
+    },
+  };
+
+  const existingResult = applyVerifiedDemandBibliography([existing]);
+
+  assert.deepEqual(existingResult, {
+    matched_items: 1,
+    applied_items: 0,
+    applied_fields: {
+      isbn: 0,
+      publisher: 0,
+      pages: 0,
+      publication_year: 0,
+    },
+    skipped_isbn_mismatch: 0,
+    preserved_existing_fields: 3,
+  });
+  assert.equal(existing.publisher, 'Editorial ya cargada');
+  assert.equal(existing.pages, 999);
+  assert.equal(existing.bibliographic.publication_year, '1999');
+  assert.equal(existing.bibliographic.format, 'Tapa blanda');
+
+  const placeholder = {
+    id: 'MLU656702417',
+    title: 'Otro título intacto',
+    isbn: '9786073113724',
+    publisher: 'Amado Libros',
+    bibliographic: null,
+  };
+
+  const placeholderResult = applyVerifiedDemandBibliography([placeholder]);
+
+  assert.equal(placeholderResult.applied_items, 1);
+  assert.equal(placeholderResult.applied_fields.publisher, 1);
+  assert.equal(placeholder.publisher, 'Debolsillo');
+  assert.equal(placeholder.title, 'Otro título intacto');
+});
+
+test('rechaza una publicación cuyo ISBN actual corresponde a otra edición', () => {
+  const item = {
+    id: 'MLU709076232',
+    title: 'Título intacto',
+    isbn: '9780000000000',
+    publisher: null,
+    pages: null,
+    bibliographic: null,
+  };
+
+  const result = applyVerifiedDemandBibliography([item]);
+
+  assert.deepEqual(result, {
+    matched_items: 1,
+    applied_items: 0,
+    applied_fields: {
+      isbn: 0,
+      publisher: 0,
+      pages: 0,
+      publication_year: 0,
+    },
+    skipped_isbn_mismatch: 1,
+    preserved_existing_fields: 0,
+  });
+  assert.equal(item.title, 'Título intacto');
+  assert.equal(item.publisher, null);
+  assert.equal(item.pages, null);
+  assert.equal(item.bibliographic, null);
+});
+
+test('acepta el ISBN-10 equivalente sin reescribirlo', () => {
+  const item = {
+    id: 'MLU709076232',
+    title: 'Título intacto',
+    isbn: '8416894868',
+    publisher: null,
+    pages: null,
+    bibliographic: {},
+  };
+
+  const result = applyVerifiedDemandBibliography([item]);
+
+  assert.equal(result.skipped_isbn_mismatch, 0);
+  assert.equal(result.applied_items, 1);
+  assert.equal(result.applied_fields.isbn, 0);
+  assert.equal(result.applied_fields.pages, 1);
+  assert.equal(result.applied_fields.publication_year, 1);
+  assert.equal(item.isbn, '8416894868');
+  assert.equal(item.pages, 224);
+  assert.equal(item.bibliographic.publication_year, '2017');
+});

--- a/worker-sync/verified-book-enrichments.js
+++ b/worker-sync/verified-book-enrichments.js
@@ -1,3 +1,5 @@
+import { applyVerifiedDemandBibliography } from './verified-demand-bibliography.js';
+
 /**
  * Datos bibliográficos revisados manualmente para lotes pequeños de fichas.
  *
@@ -92,8 +94,10 @@ function digits(value) {
 }
 
 /**
- * Aplica el lote solo cuando el ID coincide y el ISBN no contradice la ficha.
- * Devuelve métricas para que el sync deje evidencia de lo aplicado/omitido.
+ * Aplica el lote manual solo cuando el ID coincide y el ISBN no contradice la
+ * ficha. Después completa, en modo fill-only, los campos confirmados para la
+ * cohorte de demanda. Devuelve métricas para que el sync deje evidencia de lo
+ * aplicado/omitido.
  */
 export function applyVerifiedBookEnrichments(items = []) {
   let applied = 0;
@@ -128,7 +132,13 @@ export function applyVerifiedBookEnrichments(items = []) {
     applied++;
   }
 
-  return { applied, skipped_isbn_mismatch: skippedIsbnMismatch };
+  const demandBibliography = applyVerifiedDemandBibliography(items);
+
+  return {
+    applied,
+    skipped_isbn_mismatch: skippedIsbnMismatch,
+    demand_bibliography: demandBibliography,
+  };
 }
 
 export const VERIFIED_BOOK_IDS = Object.freeze([...VERIFIED_BOOK_ENRICHMENTS.keys()]);

--- a/worker-sync/verified-demand-bibliography.js
+++ b/worker-sync/verified-demand-bibliography.js
@@ -1,0 +1,175 @@
+/**
+ * Campos bibliográficos confirmados para la cohorte SEO de 130 fichas con
+ * demanda histórica de Search Console.
+ *
+ * Evidencia: issue #182 y audit-results/demand-bibliography-verified.json de
+ * la rama agent/audit-gsc-demand-bibliography, generados el 2026-08-19.
+ * Cada campo fue confirmado para el ISBN exacto por Google Books y Open
+ * Library. Library of Congress no participa en este lote y nunca bloquea el
+ * sync. No se agregan formato ni edición porque no alcanzaron dos fuentes.
+ *
+ * Reglas de aplicación:
+ * - ID de Mercado Libre e ISBN deben identificar la misma edición;
+ * - sólo se completan campos ausentes o un publisher placeholder;
+ * - nunca se reemplazan título, autor, descripción, fotos, precio ni stock;
+ * - un dato real ya presente en Mercado Libre se conserva.
+ */
+
+const VERIFIED_DEMAND_BIBLIOGRAPHY = new Map([
+  ['MLU709076232', { isbn: '9788416894864', pages: 224, publication_year: '2017' }],
+  ['MLU611170975', { isbn: '9789500203760', pages: 1126, publication_year: '2000' }],
+  ['MLU663271326', { isbn: '9788417963040', pages: 324, publication_year: '2020' }],
+  ['MLU753430344', { isbn: '9786073151702', publication_year: '2023' }],
+  ['MLU714604980', { isbn: '9786075262758', publication_year: '2017' }],
+  ['MLU1044785818', { isbn: '9788491041542', publication_year: '2015' }],
+  ['MLU667447994', { isbn: '9786073801553', publication_year: '2023' }],
+  ['MLU716663648', { isbn: '9789874922717', pages: 646, publication_year: '2020' }],
+  ['MLU827100010', { isbn: '9781442498327', publication_year: '2013' }],
+  ['MLU696591850', { isbn: '9788468475226', pages: 320, publication_year: '2011' }],
+  ['MLU644929173', { isbn: '9788467479324', pages: 320 }],
+  ['MLU704191572', { isbn: '9788417880521', publisher: 'Almuzara', pages: 232, publication_year: '2021' }],
+  ['MLU630854789', { isbn: '9788416145317', pages: 192 }],
+  ['MLU717732940', { isbn: '9780997419900', publisher: 'Am Education & Services', publication_year: '2016' }],
+  ['MLU660197052', { isbn: '9788433030474', publication_year: '2019' }],
+  ['MLU1349705242', { isbn: '9788423436750', publication_year: '2024' }],
+  ['MLU1388713612', { isbn: '9788467585803', pages: 312 }],
+  ['MLU1431949100', { isbn: '9788483580271', publication_year: '2007' }],
+  ['MLU648552863', { isbn: '9781316634875', publisher: 'Cambridge University Press', publication_year: '2017' }],
+  ['MLU656702417', { isbn: '9786073113724', publisher: 'Debolsillo' }],
+  ['MLU665138560', { isbn: '9788490731307', publication_year: '2015' }],
+  ['MLU717757810', { isbn: '9780194115124', publication_year: '2017' }],
+  ['MLU766250362', { isbn: '9788466678865', publisher: 'Ediciones B', publication_year: '2024' }],
+  ['MLU766276576', { isbn: '9781404119420', publication_year: '2023' }],
+  ['MLU925896746', { isbn: '9788445019580', publication_year: '2025' }],
+  ['MLU620531223', { isbn: '9788495973351', publication_year: '2006' }],
+  ['MLU643828797', { isbn: '9788499213811', pages: 288, publication_year: '2013' }],
+  ['MLU652240418', { isbn: '9788424629427', publisher: 'La Galera' }],
+  ['MLU654532366', { isbn: '9780738762647', publication_year: '2019' }],
+  ['MLU714465576', { isbn: '9781107668577', publication_year: '2014' }],
+  ['MLU604541596', { isbn: '9788420678818', pages: 680, publication_year: '2013' }],
+]);
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function normalizeIsbn(value) {
+  const raw = String(value || '').toUpperCase().replace(/[^0-9X]/g, '');
+  if (/^\d{13}$/.test(raw)) return raw;
+  if (!/^\d{9}[0-9X]$/.test(raw)) return raw;
+
+  const base = `978${raw.slice(0, 9)}`;
+  const sum = [...base].reduce(
+    (total, digit, index) => total + Number(digit) * (index % 2 === 0 ? 1 : 3),
+    0,
+  );
+  return `${base}${(10 - (sum % 10)) % 10}`;
+}
+
+function isPublisherPlaceholder(value) {
+  const normalized = clean(value).toLowerCase();
+  return !normalized || [
+    'amado libros',
+    'amado libros uruguay',
+    'sin editorial',
+    'no aplica',
+    'n/a',
+  ].includes(normalized);
+}
+
+function positiveInteger(value) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : null;
+}
+
+function validPublicationYear(value) {
+  const match = clean(value).match(/^(18|19|20)\d{2}$/);
+  return match ? match[0] : null;
+}
+
+/**
+ * Completa únicamente los campos confirmados que siguen ausentes.
+ * Devuelve métricas para auditar el siguiente sync sin exponer datos sensibles.
+ */
+export function applyVerifiedDemandBibliography(items = []) {
+  let matchedItems = 0;
+  let appliedItems = 0;
+  let skippedIsbnMismatch = 0;
+  let preservedExistingFields = 0;
+  const appliedFields = {
+    isbn: 0,
+    publisher: 0,
+    pages: 0,
+    publication_year: 0,
+  };
+
+  for (const item of items) {
+    const verified = VERIFIED_DEMAND_BIBLIOGRAPHY.get(String(item?.id || ''));
+    if (!verified) continue;
+    matchedItems++;
+
+    const currentIsbn = normalizeIsbn(item.isbn);
+    const verifiedIsbn = normalizeIsbn(verified.isbn);
+    if (currentIsbn && currentIsbn !== verifiedIsbn) {
+      skippedIsbnMismatch++;
+      continue;
+    }
+
+    let changed = false;
+    if (!currentIsbn) {
+      item.isbn = verified.isbn;
+      appliedFields.isbn++;
+      changed = true;
+    }
+
+    if (verified.publisher) {
+      if (isPublisherPlaceholder(item.publisher)) {
+        item.publisher = verified.publisher;
+        appliedFields.publisher++;
+        changed = true;
+      } else {
+        preservedExistingFields++;
+      }
+    }
+
+    if (verified.pages) {
+      if (!positiveInteger(item.pages)) {
+        item.pages = verified.pages;
+        appliedFields.pages++;
+        changed = true;
+      } else {
+        preservedExistingFields++;
+      }
+    }
+
+    if (verified.publication_year) {
+      const bibliographic = item.bibliographic && typeof item.bibliographic === 'object'
+        ? item.bibliographic
+        : {};
+      if (!validPublicationYear(bibliographic.publication_year)) {
+        item.bibliographic = {
+          ...bibliographic,
+          publication_year: verified.publication_year,
+        };
+        appliedFields.publication_year++;
+        changed = true;
+      } else {
+        preservedExistingFields++;
+      }
+    }
+
+    if (changed) appliedItems++;
+  }
+
+  return {
+    matched_items: matchedItems,
+    applied_items: appliedItems,
+    applied_fields: appliedFields,
+    skipped_isbn_mismatch: skippedIsbnMismatch,
+    preserved_existing_fields: preservedExistingFields,
+  };
+}
+
+export const VERIFIED_DEMAND_BOOK_IDS = Object.freeze([
+  ...VERIFIED_DEMAND_BIBLIOGRAPHY.keys(),
+]);


### PR DESCRIPTION
## Objetivo

Completar únicamente campos bibliográficos confirmados para 31 de las 130 fichas de la cohorte `gsc-demand`, sin inventar metadata ni depender de Library of Congress.

## Evidencia

La auditoría del issue #182 verificó los 130 ISBN exactos con Google Books autenticado y Open Library:

- 130/130 consultas Google Books correctas
- 84/130 ediciones exactas encontradas en Google Books
- 52/130 ediciones encontradas en Open Library
- 31 ISBN con al menos un campo coincidente entre ambas fuentes
- campos aplicables: 6 editoriales, 11 cantidades de páginas y 26 años de publicación
- 0 formatos y 0 ediciones aplicados por falta de doble confirmación

Library of Congress queda completamente fuera del lote y no participa del sync.

## Cambios

- agrega una tabla cerrada de 31 IDs + ISBN exactos y sólo sus campos confirmados;
- normaliza ISBN-10/ISBN-13 antes de aceptar una coincidencia;
- rechaza la aplicación si el ISBN actual corresponde a otra edición;
- completa únicamente valores ausentes o publisher placeholder;
- conserva cualquier editorial, páginas o año real ya presente;
- preserva título, autor, descripción, imágenes, precio, stock, formato y edición;
- registra métricas de IDs encontrados, campos aplicados, conflictos de ISBN y datos existentes preservados.

## Alcance y riesgo

Riesgo bajo y acotado al sincronizador bibliográfico. No modifica HTML, sitemap, canonical, robots, checkout, Merchant, AUTOFEED, precios, stock ni producción. El PR queda en borrador y no debe fusionarse sin validación de CI y aprobación explícita.

## Validación incluida

- cobertura exacta de 31 IDs únicos;
- conteos esperados: 6 editoriales, 11 páginas y 26 años;
- preservación de contenido comercial;
- preservación de datos bibliográficos ya existentes;
- reemplazo sólo de publisher placeholder;
- rechazo por ISBN de otra edición;
- equivalencia ISBN-10/ISBN-13;
- integración con el lote manual existente.

Closes #182 sólo después de la validación y el eventual merge; este PR no cierra el issue automáticamente.