### PR TITLE
CX: mostrar demora de 15 a 20 días en fichas por encargo

### DIFF
--- a/functions/__tests__/order-lead-time-cx.test.js
+++ b/functions/__tests__/order-lead-time-cx.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { enrichByRequestProductHtml } from '../libro/_middleware.js';
+import { PAUSED_SEO_COHORT } from '../_shared/paused-seo-cohort.js';
+
+const COHORT_PRODUCT_ID = PAUSED_SEO_COHORT[0].id;
+
+function productHtml({ inStock = false } = {}) {
+  return `<!doctype html>
+<html lang="es">
+<head>
+  <style>.order-box span{font-weight:700}</style>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Inicio","item":"https://www.amadolibros.com/"},{"@type":"ListItem","position":2,"name":"Libro de prueba"}]}</script>
+</head>
+<body>
+  <nav><a href="/">Inicio</a> › <span>Libro de prueba</span></nav>
+  <main>
+    ${inStock ? '<span class="badge in-stock">En stock</span>' : ''}
+    <div class="order-box">
+      <strong>¿Buscás este libro?</strong>
+      <span>Podemos intentar conseguirlo por encargo. Consultanos y verificamos disponibilidad, edición y precio.</span>
+    </div>
+  </main>
+</body>
+</html>`;
+}
+
+test('la ficha por encargo comunica la demora comercial aprobada antes del CTA', () => {
+  const html = enrichByRequestProductHtml(productHtml(), COHORT_PRODUCT_ID);
+
+  assert.match(html, /Demora estimada: 15 a 20 días desde la confirmación\./);
+  assert.match(html, /Salvo demoras del proveedor, courier o aduana\./);
+  assert.match(html, /Antes de avanzar verificamos disponibilidad, edición y precio\./);
+  assert.doesNotMatch(html, /Podemos intentar conseguirlo por encargo/);
+  assert.doesNotMatch(html, /días hábiles|garantizad/i);
+  assert.match(html, /class="order-lead-time"/);
+  assert.match(html, /class="order-hub-links"/);
+});
+
+test('una ficha que volvió a stock no recibe plazo de encargo', () => {
+  const source = productHtml({ inStock: true });
+  const html = enrichByRequestProductHtml(source, COHORT_PRODUCT_ID);
+
+  assert.equal(html, source);
+  assert.doesNotMatch(html, /15 a 20 días/);
+});
+
+test('una ficha fuera de la cohorte SEO queda intacta', () => {
+  const source = productHtml();
+  const html = enrichByRequestProductHtml(source, 'MLU999999999');
+
+  assert.equal(html, source);
+});
+
+test('el enriquecimiento es idempotente', () => {
+  const first = enrichByRequestProductHtml(productHtml(), COHORT_PRODUCT_ID);
+  const second = enrichByRequestProductHtml(first, COHORT_PRODUCT_ID);
+
+  assert.equal(second, first);
+  assert.equal((second.match(/15 a 20 días/g) || []).length, 1);
+});

--- a/functions/libro/_middleware.js
+++ b/functions/libro/_middleware.js
@@ -8,9 +8,14 @@ import {
 const PRODUCT_PATH_RE = /^\/libro\/(MLU\d+)(?:\/|$)/i;
 const BREADCRUMB_RE = /<nav>\s*<a href="\/">Inicio<\/a>\s*›\s*<span>/;
 const JSON_LD_RE = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
+const ORDER_BOX_GENERIC_COPY = '<span>Podemos intentar conseguirlo por encargo. Consultanos y verificamos disponibilidad, edición y precio.</span>';
+const ORDER_BOX_LEAD_TIME_COPY = `<span class="order-lead-time"><b>Demora estimada: 15 a 20 días desde la confirmación.</b> Salvo demoras del proveedor, courier o aduana.</span>
+      <span>Antes de avanzar verificamos disponibilidad, edición y precio.</span>`;
 
 function byRequestStyles() {
   return `
+    .order-box .order-lead-time{font-weight:650}
+    .order-box .order-lead-time b{display:block;font-weight:850;color:#6b4218}
     .order-hub-links{grid-column:1/-1;padding:1rem 1.1rem;background:#fff8f4;
                      border:1px solid #ecd1c6;border-radius:.65rem;color:#4b342b}
     .order-hub-links h2{font-size:1.05rem;line-height:1.35;color:#18120e;margin-bottom:.35rem}
@@ -61,7 +66,11 @@ export function enrichByRequestProductHtml(html, productId) {
     !source.includes('class="badge in-stock"');
   if (!isPausedPage) return source;
 
-  let result = source.replace(
+  // CX-POR-ENCARGO: la demora aprobada ya existe en la operación comercial.
+  // Se muestra sólo en fichas pausadas de la cohorte, sin convertirla en una
+  // promesa rígida ni alterar precio, disponibilidad, Offer o indexación.
+  let result = source.replace(ORDER_BOX_GENERIC_COPY, ORDER_BOX_LEAD_TIME_COPY);
+  result = result.replace(
     BREADCRUMB_RE,
     `<nav>\n  <a href="/">Inicio</a> ›\n  <a href="${ORDER_HUB_PATH}">Libros por encargo</a> ›\n  <span>`,
   );


### PR DESCRIPTION
## Diagnóstico

La auditoría CX del issue #180 inspeccionó las 10 fichas por encargo con mayor demanda GSC. Nueve señales quedaron 10/10; el único hueco sistemático fue el plazo concreto: 0/10.

Amado Libros ya usa y aprobó operativamente el texto `Demora estimada: 15 a 20 días desde la confirmación`, con salvedad por proveedor, courier o aduana. Este lote lo lleva a la ficha sin inventar un SLA nuevo.

## Cambio

- reemplaza el texto genérico de la caja por encargo en las fichas pausadas de la cohorte SEO;
- muestra: `Demora estimada: 15 a 20 días desde la confirmación`;
- aclara que puede extenderse por proveedor, courier o aduana;
- mantiene visible que disponibilidad, edición y precio se verifican antes de avanzar;
- no aplica el plazo si el libro volvió a stock;
- no modifica fichas fuera de la cohorte en este lote;
- conserva precio, stock, CTA, Offer, canonical, robots, sitemap y checkout.

## Riesgo

Bajo y acotado a copy/CX en fichas por encargo ya indexables. No cambia lógica comercial ni promete días hábiles o una fecha garantizada.

## Diff

- `functions/libro/_middleware.js`: +10 / -1
- `functions/__tests__/order-lead-time-cx.test.js`: archivo nuevo, 4 casos

## Validación esperada

- plazo visible una sola vez;
- salvedades visibles;
- fichas reactivadas intactas;
- fichas fuera de cohorte intactas;
- enriquecimiento idempotente;
- CI completo y Preview antes de merge.

No fusionar hasta que CI y Preview queden verdes.