### PR TITLE
SEO: enlazar fichas activas con el catálogo

### DIFF
--- a/functions/__tests__/order-lead-time-cx.test.js
+++ b/functions/__tests__/order-lead-time-cx.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  enrichActiveCatalogBreadcrumbHtml,
   enrichByRequestProductHtml,
   onRequest,
 } from '../libro/_middleware.js';
@@ -31,6 +32,14 @@ function productHtml({ inStock = false } = {}) {
   </main>
 </body>
 </html>`;
+}
+
+function breadcrumbSchema(html) {
+  for (const match of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    const parsed = JSON.parse(match[1]);
+    if (parsed?.['@type'] === 'BreadcrumbList') return parsed;
+  }
+  return null;
 }
 
 function assertLeadTime(html) {
@@ -67,6 +76,37 @@ test('una ficha activa con caja de moneda extranjera no recibe plazo de encargo'
   assert.doesNotMatch(html, /15 a 20 días/);
 });
 
+test('QW3: una ficha activa enlaza Catálogo en HTML y BreadcrumbList', () => {
+  const html = enrichActiveCatalogBreadcrumbHtml(productHtml({ inStock: true }));
+
+  assert.match(html, /<a href="\/">Inicio<\/a> ›\s*<a href="\/catalogo">Catálogo<\/a> ›\s*<span>Libro de prueba<\/span>/);
+  assert.doesNotMatch(html, /Libros por encargo/);
+
+  const schema = breadcrumbSchema(html);
+  assert.ok(schema);
+  assert.deepEqual(schema.itemListElement.map(item => [item.position, item.name]), [
+    [1, 'Inicio'],
+    [2, 'Catálogo'],
+    [3, 'Libro de prueba'],
+  ]);
+  assert.equal(schema.itemListElement[1].item, 'https://www.amadolibros.com/catalogo');
+});
+
+test('QW3: una ficha pausada queda fuera del breadcrumb de Catálogo', () => {
+  const source = productHtml();
+  assert.equal(enrichActiveCatalogBreadcrumbHtml(source), source);
+});
+
+test('QW3: el breadcrumb activo es idempotente', () => {
+  const first = enrichActiveCatalogBreadcrumbHtml(productHtml({ inStock: true }));
+  const second = enrichActiveCatalogBreadcrumbHtml(first);
+
+  assert.equal(second, first);
+  assert.equal((second.match(/href="\/catalogo">Catálogo<\/a>/g) || []).length, 1);
+  const schema = breadcrumbSchema(second);
+  assert.equal(schema.itemListElement.filter(item => item.name === 'Catálogo').length, 1);
+});
+
 test('el enriquecimiento es idempotente dentro y fuera de la cohorte', () => {
   for (const productId of [COHORT_PRODUCT_ID, OUTSIDE_COHORT_PRODUCT_ID]) {
     const first = enrichByRequestProductHtml(productHtml(), productId);
@@ -100,20 +140,27 @@ test('el middleware transforma una ficha pausada fuera de cohorte y elimina vali
   assert.equal(response.headers.get('cache-control'), 'public, max-age=3600');
 });
 
-test('el middleware devuelve intacta la Response original de una ficha activa', async () => {
+test('QW3: el middleware transforma una ficha activa, conserva cache-control y descarta validators anteriores', async () => {
   const upstream = new Response(productHtml({ inStock: true }), {
     status: 200,
     headers: {
       'content-type': 'text/html;charset=UTF-8',
+      'content-length': '999',
       etag: '"activo"',
+      'cache-control': 'public, max-age=3600',
     },
   });
   const response = await onRequest({
     request: new Request(`https://www.amadolibros.com/libro/${OUTSIDE_COHORT_PRODUCT_ID}/libro`),
     next: async () => upstream,
   });
+  const html = await response.text();
 
-  assert.equal(response, upstream);
-  assert.equal(response.headers.get('etag'), '"activo"');
-  assert.doesNotMatch(await response.text(), /15 a 20 días/);
+  assert.notEqual(response, upstream);
+  assert.match(html, /href="\/catalogo">Catálogo<\/a>/);
+  assert.doesNotMatch(html, /15 a 20 días/);
+  assert.doesNotMatch(html, /Libros por encargo/);
+  assert.equal(response.headers.get('etag'), null);
+  assert.equal(response.headers.get('content-length'), null);
+  assert.equal(response.headers.get('cache-control'), 'public, max-age=3600');
 });

--- a/functions/libro/_middleware.js
+++ b/functions/libro/_middleware.js
@@ -8,6 +8,8 @@ import {
 const PRODUCT_PATH_RE = /^\/libro\/(MLU\d+)(?:\/|$)/i;
 const BREADCRUMB_RE = /<nav>\s*<a href="\/">Inicio<\/a>\s*›\s*<span>/;
 const JSON_LD_RE = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
+const CATALOG_PATH = '/catalogo';
+const ACTIVE_PAGE_MARKER = 'class="badge in-stock"';
 const ORDER_BOX_GENERIC_COPY = '<span>Podemos intentar conseguirlo por encargo. Consultanos y verificamos disponibilidad, edición y precio.</span>';
 const ORDER_BOX_LEAD_TIME_COPY = `<span class="order-lead-time"><b>Demora estimada: 15 a 20 días desde la confirmación.</b> Salvo demoras del proveedor, courier o aduana.</span>
       <span>Antes de avanzar verificamos disponibilidad, edición y precio.</span>`;
@@ -31,6 +33,52 @@ function byRequestStyles() {
     .order-hub-actions a:hover{text-decoration:underline}
     .order-hub-actions a:focus-visible{outline:2px solid #a94e3d;outline-offset:2px}
   `;
+}
+
+function enrichCatalogBreadcrumbSchema(html) {
+  return html.replace(JSON_LD_RE, (full, rawJson) => {
+    let schema;
+    try {
+      schema = JSON.parse(rawJson);
+    } catch {
+      return full;
+    }
+    if (schema?.['@type'] !== 'BreadcrumbList' || !Array.isArray(schema.itemListElement) || schema.itemListElement.length === 0) {
+      return full;
+    }
+    const current = schema.itemListElement.at(-1);
+    schema.itemListElement = [
+      { '@type': 'ListItem', position: 1, name: 'Inicio', item: `${BASE}/` },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Catálogo',
+        item: `${BASE}${CATALOG_PATH}`,
+      },
+      { ...current, position: 3 },
+    ];
+    const serialized = JSON.stringify(schema).replace(/</g, '\\u003c');
+    return `<script type="application/ld+json">${serialized}</script>`;
+  });
+}
+
+// SEO-ACTIVE-CATALOG-BREADCRUMB: las fichas realmente disponibles recuperan
+// un enlace HTML rastreable hacia /catalogo y el mismo nivel en BreadcrumbList.
+// No se aplica a pausadas: la cohorte SEO conserva su rama específica
+// Inicio → Libros por encargo → ficha, y las pausadas fuera de cohorte no se
+// mezclan en este lote.
+export function enrichActiveCatalogBreadcrumbHtml(html) {
+  const source = String(html || '');
+  if (!source.includes(ACTIVE_PAGE_MARKER)) return source;
+
+  let result = source;
+  if (!result.includes(`<a href="${CATALOG_PATH}">Catálogo</a>`)) {
+    result = result.replace(
+      BREADCRUMB_RE,
+      `<nav>\n  <a href="/">Inicio</a> ›\n  <a href="${CATALOG_PATH}">Catálogo</a> ›\n  <span>`,
+    );
+  }
+  return enrichCatalogBreadcrumbSchema(result);
 }
 
 function enrichBreadcrumbSchema(html) {
@@ -145,10 +193,12 @@ export async function onRequest(context) {
     return response;
   }
 
-  // Se inspecciona un clon: si la página no cambia (caso normal de fichas
-  // activas), se devuelve la Response original con cuerpo y validators intactos.
+  // Se inspecciona un clon. Si ninguna transformación aplica, se devuelve la
+  // Response original con body, ETag y headers intactos. Si el HTML cambia,
+  // responseWithBody descarta validators del contenido anterior.
   const html = await response.clone().text();
-  const enriched = enrichByRequestProductHtml(html, productId);
+  const withCatalogBreadcrumb = enrichActiveCatalogBreadcrumbHtml(html);
+  const enriched = enrichByRequestProductHtml(withCatalogBreadcrumb, productId);
   if (enriched === html) return response;
   return responseWithBody(response, enriched);
 }


### PR DESCRIPTION
## Diagnóstico

Las fichas activas actualmente muestran breadcrumb HTML `Inicio → ficha` y el `BreadcrumbList` JSON-LD replica esa estructura. Eso deja a `/catalogo` sin un enlace contextual de retorno desde miles de fichas activas, aunque el catálogo es la superficie principal de descubrimiento y navegación.

## Cambio

- agrega `Inicio → Catálogo → ficha` sólo en fichas realmente activas (`badge in-stock`);
- agrega el mismo nivel `Catálogo` al `BreadcrumbList` JSON-LD;
- mantiene intactas las fichas pausadas fuera de cohorte;
- mantiene `Inicio → Libros por encargo → ficha` para la cohorte pausada SEO;
- no agrega lecturas de R2, catálogo ni requests externos;
- no cambia canonical, robots, sitemap, stock, precio, Offer, checkout, Merchant ni CTA.

## Implementación

El cambio vive en `functions/libro/_middleware.js`, que ya inspecciona el HTML de todas las fichas. Se agrega una transformación idempotente exclusiva para páginas activas antes del enriquecimiento de fichas por encargo. Si el body cambia, se eliminan `content-length` y `etag` del contenido anterior, conservando el resto de headers.

## Diff

- `functions/libro/_middleware.js`: +53 / -3
- `functions/__tests__/order-lead-time-cx.test.js`: +51 / -4
- total: 2 archivos, +104 / -7

## Tests añadidos

- ficha activa enlaza `/catalogo` en HTML;
- `BreadcrumbList` activo queda `Inicio / Catálogo / ficha`;
- ficha pausada queda fuera de este enriquecimiento;
- idempotencia del breadcrumb activo;
- middleware activo conserva `cache-control` y descarta validators del body anterior;
- no se agrega plazo ni enlaces de `Libros por encargo` a fichas activas.

## Validación

- CI `Syntax & Build`: PASS;
- Preview aislado: `https://pr-195.amadolibros-web.pages.dev`;
- primer intento de auditoría: falló por propagación del alias Cloudflare (`home 200/feed 404`, luego `home 404/feed 200`; `sitemap.xml` 404 temporal), sin fallo de código;
- rerun de los jobs fallidos: PASS completo;
- auditoría comercial: `result=pass`, `critical=0`;
- feed: 3.646 ítems, 0 critical, 0 warnings;
- catálogo auditado: 7.075 activos, 0 critical;
- imágenes: 80/80 válidas;
- páginas: 80/80 PASS sobre 10.020 URLs de libros del sitemap;
- hub por encargo: 2.949/2.949 enlazados, 62 páginas, 0 failures.

## Riesgo residual

Bajo y acotado a la navegación SSR de fichas activas. El middleware ya clonaba el HTML de producto antes de este lote; no se agrega una lectura de red. El costo nuevo es reemplazo de breadcrumb + parseo del JSON-LD BreadcrumbList en las fichas activas. Las fichas pausadas mantienen su rama SEO existente.

## Producción

Sin cambios. No fusionar sin aprobación explícita.