### PR TITLE
OPS-CATALOG-DEGRADATION-1: /catalogo responde 503 si el catálogo activo falla

### DIFF
--- a/functions/__tests__/catalogo-degradation.test.js
+++ b/functions/__tests__/catalogo-degradation.test.js
@@ -1,0 +1,226 @@
+// OPS-CATALOG-DEGRADATION-1 (issue #85) — /catalogo nunca debe responder
+// HTTP 200 con una grilla vacía o comercialmente falsa cuando la fuente
+// activa que esa vista necesita está temporalmente indisponible. Tampoco
+// debe convertir esa falla temporal en 404/410: la URL sigue siendo válida,
+// el problema es de origen.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { onRequest as catalogRequest } from '../catalogo.js';
+import { CATALOG_URL, PAUSED_MANIFEST_URL, PRODUCTION_MANIFEST_URL, R2_BASE } from '../_shared/catalog.js';
+
+const BASE_URL = 'https://www.amadolibros.com/catalogo';
+
+const VALID_CATALOG = {
+  total: 2,
+  items: [
+    {
+      id: 'MLU0001', title: 'Libro disponible', author: 'Autora Uno',
+      isbn: '9780000000001', price: 1000, status: 'active', available_quantity: 3,
+      thumbnail: '', pictures: [], permalink: 'https://x/MLU0001',
+    },
+    {
+      id: 'MLU0002', title: 'Otro libro disponible', author: 'Autor Dos',
+      isbn: '9780000000002', price: 1200, status: 'active', available_quantity: 1,
+      thumbnail: '', pictures: [], permalink: 'https://x/MLU0002',
+    },
+  ],
+};
+
+const ACTIVE_MANIFEST_CURRENT = {
+  version: 'v1',
+  index_key: 'stock1-preview/index.json',
+  active_index_key: 'stock1-preview/active-index.json',
+  block_prefix: 'stock1-preview/blocks',
+  block_count: 1,
+};
+
+const VALID_ACTIVE_INDEX = {
+  schema_version: 1,
+  fields: ['id', 'title', 'author', 'isbn', 'image', 'price', 'available_quantity'],
+  derived_fields: { slug: 'slugify-v1', status: 'active' },
+  items: [
+    ['MLU0009', 'Libro del índice compacto', 'Autora Compacta', '9780000000009', '', 1500, 2],
+  ],
+};
+
+function context(url, appEnv = 'test') {
+  return {
+    request: new Request(url),
+    params: {},
+    env: { APP_ENV: appEnv },
+    waitUntil() {},
+  };
+}
+
+// Instala un mock de `caches.default` donde cada URL listada en `hits`
+// responde con ese valor (cache HIT) y todo lo demás es un cache MISS —
+// el fallback a `fetch` real de _shared/catalog.js entonces decide.
+function installCacheHits(hits) {
+  globalThis.caches = {
+    default: {
+      async match(request) {
+        const entry = hits[request.url];
+        return entry === undefined ? null : Response.json(entry);
+      },
+      async put() {},
+    },
+  };
+}
+
+async function render(url, appEnv = 'test') {
+  const response = await catalogRequest(context(url, appEnv));
+  const html = response.status === 200 || response.status === 503
+    ? await response.text()
+    : '';
+  return { response, html };
+}
+
+test.afterEach(() => {
+  delete globalThis.fetch;
+});
+
+// ── 1. catalog.json caído en /catalogo limpio → 503 ─────────────────────────
+
+test('1. /catalogo limpio: catalog.json responde error de red → 503, no-store, noindex', async () => {
+  installCacheHits({}); // todo cache MISS
+  globalThis.fetch = async () => new Response('bad gateway', { status: 502 });
+  const { response, html } = await render(BASE_URL);
+
+  assert.equal(response.status, 503);
+  assert.equal(response.headers.get('cache-control'), 'no-store');
+  assert.equal(response.headers.get('x-robots-tag'), 'noindex, nofollow');
+  assert.match(html, /<meta name="robots" content="noindex, nofollow">/);
+  assert.match(html, /catálogo está actualizándose/);
+});
+
+test('1b. /catalogo limpio: el fetch de catalog.json lanza una excepción real (origen inalcanzable) → 503, no crashea', async () => {
+  installCacheHits({});
+  globalThis.fetch = async () => { throw new Error('network down'); };
+  const { response } = await render(BASE_URL);
+  assert.equal(response.status, 503);
+});
+
+// ── 2. catálogo con estructura inválida → 503 ───────────────────────────────
+
+test('2. /catalogo limpio: catalog.json responde 200 pero sin items[] → 503', async () => {
+  installCacheHits({});
+  globalThis.fetch = async () => Response.json({ total: 0 }); // sin `items`
+  const { response } = await render(BASE_URL);
+  assert.equal(response.status, 503);
+});
+
+test('2b. /catalogo limpio: catalog.json responde JSON no parseable → 503', async () => {
+  installCacheHits({});
+  globalThis.fetch = async () => new Response('esto no es JSON', { status: 200 });
+  const { response } = await render(BASE_URL);
+  assert.equal(response.status, 503);
+});
+
+test('2c. /catalogo limpio: items no es array → 503', async () => {
+  installCacheHits({});
+  globalThis.fetch = async () => Response.json({ total: 3, items: 'no-es-array' });
+  const { response } = await render(BASE_URL);
+  assert.equal(response.status, 503);
+});
+
+// ── 3. filtro que depende del catálogo completo → misma política 503 ───────
+
+test('3. filtro por categoría (sin q) también depende del catálogo completo → 503 si falla', async () => {
+  installCacheHits({
+    [PRODUCTION_MANIFEST_URL]: { current: null, previous: null },
+  });
+  globalThis.fetch = async url => {
+    if (String(url) === CATALOG_URL) return new Response('down', { status: 503 });
+    return new Response('not found', { status: 404 });
+  };
+  const { response } = await render(`${BASE_URL}?categoria=filosofia-ciencias-sociales`, 'production');
+  assert.equal(response.status, 503);
+});
+
+test('3b. búsqueda con ?q en entorno sin índice compacto (test/dev) también depende del catálogo completo → 503', async () => {
+  installCacheHits({});
+  globalThis.fetch = async () => new Response('down', { status: 503 });
+  // appEnv por defecto ('test') nunca activa useCompactSearch — cae siempre
+  // a fetchCatalog(), igual que antes de este cambio.
+  const { response } = await render(`${BASE_URL}?q=cualquiera`);
+  assert.equal(response.status, 503);
+});
+
+test('3c. ?q en preview/producción con índice activo compacto caído también cae al catálogo completo → 503 si ese también falla', async () => {
+  installCacheHits({
+    [PAUSED_MANIFEST_URL]: { current: null, previous: null }, // manifest inválido -> activeIndex null
+  });
+  globalThis.fetch = async url => {
+    if (String(url) === CATALOG_URL) return new Response('down', { status: 502 });
+    return new Response('not found', { status: 404 });
+  };
+  const { response } = await render(`${BASE_URL}?q=murdoku`, 'preview');
+  assert.equal(response.status, 503);
+});
+
+// ── 4. búsqueda resuelta por completo con el índice compacto sigue 200 ─────
+
+test('4. índice activo compacto válido resuelve la búsqueda sin necesitar catalog.json (que ni se llega a pedir)', async () => {
+  installCacheHits({
+    [PAUSED_MANIFEST_URL]: { schema_version: 1, current: ACTIVE_MANIFEST_CURRENT, previous: null },
+    [`${R2_BASE}/${ACTIVE_MANIFEST_CURRENT.active_index_key}`]: VALID_ACTIVE_INDEX,
+  });
+  const requestedUrls = [];
+  globalThis.fetch = async url => {
+    requestedUrls.push(String(url));
+    // Si el código igual intentara pedir catalog.json completo, esto
+    // fallaría — probando que la búsqueda compacta lo evita del todo.
+    if (String(url) === CATALOG_URL) return new Response('no debería pedirse', { status: 500 });
+    return new Response('not found', { status: 404 });
+  };
+  const { response, html } = await render(`${BASE_URL}?q=compacto`, 'preview');
+
+  assert.equal(response.status, 200);
+  assert.match(html, /MLU0009/);
+  assert.equal(requestedUrls.includes(CATALOG_URL), false, 'catalog.json no debía pedirse');
+});
+
+// ── 5. cero coincidencias legítimas sigue 200 ───────────────────────────────
+
+test('5. catalog.json válido pero sin coincidencias para la búsqueda → 200 con cero resultados', async () => {
+  installCacheHits({ [CATALOG_URL]: VALID_CATALOG });
+  const { response, html } = await render(`${BASE_URL}?q=zzzqqxyw999nadaquever`);
+  assert.equal(response.status, 200);
+  assert.match(html, /No encontramos resultados\./);
+});
+
+test('5b. catalog.json válido y sin filtros con catálogo realmente vacío → 200, no 503', async () => {
+  installCacheHits({ [CATALOG_URL]: { total: 0, items: [] } });
+  const { response, html } = await render(BASE_URL);
+  assert.equal(response.status, 200, 'una fuente válida con cero libros no es una falla');
+  assert.match(html, /No encontramos resultados\./);
+});
+
+// ── 6. un fallo temporal jamás se convierte en 404 o 410 ───────────────────
+
+test('6. catalog.json caído con ?page=5 nunca degrada a 404 (totalPages=0 no debe leerse antes del 503)', async () => {
+  installCacheHits({});
+  globalThis.fetch = async () => new Response('down', { status: 502 });
+  const { response } = await render(`${BASE_URL}?page=5`);
+  assert.equal(response.status, 503);
+  assert.notEqual(response.status, 404);
+});
+
+test('6b. catalog.json caído con categoría + página fuera de rango tampoco degrada a 404', async () => {
+  installCacheHits({
+    [PRODUCTION_MANIFEST_URL]: { current: null, previous: null },
+  });
+  globalThis.fetch = async () => new Response('down', { status: 502 });
+  const { response } = await render(`${BASE_URL}?categoria=cualquiera&page=9`, 'production');
+  assert.equal(response.status, 503);
+});
+
+// ── 7. Cache-Control: no-store en todo 503 ──────────────────────────────────
+
+test('7. cualquier 503 de /catalogo lleva Cache-Control: no-store', async () => {
+  installCacheHits({});
+  globalThis.fetch = async () => Response.json({ total: 0 });
+  const { response } = await render(BASE_URL);
+  assert.equal(response.status, 503);
+  assert.equal(response.headers.get('cache-control'), 'no-store');
+});

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -514,6 +514,28 @@ const PAGINATION_STYLES = `
         outline-offset:2px}
 `;
 
+// OPS-CATALOG-DEGRADATION-1 (issue #85): catalog.json es imprescindible para
+// las vistas que no pueden resolverse sólo con el índice activo compacto
+// (ver catalogNeeded en onRequest). Si fetchCatalog() falla o devuelve una
+// estructura sin `items` como array, la respuesta correcta es un 503
+// temporal explícito — nunca una grilla vacía con HTTP 200 (falsea "no hay
+// libros" ante compradores y arriesga que Google indexe un catálogo vacío
+// como si fuera real) ni un 404/410 (la URL sigue siendo válida; la falla
+// es de origen, no de contenido). Mismas cabeceras que noindexPage() en
+// libros-por-encargo.js para el mismo tipo de falla en esa otra vista.
+function catalogUnavailableResponse() {
+    const html = `<!doctype html><html lang="es"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex, nofollow"><title>Catálogo no disponible — Amado Libros</title>${faviconHeadHtml()}</head><body style="font-family:system-ui,sans-serif;max-width:680px;margin:4rem auto;padding:1rem;line-height:1.6"><main><h1>El catálogo está actualizándose</h1><p>No pudimos cargar el catálogo en este momento. Es una falla temporal — probá de nuevo en unos minutos.</p><p><a href="/">Volver al inicio</a></p></main></body></html>`;
+    return new Response(html, {
+        status: 503,
+        headers: {
+            'content-type': 'text/html;charset=UTF-8',
+            'cache-control': 'no-store',
+            'x-robots-tag': 'noindex, nofollow',
+            'retry-after': '60',
+        },
+    });
+}
+
 export async function onRequest(ctx) {
     const requestStartedAt = perfNow();
     ensurePerf(ctx);
@@ -584,10 +606,27 @@ export async function onRequest(ctx) {
         needPausedIndex ? fetchPausedIndex(ctx) : Promise.resolve(null),
     ]);
     // El catálogo completo sólo se necesita para el índice sin compactar,
-    // producción o fallback de una versión compacta ausente/corrupta.
-    const catalog = !useCompactSearch || !Array.isArray(activeIndex?.items)
-        ? await fetchCatalog(ctx)
-        : null;
+    // producción o fallback de una versión compacta ausente/corrupta. Una
+    // búsqueda que ya resolvió por completo con el índice activo compacto
+    // (useCompactSearch true y activeIndex válido) nunca llega a pedirlo.
+    const catalogNeeded = !useCompactSearch || !Array.isArray(activeIndex?.items);
+    // fetchCatalog() ya devuelve null ante un `!ok` o un JSON no parseable
+    // (ver fetchJsonCached en _shared/catalog.js), pero no atrapa una
+    // excepción real del `fetch()` de origen (por ejemplo R2 inalcanzable).
+    // El try/catch acá — local a esta vista, sin tocar el helper compartido
+    // con fichas/feed/sitemap — trata ese caso igual que cualquier otra
+    // falla de catalog.json: degrada a 503, nunca deja crashear la request.
+    let catalog = null;
+    if (catalogNeeded) {
+        try {
+            catalog = await fetchCatalog(ctx);
+        } catch {
+            catalog = null;
+        }
+    }
+    if (catalogNeeded && !(catalog && Array.isArray(catalog.items))) {
+        return catalogUnavailableResponse();
+    }
     const items = (catalog && Array.isArray(catalog.items)) ? catalog.items : [];
     const pausedItems = Array.isArray(pausedIndex?.items) ? pausedIndex.items : [];
     const previewBase = ctx.env?.APP_ENV === 'preview'


### PR DESCRIPTION
## Qué cambia

Cierra [#85](https://github.com/trexxeseba/amadolibros-web/issues/85). Cuando `/catalogo` necesita `catalog.json` completo (índice sin filtro, categoría sin `?q`, o fallback tras un índice activo compacto ausente/corrupto) y esa fuente falla — `!ok`, JSON no parseable, `items` no es array, o el `fetch()` de origen lanza una excepción real — la respuesta pasa a ser **503 explícito** con `Cache-Control: no-store`, `X-Robots-Tag: noindex, nofollow`, `Retry-After: 60` y un mensaje visible de indisponibilidad temporal, en vez del HTTP 200 con grilla vacía/comercialmente falsa de antes.

El chequeo se hace antes de calcular `totalPages`, así que un fallo temporal nunca se disfraza de 404 (antes, con el catálogo caído, `totalPages` caía a 1 y cualquier `?page=N>1` hubiera devuelto 404 en lugar de reflejar la falla real).

## Por qué

Issue #85: un catálogo vacío con HTTP 200 en la superficie principal de descubrimiento arriesga que Google indexe "0 libros" como estado real, y le muestra al comprador "no hay resultados" cuando en realidad el catálogo nunca cargó.

## Comportamiento preservado (no regresión)

- Una búsqueda que se resuelve por completo con el índice activo compacto (`?q=` en Preview/producción con manifest válido) **ni siquiera pide** `catalog.json` — sigue en 200.
- Una fuente válida con cero coincidencias reales sigue en 200 con "Sin resultados".
- Preview conserva su noindex/no-store global (lo aplica `functions/_middleware.js` sobre cualquier status code, sin cambios).

## Alcance estricto

Sólo `functions/catalogo.js` + su test dedicado. **No toca**: fichas, categorías (ya tenían fail-safe correcto para su propio índice), checkout, Merchant, sitemap, canonical/robots más allá del mínimo para que el 503 no sea indexable, worker-sync. No mezcla ETag/304 (eso es un lote aparte, PR #92 / issue #88).

## Validación

- **Tests focalizados**: `functions/__tests__/catalogo-degradation.test.js` — 14/14 nuevos (503 por `!ok`, excepción de red, JSON inválido, `items` no-array, filtro de categoría sin `q`, búsqueda sin índice compacto, índice compacto caído con fallback también caído, búsqueda resuelta 100% por índice compacto sin pedir `catalog.json`, cero coincidencias en 200, catálogo realmente vacío en 200, `?page=N` con catálogo caído nunca da 404, `Cache-Control: no-store` en todo 503).
- **Regresión directa**: `catalogo-paginacion.test.js` + `catalogo-categories.test.js` + `catalog-dedupe-images/display/quality-audit/source` — 117/117 OK.
- **Suite completa**: `functions/__tests__/*` 571/573 (las 2 fallas son preexistentes, no relacionadas — tests que comparan YAML de workflows contra un regex `\n` y fallan por CRLF de checkout en Windows; en CI Linux están verdes), `worker-sync` 111/111, `astro-front/src/lib` 29/29, `functions/api` 257/257.
- **Sintaxis**: `node --check` sobre `functions/scripts/worker-sync` OK.
- **Build Astro checkout OFF**: OK, con los mismos guards de `scripts/validate-ci.sh` (404.html noindex, sin controles de pago, WhatsApp presente).
- **Build Astro checkout ON**: OK, mismos guards (controles de pago presentes, Turnstile de producción, sin site key de Preview).

NO se mergea. NO se toca producción — sólo se pide deploy de Preview para esta auditoría.

🤖 Generated with [Claude Code](https://claude.com/claude-code)