### PR TITLE
SEO: recuperar tráfico de paginación legacy de tienda

### DIFF
--- a/functions/__tests__/legacy-redirects.test.js
+++ b/functions/__tests__/legacy-redirects.test.js
@@ -108,14 +108,20 @@ test('add-to-cart sin mapping WooCommerce → MLU devuelve 410', async () => {
     }
 });
 
-test('paginaciones históricas /page, /tienda/page y /shop/page devuelven 410', async () => {
-    for (const path of [
-        '/page/1',
-        '/page/122/',
-        '/tienda/page/2',
-        '/tienda/page/43/',
-        '/shop/page/8/',
-    ]) {
+test('paginación histórica /tienda/page/N redirige al catálogo sin trasladar N', async () => {
+    for (const path of ['/tienda/page/2', '/tienda/page/43/']) {
+        const response = await legacyResponseForRequest(contextFor(path));
+        assert.equal(response.status, 301, path);
+        assert.equal(
+            response.headers.get('location'),
+            'https://www.amadolibros.com/catalogo',
+            path,
+        );
+    }
+});
+
+test('paginaciones históricas /page/N y /shop/page/N sin equivalencia mantienen 410', async () => {
+    for (const path of ['/page/1', '/page/122/', '/shop/page/8/']) {
         const response = await legacyResponseForRequest(contextFor(path));
         assert.equal(response.status, 410, path);
     }
@@ -214,6 +220,16 @@ test('legacy conserva el host aislado de Preview', async () => {
     const host = 'agent-seo-p3.amadolibros-web.pages.dev';
     const response = await legacyResponseForRequest(
         contextFor('/tienda/', host, { APP_ENV: 'preview' }),
+    );
+
+    assert.equal(response.status, 301);
+    assert.equal(response.headers.get('location'), `https://${host}/catalogo`);
+});
+
+test('paginación de tienda en Preview conserva el host aislado', async () => {
+    const host = 'agent-seo-p3.amadolibros-web.pages.dev';
+    const response = await legacyResponseForRequest(
+        contextFor('/tienda/page/43/', host, { APP_ENV: 'preview' }),
     );
 
     assert.equal(response.status, 301);

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -153,7 +153,15 @@ export async function legacyResponseForRequest(context, options = {}) {
         return goneFor(request, 'query_add_to_cart');
     }
 
-    if (/^\/(?:tienda|shop)\/page\/\d+$/.test(path) || /^\/page\/\d+$/.test(path)) {
+    // SEO-LEGACY-TIENDA-PAGINATION: Search Console todavía atribuye clics e
+    // impresiones de marca a /tienda/page/N. La tienda legacy sí tiene un
+    // reemplazo inequívoco en /catalogo, pero el número de página histórico no
+    // garantiza el mismo conjunto/orden de libros, por eso no se traslada N.
+    if (/^\/tienda\/page\/\d+$/.test(path)) {
+        return redirectFor(request, 'legacy_tienda_pagination_catalog', '/catalogo');
+    }
+
+    if (/^\/shop\/page\/\d+$/.test(path) || /^\/page\/\d+$/.test(path)) {
         return goneFor(request, 'legacy_pagination');
     }
 


### PR DESCRIPTION
## Diagnóstico

Search Console sigue atribuyendo tráfico a `https://www.amadolibros.com/tienda/page/43/`: 86 impresiones, 12 clics, CTR 13,95% y posición media 4,45 en los últimos 28 días. El desglose query+page muestra que la principal consulta es `amado libros` (58 impresiones, posición 4,22), por lo que el valor es de marca/navegación y no depende del contenido exacto de la antigua página 43.

El middleware actual devuelve 410 para `/tienda/page/N`, `/shop/page/N` y `/page/N`.

## Cambio

- `/tienda/page/N` pasa a 301 permanente hacia `/catalogo`;
- no se traslada `N` a `/catalogo?page=N`, porque el orden/conjunto histórico de libros no puede garantizarse;
- `/shop/page/N` y `/page/N` mantienen 410;
- Preview conserva su host aislado;
- no se tocan fichas, canonical, robots, sitemap, catálogo, checkout, Merchant ni schema.

## Diff

- `functions/_middleware.js`: +9 / -1
- `functions/__tests__/legacy-redirects.test.js`: +24 / -8
- total: 2 archivos, +33 / -9.

## Tests

- `/tienda/page/2` y `/tienda/page/43/` → 301 `/catalogo`;
- `/page/N` y `/shop/page/N` siguen 410;
- Preview paginado conserva `pages.dev`;
- patrones parecidos no se capturan;
- cleanup sigue ocurriendo antes de `context.next()`.

## Validación

- CI `Syntax & Build`: PASS;
- Preview aislado: `https://pr-199.amadolibros-web.pages.dev`;
- primer audit Preview falló durante propagación del alias Cloudflare: 43/80 fichas devolvieron 404 mientras el alias todavía alternaba `home 404 / feed 200`; no fue una regresión del routing;
- rerun de jobs fallidos: PASS completo;
- auditoría comercial final: `result=pass`, `critical=0`;
- feed: 3.653 ítems, 0 critical, 0 warnings;
- catálogo: 7.079 activos, 0 critical;
- imágenes: 80/80 válidas;
- páginas: 80/80 PASS sobre 10.024 URLs del sitemap;
- hub por encargo: 2.949/2.949 enlazados, 62 páginas, 0 failures.

## Riesgo

Bajo y acotado al routing legacy `/tienda/page/N`. Se evita el mapeo dudoso por número de página y se usa el reemplazo inequívoco de la antigua tienda: `/catalogo`.

## Producción

Sin cambios. No fusionar sin aprobación explícita.