### PR TITLE
CX: mostrar plazo en todas las fichas por encargo

### DIFF
--- a/functions/__tests__/order-hub-product-links.test.js
+++ b/functions/__tests__/order-hub-product-links.test.js
@@ -26,6 +26,9 @@ function productHtml({ preview = false, active = false } = {}) {
     '@type': ['Product', 'Book'],
     name: 'Libro de prueba',
   };
+  const orderCopy = active
+    ? '<span>Esta publicación no se convierte automáticamente a UYU. Consultanos para confirmar precio y forma de pago, o comprala directamente en MercadoLibre.</span>'
+    : '<span>Podemos intentar conseguirlo por encargo. Consultanos y verificamos disponibilidad, edición y precio.</span>';
   return `<!doctype html><html><head>
     <meta name="robots" content="${preview ? 'noindex, follow' : 'index, follow'}">
     <link rel="canonical" href="https://www.amadolibros.com/libro/MLU1/libro-de-prueba">
@@ -40,7 +43,10 @@ function productHtml({ preview = false, active = false } = {}) {
     <main>
       <div class="info">
         ${active ? '<span class="badge in-stock">✓ En stock</span>' : ''}
-        <div class="order-box"><strong>${active ? 'Precio publicado' : '¿Buscás este libro?'}</strong></div>
+        <div class="order-box">
+          <strong>${active ? 'Precio publicado' : '¿Buscás este libro?'}</strong>
+          ${orderCopy}
+        </div>
       </div>
     </main>
   </body></html>`;
@@ -113,9 +119,19 @@ test('si el título volvió a stock, no se lo etiqueta ni enlaza como por encarg
   assert.equal(enrichByRequestProductHtml(original, productId), original);
 });
 
-test('una ficha fuera de la cohorte queda intacta', () => {
-  const original = productHtml();
-  assert.equal(enrichByRequestProductHtml(original, 'MLU999999999999'), original);
+test('una ficha pausada fuera de la cohorte recibe el plazo sin enlaces SEO', () => {
+  const html = enrichByRequestProductHtml(productHtml(), 'MLU999999999999');
+
+  assert.match(html, /Demora estimada: 15 a 20 días desde la confirmación\./);
+  assert.doesNotMatch(html, /class="order-hub-links"/);
+  assert.doesNotMatch(html, /href="\/libros-por-encargo/);
+
+  const schema = breadcrumbSchema(html);
+  assert.ok(schema);
+  assert.deepEqual(schema.itemListElement.map(item => [item.position, item.name]), [
+    [1, 'Inicio'],
+    [2, 'Libro de prueba'],
+  ]);
 });
 
 test('el middleware no agrega lecturas de catálogo o R2 al camino de la ficha', () => {

--- a/functions/__tests__/order-lead-time-cx.test.js
+++ b/functions/__tests__/order-lead-time-cx.test.js
@@ -1,12 +1,19 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { enrichByRequestProductHtml } from '../libro/_middleware.js';
+import {
+  enrichByRequestProductHtml,
+  onRequest,
+} from '../libro/_middleware.js';
 import { PAUSED_SEO_COHORT } from '../_shared/paused-seo-cohort.js';
 
 const COHORT_PRODUCT_ID = PAUSED_SEO_COHORT[0].id;
+const OUTSIDE_COHORT_PRODUCT_ID = 'MLU999999999';
 
 function productHtml({ inStock = false } = {}) {
+  const orderCopy = inStock
+    ? '<span>Esta publicación no se convierte automáticamente a UYU. Consultanos para confirmar precio y forma de pago.</span>'
+    : '<span>Podemos intentar conseguirlo por encargo. Consultanos y verificamos disponibilidad, edición y precio.</span>';
   return `<!doctype html>
 <html lang="es">
 <head>
@@ -18,45 +25,95 @@ function productHtml({ inStock = false } = {}) {
   <main>
     ${inStock ? '<span class="badge in-stock">En stock</span>' : ''}
     <div class="order-box">
-      <strong>¿Buscás este libro?</strong>
-      <span>Podemos intentar conseguirlo por encargo. Consultanos y verificamos disponibilidad, edición y precio.</span>
+      <strong>${inStock ? 'Precio publicado: USD 10' : '¿Buscás este libro?'}</strong>
+      ${orderCopy}
     </div>
   </main>
 </body>
 </html>`;
 }
 
-test('la ficha por encargo comunica la demora comercial aprobada antes del CTA', () => {
-  const html = enrichByRequestProductHtml(productHtml(), COHORT_PRODUCT_ID);
-
+function assertLeadTime(html) {
   assert.match(html, /Demora estimada: 15 a 20 días desde la confirmación\./);
   assert.match(html, /Salvo demoras del proveedor, courier o aduana\./);
   assert.match(html, /Antes de avanzar verificamos disponibilidad, edición y precio\./);
   assert.doesNotMatch(html, /Podemos intentar conseguirlo por encargo/);
   assert.doesNotMatch(html, /días hábiles|garantizad/i);
   assert.match(html, /class="order-lead-time"/);
+  assert.match(html, /\.order-box \.order-lead-time\{font-weight:650\}/);
+}
+
+test('la ficha de la cohorte comunica el plazo y conserva el hub SEO', () => {
+  const html = enrichByRequestProductHtml(productHtml(), COHORT_PRODUCT_ID);
+
+  assertLeadTime(html);
   assert.match(html, /class="order-hub-links"/);
+  assert.match(html, /<a href="\/libros-por-encargo">Libros por encargo<\/a>/);
 });
 
-test('una ficha que volvió a stock no recibe plazo de encargo', () => {
+test('una ficha pausada fuera de la cohorte también comunica el plazo sin inventar enlaces SEO', () => {
+  const html = enrichByRequestProductHtml(productHtml(), OUTSIDE_COHORT_PRODUCT_ID);
+
+  assertLeadTime(html);
+  assert.doesNotMatch(html, /class="order-hub-links"/);
+  assert.doesNotMatch(html, /<a href="\/libros-por-encargo">Libros por encargo<\/a>/);
+});
+
+test('una ficha activa con caja de moneda extranjera no recibe plazo de encargo', () => {
   const source = productHtml({ inStock: true });
-  const html = enrichByRequestProductHtml(source, COHORT_PRODUCT_ID);
+  const html = enrichByRequestProductHtml(source, OUTSIDE_COHORT_PRODUCT_ID);
 
   assert.equal(html, source);
   assert.doesNotMatch(html, /15 a 20 días/);
 });
 
-test('una ficha fuera de la cohorte SEO queda intacta', () => {
-  const source = productHtml();
-  const html = enrichByRequestProductHtml(source, 'MLU999999999');
+test('el enriquecimiento es idempotente dentro y fuera de la cohorte', () => {
+  for (const productId of [COHORT_PRODUCT_ID, OUTSIDE_COHORT_PRODUCT_ID]) {
+    const first = enrichByRequestProductHtml(productHtml(), productId);
+    const second = enrichByRequestProductHtml(first, productId);
 
-  assert.equal(html, source);
+    assert.equal(second, first);
+    assert.equal((second.match(/15 a 20 días/g) || []).length, 1);
+    assert.equal((second.match(/\.order-box \.order-lead-time\{/g) || []).length, 1);
+  }
 });
 
-test('el enriquecimiento es idempotente', () => {
-  const first = enrichByRequestProductHtml(productHtml(), COHORT_PRODUCT_ID);
-  const second = enrichByRequestProductHtml(first, COHORT_PRODUCT_ID);
+test('el middleware transforma una ficha pausada fuera de cohorte y elimina validators del body anterior', async () => {
+  const upstream = new Response(productHtml(), {
+    status: 200,
+    headers: {
+      'content-type': 'text/html;charset=UTF-8',
+      'content-length': '999',
+      etag: '"anterior"',
+      'cache-control': 'public, max-age=3600',
+    },
+  });
+  const response = await onRequest({
+    request: new Request(`https://www.amadolibros.com/libro/${OUTSIDE_COHORT_PRODUCT_ID}/libro`),
+    next: async () => upstream,
+  });
+  const html = await response.text();
 
-  assert.equal(second, first);
-  assert.equal((second.match(/15 a 20 días/g) || []).length, 1);
+  assertLeadTime(html);
+  assert.equal(response.headers.get('etag'), null);
+  assert.equal(response.headers.get('content-length'), null);
+  assert.equal(response.headers.get('cache-control'), 'public, max-age=3600');
+});
+
+test('el middleware devuelve intacta la Response original de una ficha activa', async () => {
+  const upstream = new Response(productHtml({ inStock: true }), {
+    status: 200,
+    headers: {
+      'content-type': 'text/html;charset=UTF-8',
+      etag: '"activo"',
+    },
+  });
+  const response = await onRequest({
+    request: new Request(`https://www.amadolibros.com/libro/${OUTSIDE_COHORT_PRODUCT_ID}/libro`),
+    next: async () => upstream,
+  });
+
+  assert.equal(response, upstream);
+  assert.equal(response.headers.get('etag'), '"activo"');
+  assert.doesNotMatch(await response.text(), /15 a 20 días/);
 });

--- a/functions/libro/_middleware.js
+++ b/functions/libro/_middleware.js
@@ -11,11 +11,17 @@ const JSON_LD_RE = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
 const ORDER_BOX_GENERIC_COPY = '<span>Podemos intentar conseguirlo por encargo. Consultanos y verificamos disponibilidad, edición y precio.</span>';
 const ORDER_BOX_LEAD_TIME_COPY = `<span class="order-lead-time"><b>Demora estimada: 15 a 20 días desde la confirmación.</b> Salvo demoras del proveedor, courier o aduana.</span>
       <span>Antes de avanzar verificamos disponibilidad, edición y precio.</span>`;
+const ORDER_LEAD_TIME_STYLE_MARKER = '.order-box .order-lead-time{';
 
-function byRequestStyles() {
+function leadTimeStyles() {
   return `
     .order-box .order-lead-time{font-weight:650}
     .order-box .order-lead-time b{display:block;font-weight:850;color:#6b4218}
+  `;
+}
+
+function byRequestStyles() {
+  return `
     .order-hub-links{grid-column:1/-1;padding:1rem 1.1rem;background:#fff8f4;
                      border:1px solid #ecd1c6;border-radius:.65rem;color:#4b342b}
     .order-hub-links h2{font-size:1.05rem;line-height:1.35;color:#18120e;margin-bottom:.35rem}
@@ -56,20 +62,32 @@ function enrichBreadcrumbSchema(html) {
 
 export function enrichByRequestProductHtml(html, productId) {
   const source = String(html || '');
-  const hubPage = orderHubPageForProductId(productId);
-  if (!hubPage || source.includes('class="order-hub-links"')) return source;
+  const hasGenericOrderCopy = source.includes(ORDER_BOX_GENERIC_COPY);
+  const hasLeadTime = source.includes('class="order-lead-time"');
 
-  // La cohorte es estática durante el lote SEO, pero un título puede volver a
-  // stock antes de regenerarla. El HTML SSR es la última verdad comercial:
-  // jamás etiquetar como "por encargo" una ficha que ya muestra stock activo.
-  const isPausedPage = source.includes('class="order-box"') &&
+  // El copy exacto de la caja es la señal de una ficha pausada. Las fichas
+  // activas en moneda no-UYU también usan .order-box, pero tienen otro texto:
+  // nunca deben recibir el plazo de un encargo.
+  const isPausedPage = (hasGenericOrderCopy || hasLeadTime) &&
     !source.includes('class="badge in-stock"');
   if (!isPausedPage) return source;
 
-  // CX-POR-ENCARGO: la demora aprobada ya existe en la operación comercial.
-  // Se muestra sólo en fichas pausadas de la cohorte, sin convertirla en una
-  // promesa rígida ni alterar precio, disponibilidad, Offer o indexación.
-  let result = source.replace(ORDER_BOX_GENERIC_COPY, ORDER_BOX_LEAD_TIME_COPY);
+  // CX-POR-ENCARGO-ALL: el plazo aprobado es una condición operativa común,
+  // no una regla SEO. Se muestra en toda ficha pausada válida, aunque sea
+  // noindex, sin alterar precio, Offer, canonical, robots ni disponibilidad.
+  let result = hasGenericOrderCopy
+    ? source.replace(ORDER_BOX_GENERIC_COPY, ORDER_BOX_LEAD_TIME_COPY)
+    : source;
+  if (!result.includes(ORDER_LEAD_TIME_STYLE_MARKER)) {
+    result = result.replace('</style>', `${leadTimeStyles()}\n  </style>`);
+  }
+
+  const hubPage = orderHubPageForProductId(productId);
+  if (!hubPage || result.includes('class="order-hub-links"')) return result;
+
+  // La cohorte es estática durante el lote SEO, pero un título puede volver a
+  // stock antes de regenerarla. La guarda isPausedPage evita etiquetar como
+  // "por encargo" una ficha que ya volvió a estar disponible.
   result = result.replace(
     BREADCRUMB_RE,
     `<nav>\n  <a href="/">Inicio</a> ›\n  <a href="${ORDER_HUB_PATH}">Libros por encargo</a> ›\n  <span>`,
@@ -106,12 +124,10 @@ function productIdFromRequest(request) {
   }
 }
 
-function responseWithBody(response, body, changed) {
+function responseWithBody(response, body) {
   const headers = new Headers(response.headers);
-  if (changed) {
-    headers.delete('content-length');
-    headers.delete('etag');
-  }
+  headers.delete('content-length');
+  headers.delete('etag');
   return new Response(body, {
     status: response.status,
     statusText: response.statusText,
@@ -121,9 +137,7 @@ function responseWithBody(response, body, changed) {
 
 export async function onRequest(context) {
   const productId = productIdFromRequest(context.request);
-  if (!productId || orderHubPageForProductId(productId) == null) {
-    return context.next();
-  }
+  if (!productId) return context.next();
 
   const response = await context.next();
   const contentType = response.headers.get('content-type') || '';
@@ -131,7 +145,10 @@ export async function onRequest(context) {
     return response;
   }
 
-  const html = await response.text();
+  // Se inspecciona un clon: si la página no cambia (caso normal de fichas
+  // activas), se devuelve la Response original con cuerpo y validators intactos.
+  const html = await response.clone().text();
   const enriched = enrichByRequestProductHtml(html, productId);
-  return responseWithBody(response, enriched, enriched !== html);
+  if (enriched === html) return response;
+  return responseWithBody(response, enriched);
 }


### PR DESCRIPTION
## Estado previo

El PR #188 cerró el hueco CX en la cohorte SEO de 3.000 fichas. Producción tiene además miles de fichas pausadas visibles en el catálogo que seguían mostrando el texto genérico sin plazo.

## Diagnóstico

El plazo `15 a 20 días desde la confirmación` es una condición operativa del servicio de encargos, no una regla de indexación. Limitarlo a la cohorte SEO dejaba una experiencia distinta para el mismo servicio según la ficha hubiese sido seleccionada o no para el sitemap pausado.

## Cambio implementado

- aplica el mismo plazo a toda ficha SSR que conserve el estado pausado y el copy exacto de encargo;
- mantiene la salvedad por proveedor, courier o aduana;
- conserva la verificación previa de disponibilidad, edición y precio;
- las fichas activas con caja de moneda extranjera no reciben el plazo;
- sólo la cohorte SEO conserva breadcrumb y enlaces hacia `/libros-por-encargo`;
- fuera de la cohorte no se inventan enlaces SEO ni se cambia `robots`;
- si el HTML no cambia, el middleware devuelve la `Response` original con body, ETag y headers intactos;
- si cambia el body, elimina únicamente `content-length` y `etag` del contenido anterior.

## Corrección posterior al primer CI

El primer CI detectó dos fixtures desactualizados en `order-hub-product-links.test.js`: no reproducían el copy real de una ficha pausada y todavía esperaban que una ficha fuera de la cohorte quedara completamente intacta. Se alinearon los fixtures con el HTML real y se agregó la expectativa correcta: plazo para todas las pausadas, enlaces SEO sólo para la cohorte.

## Diff final

- `functions/libro/_middleware.js`
- `functions/__tests__/order-lead-time-cx.test.js`
- `functions/__tests__/order-hub-product-links.test.js`
- total: 3 archivos, +132 / -42

## Validación

- commit de corrección: `c6763de35fb176f3b0b3261069faf19c5bf0fdb6`;
- CI `Syntax & Build`: PASS;
- Preview aislado: `https://pr-191.amadolibros-web.pages.dev`;
- auditoría completa del Preview: PASS;
- páginas auditadas: 80;
- enlaces verificados: 2.949;
- enlaces rotos: 0;
- faltantes de carrito: 0;
- inconsistencias checkout/Mercado Pago: 0;
- assets faltantes: 0;
- problemas SEO: 0;
- problemas de datos estructurados: 0;
- portadas R2 verificadas: 60/80.

## Riesgo residual

Bajo a moderado y acotado a la ficha SSR. El middleware inspecciona un clon del HTML de cada ruta `/libro/`; las fichas activas salen intactas y la auditoría funcional quedó verde. No se hizo una comparación aislada de TTFB antes/después, por lo que el costo de clonar el HTML queda como riesgo de performance menor a observar.

## Producción

Sin cambios. No fusionar ni desplegar sin aprobación explícita.