### PR TITLE
SEO: corregir Product schema sin oferta real

### DIFF
--- a/docs/seo/product-schema-fix-note.md
+++ b/docs/seo/product-schema-fix-note.md
@@ -1,0 +1,8 @@
+# SEO-PRODUCT-SCHEMA-1
+
+Corrección semántica para fichas de libro sin una señal elegible de Product snippet.
+
+- Si el JSON-LD declara `Product` + `Book` pero no contiene `offers`, `review` ni `aggregateRating`, se degrada a `Book`.
+- No se inventan precios, disponibilidad, reseñas ni ratings.
+- Las fichas vendibles con `Offer` real conservan `Product` + `Book`.
+- Canonical, robots, sitemap, stock, checkout y Merchant quedan fuera de alcance.

--- a/docs/seo/product-schema-fix-note.md
+++ b/docs/seo/product-schema-fix-note.md
@@ -1,8 +1,0 @@
-# SEO-PRODUCT-SCHEMA-1
-
-Corrección semántica para fichas de libro sin una señal elegible de Product snippet.
-
-- Si el JSON-LD declara `Product` + `Book` pero no contiene `offers`, `review` ni `aggregateRating`, se degrada a `Book`.
-- No se inventan precios, disponibilidad, reseñas ni ratings.
-- Las fichas vendibles con `Offer` real conservan `Product` + `Book`.
-- Canonical, robots, sitemap, stock, checkout y Merchant quedan fuera de alcance.

--- a/functions/__tests__/product-schema-eligibility.test.js
+++ b/functions/__tests__/product-schema-eligibility.test.js
@@ -1,0 +1,177 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normalizeProductSnippetSchemaHtml,
+  onRequest,
+} from '../libro/_middleware.js';
+
+const PRODUCT_ID = 'MLU123456789';
+
+function htmlWithSchema({
+  productType = ['Product', 'Book'],
+  offers,
+  review,
+  aggregateRating,
+  active = false,
+  paused = false,
+  robots = 'index, follow',
+} = {}) {
+  const product = {
+    '@context': 'https://schema.org',
+    '@type': productType,
+    name: 'Libro de prueba',
+    sku: PRODUCT_ID,
+    isbn: '9780000000001',
+    author: { '@type': 'Person', name: 'Autora Prueba' },
+    ...(offers ? { offers } : {}),
+    ...(review ? { review } : {}),
+    ...(aggregateRating ? { aggregateRating } : {}),
+  };
+  const breadcrumb = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Inicio', item: 'https://www.amadolibros.com/' },
+      { '@type': 'ListItem', position: 2, name: 'Libro de prueba' },
+    ],
+  };
+  const commercial = active
+    ? '<span class="badge in-stock">✓ En stock</span><div class="price-box">$1.000 UYU</div>'
+    : paused
+      ? '<div class="order-box"><strong>¿Buscás este libro?</strong><span>Podemos intentar conseguirlo por encargo. Consultanos y verificamos disponibilidad, edición y precio.</span></div>'
+      : '<span class="badge in-stock">✓ En stock</span><div class="order-box"><strong>Precio publicado: USD 10</strong><span>Esta publicación no se convierte automáticamente a UYU. Consultanos para confirmar precio y forma de pago, o comprala directamente en MercadoLibre.</span></div>';
+
+  return `<!doctype html><html><head>
+    <meta name="robots" content="${robots}">
+    <link rel="canonical" href="https://www.amadolibros.com/libro/${PRODUCT_ID}/libro-de-prueba">
+    <script type="application/ld+json">${JSON.stringify(product)}</script>
+    <script type="application/ld+json">${JSON.stringify(breadcrumb)}</script>
+    <style>main{display:grid}</style>
+  </head><body>
+    <nav><a href="/">Inicio</a> › <span>Libro de prueba</span></nav>
+    <main>${commercial}</main>
+  </body></html>`;
+}
+
+function jsonLd(html) {
+  return [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+    .map((match) => JSON.parse(match[1]));
+}
+
+function productSchema(html) {
+  return jsonLd(html).find((schema) => schema?.sku === PRODUCT_ID);
+}
+
+test('ficha activa vendible conserva Product + Book + Offer real', () => {
+  const offer = {
+    '@type': 'Offer',
+    priceCurrency: 'UYU',
+    price: '1000',
+    availability: 'https://schema.org/InStock',
+  };
+  const source = htmlWithSchema({ active: true, offers: offer });
+  const result = normalizeProductSnippetSchemaHtml(source);
+  const schema = productSchema(result);
+
+  assert.deepEqual(schema['@type'], ['Product', 'Book']);
+  assert.deepEqual(schema.offers, offer);
+});
+
+test('ficha por encargo sin Offer queda como Book y no inventa señales comerciales', () => {
+  const source = htmlWithSchema({ paused: true });
+  const result = normalizeProductSnippetSchemaHtml(source);
+  const schema = productSchema(result);
+
+  assert.equal(schema['@type'], 'Book');
+  assert.equal(schema.offers, undefined);
+  assert.equal(schema.review, undefined);
+  assert.equal(schema.aggregateRating, undefined);
+  assert.equal(schema.isbn, '9780000000001');
+  assert.equal(schema.author.name, 'Autora Prueba');
+});
+
+test('activo en moneda no soportada sin Offer queda como Book', () => {
+  const source = htmlWithSchema();
+  const result = normalizeProductSnippetSchemaHtml(source);
+  const schema = productSchema(result);
+
+  assert.equal(schema['@type'], 'Book');
+  assert.equal(schema.offers, undefined);
+});
+
+test('Product + Book con review real permanece elegible', () => {
+  const review = {
+    '@type': 'Review',
+    reviewRating: { '@type': 'Rating', ratingValue: '5' },
+    author: { '@type': 'Person', name: 'Cliente real' },
+  };
+  const source = htmlWithSchema({ review });
+  const result = normalizeProductSnippetSchemaHtml(source);
+  const schema = productSchema(result);
+
+  assert.deepEqual(schema['@type'], ['Product', 'Book']);
+  assert.deepEqual(schema.review, review);
+});
+
+test('normalización es idempotente', () => {
+  const first = normalizeProductSnippetSchemaHtml(htmlWithSchema({ paused: true }));
+  const second = normalizeProductSnippetSchemaHtml(first);
+  assert.equal(second, first);
+});
+
+test('middleware preserva canonical y robots de ficha por encargo mientras corrige schema', async () => {
+  const source = htmlWithSchema({ paused: true, robots: 'index, follow' });
+  const upstream = new Response(source, {
+    status: 200,
+    headers: {
+      'content-type': 'text/html;charset=UTF-8',
+      'cache-control': 'public, max-age=3600',
+      etag: '"anterior"',
+    },
+  });
+  const response = await onRequest({
+    request: new Request(`https://www.amadolibros.com/libro/${PRODUCT_ID}/libro-de-prueba`),
+    next: async () => upstream,
+  });
+  const html = await response.text();
+  const schema = productSchema(html);
+
+  assert.equal(schema['@type'], 'Book');
+  assert.match(html, /<meta name="robots" content="index, follow">/);
+  assert.match(html, new RegExp(`<link rel="canonical" href="https://www\\.amadolibros\\.com/libro/${PRODUCT_ID}/libro-de-prueba">`));
+  assert.equal(response.headers.get('cache-control'), 'public, max-age=3600');
+  assert.equal(response.headers.get('etag'), null);
+});
+
+test('middleware activo vendible conserva Product + Book + Offer y breadcrumb de catálogo', async () => {
+  const source = htmlWithSchema({
+    active: true,
+    offers: {
+      '@type': 'Offer',
+      priceCurrency: 'UYU',
+      price: '1000',
+      availability: 'https://schema.org/InStock',
+    },
+  });
+  const upstream = new Response(source, {
+    status: 200,
+    headers: { 'content-type': 'text/html;charset=UTF-8' },
+  });
+  const response = await onRequest({
+    request: new Request(`https://www.amadolibros.com/libro/${PRODUCT_ID}/libro-de-prueba`),
+    next: async () => upstream,
+  });
+  const html = await response.text();
+  const schema = productSchema(html);
+
+  assert.deepEqual(schema['@type'], ['Product', 'Book']);
+  assert.ok(schema.offers);
+  assert.match(html, /<a href="\/catalogo">Catálogo<\/a>/);
+});
+
+test('schema que no es Product/Book queda intacto', () => {
+  const source = htmlWithSchema({ productType: 'Book', paused: true });
+  const result = normalizeProductSnippetSchemaHtml(source);
+  assert.equal(result, source);
+});

--- a/functions/libro/_middleware.js
+++ b/functions/libro/_middleware.js
@@ -164,6 +164,36 @@ export function enrichByRequestProductHtml(html, productId) {
   return result;
 }
 
+// SEO-PRODUCT-SCHEMA-1: Google exige que Product tenga al menos una señal
+// elegible para fragmentos de producto (Offer, review o aggregateRating).
+// Las fichas sin oferta real no deben fingir precio, disponibilidad ni reseñas:
+// conservan toda la semántica bibliográfica como Book y dejan de declarar
+// Product hasta que exista una señal elegible real.
+export function normalizeProductSnippetSchemaHtml(html) {
+  const source = String(html || '');
+  return source.replace(JSON_LD_RE, (full, rawJson) => {
+    let schema;
+    try {
+      schema = JSON.parse(rawJson);
+    } catch {
+      return full;
+    }
+
+    const rawType = schema?.['@type'];
+    const types = Array.isArray(rawType) ? rawType : [rawType].filter(Boolean);
+    if (!types.includes('Product') || !types.includes('Book')) return full;
+
+    const hasEligibleProductSignal = Boolean(
+      schema.offers || schema.review || schema.aggregateRating,
+    );
+    if (hasEligibleProductSignal) return full;
+
+    schema['@type'] = 'Book';
+    const serialized = JSON.stringify(schema).replace(/</g, '\\u003c');
+    return `<script type="application/ld+json">${serialized}</script>`;
+  });
+}
+
 function productIdFromRequest(request) {
   try {
     return new URL(request.url).pathname.match(PRODUCT_PATH_RE)?.[1]?.toUpperCase() || null;
@@ -198,7 +228,8 @@ export async function onRequest(context) {
   // responseWithBody descarta validators del contenido anterior.
   const html = await response.clone().text();
   const withCatalogBreadcrumb = enrichActiveCatalogBreadcrumbHtml(html);
-  const enriched = enrichByRequestProductHtml(withCatalogBreadcrumb, productId);
+  const withByRequestCx = enrichByRequestProductHtml(withCatalogBreadcrumb, productId);
+  const enriched = normalizeProductSnippetSchemaHtml(withByRequestCx);
   if (enriched === html) return response;
   return responseWithBody(response, enriched);
 }


### PR DESCRIPTION
## Diagnóstico

Search Console reportó el problema crítico de Product snippets: debe especificarse `offers`, `review` o `aggregateRating`. En la ficha SSR, todas las obras se declaran hoy como `Product + Book`, pero `offers` sólo existe cuando hay una oferta real vendible. Eso deja fichas por encargo y activas no vendibles declaradas como `Product` sin una señal elegible.

La lectura viva de Search Console confirma que esta superficie importa: en los últimos 28 días `PRODUCT_SNIPPETS` generó 2.732 impresiones y 113 clics (CTR 4,14%, posición media 17,03). En el período anterior comparable había 2.473 impresiones y 75 clics (CTR 3,03%, posición 19,38).

## Cambio

- si un JSON-LD `Product + Book` no tiene `offers`, `review` ni `aggregateRating`, se normaliza a `Book`;
- una ficha activa vendible con `Offer` real conserva `Product + Book + Offer`;
- no se inventan precios, stock, `Offer`, reseñas ni ratings;
- se preservan ISBN, autor y el resto de datos bibliográficos;
- canonical, robots, sitemap, stock, checkout, Merchant y CTA quedan fuera de alcance.

## Implementación

El ajuste vive en `functions/libro/_middleware.js`, donde ya se inspecciona el HTML SSR de las fichas. Se aplica después de los enriquecimientos existentes de breadcrumb y por-encargo. La transformación es idempotente y sólo modifica el JSON-LD cuando detecta exactamente `Product + Book` sin ninguna señal elegible.

## Diff

- `functions/libro/_middleware.js`: +32 / -1
- `functions/__tests__/product-schema-eligibility.test.js`: +177
- total efectivo: 2 archivos, +209 / -1.

## Tests nuevos

- activa vendible conserva `Product + Book + Offer`;
- por encargo sin Offer queda `Book` sin inventar campos comerciales;
- activa en moneda no soportada queda `Book`;
- `review` real preserva elegibilidad de Product;
- normalización idempotente;
- middleware preserva canonical/robots/cache-control;
- activa vendible conserva breadcrumb de catálogo y Offer;
- schema que ya es sólo `Book` queda intacto.

## Validación

- CI `Syntax & Build`: PASS;
- Preview: `https://pr-197.amadolibros-web.pages.dev`;
- primer audit Preview: 78/80 páginas, con 2 respuestas 404 transitorias de catálogo/snapshot; feed y catálogo sin críticos;
- rerun del mismo Preview: PASS completo;
- auditoría comercial final: `result=pass`, `critical=0`;
- feed: 3.653 ítems, 0 critical, 0 warnings;
- catálogo: 7.079 activos, 0 critical;
- imágenes: 80/80 válidas;
- páginas: 80/80 PASS sobre 10.024 URLs de libros del sitemap;
- hub por encargo: 2.949/2.949 enlazados, 62 páginas, 0 failures.

## Riesgo residual

Bajo. El cambio sólo corrige la clasificación JSON-LD de fichas que hoy declaran `Product` sin ninguna señal elegible. Las fichas con Offer real no cambian. Google deberá recrawlear las URLs antes de que Search Console cierre el problema.

## Producción

Sin cambios. No fusionar sin aprobación explícita.