### PR TITLE
SEO/CX: desplegar las primeras 1000 fichas vidriera

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -84,6 +84,14 @@ jobs:
           COMMERCE_FAIL_ON_CRITICAL: 'true'
         run: node scripts/commerce/full-commerce-audit.mjs
 
+      - name: Audit showcase product samples
+        env:
+          SHOWCASE_BASE_URL: ${{ steps.deploy.outputs.preview_url }}
+          SHOWCASE_EXPECT_INDEXABLE: 'false'
+          SHOWCASE_OUTPUT_DIR: artifacts/showcase-preview
+          SHOWCASE_CONCURRENCY: '5'
+        run: node scripts/seo/showcase-live-audit.mjs
+
       - name: Audit by-request hub link graph
         env:
           SEO_BASE_URL: ${{ steps.deploy.outputs.preview_url }}
@@ -98,6 +106,15 @@ jobs:
         with:
           name: commerce-preview-pr-${{ github.event.pull_request.number }}
           path: artifacts/commerce-preview/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload showcase report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: showcase-preview-pr-${{ github.event.pull_request.number }}
+          path: artifacts/showcase-preview/
           if-no-files-found: error
           retention-days: 30
 

--- a/functions/__tests__/automatic-product-showcase.test.js
+++ b/functions/__tests__/automatic-product-showcase.test.js
@@ -1,0 +1,182 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildAutomaticProductShowcase,
+  productItemFromProductHtml,
+} from '../_shared/automatic-product-showcase.js';
+import {
+  enrichAutomaticProductShowcaseHtml,
+  enrichProductShowcaseHtml,
+} from '../libro/_middleware.js';
+import { renderPage } from '../libro/[[path]].js';
+
+const PRODUCT_ID = 'MLU123456789';
+const SLUG = 'manual-de-prueba-clinica';
+
+function book(overrides = {}) {
+  return {
+    id: PRODUCT_ID,
+    title: 'Manual de prueba clínica',
+    author: 'Ana Pérez',
+    isbn: '9788496836693',
+    publisher: 'Editorial Real',
+    pages: 320,
+    price: 1990,
+    currency: 'UYU',
+    status: 'active',
+    available_quantity: 3,
+    condition: 'new',
+    thumbnail: 'https://http2.mlstatic.com/D_1-I.jpg',
+    pictures: [
+      'https://http2.mlstatic.com/D_1-O.jpg',
+      'https://http2.mlstatic.com/D_2-O.jpg',
+    ],
+    permalink: 'https://articulo.mercadolibre.com.uy/MLU-123456789',
+    bibliographic: {
+      subtitle: 'Herramientas para la práctica',
+      language: 'Español',
+      format: 'Tapa blanda',
+      edition: '2.ª edición',
+      publication_year: '2024',
+      genre: 'Psicología clínica',
+      collection: 'Biblioteca Profesional',
+      translator: 'María Gómez',
+    },
+    dimensions: { width: '16 cm', height: '23 cm', weight: '540 g' },
+    description: 'Este manual presenta un recorrido sistemático por la evaluación clínica. Incluye criterios para organizar entrevistas, registrar hipótesis y revisar decisiones. Está orientado a una aplicación responsable y contextualizada. También incorpora ejemplos para acompañar el estudio y la práctica profesional.',
+    ...overrides,
+  };
+}
+
+function rendered(item = book(), relatedBooks = []) {
+  return renderPage(item, SLUG, false, '', '', relatedBooks);
+}
+
+function productSchema(html) {
+  for (const match of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    const schema = JSON.parse(match[1]);
+    const types = Array.isArray(schema['@type']) ? schema['@type'] : [schema['@type']];
+    if (types.includes('Book') && schema.sku === PRODUCT_ID) return schema;
+  }
+  return null;
+}
+
+test('extrae del HTML SSR únicamente datos reales de la publicación', () => {
+  const item = productItemFromProductHtml(rendered(), PRODUCT_ID);
+
+  assert.equal(item.id, PRODUCT_ID);
+  assert.equal(item.title, 'Manual de prueba clínica');
+  assert.equal(item.author, 'Ana Pérez');
+  assert.equal(item.isbn, '9788496836693');
+  assert.equal(item.publisher, 'Editorial Real');
+  assert.equal(item.pages, 320);
+  assert.equal(item.condition, 'Nuevo');
+  assert.equal(item.bibliographic.subtitle, 'Herramientas para la práctica');
+  assert.equal(item.bibliographic.genre, 'Psicología clínica');
+  assert.equal(item.bibliographic.translator, 'María Gómez');
+  assert.match(item.description, /evaluación clínica/);
+  assert.equal(item.pictures.length, 2);
+  assert.match(item.dimensions_text, /Ancho 16 cm/);
+});
+
+test('usa la descripción real y todos los datos verificables', () => {
+  const showcase = buildAutomaticProductShowcase(book());
+
+  assert.equal(showcase.subtitle, 'Herramientas para la práctica');
+  assert.match(showcase.introHeading, /¿De qué trata Manual de prueba clínica\?/);
+  assert.ok(showcase.summary.join(' ').includes('evaluación clínica'));
+  assert.ok(showcase.highlights.some(value => value.includes('Psicología clínica')));
+  assert.ok(showcase.editionFacts.some(fact => fact.label === 'ISBN' && fact.value === '9788496836693'));
+  assert.ok(showcase.editionFacts.some(fact => fact.label === 'Medidas' && fact.value.includes('alto 23 cm')));
+  assert.ok(showcase.links.some(link => link.href.includes('Ana%20P%C3%A9rez')));
+  assert.match(showcase.metaDescription, /12% menos por transferencia/);
+  assert.ok(showcase.metaDescription.length <= 170);
+});
+
+test('sin descripción no inventa una sinopsis y lo declara con hechos', () => {
+  const showcase = buildAutomaticProductShowcase(book({ description: null }));
+
+  assert.equal(showcase.introHeading, 'Sobre Manual de prueba clínica');
+  assert.match(showcase.summary[0], /Esta ficha corresponde/);
+  assert.match(showcase.summary.join(' '), /ISBN 9788496836693/);
+  assert.doesNotMatch(showcase.summary.join(' '), /presenta un recorrido sistemático/);
+});
+
+test('sin autor confiable no inventa biografía', () => {
+  const showcase = buildAutomaticProductShowcase(book({ author: 'Varios autores' }));
+
+  assert.equal(showcase.authorHeading, 'Sobre la autoría');
+  assert.match(showcase.authorBio, /No completamos ese dato por inferencia/);
+  assert.ok(!showcase.links.some(link => link.label.includes('Varios autores')));
+});
+
+test('no duplica un subtítulo ya incluido en el título', () => {
+  const showcase = buildAutomaticProductShowcase(book({
+    title: 'Manual de prueba clínica: Herramientas para la práctica',
+  }));
+
+  assert.equal(showcase.subtitle, 'De Ana Pérez');
+});
+
+test('convierte una ficha activa en vidriera sin tocar precio, stock ni acciones', () => {
+  const source = rendered();
+  const html = enrichAutomaticProductShowcaseHtml(source, PRODUCT_ID);
+
+  assert.match(html, /class="product-showcase"/);
+  assert.match(html, /¿De qué trata Manual de prueba clínica\?/);
+  assert.match(html, /Datos destacados/);
+  assert.match(html, /¿Para quién puede ser útil\?/);
+  assert.match(html, /Más sobre Ana Pérez/);
+  assert.match(html, /Ficha de esta edición/);
+  assert.match(html, /Herramientas para la práctica/);
+  assert.match(html, /Editorial Real/);
+  assert.match(html, /data-action="add-to-cart"/);
+  assert.match(html, /Precio web\/tarjeta:/);
+  assert.match(html, /12% menos por transferencia/);
+  assert.match(html, /Comprar en MercadoLibre/);
+  assert.match(html, /https:\/\/articulo\.mercadolibre\.com\.uy\/MLU-123456789/);
+  assert.match(html, /<meta name="description" content="Comprá Manual de prueba clínica de Ana Pérez en Uruguay\./);
+
+  const schema = productSchema(html);
+  assert.ok(schema);
+  assert.deepEqual(schema['@type'], ['Product', 'Book']);
+  assert.equal(schema.offers.price, '1990');
+  assert.equal(schema.offers.availability, 'https://schema.org/InStock');
+  assert.match(schema.description, /evaluación clínica/);
+  assert.equal(schema.review, undefined);
+  assert.equal(schema.aggregateRating, undefined);
+});
+
+test('la vidriera aparece antes de los libros relacionados', () => {
+  const related = [{
+    id: 'MLU987654321',
+    title: 'Otro libro de Ana Pérez',
+    author: 'Ana Pérez',
+    status: 'active',
+    available_quantity: 1,
+    thumbnail: 'https://http2.mlstatic.com/D_3-I.jpg',
+    pictures: [],
+  }];
+  const html = enrichAutomaticProductShowcaseHtml(rendered(book(), related), PRODUCT_ID);
+
+  assert.ok(html.indexOf('class="product-showcase"') < html.indexOf('class="related-books"'));
+});
+
+test('es idempotente y no reemplaza una ficha curada manualmente', () => {
+  const source = rendered();
+  const first = enrichAutomaticProductShowcaseHtml(source, PRODUCT_ID);
+  const second = enrichAutomaticProductShowcaseHtml(first, PRODUCT_ID);
+  assert.equal(second, first);
+  assert.equal((second.match(/class="product-showcase"/g) || []).length, 1);
+
+  const curatedId = 'MLU633557235';
+  const curatedSource = rendered(book({ id: curatedId }));
+  assert.equal(enrichAutomaticProductShowcaseHtml(curatedSource, curatedId), curatedSource);
+  assert.notEqual(enrichProductShowcaseHtml(curatedSource, curatedId), curatedSource);
+});
+
+test('una ficha pausada no recibe la vidriera automática activa', () => {
+  const source = rendered(book({ status: 'paused', available_quantity: 0 }));
+  assert.equal(enrichAutomaticProductShowcaseHtml(source, PRODUCT_ID), source);
+});

--- a/functions/__tests__/order-hub-product-links.test.js
+++ b/functions/__tests__/order-hub-product-links.test.js
@@ -134,7 +134,8 @@ test('una ficha pausada fuera de la cohorte recibe el plazo sin enlaces SEO', ()
   ]);
 });
 
-test('el middleware no agrega lecturas de catálogo o R2 al camino de la ficha', () => {
+test('el middleware evita el catálogo completo y usa sólo la cohorte compacta de IDs', () => {
   const source = readFileSync('functions/libro/_middleware.js', 'utf8');
   assert.doesNotMatch(source, /fetchPausedIndex|fetchPausedItem|fetchCatalog|R2_BASE/);
+  assert.match(source, /isProductInShowcaseCohort/);
 });

--- a/functions/__tests__/showcase-cohort.test.js
+++ b/functions/__tests__/showcase-cohort.test.js
@@ -1,0 +1,158 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  fetchShowcaseCohort,
+  isProductInShowcaseCohort,
+  normalizeShowcaseCohort,
+  resetShowcaseCohortMemoryForTests,
+  SHOWCASE_PREVIEW_SAMPLE_IDS,
+} from '../_shared/showcase-cohort.js';
+
+function context(appEnv = 'preview') {
+  return {
+    env: { APP_ENV: appEnv },
+    data: {},
+    waitUntil() {},
+  };
+}
+
+function installCache() {
+  const writes = [];
+  globalThis.caches = {
+    default: {
+      async match() { return null; },
+      async put(key, value) { writes.push({ key, value }); },
+    },
+  };
+  return writes;
+}
+
+test('acepta una cohorte compacta, única y limitada a 1000 MLU', () => {
+  const ids = Array.from({ length: 1000 }, (_, index) => `MLU${100000000 + index}`);
+  const cohort = normalizeShowcaseCohort({
+    schema_version: 1,
+    generated_at: '2026-08-20T12:00:00.000Z',
+    catalog_version: '2026-08-20T12:00:00.000Z',
+    total: ids.length,
+    ids,
+  });
+
+  assert.ok(cohort);
+  assert.equal(cohort.total, 1000);
+  assert.equal(cohort.ids.size, 1000);
+  assert.equal(cohort.ids.has(ids[999]), true);
+  assert.equal(cohort.source, 'r2');
+});
+
+test('rechaza duplicados, IDs inválidos, total cruzado y más de 1000', () => {
+  assert.equal(normalizeShowcaseCohort({
+    schema_version: 1,
+    total: 2,
+    ids: ['MLU1', 'MLU1'],
+  }), null);
+  assert.equal(normalizeShowcaseCohort({
+    schema_version: 1,
+    total: 1,
+    ids: ['ABC1'],
+  }), null);
+  assert.equal(normalizeShowcaseCohort({
+    schema_version: 1,
+    total: 2,
+    ids: ['MLU1'],
+  }), null);
+  assert.equal(normalizeShowcaseCohort({
+    schema_version: 1,
+    total: 1001,
+    ids: Array.from({ length: 1001 }, (_, index) => `MLU${index + 1}`),
+  }), null);
+});
+
+test('Preview usa una muestra controlada si la cohorte todavía no existe', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalCaches = globalThis.caches;
+  installCache();
+  globalThis.fetch = async () => new Response('ausente', { status: 404 });
+  resetShowcaseCohortMemoryForTests();
+
+  try {
+    const preview = await fetchShowcaseCohort(context('preview'));
+    assert.equal(preview.source, 'preview-fallback');
+    assert.deepEqual([...preview.ids], SHOWCASE_PREVIEW_SAMPLE_IDS);
+    assert.equal(
+      await isProductInShowcaseCohort(context('preview'), SHOWCASE_PREVIEW_SAMPLE_IDS[0]),
+      true,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.caches = originalCaches;
+    resetShowcaseCohortMemoryForTests();
+  }
+});
+
+test('Producción nunca usa la muestra de Preview si falta el archivo', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalCaches = globalThis.caches;
+  installCache();
+  globalThis.fetch = async () => new Response('ausente', { status: 404 });
+  resetShowcaseCohortMemoryForTests();
+
+  try {
+    assert.equal(await fetchShowcaseCohort(context('production')), null);
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.caches = originalCaches;
+    resetShowcaseCohortMemoryForTests();
+  }
+});
+
+test('lee R2, normaliza la cohorte y permite consultar pertenencia por ID', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalCaches = globalThis.caches;
+  const writes = installCache();
+  globalThis.fetch = async () => Response.json({
+    schema_version: 1,
+    generated_at: '2026-08-20T12:00:00.000Z',
+    catalog_version: '2026-08-20T12:00:00.000Z',
+    total: 3,
+    ids: ['MLU10', 'MLU20', 'MLU30'],
+  });
+  resetShowcaseCohortMemoryForTests();
+
+  try {
+    const ctx = context('production');
+    const cohort = await fetchShowcaseCohort(ctx);
+    assert.equal(cohort.source, 'r2');
+    assert.equal(cohort.ids.has('MLU20'), true);
+    assert.equal(writes.length, 1);
+    assert.equal(await isProductInShowcaseCohort(ctx, 'mlu20'), true);
+    assert.equal(await isProductInShowcaseCohort(ctx, 'MLU99'), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.caches = originalCaches;
+    resetShowcaseCohortMemoryForTests();
+  }
+});
+
+test('fuera de Preview/Producción no hace fetch ni consulta caché', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalCaches = globalThis.caches;
+  let calls = 0;
+  globalThis.fetch = async () => { calls++; return Response.json({}); };
+  globalThis.caches = {
+    default: {
+      async match() { calls++; return null; },
+      async put() { calls++; },
+    },
+  };
+  resetShowcaseCohortMemoryForTests();
+
+  try {
+    assert.equal(await fetchShowcaseCohort(context('test')), null);
+    assert.equal(calls, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.caches = originalCaches;
+    resetShowcaseCohortMemoryForTests();
+  }
+});

--- a/functions/__tests__/showcase-ranking.test.js
+++ b/functions/__tests__/showcase-ranking.test.js
@@ -1,0 +1,144 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  assignShowcaseRanking,
+  isShowcaseEligible,
+  normalizeValidIsbn,
+  rankShowcaseItems,
+  showcaseEditionKey,
+} from '../_shared/showcase-ranking.js';
+
+function item(index, overrides = {}) {
+  return {
+    id: `MLU${100000000 + index}`,
+    title: `Libro de prueba ${index}`,
+    author: `Autor ${index}`,
+    price: 1000 + index,
+    currency: 'UYU',
+    status: 'active',
+    available_quantity: 1,
+    condition: 'new',
+    pictures: [`https://img/${index}.jpg`],
+    publisher: 'Editorial real',
+    pages: 200,
+    bibliographic: { language: 'Español', format: 'Tapa blanda' },
+    ...overrides,
+  };
+}
+
+test('normaliza ISBN válidos y rechaza checksums falsos', () => {
+  assert.equal(normalizeValidIsbn('978-84-96836-69-3'), '9788496836693');
+  assert.equal(normalizeValidIsbn('849683669X'), '9788496836693');
+  assert.equal(normalizeValidIsbn('9780000000000'), null);
+  assert.equal(normalizeValidIsbn('1234567890128'), null);
+});
+
+test('selecciona exactamente mil ediciones y asigna rango continuo', () => {
+  const items = Array.from({ length: 1200 }, (_, index) => item(index));
+  const metrics = assignShowcaseRanking(items, { limit: 1000 });
+  const selected = items.filter(entry => entry.showcase_rank);
+
+  assert.equal(metrics.selected_items, 1000);
+  assert.equal(selected.length, 1000);
+  assert.deepEqual(
+    selected.map(entry => entry.showcase_rank).sort((a, b) => a - b),
+    Array.from({ length: 1000 }, (_, index) => index + 1),
+  );
+  assert.equal(items.filter(entry => entry.showcase_rank == null).length, 200);
+});
+
+test('excluye pausados, sin stock, moneda no UYU y objetos sin señal de libro', () => {
+  const invalid = [
+    item(1, { status: 'paused' }),
+    item(2, { available_quantity: 0 }),
+    item(3, { currency: 'USD' }),
+    item(4, {
+      author: null,
+      publisher: null,
+      pages: null,
+      bibliographic: null,
+      isbn: null,
+      domain_id: 'MLU-ELECTRONICS',
+    }),
+  ];
+  assert.ok(invalid.every(entry => !isShowcaseEligible(entry)));
+  assert.equal(rankShowcaseItems(invalid).selected.length, 0);
+});
+
+test('dominio BOOKS alcanza; otro dominio exige ISBN y apoyo bibliográfico', () => {
+  assert.equal(isShowcaseEligible(item(1, {
+    domain_id: 'MLU-BOOKS',
+    author: null,
+    pages: null,
+    bibliographic: null,
+  })), true);
+  assert.equal(isShowcaseEligible(item(2, {
+    domain_id: 'MLU-COLLECTIBLES',
+    isbn: '9788496836693',
+    author: 'Meg Meeker',
+    pages: null,
+    bibliographic: null,
+  })), true);
+  assert.equal(isShowcaseEligible(item(3, {
+    domain_id: 'MLU-COLLECTIBLES',
+    isbn: '9788496836693',
+    author: null,
+    pages: null,
+    bibliographic: null,
+  })), false);
+});
+
+test('deduplica la misma edición y conserva condición distinta', () => {
+  const first = item(1, { isbn: '9788496836693', available_quantity: 1 });
+  const better = item(2, {
+    isbn: '9788496836693',
+    available_quantity: 8,
+    pictures: ['a', 'b', 'c'],
+  });
+  const used = item(3, { isbn: '9788496836693', condition: 'used' });
+  const result = rankShowcaseItems([first, better, used], { limit: 10 });
+
+  assert.equal(showcaseEditionKey(first), showcaseEditionKey(better));
+  assert.notEqual(showcaseEditionKey(first), showcaseEditionKey(used));
+  assert.equal(result.selected.length, 2);
+  assert.ok(result.selected.some(entry => entry.id === better.id));
+  assert.ok(!result.selected.some(entry => entry.id === first.id));
+  assert.ok(result.selected.some(entry => entry.id === used.id));
+});
+
+test('el orden no depende del orden de entrada y un ID prioritario gana', () => {
+  const a = item(1, { description: 'Descripción breve '.repeat(20) });
+  const b = item(2);
+  const c = item(3);
+  const options = { limit: 3, priorityIds: [c.id] };
+  const forward = rankShowcaseItems([a, b, c], options).selected.map(entry => entry.id);
+  const reverse = rankShowcaseItems([c, b, a], options).selected.map(entry => entry.id);
+
+  assert.deepEqual(forward, reverse);
+  assert.equal(forward[0], c.id);
+});
+
+test('clasifica el nivel de contenido sin inventarlo', () => {
+  const result = rankShowcaseItems([
+    item(1, { description: 'a'.repeat(500) }),
+    item(2, { description: 'a'.repeat(120) }),
+    item(3, { description: null }),
+  ], { limit: 3 }).selected;
+  const levels = new Map(result.map(entry => [entry.id, entry.contentLevel]));
+
+  assert.equal(levels.get(item(1).id), 'editorial');
+  assert.equal(levels.get(item(2).id), 'descriptive');
+  assert.equal(levels.get(item(3).id), 'bibliographic');
+});
+
+test('una nueva corrida limpia marcas viejas antes de reasignar', () => {
+  const items = [item(1), item(2), item(3)];
+  assignShowcaseRanking(items, { limit: 3 });
+  assert.ok(items.every(entry => entry.showcase_rank));
+
+  assignShowcaseRanking(items, { limit: 1, priorityIds: [items[2].id] });
+  assert.equal(items.filter(entry => entry.showcase_rank).length, 1);
+  assert.equal(items[2].showcase_rank, 1);
+  assert.equal(items[0].showcase_rank, undefined);
+  assert.equal(items[1].showcase_score, undefined);
+});

--- a/functions/_shared/automatic-product-showcase.js
+++ b/functions/_shared/automatic-product-showcase.js
@@ -1,0 +1,313 @@
+// FICHAS-VIDRIERA-1000: transforma datos reales del catálogo en una ficha
+// visible y útil. No inventa sinopsis, biografías, reseñas ni calificaciones.
+
+import { isGenericAuthor, normalizeValidIsbn } from './showcase-ranking.js';
+
+const PLACEHOLDER_PUBLISHERS = new Set([
+  'amado libros',
+  'amado libros uruguay',
+  'sin editorial',
+  'no aplica',
+  'n/a',
+]);
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function normalizedText(value) {
+  return clean(value)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLocaleLowerCase('es');
+}
+
+function realPublisher(value) {
+  const publisher = clean(value);
+  if (!publisher || PLACEHOLDER_PUBLISHERS.has(normalizedText(publisher))) return null;
+  return publisher;
+}
+
+function positiveInteger(value) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : null;
+}
+
+function titleWithoutDuplicateSubtitle(title, subtitle) {
+  const value = clean(subtitle);
+  if (!value) return null;
+  const titleKey = normalizedText(title);
+  const subtitleKey = normalizedText(value);
+  if (!subtitleKey || titleKey.includes(subtitleKey) || subtitleKey.includes(titleKey)) return null;
+  return value;
+}
+
+function sentenceGroups(text, maxChars = 650, maxParagraphs = 4) {
+  const normalized = String(text || '')
+    .replace(/\r\n?/g, '\n')
+    .replace(/[ \t]+/g, ' ')
+    .trim();
+  if (!normalized) return [];
+
+  const existingParagraphs = normalized
+    .split(/\n{2,}/)
+    .map(paragraph => clean(paragraph))
+    .filter(Boolean);
+  const units = existingParagraphs.length > 1
+    ? existingParagraphs
+    : normalized.split(/(?<=[.!?])\s+/u).map(clean).filter(Boolean);
+
+  const paragraphs = [];
+  let current = '';
+  for (const unit of units) {
+    if (paragraphs.length >= maxParagraphs) break;
+    if (!current) {
+      current = unit;
+      continue;
+    }
+    if (`${current} ${unit}`.length <= maxChars) {
+      current = `${current} ${unit}`;
+      continue;
+    }
+    paragraphs.push(current);
+    current = unit;
+  }
+  if (current && paragraphs.length < maxParagraphs) paragraphs.push(current);
+
+  return paragraphs.map(paragraph => paragraph.length <= maxChars
+    ? paragraph
+    : `${paragraph.slice(0, maxChars).replace(/\s+\S*$/u, '')}…`);
+}
+
+function formatDimensions(dimensions) {
+  if (!dimensions || typeof dimensions !== 'object' || Array.isArray(dimensions)) return null;
+  const values = [
+    dimensions.height ? `alto ${clean(dimensions.height)}` : null,
+    dimensions.width ? `ancho ${clean(dimensions.width)}` : null,
+    dimensions.length ? `lomo/largo ${clean(dimensions.length)}` : null,
+    dimensions.weight ? `peso ${clean(dimensions.weight)}` : null,
+  ].filter(Boolean);
+  return values.length ? values.join(' · ') : null;
+}
+
+function formatCondition(value) {
+  const condition = normalizedText(value);
+  if (condition === 'new') return 'Nuevo';
+  if (condition === 'used') return 'Usado';
+  if (condition === 'not_specified') return 'No especificada';
+  return clean(value) || null;
+}
+
+function buildEditionFacts(item) {
+  const bibliography = item?.bibliographic && typeof item.bibliographic === 'object'
+    ? item.bibliographic
+    : {};
+  const facts = [
+    ['Autoría', !isGenericAuthor(item?.author) ? clean(item.author) : null],
+    ['Subtítulo', titleWithoutDuplicateSubtitle(item?.title, bibliography.subtitle)],
+    ['Editorial', realPublisher(item?.publisher)],
+    ['Colección', clean(bibliography.collection) || null],
+    ['ISBN', normalizeValidIsbn(item?.isbn) || clean(item?.isbn) || null],
+    ['Edición', clean(bibliography.edition) || null],
+    ['Año de publicación', clean(bibliography.publication_year) || null],
+    ['Páginas', positiveInteger(item?.pages)],
+    ['Formato', clean(bibliography.format) || null],
+    ['Idioma', clean(bibliography.language) || null],
+    ['Género/temática', clean(bibliography.genre) || null],
+    ['Traducción', clean(bibliography.translator) || null],
+    ['Ilustración', clean(bibliography.illustrator) || null],
+    ['Medidas', formatDimensions(item?.dimensions)],
+    ['Condición', formatCondition(item?.condition)],
+  ];
+
+  return facts
+    .filter(([, value]) => value !== null && value !== undefined && clean(value))
+    .map(([label, value]) => ({ label, value: String(value) }));
+}
+
+function buildFactualSummary(item, facts) {
+  const title = clean(item.title);
+  const author = !isGenericAuthor(item.author) ? clean(item.author) : null;
+  const isbn = normalizeValidIsbn(item.isbn);
+  const publisher = realPublisher(item.publisher);
+  const pages = positiveInteger(item.pages);
+  const bibliography = item?.bibliographic && typeof item.bibliographic === 'object'
+    ? item.bibliographic
+    : {};
+  const format = clean(bibliography.format) || null;
+
+  const identity = `Esta ficha corresponde a «${title}»${author ? `, de ${author}` : ''}.`;
+  const edition = [
+    isbn ? `ISBN ${isbn}` : null,
+    publisher ? `editorial ${publisher}` : null,
+    pages ? `${pages} páginas` : null,
+    format,
+  ].filter(Boolean);
+  const detail = edition.length
+    ? `La publicación aporta estos datos de edición: ${edition.join(', ')}.`
+    : 'La publicación no aporta todavía una ficha bibliográfica completa; por eso no agregamos datos que no estén confirmados.';
+  const verification = facts.length >= 5
+    ? 'Podés revisar debajo los datos disponibles de esta edición antes de comprar y compararlos con el ejemplar que buscás.'
+    : 'Antes de comprar, consultanos cualquier dato de edición que necesites confirmar.';
+
+  return [identity, `${detail} ${verification}`];
+}
+
+function buildHighlights(item, facts) {
+  const bibliography = item?.bibliographic && typeof item.bibliographic === 'object'
+    ? item.bibliographic
+    : {};
+  const images = new Set([
+    ...(Array.isArray(item?.pictures) ? item.pictures : []),
+    item?.thumbnail,
+  ].filter(Boolean)).size;
+  const highlights = [
+    clean(bibliography.genre) ? `Género o temática registrada: ${clean(bibliography.genre)}.` : null,
+    clean(bibliography.format) ? `Formato: ${clean(bibliography.format)}.` : null,
+    clean(bibliography.edition) ? `Edición: ${clean(bibliography.edition)}.` : null,
+    positiveInteger(item?.pages) ? `${positiveInteger(item.pages)} páginas.` : null,
+    clean(bibliography.language) ? `Idioma: ${clean(bibliography.language)}.` : null,
+    clean(bibliography.collection) ? `Colección: ${clean(bibliography.collection)}.` : null,
+    normalizeValidIsbn(item?.isbn) ? `Edición identificada con ISBN ${normalizeValidIsbn(item.isbn)}.` : null,
+    images >= 2 ? `La publicación incluye ${images} imágenes para revisar portada y edición.` : null,
+    realPublisher(item?.publisher) ? `Editorial: ${realPublisher(item.publisher)}.` : null,
+  ].filter(Boolean);
+
+  for (const fact of facts) {
+    if (highlights.length >= 5) break;
+    const candidate = `${fact.label}: ${fact.value}.`;
+    if (!highlights.some(value => normalizedText(value) === normalizedText(candidate))) {
+      highlights.push(candidate);
+    }
+  }
+  if (highlights.length < 3) {
+    highlights.push('Disponible para compra inmediata en Amado Libros.');
+  }
+  return highlights.slice(0, 5);
+}
+
+function audienceCopy(item) {
+  const bibliography = item?.bibliographic && typeof item.bibliographic === 'object'
+    ? item.bibliographic
+    : {};
+  const genre = clean(bibliography.genre);
+  const author = !isGenericAuthor(item?.author) ? clean(item.author) : null;
+  if (genre && author) {
+    return `Puede interesar a lectores de ${author} y a quienes buscan obras registradas dentro de ${genre}. La ficha permite verificar la edición concreta antes de comprar.`;
+  }
+  if (genre) {
+    return `Puede interesar a quienes buscan lecturas de ${genre}. La ficha reúne los datos disponibles para comprobar que se trata de la edición correcta.`;
+  }
+  if (author) {
+    return `Pensado para lectores de ${author} y para quienes buscan esta obra o una edición específica. Revisá ISBN, editorial y formato antes de confirmar la compra.`;
+  }
+  return 'Para quienes buscan esta obra y necesitan comprobar edición, ISBN, editorial, formato o condición antes de comprar.';
+}
+
+function authorCopy(item) {
+  const author = !isGenericAuthor(item?.author) ? clean(item.author) : null;
+  if (author) {
+    return {
+      heading: `Más sobre ${author}`,
+      copy: `La autoría de esta publicación figura como ${author}. Desde esta ficha podés consultar otros títulos disponibles de la misma autoría y comparar ediciones en el catálogo de Amado Libros.`,
+    };
+  }
+  return {
+    heading: 'Sobre la autoría',
+    copy: 'La publicación no aporta una autoría suficientemente clara. No completamos ese dato por inferencia: podés consultarnos para verificarlo antes de comprar.',
+  };
+}
+
+function buildLinks(item) {
+  const links = [];
+  const author = !isGenericAuthor(item?.author) ? clean(item.author) : null;
+  const bibliography = item?.bibliographic && typeof item.bibliographic === 'object'
+    ? item.bibliographic
+    : {};
+  const genre = clean(bibliography.genre);
+  if (author) {
+    links.push({
+      href: `/catalogo?q=${encodeURIComponent(author)}`,
+      label: `Ver otros libros de ${author}`,
+    });
+  }
+  if (genre) {
+    links.push({
+      href: `/catalogo?q=${encodeURIComponent(genre)}`,
+      label: `Explorar libros de ${genre}`,
+    });
+  }
+  if (normalizeValidIsbn(item?.isbn)) {
+    links.push({
+      href: '/como-identificar-edicion-correcta-isbn',
+      label: 'Cómo verificar una edición por ISBN',
+    });
+  }
+  if (links.length === 0) {
+    links.push({ href: '/catalogo', label: 'Seguir explorando el catálogo' });
+  }
+  return links.slice(0, 3);
+}
+
+function shortenByWord(value, maxLength) {
+  const text = clean(value);
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength - 1).replace(/\s+\S*$/u, '')}…`;
+}
+
+function buildMetaDescription(item) {
+  const title = clean(item.title);
+  const author = !isGenericAuthor(item.author) ? clean(item.author) : null;
+  const isbn = normalizeValidIsbn(item.isbn);
+  const identity = `Comprá ${title}${author ? ` de ${author}` : ''} en Uruguay.`;
+  const edition = isbn ? ` ISBN ${isbn}.` : '';
+  return shortenByWord(
+    `${identity}${edition} Consultá stock, 12% menos por transferencia, cuotas y envíos a todo el país.`,
+    170,
+  );
+}
+
+export function buildAutomaticProductShowcase(item) {
+  if (!item || typeof item !== 'object' || !clean(item.title)) return null;
+  const facts = buildEditionFacts(item);
+  const description = clean(item.description);
+  const descriptionParagraphs = description.length >= 80
+    ? sentenceGroups(item.description)
+    : [];
+  const summary = descriptionParagraphs.length
+    ? descriptionParagraphs
+    : buildFactualSummary(item, facts);
+  const author = authorCopy(item);
+  const bibliography = item.bibliographic && typeof item.bibliographic === 'object'
+    ? item.bibliographic
+    : {};
+  const subtitle = titleWithoutDuplicateSubtitle(item.title, bibliography.subtitle) ||
+    (!isGenericAuthor(item.author) ? `De ${clean(item.author)}` : null);
+  const schemaDescription = shortenByWord(summary.join(' '), 500);
+
+  return {
+    h1: clean(item.title),
+    subtitle,
+    eyebrow: descriptionParagraphs.length
+      ? (clean(bibliography.genre) || 'Descripción y datos de la edición')
+      : 'Ficha ampliada de esta edición',
+    introHeading: descriptionParagraphs.length
+      ? `¿De qué trata ${clean(item.title)}?`
+      : `Sobre ${clean(item.title)}`,
+    summary,
+    highlightsHeading: 'Datos destacados',
+    highlights: buildHighlights(item, facts),
+    audienceHeading: '¿Para quién puede ser útil?',
+    audience: audienceCopy(item),
+    authorHeading: author.heading,
+    authorBio: author.copy,
+    editionHeading: 'Ficha de esta edición',
+    verifiedLabel: normalizeValidIsbn(item.isbn)
+      ? 'Edición identificada por ISBN'
+      : 'Datos tomados de la publicación',
+    editionFacts: facts,
+    links: buildLinks(item),
+    schemaDescription,
+    metaDescription: buildMetaDescription(item),
+  };
+}

--- a/functions/_shared/automatic-product-showcase.js
+++ b/functions/_shared/automatic-product-showcase.js
@@ -3,6 +3,8 @@
 
 import { isGenericAuthor, normalizeValidIsbn } from './showcase-ranking.js';
 
+const JSON_LD_RE = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
+const DETAIL_ROW_RE = /<div class="detail-row"><dt>([\s\S]*?)<\/dt><dd>([\s\S]*?)<\/dd><\/div>/g;
 const PLACEHOLDER_PUBLISHERS = new Set([
   'amado libros',
   'amado libros uruguay',
@@ -20,6 +22,21 @@ function normalizedText(value) {
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
     .toLocaleLowerCase('es');
+}
+
+function decodeHtml(value) {
+  return String(value ?? '')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&#(\d+);/g, (_full, code) => String.fromCodePoint(Number(code)))
+    .replace(/&#x([0-9a-f]+);/gi, (_full, code) => String.fromCodePoint(parseInt(code, 16)))
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 function realPublisher(value) {
@@ -92,8 +109,8 @@ function formatDimensions(dimensions) {
 
 function formatCondition(value) {
   const condition = normalizedText(value);
-  if (condition === 'new') return 'Nuevo';
-  if (condition === 'used') return 'Usado';
+  if (condition === 'new' || condition.endsWith('/newcondition')) return 'Nuevo';
+  if (condition === 'used' || condition.endsWith('/usedcondition')) return 'Usado';
   if (condition === 'not_specified') return 'No especificada';
   return clean(value) || null;
 }
@@ -116,7 +133,7 @@ function buildEditionFacts(item) {
     ['Género/temática', clean(bibliography.genre) || null],
     ['Traducción', clean(bibliography.translator) || null],
     ['Ilustración', clean(bibliography.illustrator) || null],
-    ['Medidas', formatDimensions(item?.dimensions)],
+    ['Medidas', formatDimensions(item?.dimensions) || clean(item?.dimensions_text) || null],
     ['Condición', formatCondition(item?.condition)],
   ];
 
@@ -180,8 +197,13 @@ function buildHighlights(item, facts) {
       highlights.push(candidate);
     }
   }
-  if (highlights.length < 3) {
-    highlights.push('Disponible para compra inmediata en Amado Libros.');
+  while (highlights.length < 3) {
+    const fallback = [
+      'Disponible para compra inmediata en Amado Libros.',
+      'La ficha reúne los datos aportados por la publicación.',
+      'Podés consultar cualquier dato de edición antes de comprar.',
+    ][highlights.length] || 'Información comercial verificada al momento de la consulta.';
+    highlights.push(fallback);
   }
   return highlights.slice(0, 5);
 }
@@ -265,6 +287,106 @@ function buildMetaDescription(item) {
     `${identity}${edition} Consultá stock, 12% menos por transferencia, cuotas y envíos a todo el país.`,
     170,
   );
+}
+
+function schemaTypes(schema) {
+  const raw = schema?.['@type'];
+  return Array.isArray(raw) ? raw : [raw].filter(Boolean);
+}
+
+function personName(value) {
+  if (typeof value === 'string') return clean(value);
+  if (Array.isArray(value)) return value.map(personName).filter(Boolean).join(', ');
+  return clean(value?.name);
+}
+
+function organizationName(value) {
+  if (typeof value === 'string') return clean(value);
+  return clean(value?.name);
+}
+
+function detailMapFromHtml(html) {
+  const details = new Map();
+  for (const match of String(html || '').matchAll(DETAIL_ROW_RE)) {
+    details.set(normalizedText(decodeHtml(match[1])), decodeHtml(match[2]));
+  }
+  return details;
+}
+
+function detail(details, ...labels) {
+  for (const label of labels) {
+    const value = details.get(normalizedText(label));
+    if (value) return value;
+  }
+  return null;
+}
+
+function productSchemaFromHtml(html, productId) {
+  for (const match of String(html || '').matchAll(JSON_LD_RE)) {
+    try {
+      const schema = JSON.parse(match[1]);
+      if (schemaTypes(schema).includes('Book') && String(schema.sku || '').toUpperCase() === productId) {
+        return schema;
+      }
+    } catch {
+      // Otro bloque JSON-LD inválido no debe impedir leer la ficha.
+    }
+  }
+  return null;
+}
+
+function usableDescription(description, title, author) {
+  const value = clean(description);
+  if (!value) return null;
+  const key = normalizedText(value);
+  const generic = [
+    normalizedText(title),
+    normalizedText(author ? `${title} — ${author}` : title),
+    normalizedText(author ? `${title} - ${author}` : title),
+  ];
+  return generic.includes(key) ? null : value;
+}
+
+export function productItemFromProductHtml(html, productId) {
+  const id = String(productId || '').toUpperCase();
+  const schema = productSchemaFromHtml(html, id);
+  if (!schema) return null;
+
+  const details = detailMapFromHtml(html);
+  const title = clean(schema.name) || decodeHtml(String(html || '').match(/<h1>([\s\S]*?)<\/h1>/)?.[1]);
+  if (!title) return null;
+  const author = personName(schema.author) || detail(details, 'Autor', 'Autoría');
+  const images = Array.isArray(schema.image)
+    ? schema.image.filter(Boolean)
+    : [schema.image].filter(Boolean);
+  const offer = Array.isArray(schema.offers) ? schema.offers[0] : schema.offers;
+  const publisher = organizationName(schema.publisher) || detail(details, 'Editorial');
+  const pages = positiveInteger(schema.numberOfPages) || positiveInteger(detail(details, 'Páginas'));
+  const description = usableDescription(schema.description, title, author);
+
+  return {
+    id,
+    title,
+    author: author || null,
+    isbn: clean(schema.isbn) || detail(details, 'ISBN'),
+    publisher: publisher || null,
+    pages,
+    description,
+    pictures: images,
+    condition: detail(details, 'Condición') || offer?.itemCondition || null,
+    dimensions_text: detail(details, 'Medidas'),
+    bibliographic: {
+      subtitle: detail(details, 'Subtítulo'),
+      language: detail(details, 'Idioma') || clean(schema.inLanguage) || null,
+      format: detail(details, 'Formato') || clean(schema.bookFormat) || null,
+      edition: detail(details, 'Edición') || clean(schema.bookEdition) || null,
+      publication_year: detail(details, 'Año') || clean(schema.datePublished) || null,
+      genre: detail(details, 'Género', 'Género/temática') || clean(schema.genre) || null,
+      collection: detail(details, 'Colección'),
+      translator: detail(details, 'Traductor/a', 'Traducción') || personName(schema.translator) || null,
+      illustrator: detail(details, 'Ilustrador/a', 'Ilustración') || personName(schema.illustrator) || null,
+    },
+  };
 }
 
 export function buildAutomaticProductShowcase(item) {

--- a/functions/_shared/product-showcases.js
+++ b/functions/_shared/product-showcases.js
@@ -6,6 +6,12 @@ const PADRES_FUERTES = Object.freeze({
   h1: 'Padres fuertes, hijas felices',
   subtitle: '10 secretos que todo padre debería conocer',
   eyebrow: 'Guía práctica sobre el vínculo entre padres e hijas',
+  introHeading: '¿De qué trata Padres fuertes, hijas felices?',
+  highlightsHeading: 'Qué vas a encontrar',
+  audienceHeading: '¿Para quién es este libro?',
+  authorHeading: 'Sobre Meg Meeker',
+  editionHeading: 'Ficha de esta edición',
+  verifiedLabel: 'Edición identificada por ISBN',
   summary: Object.freeze([
     'Padres fuertes, hijas felices es una guía de Meg Meeker para padres que quieren construir una relación cercana, firme y confiable con sus hijas. Desde su experiencia como pediatra y consejera familiar, la autora analiza cómo la presencia cotidiana, el afecto, los límites y el ejemplo del padre pueden influir en la seguridad personal y el equilibrio emocional de una hija.',
     'El libro recorre situaciones concretas de la infancia, la adolescencia y el comienzo de la vida adulta. Aborda la comunicación, la autoestima, la presión social, las decisiones de riesgo y la forma en que una hija aprende a relacionarse con los demás. El foco no está en controlar cada paso, sino en ofrecer una referencia estable: escuchar, acompañar, sostener límites razonables y estar disponible cuando aparecen dudas o conflictos.',

--- a/functions/_shared/showcase-cohort.js
+++ b/functions/_shared/showcase-cohort.js
@@ -1,0 +1,125 @@
+import { R2_BASE } from './catalog.js';
+import { perfNow, recordPerf } from './perf.js';
+
+export const SHOWCASE_COHORT_URL = `${R2_BASE}/showcase/v1/cohort.json`;
+export const SHOWCASE_COHORT_LIMIT = 1000;
+
+// Sólo permite comprobar el renderer en un Preview anterior al primer sync que
+// publique la cohorte. Producción jamás usa esta lista de respaldo.
+export const SHOWCASE_PREVIEW_SAMPLE_IDS = Object.freeze([
+  'MLU644161565',
+  'MLU678034726',
+  'MLU1467827214',
+  'MLU633677061',
+  'MLU1304008698',
+]);
+
+let memoryCache = {
+  expiresAt: 0,
+  value: null,
+};
+
+function validProductId(value) {
+  return /^MLU\d+$/.test(String(value || '').toUpperCase());
+}
+
+export function normalizeShowcaseCohort(payload) {
+  if (!payload || payload.schema_version !== 1 || !Array.isArray(payload.ids)) return null;
+  const ids = payload.ids.map(value => String(value || '').toUpperCase());
+  if (ids.length < 1 || ids.length > SHOWCASE_COHORT_LIMIT) return null;
+  if (ids.some(id => !validProductId(id))) return null;
+  if (new Set(ids).size !== ids.length) return null;
+  if (Number(payload.total) !== ids.length) return null;
+
+  return {
+    schema_version: 1,
+    generated_at: typeof payload.generated_at === 'string' ? payload.generated_at : null,
+    catalog_version: typeof payload.catalog_version === 'string' ? payload.catalog_version : null,
+    total: ids.length,
+    ids: new Set(ids),
+    source: 'r2',
+  };
+}
+
+function previewFallback(context) {
+  if (context?.env?.APP_ENV !== 'preview') return null;
+  return {
+    schema_version: 1,
+    generated_at: null,
+    catalog_version: null,
+    total: SHOWCASE_PREVIEW_SAMPLE_IDS.length,
+    ids: new Set(SHOWCASE_PREVIEW_SAMPLE_IDS),
+    source: 'preview-fallback',
+  };
+}
+
+async function fetchCohort(context) {
+  const cache = caches.default;
+  const cacheKey = new Request(SHOWCASE_COHORT_URL);
+  const readStartedAt = perfNow();
+  const cacheStartedAt = perfNow();
+  let response = await cache.match(cacheKey);
+  recordPerf(context, 'showcase_cohort_cache', cacheStartedAt, {
+    cache: response ? 'hit' : 'miss',
+  });
+
+  if (!response) {
+    const originStartedAt = perfNow();
+    const fetched = await fetch(SHOWCASE_COHORT_URL);
+    recordPerf(context, 'showcase_cohort_origin', originStartedAt);
+    if (!fetched.ok) return previewFallback(context);
+    response = new Response(fetched.body, {
+      status: fetched.status,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, max-age=3600',
+      },
+    });
+    if (typeof context?.waitUntil === 'function') {
+      context.waitUntil(cache.put(cacheKey, response.clone()));
+    }
+  }
+
+  try {
+    const bodyStartedAt = perfNow();
+    const body = await response.arrayBuffer();
+    recordPerf(context, 'showcase_cohort_body', bodyStartedAt, { bytes: body.byteLength });
+    recordPerf(context, 'showcase_cohort_read', readStartedAt, { bytes: body.byteLength });
+    const parseStartedAt = perfNow();
+    const payload = JSON.parse(new TextDecoder().decode(body));
+    recordPerf(context, 'showcase_cohort_parse', parseStartedAt);
+    return normalizeShowcaseCohort(payload) || previewFallback(context);
+  } catch {
+    return previewFallback(context);
+  }
+}
+
+export async function fetchShowcaseCohort(context) {
+  if (!['preview', 'production'].includes(context?.env?.APP_ENV)) return null;
+  const now = Date.now();
+  if (memoryCache.value && memoryCache.expiresAt > now) return memoryCache.value;
+
+  if (!context.data || typeof context.data !== 'object') context.data = {};
+  if (!context.data.__showcaseCohortPromise) {
+    context.data.__showcaseCohortPromise = fetchCohort(context);
+  }
+  const value = await context.data.__showcaseCohortPromise;
+  if (value) {
+    memoryCache = {
+      expiresAt: now + 5 * 60 * 1000,
+      value,
+    };
+  }
+  return value;
+}
+
+export async function isProductInShowcaseCohort(context, productId) {
+  const id = String(productId || '').toUpperCase();
+  if (!validProductId(id)) return false;
+  const cohort = await fetchShowcaseCohort(context);
+  return Boolean(cohort?.ids?.has(id));
+}
+
+export function resetShowcaseCohortMemoryForTests() {
+  memoryCache = { expiresAt: 0, value: null };
+}

--- a/functions/_shared/showcase-ranking.js
+++ b/functions/_shared/showcase-ranking.js
@@ -1,0 +1,292 @@
+// FICHAS-VIDRIERA-1000: selección comercial determinista de ediciones activas.
+// No inventa demanda ni contenido. Ordena únicamente señales reales del catálogo.
+
+export const DEFAULT_SHOWCASE_LIMIT = 1000;
+
+const GENERIC_AUTHORS = new Set([
+  'anónimo',
+  'anonimo',
+  'autor',
+  'autores',
+  'autor no especificado',
+  'no aplica',
+  'n/a',
+  's/a',
+  'sin autor',
+  'varios',
+  'varios autores',
+  'vv aa',
+  'vv. aa.',
+]);
+
+const PLACEHOLDER_PUBLISHERS = new Set([
+  'amado libros',
+  'amado libros uruguay',
+  'sin editorial',
+  'no aplica',
+  'n/a',
+]);
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function normalizedText(value) {
+  return clean(value)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLocaleLowerCase('es');
+}
+
+function isbn13Checksum(value) {
+  const digits = String(value || '').replace(/\D/g, '');
+  if (!/^\d{13}$/.test(digits)) return false;
+  const sum = [...digits.slice(0, 12)].reduce(
+    (total, digit, index) => total + Number(digit) * (index % 2 === 0 ? 1 : 3),
+    0,
+  );
+  return Number(digits[12]) === (10 - (sum % 10)) % 10;
+}
+
+function isbn10Checksum(value) {
+  const raw = String(value || '').toUpperCase().replace(/[^0-9X]/g, '');
+  if (!/^\d{9}[0-9X]$/.test(raw)) return false;
+  const sum = [...raw].reduce((total, digit, index) => {
+    const number = digit === 'X' ? 10 : Number(digit);
+    return total + number * (10 - index);
+  }, 0);
+  return sum % 11 === 0;
+}
+
+export function normalizeValidIsbn(value) {
+  const raw = String(value || '').toUpperCase().replace(/[^0-9X]/g, '');
+  if (/^\d{13}$/.test(raw) && isbn13Checksum(raw)) return raw;
+  if (!isbn10Checksum(raw)) return null;
+
+  const base = `978${raw.slice(0, 9)}`;
+  const sum = [...base].reduce(
+    (total, digit, index) => total + Number(digit) * (index % 2 === 0 ? 1 : 3),
+    0,
+  );
+  return `${base}${(10 - (sum % 10)) % 10}`;
+}
+
+export function isGenericAuthor(value) {
+  const key = normalizedText(value);
+  return !key || GENERIC_AUTHORS.has(key);
+}
+
+function realPublisher(value) {
+  const key = normalizedText(value);
+  return Boolean(key) && !PLACEHOLDER_PUBLISHERS.has(key);
+}
+
+function positiveInteger(value) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : null;
+}
+
+function descriptionLength(item) {
+  return clean(item?.description).length;
+}
+
+function pictureCount(item) {
+  const sources = [
+    ...(Array.isArray(item?.pictures) ? item.pictures : []),
+    item?.thumbnail,
+  ].filter(Boolean);
+  return new Set(sources.map(value => clean(value))).size;
+}
+
+function fieldCount(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return 0;
+  return Object.values(value).filter(field => clean(field)).length;
+}
+
+function validDate(value) {
+  const time = Date.parse(value || '');
+  return Number.isFinite(time) ? time : 0;
+}
+
+function validCurrency(item) {
+  return clean(item?.currency || item?.currency_id).toUpperCase() === 'UYU';
+}
+
+function hasBookSignal(item) {
+  const domain = clean(item?.domain_id).toUpperCase();
+  return domain.includes('BOOK') ||
+    Boolean(normalizeValidIsbn(item?.isbn)) ||
+    !isGenericAuthor(item?.author) ||
+    realPublisher(item?.publisher) ||
+    Boolean(positiveInteger(item?.pages)) ||
+    fieldCount(item?.bibliographic) > 0;
+}
+
+export function isShowcaseEligible(item) {
+  return /^MLU\d+$/.test(clean(item?.id).toUpperCase()) &&
+    clean(item?.title).length >= 2 &&
+    item?.status === 'active' &&
+    Number(item?.available_quantity) > 0 &&
+    Number(item?.price) > 0 &&
+    validCurrency(item) &&
+    hasBookSignal(item);
+}
+
+export function showcaseEditionKey(item) {
+  const condition = normalizedText(item?.condition) || 'unknown';
+  const isbn = normalizeValidIsbn(item?.isbn);
+  if (isbn) return `isbn:${isbn}:${condition}`;
+
+  return [
+    'work',
+    normalizedText(item?.title),
+    normalizedText(item?.author),
+    condition,
+  ].join(':');
+}
+
+function prioritySet(value) {
+  if (value instanceof Set) return value;
+  return new Set(Array.isArray(value) ? value.map(id => clean(id).toUpperCase()) : []);
+}
+
+export function scoreShowcaseItem(item, { priorityIds = [] } = {}) {
+  if (!isShowcaseEligible(item)) return Number.NEGATIVE_INFINITY;
+
+  const priorities = prioritySet(priorityIds);
+  const description = descriptionLength(item);
+  const images = pictureCount(item);
+  const bibliography = fieldCount(item?.bibliographic);
+  const dimensions = fieldCount(item?.dimensions);
+  const stock = Math.max(0, Number(item?.available_quantity) || 0);
+  const title = clean(item?.title);
+  let score = 0;
+
+  if (priorities.has(clean(item.id).toUpperCase())) score += 2200;
+
+  if (description >= 80) score += 260;
+  if (description >= 280) score += 180;
+  if (description >= 700) score += 100;
+  if (description >= 1400) score += 60;
+
+  if (normalizeValidIsbn(item?.isbn)) score += 220;
+  if (!isGenericAuthor(item?.author)) score += 190;
+  if (realPublisher(item?.publisher)) score += 140;
+  if (positiveInteger(item?.pages)) score += 110;
+
+  score += Math.min(210, bibliography * 35);
+  score += Math.min(70, dimensions * 18);
+
+  if (images >= 1) score += 100;
+  if (images >= 2) score += 80;
+  if (images >= 4) score += 70;
+
+  if (clean(item?.catalog_product_id)) score += 70;
+  if (item?.catalog_listing === true) score += 45;
+  if (normalizedText(item?.condition) === 'new') score += 40;
+  score += Math.min(100, Math.round(Math.log2(stock + 1) * 25));
+
+  if (title.length >= 8 && title.length <= 150) score += 30;
+  if (/Ã|Â|â|�/.test(title)) score -= 250;
+
+  return score;
+}
+
+function candidateFor(item, priorityIds) {
+  return {
+    item,
+    id: clean(item.id).toUpperCase(),
+    score: scoreShowcaseItem(item, { priorityIds }),
+    stock: Math.max(0, Number(item.available_quantity) || 0),
+    description: descriptionLength(item),
+    pictures: pictureCount(item),
+    startedAt: validDate(item.start_time),
+  };
+}
+
+function compareCandidates(a, b) {
+  return b.score - a.score ||
+    b.stock - a.stock ||
+    b.description - a.description ||
+    b.pictures - a.pictures ||
+    b.startedAt - a.startedAt ||
+    a.id.localeCompare(b.id);
+}
+
+export function rankShowcaseItems(items = [], {
+  limit = DEFAULT_SHOWCASE_LIMIT,
+  priorityIds = [],
+} = {}) {
+  const safeLimit = Math.max(0, Math.floor(Number(limit) || 0));
+  const priorities = prioritySet(priorityIds);
+  const bestByEdition = new Map();
+  let eligibleItems = 0;
+
+  for (const item of items) {
+    if (!isShowcaseEligible(item)) continue;
+    eligibleItems++;
+    const candidate = candidateFor(item, priorities);
+    const key = showcaseEditionKey(item);
+    const current = bestByEdition.get(key);
+    if (!current || compareCandidates(candidate, current) < 0) {
+      bestByEdition.set(key, candidate);
+    }
+  }
+
+  const selected = [...bestByEdition.values()]
+    .sort(compareCandidates)
+    .slice(0, safeLimit)
+    .map((candidate, index) => ({
+      ...candidate,
+      rank: index + 1,
+      contentLevel: candidate.description >= 280
+        ? 'editorial'
+        : candidate.description >= 80
+          ? 'descriptive'
+          : 'bibliographic',
+    }));
+
+  return {
+    eligibleItems,
+    uniqueEditions: bestByEdition.size,
+    duplicateEditionsExcluded: Math.max(0, eligibleItems - bestByEdition.size),
+    selected,
+  };
+}
+
+export function assignShowcaseRanking(items = [], options = {}) {
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    delete item.showcase_rank;
+    delete item.showcase_score;
+    delete item.showcase_content_level;
+  }
+
+  const ranked = rankShowcaseItems(items, options);
+  for (const candidate of ranked.selected) {
+    candidate.item.showcase_rank = candidate.rank;
+    candidate.item.showcase_score = candidate.score;
+    candidate.item.showcase_content_level = candidate.contentLevel;
+  }
+
+  const selectedWithDescription = ranked.selected
+    .filter(candidate => candidate.description >= 80).length;
+  const selectedWithIsbn = ranked.selected
+    .filter(candidate => Boolean(normalizeValidIsbn(candidate.item.isbn))).length;
+  const selectedWithMultipleImages = ranked.selected
+    .filter(candidate => candidate.pictures >= 2).length;
+
+  return {
+    schema_version: 1,
+    limit: Math.max(0, Math.floor(Number(options.limit ?? DEFAULT_SHOWCASE_LIMIT) || 0)),
+    eligible_items: ranked.eligibleItems,
+    unique_editions: ranked.uniqueEditions,
+    duplicate_editions_excluded: ranked.duplicateEditionsExcluded,
+    selected_items: ranked.selected.length,
+    selected_with_description: selectedWithDescription,
+    selected_with_isbn: selectedWithIsbn,
+    selected_with_multiple_images: selectedWithMultipleImages,
+    highest_score: ranked.selected[0]?.score ?? null,
+    lowest_score: ranked.selected.at(-1)?.score ?? null,
+  };
+}

--- a/functions/_shared/showcase-ranking.js
+++ b/functions/_shared/showcase-ranking.js
@@ -40,7 +40,7 @@ function normalizedText(value) {
 
 function isbn13Checksum(value) {
   const digits = String(value || '').replace(/\D/g, '');
-  if (!/^\d{13}$/.test(digits)) return false;
+  if (!/^(978|979)\d{10}$/.test(digits)) return false;
   const sum = [...digits.slice(0, 12)].reduce(
     (total, digit, index) => total + Number(digit) * (index % 2 === 0 ? 1 : 3),
     0,
@@ -112,14 +112,21 @@ function validCurrency(item) {
   return clean(item?.currency || item?.currency_id).toUpperCase() === 'UYU';
 }
 
+// Mismo contrato de libro que usa Merchant: un dominio BOOKS basta; con un
+// dominio de otra familia se exige ISBN válido + otra señal; sin dominio se
+// exige ISBN o dos señales bibliográficas independientes.
 function hasBookSignal(item) {
   const domain = clean(item?.domain_id).toUpperCase();
-  return domain.includes('BOOK') ||
-    Boolean(normalizeValidIsbn(item?.isbn)) ||
-    !isGenericAuthor(item?.author) ||
-    realPublisher(item?.publisher) ||
-    Boolean(positiveInteger(item?.pages)) ||
-    fieldCount(item?.bibliographic) > 0;
+  const hasIsbn = Boolean(normalizeValidIsbn(item?.isbn));
+  const supportingSignals = [
+    !isGenericAuthor(item?.author),
+    Boolean(positiveInteger(item?.pages)),
+    fieldCount(item?.bibliographic) > 0,
+  ].filter(Boolean).length;
+
+  if (/(?:^|[-_])BOOKS(?:$|[-_])/.test(domain)) return true;
+  if (domain) return hasIsbn && supportingSignals >= 1;
+  return hasIsbn || supportingSignals >= 2;
 }
 
 export function isShowcaseEligible(item) {

--- a/functions/libro/_middleware.js
+++ b/functions/libro/_middleware.js
@@ -1,9 +1,14 @@
 import { BASE } from '../_shared/catalog.js';
 import {
+  buildAutomaticProductShowcase,
+  productItemFromProductHtml,
+} from '../_shared/automatic-product-showcase.js';
+import {
   ORDER_HUB_PATH,
   orderHubPageForProductId,
   orderHubPath,
 } from '../_shared/order-hub.js';
+import { isProductInShowcaseCohort } from '../_shared/showcase-cohort.js';
 import { PRODUCT_SHOWCASE_OVERRIDES } from '../_shared/product-showcases.js';
 
 const PRODUCT_PATH_RE = /^\/libro\/(MLU\d+)(?:\/|$)/i;
@@ -13,6 +18,7 @@ const PRODUCT_H1_RE = /<h1>[\s\S]*?<\/h1>/;
 const JSON_LD_RE = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
 const CATALOG_PATH = '/catalogo';
 const ACTIVE_PAGE_MARKER = 'class="badge in-stock"';
+const RELATED_BOOKS_MARKER = '<section class="related-books"';
 const ORDER_BOX_GENERIC_COPY = '<span>Podemos intentar conseguirlo por encargo. Consultanos y verificamos disponibilidad, edición y precio.</span>';
 const ORDER_BOX_LEAD_TIME_COPY = `<span class="order-lead-time"><b>Demora estimada: 15 a 20 días desde la confirmación.</b> Salvo demoras del proveedor, courier o aduana.</span>
       <span>Antes de avanzar verificamos disponibilidad, edición y precio.</span>`;
@@ -237,52 +243,53 @@ export function enrichByRequestProductHtml(html, productId) {
 }
 
 function renderProductShowcase(config) {
-  const paragraphs = config.summary
+  const paragraphs = (Array.isArray(config.summary) ? config.summary : [])
     .map(paragraph => `    <p>${escapeHtml(paragraph)}</p>`)
     .join('\n');
-  const highlights = config.highlights
+  const highlights = (Array.isArray(config.highlights) ? config.highlights : [])
     .map(item => `        <li>${escapeHtml(item)}</li>`)
     .join('\n');
-  const facts = config.editionFacts
+  const facts = (Array.isArray(config.editionFacts) ? config.editionFacts : [])
     .map(({ label, value }) => `<div class="showcase-fact"><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`)
     .join('\n      ');
-  const links = config.links
+  const links = (Array.isArray(config.links) ? config.links : [])
     .map(({ href, label }) => `<a href="${escapeHtml(href)}">${escapeHtml(label)} →</a>`)
     .join('\n      ');
+  const linksHtml = links
+    ? `<div class="showcase-links">\n      ${links}\n    </div>`
+    : '';
 
   return `<section class="product-showcase" aria-labelledby="showcase-title">
   <div class="showcase-intro">
     <p class="showcase-eyebrow">${escapeHtml(config.eyebrow)}</p>
-    <h2 id="showcase-title">¿De qué trata ${escapeHtml(config.h1)}?</h2>
+    <h2 id="showcase-title">${escapeHtml(config.introHeading || `¿De qué trata ${config.h1}?`)}</h2>
 ${paragraphs}
   </div>
   <div class="showcase-grid">
     <section class="showcase-card" aria-labelledby="showcase-highlights-title">
-      <h3 id="showcase-highlights-title">Qué vas a encontrar</h3>
+      <h3 id="showcase-highlights-title">${escapeHtml(config.highlightsHeading || 'Datos destacados')}</h3>
       <ul>
 ${highlights}
       </ul>
     </section>
     <section class="showcase-card" aria-labelledby="showcase-audience-title">
-      <h3 id="showcase-audience-title">¿Para quién es este libro?</h3>
+      <h3 id="showcase-audience-title">${escapeHtml(config.audienceHeading || '¿Para quién es este libro?')}</h3>
       <p>${escapeHtml(config.audience)}</p>
     </section>
     <section class="showcase-card" aria-labelledby="showcase-author-title">
-      <h3 id="showcase-author-title">Sobre Meg Meeker</h3>
+      <h3 id="showcase-author-title">${escapeHtml(config.authorHeading || 'Sobre la autoría')}</h3>
       <p>${escapeHtml(config.authorBio)}</p>
     </section>
   </div>
   <section class="showcase-edition" aria-labelledby="showcase-edition-title">
     <div class="showcase-edition-head">
-      <h2 id="showcase-edition-title">Ficha de esta edición</h2>
-      <span class="showcase-verified">Edición identificada por ISBN</span>
+      <h2 id="showcase-edition-title">${escapeHtml(config.editionHeading || 'Ficha de esta edición')}</h2>
+      <span class="showcase-verified">${escapeHtml(config.verifiedLabel || 'Datos tomados de la publicación')}</span>
     </div>
     <dl class="showcase-facts">
       ${facts}
     </dl>
-    <div class="showcase-links">
-      ${links}
-    </div>
+    ${linksHtml}
   </section>
 </section>`;
 }
@@ -321,6 +328,75 @@ function enrichShowcaseSchema(html, productId, config) {
     schema.translator = { ...verified.translator };
     return `<script type="application/ld+json">${serializeSchema(schema)}</script>`;
   });
+}
+
+function enrichAutomaticShowcaseSchema(html, productId, config) {
+  return html.replace(JSON_LD_RE, (full, rawJson) => {
+    let schema;
+    try {
+      schema = JSON.parse(rawJson);
+    } catch {
+      return full;
+    }
+    const rawType = schema?.['@type'];
+    const types = Array.isArray(rawType) ? rawType : [rawType].filter(Boolean);
+    if (!types.includes('Book') || String(schema.sku || '').toUpperCase() !== productId) return full;
+
+    schema.description = config.schemaDescription;
+    return `<script type="application/ld+json">${serializeSchema(schema)}</script>`;
+  });
+}
+
+function replaceDescriptionMeta(html, config) {
+  const safeDescription = escapeHtml(config.metaDescription);
+  return html
+    .replace(
+      /<meta name="description" content="[^"]*">/,
+      `<meta name="description" content="${safeDescription}">`,
+    )
+    .replace(
+      /<meta property="og:description" content="[^"]*">/,
+      `<meta property="og:description" content="${safeDescription}">`,
+    )
+    .replace(
+      /<meta name="twitter:description" content="[^"]*">/,
+      `<meta name="twitter:description" content="${safeDescription}">`,
+    );
+}
+
+function insertShowcaseBeforeRelated(html, block) {
+  const index = html.indexOf(RELATED_BOOKS_MARKER);
+  if (index >= 0) return `${html.slice(0, index)}${block}\n  ${html.slice(index)}`;
+  return html.replace('</main>', `${block}\n</main>`);
+}
+
+export function enrichAutomaticProductShowcaseHtml(html, productId) {
+  const source = String(html || '');
+  const id = String(productId || '').toUpperCase();
+  if (!source.includes(ACTIVE_PAGE_MARKER) ||
+      source.includes(SHOWCASE_MARKER) ||
+      PRODUCT_SHOWCASE_OVERRIDES[id]) {
+    return source;
+  }
+
+  const item = productItemFromProductHtml(source, id);
+  const config = buildAutomaticProductShowcase(item);
+  if (!config) return source;
+
+  let result = source;
+  if (config.subtitle && !result.includes('class="book-subtitle"')) {
+    result = result.replace(
+      PRODUCT_H1_RE,
+      match => `${match}\n    <p class="book-subtitle">${escapeHtml(config.subtitle)}</p>`,
+    );
+  }
+  result = replaceDescriptionMeta(result, config);
+  result = enrichAutomaticShowcaseSchema(result, id, config);
+  result = insertShowcaseBeforeRelated(result, renderProductShowcase(config));
+  if (!result.includes(SHOWCASE_STYLE_MARKER)) {
+    result = result.replace('</style>', `${showcaseStyles()}\n  </style>`);
+  }
+  return result;
 }
 
 // FICHAS-VIDRIERA-1: capa editorial visible para un MLU/ISBN exacto. Usa la
@@ -411,7 +487,16 @@ export async function onRequest(context) {
   const html = await response.clone().text();
   const withCatalogBreadcrumb = enrichActiveCatalogBreadcrumbHtml(html);
   const withByRequestCx = enrichByRequestProductHtml(withCatalogBreadcrumb, productId);
-  const withShowcase = enrichProductShowcaseHtml(withByRequestCx, productId);
+
+  let withAutomaticShowcase = withByRequestCx;
+  if (withByRequestCx.includes(ACTIVE_PAGE_MARKER) && !PRODUCT_SHOWCASE_OVERRIDES[productId]) {
+    const selected = await isProductInShowcaseCohort(context, productId);
+    if (selected) {
+      withAutomaticShowcase = enrichAutomaticProductShowcaseHtml(withByRequestCx, productId);
+    }
+  }
+
+  const withShowcase = enrichProductShowcaseHtml(withAutomaticShowcase, productId);
   const enriched = normalizeProductSnippetSchemaHtml(withShowcase);
   if (enriched === html) return response;
   return responseWithBody(response, enriched);

--- a/scripts/seo/showcase-live-audit.mjs
+++ b/scripts/seo/showcase-live-audit.mjs
@@ -1,0 +1,216 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { SHOWCASE_PREVIEW_SAMPLE_IDS } from '../../functions/_shared/showcase-cohort.js';
+
+const BASE_URL = (process.env.SHOWCASE_BASE_URL || 'https://www.amadolibros.com').replace(/\/$/, '');
+const EXPECT_INDEXABLE = process.env.SHOWCASE_EXPECT_INDEXABLE !== 'false';
+const OUTPUT_DIR = process.env.SHOWCASE_OUTPUT_DIR || 'artifacts/showcase-live';
+const CONCURRENCY = Math.max(1, Math.min(8, Number(process.env.SHOWCASE_CONCURRENCY) || 5));
+const CURATED_ID = 'MLU633557235';
+
+function decodeHtml(value) {
+  return String(value || '')
+    .replace(/<[^>]+>/g, ' ')
+    .replaceAll('&amp;', '&')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#39;', "'")
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function robots(html) {
+  return String(html.match(/<meta\s+name="robots"\s+content="([^"]+)"/i)?.[1] || '').toLowerCase();
+}
+
+function canonical(html) {
+  return String(html.match(/<link\s+rel="canonical"\s+href="([^"]+)"/i)?.[1] || '');
+}
+
+function h1(html) {
+  return decodeHtml(html.match(/<h1>([\s\S]*?)<\/h1>/i)?.[1] || '');
+}
+
+function section(html, className) {
+  const marker = `<section class="${className}"`;
+  const start = html.indexOf(marker);
+  if (start < 0) return '';
+  const nextSection = html.indexOf('<section class="', start + marker.length);
+  const mainEnd = html.indexOf('</main>', start + marker.length);
+  const end = [nextSection, mainEnd].filter(index => index > start).sort((a, b) => a - b)[0];
+  return html.slice(start, end > start ? end : undefined);
+}
+
+function schemas(html) {
+  const values = [];
+  for (const match of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    try {
+      values.push(JSON.parse(match[1]));
+    } catch {
+      // El reporte agrega una falla independiente si no encuentra Product/Book.
+    }
+  }
+  return values;
+}
+
+function productSchema(html, productId) {
+  return schemas(html).find(schema => {
+    const rawType = schema?.['@type'];
+    const types = Array.isArray(rawType) ? rawType : [rawType].filter(Boolean);
+    return types.includes('Book') && String(schema.sku || '').toUpperCase() === productId;
+  }) || null;
+}
+
+async function fetchProduct(productId) {
+  const response = await fetch(`${BASE_URL}/libro/${productId}`, {
+    redirect: 'follow',
+    headers: { 'user-agent': 'AmadoLibros-Showcase-Audit/1.0' },
+    signal: AbortSignal.timeout(45_000),
+  });
+  return {
+    productId,
+    status: response.status,
+    finalUrl: response.url,
+    headers: Object.fromEntries(response.headers.entries()),
+    html: await response.text(),
+  };
+}
+
+async function mapConcurrent(values, mapper) {
+  const results = new Array(values.length);
+  let cursor = 0;
+  async function worker() {
+    while (cursor < values.length) {
+      const index = cursor++;
+      results[index] = await mapper(values[index], index);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, values.length) }, worker));
+  return results;
+}
+
+function inspectProduct(result, { curated = false } = {}) {
+  const failures = [];
+  const html = result.html;
+  const showcase = section(html, 'product-showcase');
+  const title = h1(html);
+  const metaRobots = robots(html);
+  const xRobots = String(result.headers['x-robots-tag'] || '').toLowerCase();
+  const schema = productSchema(html, result.productId);
+  const rawTypes = schema?.['@type'];
+  const types = Array.isArray(rawTypes) ? rawTypes : [rawTypes].filter(Boolean);
+  const priceIndex = html.indexOf('Precio web/tarjeta:');
+  const showcaseIndex = html.indexOf('class="product-showcase"');
+  const showcaseWords = decodeHtml(showcase).split(/\s+/).filter(Boolean).length;
+
+  if (result.status !== 200) failures.push(`HTTP ${result.status}`);
+  if (!title) failures.push('H1 vacío');
+  if (!showcase) failures.push('falta .product-showcase');
+  if (showcase && showcaseWords < 80) failures.push(`vidriera demasiado breve (${showcaseWords} palabras)`);
+  if (!html.includes('class="book-subtitle"')) failures.push('falta subtítulo visible');
+  if (!html.includes('Datos destacados') && !html.includes('Qué vas a encontrar')) {
+    failures.push('falta bloque de datos destacados');
+  }
+  if (!html.includes('Ficha de esta edición')) failures.push('falta ficha de edición');
+  if (!html.includes('data-action="add-to-cart"')) failures.push('falta agregar al carrito');
+  if (!html.includes('wa.me/')) failures.push('falta WhatsApp');
+  if (!html.includes('mercadolibre.com.uy')) failures.push('falta enlace Mercado Libre');
+  if (priceIndex < 0) failures.push('falta precio web/tarjeta');
+  if (priceIndex >= 0 && showcaseIndex >= 0 && priceIndex > showcaseIndex) {
+    failures.push('la vidriera desplazó el precio debajo del contenido');
+  }
+  if (!schema) failures.push('falta schema Book/Product');
+  if (schema && !types.includes('Product')) failures.push('ficha vendible perdió Product');
+  if (schema && !schema.offers) failures.push('ficha vendible perdió Offer real');
+  if (schema?.review || schema?.aggregateRating) failures.push('apareció review/rating no autorizado');
+  if (/class="product-showcase"[\s\S]*?(?:★★★★★|5\/5|rating)/i.test(showcase)) {
+    failures.push('la vidriera contiene una calificación no autorizada');
+  }
+
+  try {
+    const finalOrigin = new URL(result.finalUrl).origin;
+    if (finalOrigin !== new URL(BASE_URL).origin) failures.push(`redirect fuera de Preview: ${finalOrigin}`);
+  } catch {
+    failures.push('URL final inválida');
+  }
+  if (!canonical(html).startsWith('https://www.amadolibros.com/libro/')) {
+    failures.push(`canonical inválido: ${canonical(html) || 'vacío'}`);
+  }
+
+  if (EXPECT_INDEXABLE) {
+    if (!metaRobots.includes('index') || metaRobots.includes('noindex')) failures.push('robots no es index, follow');
+    if (xRobots.includes('noindex')) failures.push('X-Robots-Tag noindex en producción');
+  } else {
+    if (!metaRobots.includes('noindex')) failures.push('meta robots noindex ausente en Preview');
+    if (!xRobots.includes('noindex')) failures.push('X-Robots-Tag noindex ausente en Preview');
+  }
+
+  if (curated) {
+    if (title !== 'Padres fuertes, hijas felices') failures.push('el piloto curado perdió su H1');
+    if (!html.includes('Guía práctica sobre el vínculo entre padres e hijas')) {
+      failures.push('el piloto curado fue reemplazado por contenido automático');
+    }
+  }
+
+  return {
+    productId: result.productId,
+    status: result.status,
+    finalUrl: result.finalUrl,
+    title,
+    canonical: canonical(html),
+    robots: metaRobots,
+    xRobotsTag: xRobots,
+    showcaseWords,
+    curated,
+    hasCart: html.includes('data-action="add-to-cart"'),
+    hasWhatsApp: html.includes('wa.me/'),
+    hasMercadoLibre: html.includes('mercadolibre.com.uy'),
+    hasOffer: Boolean(schema?.offers),
+    failures,
+  };
+}
+
+async function main() {
+  const ids = [...SHOWCASE_PREVIEW_SAMPLE_IDS, CURATED_ID];
+  const fetched = await mapConcurrent(ids, fetchProduct);
+  const products = fetched.map(result => inspectProduct(result, {
+    curated: result.productId === CURATED_ID,
+  }));
+  const failures = products.flatMap(product =>
+    product.failures.map(failure => `${product.productId}: ${failure}`));
+  const automatic = products.filter(product => !product.curated);
+
+  const report = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    baseUrl: BASE_URL,
+    expectIndexable: EXPECT_INDEXABLE,
+    automaticSamples: automatic.length,
+    automaticPassed: automatic.filter(product => product.failures.length === 0).length,
+    curatedPassed: products.find(product => product.curated)?.failures.length === 0,
+    failures,
+    products,
+  };
+
+  await mkdir(OUTPUT_DIR, { recursive: true });
+  const outputPath = path.join(OUTPUT_DIR, 'showcase-live-audit.json');
+  await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+  console.log(JSON.stringify({
+    automaticSamples: report.automaticSamples,
+    automaticPassed: report.automaticPassed,
+    curatedPassed: report.curatedPassed,
+    failures: report.failures.length,
+  }));
+  console.log(`Escrito: ${outputPath}`);
+
+  if (failures.length) {
+    throw new Error(`Auditoría de fichas vidriera falló: ${failures.join(' | ')}`);
+  }
+}
+
+main().catch(error => {
+  console.error(error.stack || error.message);
+  process.exitCode = 1;
+});

--- a/scripts/seo/showcase-live-audit.mjs
+++ b/scripts/seo/showcase-live-audit.mjs
@@ -37,9 +37,14 @@ function section(html, className) {
   const marker = `<section class="${className}"`;
   const start = html.indexOf(marker);
   if (start < 0) return '';
-  const nextSection = html.indexOf('<section class="', start + marker.length);
+
+  // product-showcase contiene secciones anidadas. No se puede cortar en el
+  // siguiente <section>: se toma el bloque completo hasta relacionados o main.
+  const relatedBooks = html.indexOf('<section class="related-books"', start + marker.length);
   const mainEnd = html.indexOf('</main>', start + marker.length);
-  const end = [nextSection, mainEnd].filter(index => index > start).sort((a, b) => a - b)[0];
+  const end = [relatedBooks, mainEnd]
+    .filter(index => index > start)
+    .sort((a, b) => a - b)[0];
   return html.slice(start, end > start ? end : undefined);
 }
 

--- a/worker-sync/__tests__/showcase-publish.test.js
+++ b/worker-sync/__tests__/showcase-publish.test.js
@@ -107,7 +107,7 @@ test('no incorpora pausados ni repite la misma edición', () => {
   assert.equal(original.showcase_rank, undefined);
 });
 
-test('publica staging, valida readback y promueve cohorte + catálogo + meta', async () => {
+test('publica staging, valida readback y promueve catálogo + meta + cohorte como último puntero', async () => {
   const objects = new Map();
   const writes = [];
   const env = {
@@ -133,16 +133,16 @@ test('publica staging, valida readback y promueve cohorte + catálogo + meta', a
     'staging/catalog.json',
     'staging/meta.json',
     'staging/showcase-cohort.json',
-    'showcase/v1/cohort.json',
     'catalog.json',
     'meta.json',
+    'showcase/v1/cohort.json',
   ]);
   const cohort = JSON.parse(objects.get('showcase/v1/cohort.json'));
   const liveCatalog = JSON.parse(objects.get('catalog.json'));
   assert.equal(cohort.total, 1000);
   assert.equal(liveCatalog.data_quality.showcase_selection.selected_items, 1000);
   assert.equal(syncMeta.showcase_selection.selected_items, 1000);
-  assert.equal(writes[3].options.httpMetadata.cacheControl, 'public, max-age=3600');
+  assert.equal(writes[5].options.httpMetadata.cacheControl, 'public, max-age=3600');
 });
 
 test('si el readback de la cohorte falla no toca ningún archivo live', async () => {

--- a/worker-sync/__tests__/showcase-publish.test.js
+++ b/worker-sync/__tests__/showcase-publish.test.js
@@ -1,0 +1,172 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  prepareShowcaseCatalog,
+  publishToR2,
+} from '../r2-publish.js';
+
+function item(index, overrides = {}) {
+  return {
+    id: `MLU${200000000 + index}`,
+    title: `Libro seleccionado ${index}`,
+    author: `Autor ${index}`,
+    price: 1200 + index,
+    currency: 'UYU',
+    status: 'active',
+    available_quantity: 1,
+    condition: 'new',
+    domain_id: 'MLU-BOOKS',
+    pictures: [`https://img/${index}.jpg`],
+    bibliographic: {},
+    ...overrides,
+  };
+}
+
+function catalog(count = 1200) {
+  return {
+    total: count,
+    updated_at: '2026-08-20T12:00:00.000Z',
+    items: Array.from({ length: count }, (_, index) => item(index)),
+  };
+}
+
+test('prepara exactamente las 1000 mejores ediciones activas', () => {
+  const value = catalog(1200);
+  const syncMeta = {};
+  const { cohort, metrics } = prepareShowcaseCatalog(value, syncMeta);
+
+  assert.equal(cohort.schema_version, 1);
+  assert.equal(cohort.total, 1000);
+  assert.equal(cohort.ids.length, 1000);
+  assert.equal(new Set(cohort.ids).size, 1000);
+  assert.equal(metrics.selected_items, 1000);
+  assert.equal(value.items.filter(entry => entry.showcase_rank).length, 1000);
+  assert.equal(value.data_quality.showcase_selection.selected_items, 1000);
+  assert.equal(syncMeta.showcase_selection.selected_items, 1000);
+  assert.deepEqual(
+    value.items
+      .filter(entry => entry.showcase_rank)
+      .map(entry => entry.showcase_rank)
+      .sort((a, b) => a - b),
+    Array.from({ length: 1000 }, (_, index) => index + 1),
+  );
+});
+
+test('la prioridad editorial verificada gana sin inventar señales de demanda', () => {
+  const priority = item(1, {
+    id: 'MLU633557235',
+    title: 'Padres fuertes, hijas felices',
+    author: null,
+    pictures: [],
+    pages: null,
+    bibliographic: null,
+  });
+  const richer = item(2, {
+    description: 'Descripción extensa y real. '.repeat(80),
+    pictures: ['a', 'b', 'c', 'd'],
+    pages: 500,
+    isbn: '9788496836693',
+    bibliographic: { language: 'Español', format: 'Tapa dura' },
+  });
+  const value = {
+    total: 2,
+    updated_at: '2026-08-20T12:00:00.000Z',
+    items: [richer, priority],
+  };
+
+  const { cohort } = prepareShowcaseCatalog(value);
+  assert.equal(cohort.ids[0], 'MLU633557235');
+  assert.equal(priority.showcase_rank, 1);
+});
+
+test('no incorpora pausados ni repite la misma edición', () => {
+  const original = item(1, {
+    isbn: '9788496836693',
+    available_quantity: 1,
+  });
+  const representative = item(2, {
+    isbn: '9788496836693',
+    available_quantity: 9,
+    pictures: ['a', 'b', 'c'],
+  });
+  const paused = item(3, {
+    status: 'paused',
+    available_quantity: 0,
+  });
+  const value = {
+    total: 3,
+    updated_at: '2026-08-20T12:00:00.000Z',
+    items: [original, representative, paused],
+  };
+
+  const { cohort, metrics } = prepareShowcaseCatalog(value);
+  assert.deepEqual(cohort.ids, [representative.id]);
+  assert.equal(metrics.duplicate_editions_excluded, 1);
+  assert.equal(paused.showcase_rank, undefined);
+  assert.equal(original.showcase_rank, undefined);
+});
+
+test('publica staging, valida readback y promueve cohorte + catálogo + meta', async () => {
+  const objects = new Map();
+  const writes = [];
+  const env = {
+    CATALOG_R2: {
+      async put(key, body, options) {
+        writes.push({ key, body, options });
+        objects.set(key, body);
+      },
+      async get(key) {
+        const body = objects.get(key);
+        return body == null ? null : {
+          async text() { return body; },
+        };
+      },
+    },
+  };
+  const value = catalog(1005);
+  const syncMeta = { status: 'success' };
+
+  await publishToR2(env, value, syncMeta);
+
+  assert.deepEqual(writes.map(write => write.key), [
+    'staging/catalog.json',
+    'staging/meta.json',
+    'staging/showcase-cohort.json',
+    'showcase/v1/cohort.json',
+    'catalog.json',
+    'meta.json',
+  ]);
+  const cohort = JSON.parse(objects.get('showcase/v1/cohort.json'));
+  const liveCatalog = JSON.parse(objects.get('catalog.json'));
+  assert.equal(cohort.total, 1000);
+  assert.equal(liveCatalog.data_quality.showcase_selection.selected_items, 1000);
+  assert.equal(syncMeta.showcase_selection.selected_items, 1000);
+  assert.equal(writes[3].options.httpMetadata.cacheControl, 'public, max-age=3600');
+});
+
+test('si el readback de la cohorte falla no toca ningún archivo live', async () => {
+  const objects = new Map();
+  const writes = [];
+  const env = {
+    CATALOG_R2: {
+      async put(key, body) {
+        writes.push(key);
+        objects.set(key, body);
+      },
+      async get(key) {
+        if (key === 'staging/showcase-cohort.json') return null;
+        const body = objects.get(key);
+        return body == null ? null : { async text() { return body; } };
+      },
+    },
+  };
+
+  await assert.rejects(
+    publishToR2(env, catalog(10), {}),
+    /showcase-cohort\.json devolvió null/,
+  );
+  assert.equal(writes.includes('showcase/v1/cohort.json'), false);
+  assert.equal(writes.includes('catalog.json'), false);
+  assert.equal(writes.includes('meta.json'), false);
+});

--- a/worker-sync/r2-publish.js
+++ b/worker-sync/r2-publish.js
@@ -168,16 +168,10 @@ export async function publishToR2(env, catalog, syncMeta) {
   );
 
   // ── 3. Promote a live ──────────────────────────────────────────────────────
-  // La cohorte se publica antes del catálogo. Si un put posterior fallara, la
-  // cohorte contiene sólo IDs de libros activos que también existían en la foto
-  // anterior; Pages degrada de forma segura si algún ID no resuelve.
-  await env.CATALOG_R2.put(SHOWCASE_COHORT_LIVE_KEY, cohortBody, {
-    httpMetadata: {
-      contentType: 'application/json',
-      cacheControl: 'public, max-age=3600',
-    },
-  });
-
+  // Primero se publica la fotografía completa y recién al final la cohorte que
+  // la referencia. Si catálogo o meta fallan, Pages conserva la cohorte previa;
+  // si falla el último put, sólo queda el catálogo nuevo con la cohorte anterior,
+  // una degradación segura sin IDs adelantados ni fichas rotas.
   await env.CATALOG_R2.put('catalog.json', catalogBody, {
     httpMetadata: {
       contentType: 'application/json',
@@ -189,6 +183,15 @@ export async function publishToR2(env, catalog, syncMeta) {
     httpMetadata: {
       contentType: 'application/json',
       cacheControl: 'public, max-age=300',
+    },
+  });
+
+  // Puntero/allowlist último: nunca anuncia una edición antes de que el catálogo
+  // completo que la contiene haya quedado publicado.
+  await env.CATALOG_R2.put(SHOWCASE_COHORT_LIVE_KEY, cohortBody, {
+    httpMetadata: {
+      contentType: 'application/json',
+      cacheControl: 'public, max-age=3600',
     },
   });
 

--- a/worker-sync/r2-publish.js
+++ b/worker-sync/r2-publish.js
@@ -1,40 +1,119 @@
+import {
+  assignShowcaseRanking,
+  DEFAULT_SHOWCASE_LIMIT,
+} from '../functions/_shared/showcase-ranking.js';
+import { PRODUCT_SHOWCASE_OVERRIDES } from '../functions/_shared/product-showcases.js';
+import { PRODUCT_SEO_OVERRIDES } from '../functions/_shared/seo-products.js';
+import { VERIFIED_BOOK_IDS } from './verified-book-enrichments.js';
+import { VERIFIED_DEMAND_BOOK_IDS } from './verified-demand-bibliography.js';
+
 /**
  * worker-sync/r2-publish.js
  *
- * Escribe catalog.json y meta.json en el bucket R2 amadolibros-catalog
- * usando el patrón staging → validación → promote.
- *
- * Flujo:
- *   1. Escribir staging/catalog.json + staging/meta.json
- *   2. Leer de vuelta staging/catalog.json y validar estructura
- *   3. Solo si válido: promover a catalog.json + meta.json (archivos live)
- *   4. Si inválido: lanzar error — catalog.json live NO se toca
- *
- * Validaciones antes de promote:
- *   - JSON parseable
- *   - Tiene campos: total (number), updated_at (string), items (array)
- *   - items.length > 0
- *   - items.length === total
- *
- * R2 put es atómico: el objeto live sigue siendo visible para lectores
- * hasta que el put de promote completa. No hay ventana de inconsistencia.
+ * Escribe catalog.json, meta.json y la cohorte compacta de fichas vidriera en
+ * el bucket R2 amadolibros-catalog usando staging → validación → promote.
  */
 
+const SHOWCASE_COHORT_STAGING_KEY = 'staging/showcase-cohort.json';
+const SHOWCASE_COHORT_LIVE_KEY = 'showcase/v1/cohort.json';
+const SHOWCASE_PRIORITY_IDS = new Set([
+  ...Object.keys(PRODUCT_SHOWCASE_OVERRIDES),
+  ...Object.keys(PRODUCT_SEO_OVERRIDES),
+  ...VERIFIED_BOOK_IDS,
+  ...VERIFIED_DEMAND_BOOK_IDS,
+]);
+
+function validShowcasePayload(payload) {
+  return payload &&
+    payload.schema_version === 1 &&
+    Number.isInteger(payload.total) &&
+    payload.total >= 1 &&
+    payload.total <= DEFAULT_SHOWCASE_LIMIT &&
+    Array.isArray(payload.ids) &&
+    payload.ids.length === payload.total &&
+    new Set(payload.ids).size === payload.ids.length &&
+    payload.ids.every(id => /^MLU\d+$/.test(String(id || '')));
+}
+
+/**
+ * Marca exactamente las mejores ediciones activas del catálogo y genera un
+ * puntero liviano para Pages. La selección usa únicamente campos reales:
+ * descripción, ISBN, autoría, editorial, páginas, bibliografía, imágenes,
+ * identidad de catálogo y stock. Las oportunidades ya verificadas reciben un
+ * bonus explícito, sin consultar conectores de publicidad.
+ */
+export function prepareShowcaseCatalog(catalog, syncMeta = null) {
+  if (!catalog || !Array.isArray(catalog.items)) {
+    throw new Error('[R2] No se puede preparar la cohorte vidriera: catálogo inválido.');
+  }
+
+  const metrics = assignShowcaseRanking(catalog.items, {
+    limit: DEFAULT_SHOWCASE_LIMIT,
+    priorityIds: SHOWCASE_PRIORITY_IDS,
+  });
+  if (metrics.selected_items < 1) {
+    throw new Error('[R2] No se puede publicar una cohorte vidriera vacía.');
+  }
+
+  catalog.data_quality = {
+    ...(catalog.data_quality || {}),
+    showcase_selection: metrics,
+  };
+
+  const ids = catalog.items
+    .filter(item => Number.isInteger(item.showcase_rank))
+    .sort((a, b) => a.showcase_rank - b.showcase_rank)
+    .map(item => item.id);
+  const cohort = {
+    schema_version: 1,
+    generated_at: catalog.updated_at,
+    catalog_version: catalog.updated_at,
+    total: ids.length,
+    ids,
+  };
+
+  if (!validShowcasePayload(cohort)) {
+    throw new Error('[R2] La cohorte vidriera generada no cumple el contrato.');
+  }
+
+  if (syncMeta && typeof syncMeta === 'object') {
+    syncMeta.showcase_selection = {
+      schema_version: metrics.schema_version,
+      limit: metrics.limit,
+      selected_items: metrics.selected_items,
+      selected_with_description: metrics.selected_with_description,
+      selected_with_isbn: metrics.selected_with_isbn,
+      selected_with_multiple_images: metrics.selected_with_multiple_images,
+    };
+  }
+
+  return { cohort, metrics };
+}
+
 export async function publishToR2(env, catalog, syncMeta) {
+  const { cohort, metrics } = prepareShowcaseCatalog(catalog, syncMeta);
   const catalogBody = JSON.stringify(catalog);
-  const metaBody    = JSON.stringify(syncMeta);
+  const metaBody = JSON.stringify(syncMeta);
+  const cohortBody = JSON.stringify(cohort);
 
   // ── 1. Escribir staging ────────────────────────────────────────────────────
   await env.CATALOG_R2.put('staging/catalog.json', catalogBody, {
     httpMetadata: {
-      contentType:  'application/json',
+      contentType: 'application/json',
       cacheControl: 'no-store',
     },
   });
 
   await env.CATALOG_R2.put('staging/meta.json', metaBody, {
     httpMetadata: {
-      contentType:  'application/json',
+      contentType: 'application/json',
+      cacheControl: 'no-store',
+    },
+  });
+
+  await env.CATALOG_R2.put(SHOWCASE_COHORT_STAGING_KEY, cohortBody, {
+    httpMetadata: {
+      contentType: 'application/json',
       cacheControl: 'no-store',
     },
   });
@@ -42,47 +121,73 @@ export async function publishToR2(env, catalog, syncMeta) {
   console.log('[R2] Staging escrito. Validando readback...');
 
   // ── 2. Leer de vuelta y validar ────────────────────────────────────────────
-  const stagingObj = await env.CATALOG_R2.get('staging/catalog.json');
+  const [stagingObj, stagingShowcaseObj] = await Promise.all([
+    env.CATALOG_R2.get('staging/catalog.json'),
+    env.CATALOG_R2.get(SHOWCASE_COHORT_STAGING_KEY),
+  ]);
   if (!stagingObj) {
     throw new Error('[R2] Readback de staging/catalog.json devolvió null — R2 inconsistente. Abortando promote.');
   }
-
-  let parsed;
-  try {
-    const text = await stagingObj.text();
-    parsed = JSON.parse(text);
-  } catch (e) {
-    throw new Error(`[R2] staging/catalog.json no es JSON válido: ${e.message}`);
+  if (!stagingShowcaseObj) {
+    throw new Error('[R2] Readback de staging/showcase-cohort.json devolvió null. Abortando promote.');
   }
 
-  // Validar estructura
-  const errs = [];
+  let parsed;
+  let parsedShowcase;
+  try {
+    const [catalogText, showcaseText] = await Promise.all([
+      stagingObj.text(),
+      stagingShowcaseObj.text(),
+    ]);
+    parsed = JSON.parse(catalogText);
+    parsedShowcase = JSON.parse(showcaseText);
+  } catch (error) {
+    throw new Error(`[R2] El staging no es JSON válido: ${error.message}`);
+  }
 
-  if (typeof parsed.total !== 'number')              errs.push('total no es number');
-  if (typeof parsed.updated_at !== 'string')         errs.push('updated_at no es string');
-  if (!Array.isArray(parsed.items))                  errs.push('items no es array');
+  const errs = [];
+  if (typeof parsed.total !== 'number') errs.push('total no es number');
+  if (typeof parsed.updated_at !== 'string') errs.push('updated_at no es string');
+  if (!Array.isArray(parsed.items)) errs.push('items no es array');
   if (Array.isArray(parsed.items) && parsed.items.length === 0) errs.push('items está vacío');
   if (Array.isArray(parsed.items) && typeof parsed.total === 'number' && parsed.items.length !== parsed.total) {
     errs.push(`items.length (${parsed.items.length}) !== total (${parsed.total})`);
   }
-
-  if (errs.length > 0) {
-    throw new Error(`[R2] Validación fallida — catalog.json live NO modificado. Errores: ${errs.join('; ')}`);
+  if (!validShowcasePayload(parsedShowcase)) errs.push('cohorte vidriera inválida');
+  if (validShowcasePayload(parsedShowcase) && parsedShowcase.total !== metrics.selected_items) {
+    errs.push(`cohorte.total (${parsedShowcase.total}) !== selected_items (${metrics.selected_items})`);
   }
 
-  console.log(`[R2] Validación OK: ${parsed.total} items, updated_at: ${parsed.updated_at}`);
+  if (errs.length > 0) {
+    throw new Error(`[R2] Validación fallida — archivos live NO modificados. Errores: ${errs.join('; ')}`);
+  }
+
+  console.log(
+    `[R2] Validación OK: ${parsed.total} items; ` +
+    `${parsedShowcase.total} fichas vidriera; updated_at: ${parsed.updated_at}`,
+  );
 
   // ── 3. Promote a live ──────────────────────────────────────────────────────
+  // La cohorte se publica antes del catálogo. Si un put posterior fallara, la
+  // cohorte contiene sólo IDs de libros activos que también existían en la foto
+  // anterior; Pages degrada de forma segura si algún ID no resuelve.
+  await env.CATALOG_R2.put(SHOWCASE_COHORT_LIVE_KEY, cohortBody, {
+    httpMetadata: {
+      contentType: 'application/json',
+      cacheControl: 'public, max-age=3600',
+    },
+  });
+
   await env.CATALOG_R2.put('catalog.json', catalogBody, {
     httpMetadata: {
-      contentType:  'application/json',
+      contentType: 'application/json',
       cacheControl: 'public, max-age=3600',
     },
   });
 
   await env.CATALOG_R2.put('meta.json', metaBody, {
     httpMetadata: {
-      contentType:  'application/json',
+      contentType: 'application/json',
       cacheControl: 'public, max-age=300',
     },
   });
@@ -90,6 +195,7 @@ export async function publishToR2(env, catalog, syncMeta) {
   const bytes = new TextEncoder().encode(catalogBody).length;
   console.log(
     `[R2] Promote completado: ${catalog.total} items, ` +
-    `${(bytes / 1024 / 1024).toFixed(2)} MB, updated_at: ${catalog.updated_at}`
+    `${cohort.total} fichas vidriera, ` +
+    `${(bytes / 1024 / 1024).toFixed(2)} MB, updated_at: ${catalog.updated_at}`,
   );
 }

--- a/worker-sync/wrangler.toml
+++ b/worker-sync/wrangler.toml
@@ -17,9 +17,10 @@ APP_ID          = "4741021817925208"
 USER_ID         = "440298103"
 # Mínimo de items activos aceptables — aborta si R2 se quedaría con menos.
 MIN_ACTIVE_ITEMS = "500"
-# Descripciones ML: endpoint individual. Se completa un cupo diario y se
-# reutiliza por 90 días para no convertir 7.000 ítems en 7.000 requests/día.
-ML_DESCRIPTION_ENRICH_LIMIT = "100"
+# Descripciones ML: endpoint individual. El primer lote vidriera acelera el
+# cupo de 100 a 300 por día, con la misma pausa y caché de 90 días. No intenta
+# hacer 1.000 requests en una sola corrida ni pone en riesgo el sync completo.
+ML_DESCRIPTION_ENRICH_LIMIT = "300"
 ML_DESCRIPTION_REFRESH_DAYS = "90"
 ML_DESCRIPTION_SLEEP_MS = "100"
 # Galerías oficiales de productos de catálogo: se cachean en R2 y se


### PR DESCRIPTION
## Objetivo

Aplicar el modelo aprobado y fusionado en PR #200 a las primeras 1.000 mejores ediciones activas del catálogo, sin volver a conectores de publicidad y sin inventar contenido.

## Alcance final

Este lote une dos piezas inseparables para el rollout:

1. **Worker/catalogación:** selecciona hasta 1.000 ediciones activas, con stock, precio positivo y moneda UYU, deduplicadas por ISBN+condición o por obra+autor+condición cuando no hay ISBN.
2. **Pages/ficha:** consulta una cohorte compacta de IDs y convierte sólo esas fichas en una vidriera ampliada.

## Criterio de selección

Ranking determinista basado exclusivamente en señales reales del catálogo:

- descripción disponible;
- ISBN válido;
- autoría no genérica;
- editorial real;
- páginas y bibliografía;
- medidas;
- cantidad de imágenes;
- identidad de catálogo Mercado Libre;
- stock;
- condición y limpieza del título.

Las oportunidades ya verificadas por GSC, enriquecimientos bibliográficos y la ficha piloto reciben prioridad explícita. No se atribuye demanda nueva ni se usan Ads.

## Contenido visible

- Si Mercado Libre aporta una descripción real suficiente, se presenta y estructura sin reescribir su sentido.
- Si falta descripción, se genera una explicación estrictamente factual de la obra y de la edición: autor, ISBN, editorial, páginas, formato y otros datos realmente presentes.
- Agrega datos destacados, público orientativo, bloque de autoría sin biografías inventadas, ficha de edición y enlaces internos.
- Mejora meta description y la descripción Book del JSON-LD usando sólo el contenido real disponible.
- La ficha curada `MLU633557235` sigue teniendo prioridad y no se reemplaza por el generador automático.

## Guardas

- sólo activos con stock y precio UYU;
- contrato de libro alineado con Merchant;
- una sola publicación por edición y condición;
- máximo 1.000 IDs;
- Preview puede usar únicamente cinco IDs verificados como muestra si el archivo R2 todavía no existe;
- Producción nunca usa ese fallback;
- no modifica precio, stock, imágenes, carrito, WhatsApp, Mercado Libre, canonical, robots ni Offer;
- no inventa sinopsis, reseñas, estrellas, testimonios o biografías;
- no vuelve a cargar el catálogo completo desde el middleware;
- la transformación es idempotente;
- la ficha piloto curada mantiene prioridad sobre la automática.

## Publicación segura

El Worker publica por staging/readback/promote:

- `staging/catalog.json`
- `staging/meta.json`
- `staging/showcase-cohort.json`
- `catalog.json`
- `meta.json`
- `showcase/v1/cohort.json`

La cohorte/allowlist se publica **última**, después del catálogo y del meta. De esa forma nunca anuncia una edición antes de que la fotografía completa que la contiene esté disponible.

La selección y sus métricas quedan dentro de `catalog.data_quality.showcase_selection` y también en el meta del sync.

## Aceleración controlada

El cupo diario de descripciones oficiales de Mercado Libre sube de 100 a 300, manteniendo pausa de 100 ms entre requests y caché de 90 días. No se hacen 1.000 consultas en una sola corrida ni se pone en riesgo el sync completo.

## Diff final

- 14 archivos modificados o creados;
- 19 commits de implementación y corrección;
- `+2.008 / -53` líneas.

Archivos principales:

- `functions/_shared/showcase-ranking.js`
- `functions/_shared/automatic-product-showcase.js`
- `functions/_shared/showcase-cohort.js`
- `functions/libro/_middleware.js`
- `worker-sync/r2-publish.js`
- `scripts/seo/showcase-live-audit.mjs`
- `.github/workflows/deploy-pr-preview.yml`
- cuatro suites nuevas de tests y una suite actualizada.

## Validación final

### CI y build

- suite worker/sync: `111/111 PASS`;
- suite principal: `631/631 PASS`;
- fallas: `0`;
- sintaxis completa: PASS;
- Astro build: PASS;
- 13 páginas generadas;
- SEO baseline público: PASS.

### Preview protegido

Alias estable:

`https://pr-202.amadolibros-web.pages.dev`

Último deployment validado:

`https://f3810076.amadolibros-web.pages.dev`

### Auditoría comercial

- resultado: `pass`;
- críticos: `0`;
- catálogo: 7.079 ítems;
- feed: 3.653 ítems, 0 críticos, 0 warnings;
- imágenes: 80/80 válidas, 0 fallidas;
- páginas: 80/80 PASS sobre 10.024 URLs de libros del sitemap.

### Auditoría específica de fichas vidriera

- muestras automáticas reales: `5/5 PASS`;
- ficha piloto curada: PASS;
- fallas: `0`;
- precio visible antes del contenido editorial;
- carrito, WhatsApp y Mercado Libre presentes;
- Product + Book + Offer real preservados;
- sin review ni rating inventados;
- canonical productivo preservado;
- Preview con meta y header noindex correctos.

### Auditoría del hub por encargo

- 2.949 fichas enlazadas sobre 2.949;
- 62 páginas;
- 24 enlaces prioritarios;
- fallas: `0`.

## Activación en Producción

Este PR todavía no modifica Producción.

Después del merge:

1. Pages publica el renderer y conserva comportamiento actual mientras no exista una cohorte productiva válida.
2. El siguiente sync exitoso del Worker calcula las 1.000 mejores ediciones y publica catálogo, meta y cohorte en ese orden.
3. Recién entonces las 1.000 fichas automáticas quedan activas.

El rollout degrada de forma segura: sin cohorte productiva válida, sólo permanece la ficha curada del PR #200.

## Riesgo residual

Controlado, pero el radio visual es grande: hasta 1.000 fichas. Las guardas, la cohorte compacta, el orden de publicación, los tests y la auditoría de Preview reducen el riesgo técnico. No se promete una posición concreta en Google; el resultado SEO depende del recrawl y de la competencia.

## Producción

No fusionar sin aprobación explícita de Seba.