### PR TITLE
chore: temporary GSC BigQuery readiness check

### DIFF
--- a/.github/workflows/gsc-bigquery-ready-check-temp.yml
+++ b/.github/workflows/gsc-bigquery-ready-check-temp.yml
@@ -1,0 +1,53 @@
+name: GSC BigQuery ready check temporary
+
+on:
+  push:
+    branches:
+      - agent/gsc-bigquery-ready-check-20260819-2008
+    paths:
+      - '.github/workflows/gsc-bigquery-ready-check-temp.yml'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Authenticate with Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: amado-libros-analytics
+          workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
+          service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/bigquery.readonly
+          create_credentials_file: false
+      - name: Inspect Search Console BigQuery dataset
+        env:
+          TOKEN: ${{ steps.auth.outputs.access_token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          base='https://bigquery.googleapis.com/bigquery/v2/projects/amado-libros-analytics/datasets/searchconsole'
+          code=$(curl -sS -o /tmp/dataset.json -w '%{http_code}' -H "Authorization: Bearer $TOKEN" "$base")
+          echo "DATASET_HTTP=$code"
+          if [ "$code" != "200" ]; then
+            cat /tmp/dataset.json
+            exit 0
+          fi
+          curl -sS -H "Authorization: Bearer $TOKEN" "$base/tables?maxResults=1000" > /tmp/tables.json
+          echo 'TABLE_IDS_BEGIN'
+          jq -r '.tables[]?.tableReference.tableId' /tmp/tables.json | sort
+          echo 'TABLE_IDS_END'
+          for t in ExportLog searchdata_url_impression searchdata_site_impression; do
+            code=$(curl -sS -o "/tmp/$t.json" -w '%{http_code}' -H "Authorization: Bearer $TOKEN" "$base/tables/$t")
+            echo "TABLE_$t_HTTP=$code"
+            if [ "$code" = "200" ]; then
+              jq -r '"TABLE_ID=" + .tableReference.tableId, "NUM_ROWS=" + (.numRows // "0"), "NUM_BYTES=" + (.numBytes // "0"), "LAST_MODIFIED_TIME=" + (.lastModifiedTime // "")' "/tmp/$t.json"
+            fi
+          done

--- a/.github/workflows/gsc-bigquery-ready-check-temp.yml
+++ b/.github/workflows/gsc-bigquery-ready-check-temp.yml
@@ -6,6 +6,9 @@ on:
       - agent/gsc-bigquery-ready-check-20260819-2008
     paths:
       - '.github/workflows/gsc-bigquery-ready-check-temp.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/gsc-bigquery-ready-check-temp.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Temporary read-only probe for Search Console bulk export readiness in BigQuery. No production changes; checks dataset/table metadata only.