### PR TITLE
GSC: corregir restricción de dominio para exportación BigQuery

### DIFF
--- a/.github/workflows/gsc-bigquery-domain-fix.yml
+++ b/.github/workflows/gsc-bigquery-domain-fix.yml
@@ -68,6 +68,12 @@ jobs:
         with:
           project_id: amado-libros-analytics
 
+      - name: Enable Organization Policy API in the analytics project
+        run: >-
+          gcloud services enable orgpolicy.googleapis.com
+          --project=amado-libros-analytics
+          --quiet
+
       - name: Apply or verify the project-only correction
         env:
           INPUT_MODE: ${{ inputs.mode }}

--- a/.github/workflows/gsc-bigquery-domain-fix.yml
+++ b/.github/workflows/gsc-bigquery-domain-fix.yml
@@ -1,0 +1,106 @@
+name: GSC BigQuery domain restriction repair
+
+on:
+  push:
+    branches:
+      - agent/gsc-bigquery-domain-fix
+    paths:
+      - '.github/workflows/gsc-bigquery-domain-fix.yml'
+      - 'scripts/seo/gsc-bigquery-domain-fix.sh'
+      - 'functions/__tests__/gsc-bigquery-domain-fix.test.js'
+      - 'functions/__tests__/google-workload-identity.test.js'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: apply corrige; verify sólo comprueba; rollback elimina únicamente el override exacto de este lote
+        required: true
+        default: verify
+        type: choice
+        options:
+          - verify
+          - apply
+          - rollback
+      target_date:
+        description: Fecha de datos GSC a comprobar (YYYY-MM-DD)
+        required: true
+        default: '2026-08-18'
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: gsc-bigquery-domain-fix
+  cancel-in-progress: false
+
+env:
+  GSC_BQ_PROJECT_ID: amado-libros-analytics
+  GSC_BQ_PROJECT_NUMBER: '667747565315'
+  GSC_BQ_DATASET_ID: searchconsole
+  GSC_BQ_FIX_MODE: apply
+  GSC_BQ_OUTPUT_DIR: artifacts/gsc-bigquery-domain-fix
+
+jobs:
+  repair:
+    name: Repair and verify GSC BigQuery export policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate with Google
+        id: google_auth
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: amado-libros-analytics
+          workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
+          service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/cloud-platform
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          project_id: amado-libros-analytics
+
+      - name: Apply or verify the project-only correction
+        env:
+          INPUT_MODE: ${{ inputs.mode }}
+          INPUT_TARGET_DATE: ${{ inputs.target_date }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            export GSC_BQ_FIX_MODE="${INPUT_MODE:-verify}"
+            export GSC_BQ_TARGET_DATE="${INPUT_TARGET_DATE:-2026-08-18}"
+          else
+            export GSC_BQ_FIX_MODE=apply
+            export GSC_BQ_TARGET_DATE=2026-08-18
+          fi
+          bash scripts/seo/gsc-bigquery-domain-fix.sh
+
+      - name: Write run summary
+        if: always()
+        run: |
+          if [ -f artifacts/gsc-bigquery-domain-fix/summary.md ]; then
+            cat artifacts/gsc-bigquery-domain-fix/summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## GSC BigQuery domain fix incompleto" >> "$GITHUB_STEP_SUMMARY"
+            echo "No se generó summary.md; revisar el paso de reparación." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo >> "$GITHUB_STEP_SUMMARY"
+          echo "- Web deploy: no" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Worker deploy: no" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Dataset deletion: no" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload policy, IAM and BigQuery evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gsc-bigquery-domain-fix-${{ github.run_id }}
+          path: artifacts/gsc-bigquery-domain-fix/
+          if-no-files-found: warn
+          retention-days: 30

--- a/functions/__tests__/google-workload-identity.test.js
+++ b/functions/__tests__/google-workload-identity.test.js
@@ -6,6 +6,7 @@ const workflowPaths = [
   '.github/workflows/ga4-export.yml',
   '.github/workflows/gsc-export.yml',
   '.github/workflows/ai-measurement-baseline.yml',
+  '.github/workflows/gsc-bigquery-domain-fix.yml',
 ];
 
 const provider =

--- a/functions/__tests__/gsc-bigquery-domain-fix.test.js
+++ b/functions/__tests__/gsc-bigquery-domain-fix.test.js
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const workflowPath = '.github/workflows/gsc-bigquery-domain-fix.yml';
+const scriptPath = 'scripts/seo/gsc-bigquery-domain-fix.sh';
+
+function workflow() {
+  return readFileSync(workflowPath, 'utf8');
+}
+
+function script() {
+  return readFileSync(scriptPath, 'utf8');
+}
+
+test('el workflow de reparación corre en rama aislada y no despliega la web', () => {
+  const source = workflow();
+
+  assert.match(source, /name: GSC BigQuery domain restriction repair/);
+  assert.match(source, /- agent\/gsc-bigquery-domain-fix/);
+  assert.doesNotMatch(source, /branches:\s*\[?main\]?/);
+  assert.doesNotMatch(source, /wrangler|pages deploy|npm run build|deploy-worker/i);
+  assert.match(source, /GSC_BQ_FIX_MODE: apply/);
+});
+
+test('autentica con WIF y sólo solicita cloud-platform', () => {
+  const source = workflow();
+
+  assert.match(source, /^  id-token: write$/m);
+  assert.match(source, /uses: google-github-actions\/auth@v3/);
+  assert.match(source, /uses: google-github-actions\/setup-gcloud@v3/);
+  assert.match(source, /project_id: amado-libros-analytics/);
+  assert.match(source, /projects\/667747565315\/locations\/global\/workloadIdentityPools\/github-actions\/providers\/amadolibros-web/);
+  assert.match(source, /service_account: ga4-reporter@amado-libros-analytics\.iam\.gserviceaccount\.com/);
+  assert.match(source, /https:\/\/www\.googleapis\.com\/auth\/cloud-platform/);
+  assert.doesNotMatch(source, /credentials_json:|SERVICE_ACCOUNT_JSON|private_key/);
+});
+
+test('la corrección queda limitada al proyecto analítico conocido', () => {
+  const source = script();
+
+  assert.match(source, /PROJECT_ID="\$\{GSC_BQ_PROJECT_ID:-amado-libros-analytics\}"/);
+  assert.match(source, /EXPECTED_PROJECT_NUMBER="\$\{GSC_BQ_PROJECT_NUMBER:-667747565315\}"/);
+  assert.match(source, /DATASET_ID="\$\{GSC_BQ_DATASET_ID:-searchconsole\}"/);
+  assert.match(source, /CONSTRAINT="iam\.allowedPolicyMemberDomains"/);
+  assert.match(source, /name: projects\/\$\{PROJECT_NUMBER\}\/policies\/\$\{CONSTRAINT\}/);
+  assert.doesNotMatch(source, /name: organizations\//);
+  assert.doesNotMatch(source, /--organization=/);
+});
+
+test('no pisa una política de proyecto desconocida y el rollback es conservador', () => {
+  const source = script();
+
+  assert.match(source, /ya existe una política de proyecto distinta\. No se sobrescribe/);
+  assert.match(source, /policy_is_exact_allow_all/);
+  assert.match(source, /inheritFromParent: false/);
+  assert.match(source, /- allowAll: true/);
+  assert.match(source, /el override existente no coincide exactamente con el creado por este lote; no se elimina/);
+  assert.match(source, /gcloud org-policies delete/);
+});
+
+test('garantiza sólo los dos roles oficiales del exportador de Search Console', () => {
+  const source = script();
+
+  assert.match(source, /search-console-data-export@system\.gserviceaccount\.com/);
+  assert.match(source, /ensure_export_role roles\/bigquery\.jobUser/);
+  assert.match(source, /ensure_export_role roles\/bigquery\.dataEditor/);
+  assert.doesNotMatch(source, /roles\/owner|roles\/editor|roles\/bigquery\.admin/);
+});
+
+test('no borra datos ni retira privilegios antes de confirmar la recuperación', () => {
+  const source = script();
+
+  assert.doesNotMatch(source, /\bbq\s+rm\b|datasets\.delete|tables\.delete|rm -rf/);
+  assert.doesNotMatch(source, /remove-iam-policy-binding/);
+  assert.match(source, /TARGET_DATE="\$\{GSC_BQ_TARGET_DATE:-2026-08-18\}"/);
+  assert.match(source, /ExportLog searchdata_url_impression searchdata_site_impression/);
+  assert.match(source, /zero rows immediately after the fix are not treated as a policy failure/);
+});

--- a/functions/__tests__/gsc-bigquery-domain-fix.test.js
+++ b/functions/__tests__/gsc-bigquery-domain-fix.test.js
@@ -23,7 +23,7 @@ test('el workflow de reparación corre en rama aislada y no despliega la web', (
   assert.match(source, /GSC_BQ_FIX_MODE: apply/);
 });
 
-test('autentica con WIF y sólo solicita cloud-platform', () => {
+test('autentica con WIF, habilita sólo la API necesaria y solicita cloud-platform', () => {
   const source = workflow();
 
   assert.match(source, /^  id-token: write$/m);
@@ -33,6 +33,8 @@ test('autentica con WIF y sólo solicita cloud-platform', () => {
   assert.match(source, /projects\/667747565315\/locations\/global\/workloadIdentityPools\/github-actions\/providers\/amadolibros-web/);
   assert.match(source, /service_account: ga4-reporter@amado-libros-analytics\.iam\.gserviceaccount\.com/);
   assert.match(source, /https:\/\/www\.googleapis\.com\/auth\/cloud-platform/);
+  assert.match(source, /gcloud services enable orgpolicy\.googleapis\.com/);
+  assert.match(source, /--project=amado-libros-analytics/);
   assert.doesNotMatch(source, /credentials_json:|SERVICE_ACCOUNT_JSON|private_key/);
 });
 

--- a/scripts/seo/gsc-bigquery-domain-fix.sh
+++ b/scripts/seo/gsc-bigquery-domain-fix.sh
@@ -204,7 +204,8 @@ jq -r --arg member "$REPORTER_MEMBER" '
 
 DATASET_EXISTS=false
 if bq --project_id="$PROJECT_ID" show --format=prettyjson \
-  "$PROJECT_ID:$DATASET_ID" > "$OUTPUT_DIR/dataset.json" 2> "$OUTPUT_DIR/dataset.err"; then
+  "$PROJECT_ID:$DATASET_ID" 2> "$OUTPUT_DIR/dataset.err" \
+  | sed '/^WARNING:/d' > "$OUTPUT_DIR/dataset.json"; then
   DATASET_EXISTS=true
 fi
 
@@ -217,7 +218,8 @@ for table in "${TABLES[@]}"; do
   query_json="$OUTPUT_DIR/query-${table}.json"
   if [[ "$DATASET_EXISTS" == "true" ]] && \
     bq --project_id="$PROJECT_ID" show --format=prettyjson \
-      "$PROJECT_ID:$DATASET_ID.$table" > "$table_json" 2> "$OUTPUT_DIR/table-${table}.err"; then
+      "$PROJECT_ID:$DATASET_ID.$table" 2> "$OUTPUT_DIR/table-${table}.err" \
+      | sed '/^WARNING:/d' > "$table_json"; then
     num_rows="$(jq -r '.numRows // "0"' "$table_json")"
     target_rows="unknown"
     max_date="unknown"
@@ -226,7 +228,8 @@ for table in "${TABLES[@]}"; do
       --use_legacy_sql=false \
       --format=json \
       "SELECT COUNTIF(data_date = DATE('${TARGET_DATE}')) AS target_date_rows, CAST(MAX(data_date) AS STRING) AS max_data_date FROM \`${PROJECT_ID}.${DATASET_ID}.${table}\`" \
-      > "$query_json" 2> "$OUTPUT_DIR/query-${table}.err"; then
+      2> "$OUTPUT_DIR/query-${table}.err" \
+      | sed '/^WARNING:/d' > "$query_json"; then
       target_rows="$(jq -r '.[0].target_date_rows // "0"' "$query_json")"
       max_date="$(jq -r '.[0].max_data_date // "null"' "$query_json")"
     fi

--- a/scripts/seo/gsc-bigquery-domain-fix.sh
+++ b/scripts/seo/gsc-bigquery-domain-fix.sh
@@ -38,7 +38,7 @@ echo "project_id=$PROJECT_ID"
 echo "project_number=$PROJECT_NUMBER"
 echo "mode=$MODE"
 echo "target_date=$TARGET_DATE"
-gcloud config list account project --format=yaml > "$OUTPUT_DIR/gcloud-context.yaml"
+gcloud config list --format=yaml > "$OUTPUT_DIR/gcloud-context.yaml"
 
 project_policy_exists=false
 if gcloud org-policies describe "$CONSTRAINT" \

--- a/scripts/seo/gsc-bigquery-domain-fix.sh
+++ b/scripts/seo/gsc-bigquery-domain-fix.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+PROJECT_ID="${GSC_BQ_PROJECT_ID:-amado-libros-analytics}"
+EXPECTED_PROJECT_NUMBER="${GSC_BQ_PROJECT_NUMBER:-667747565315}"
+DATASET_ID="${GSC_BQ_DATASET_ID:-searchconsole}"
+CONSTRAINT="iam.allowedPolicyMemberDomains"
+EXPORT_MEMBER="serviceAccount:search-console-data-export@system.gserviceaccount.com"
+REPORTER_MEMBER="serviceAccount:ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com"
+TARGET_DATE="${GSC_BQ_TARGET_DATE:-2026-08-18}"
+MODE="${GSC_BQ_FIX_MODE:-verify}"
+OUTPUT_DIR="${GSC_BQ_OUTPUT_DIR:-artifacts/gsc-bigquery-domain-fix}"
+
+case "$MODE" in
+  apply|verify|rollback) ;;
+  *)
+    echo "ERROR: GSC_BQ_FIX_MODE debe ser apply, verify o rollback; recibido: $MODE" >&2
+    exit 2
+    ;;
+esac
+
+for command in gcloud bq jq; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "ERROR: falta el comando requerido: $command" >&2
+    exit 2
+  fi
+done
+
+mkdir -p "$OUTPUT_DIR"
+
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+if [[ "$PROJECT_NUMBER" != "$EXPECTED_PROJECT_NUMBER" ]]; then
+  echo "ERROR: projectNumber inesperado para $PROJECT_ID: $PROJECT_NUMBER" >&2
+  exit 3
+fi
+
+echo "project_id=$PROJECT_ID"
+echo "project_number=$PROJECT_NUMBER"
+echo "mode=$MODE"
+echo "target_date=$TARGET_DATE"
+gcloud config list account project --format=yaml > "$OUTPUT_DIR/gcloud-context.yaml"
+
+project_policy_exists=false
+if gcloud org-policies describe "$CONSTRAINT" \
+  --project="$PROJECT_ID" \
+  --format=json > "$OUTPUT_DIR/project-policy-before.json" \
+  2> "$OUTPUT_DIR/project-policy-before.err"; then
+  project_policy_exists=true
+else
+  if grep -q 'NOT_FOUND' "$OUTPUT_DIR/project-policy-before.err"; then
+    printf '{"status":"NOT_FOUND"}\n' > "$OUTPUT_DIR/project-policy-before.json"
+  else
+    cat "$OUTPUT_DIR/project-policy-before.err" >&2
+    echo "ERROR: no se pudo leer la política de proyecto." >&2
+    exit 4
+  fi
+fi
+
+gcloud org-policies describe "$CONSTRAINT" \
+  --project="$PROJECT_ID" \
+  --effective \
+  --format=json > "$OUTPUT_DIR/effective-policy-before.json"
+
+gcloud projects get-iam-policy "$PROJECT_ID" \
+  --format=json > "$OUTPUT_DIR/project-iam-before.json"
+
+policy_is_exact_allow_all() {
+  local file="$1"
+  jq -e '
+    (.spec.inheritFromParent // false) == false and
+    (.spec.rules | type == "array") and
+    (.spec.rules | length == 1) and
+    (.spec.rules[0].allowAll == true) and
+    ((.spec.rules[0] | keys_unsorted | sort) == ["allowAll"])
+  ' "$file" >/dev/null
+}
+
+effective_policy_allows_all() {
+  local file="$1"
+  jq -e 'any(.spec.rules[]?; .allowAll == true)' "$file" >/dev/null
+}
+
+wait_for_effective_allow_all() {
+  local attempts="${1:-30}"
+  local delay="${2:-30}"
+  local attempt
+  for ((attempt = 1; attempt <= attempts; attempt += 1)); do
+    if gcloud org-policies describe "$CONSTRAINT" \
+      --project="$PROJECT_ID" \
+      --effective \
+      --format=json > "$OUTPUT_DIR/effective-policy-after.json"; then
+      if effective_policy_allows_all "$OUTPUT_DIR/effective-policy-after.json"; then
+        echo "Política efectiva allowAll=true confirmada en intento $attempt/$attempts."
+        return 0
+      fi
+    fi
+    echo "Esperando propagación de Organization Policy ($attempt/$attempts)..."
+    sleep "$delay"
+  done
+  echo "ERROR: la política efectiva no llegó a allowAll=true dentro de la ventana." >&2
+  return 1
+}
+
+ensure_export_role() {
+  local role="$1"
+  local iam_file="$OUTPUT_DIR/project-iam-current.json"
+  gcloud projects get-iam-policy "$PROJECT_ID" --format=json > "$iam_file"
+  if jq -e --arg role "$role" --arg member "$EXPORT_MEMBER" '
+    any(.bindings[]?; .role == $role and ((.members // []) | index($member) != null))
+  ' "$iam_file" >/dev/null; then
+    echo "IAM ya contiene $role para $EXPORT_MEMBER."
+    return 0
+  fi
+
+  echo "Agregando $role a $EXPORT_MEMBER..."
+  gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="$EXPORT_MEMBER" \
+    --role="$role" \
+    --condition=None \
+    --quiet >/dev/null
+}
+
+if [[ "$MODE" == "apply" ]]; then
+  if [[ "$project_policy_exists" == "true" ]]; then
+    if policy_is_exact_allow_all "$OUTPUT_DIR/project-policy-before.json"; then
+      echo "El override de proyecto ya es exactamente allowAll=true; ejecución idempotente."
+    else
+      echo "ERROR: ya existe una política de proyecto distinta. No se sobrescribe." >&2
+      cat "$OUTPUT_DIR/project-policy-before.json" >&2
+      exit 5
+    fi
+  else
+    cat > "$OUTPUT_DIR/policy-applied.yaml" <<EOF
+name: projects/${PROJECT_NUMBER}/policies/${CONSTRAINT}
+spec:
+  inheritFromParent: false
+  rules:
+  - allowAll: true
+EOF
+
+    gcloud org-policies set-policy "$OUTPUT_DIR/policy-applied.yaml" \
+      --update-mask=spec \
+      --quiet
+  fi
+
+  wait_for_effective_allow_all
+  ensure_export_role roles/bigquery.jobUser
+  ensure_export_role roles/bigquery.dataEditor
+elif [[ "$MODE" == "rollback" ]]; then
+  if [[ "$project_policy_exists" != "true" ]]; then
+    echo "No existe override de proyecto; rollback idempotente."
+  elif policy_is_exact_allow_all "$OUTPUT_DIR/project-policy-before.json"; then
+    gcloud org-policies delete "$CONSTRAINT" \
+      --project="$PROJECT_ID" \
+      --quiet
+    echo "Override allowAll eliminado; vuelve a heredarse la política superior."
+  else
+    echo "ERROR: el override existente no coincide exactamente con el creado por este lote; no se elimina." >&2
+    exit 6
+  fi
+else
+  if ! effective_policy_allows_all "$OUTPUT_DIR/effective-policy-before.json"; then
+    echo "ERROR: verify encontró que la política efectiva no permite todos los miembros." >&2
+    exit 7
+  fi
+fi
+
+if [[ "$MODE" != "rollback" ]]; then
+  gcloud org-policies describe "$CONSTRAINT" \
+    --project="$PROJECT_ID" \
+    --format=json > "$OUTPUT_DIR/project-policy-after.json"
+  gcloud org-policies describe "$CONSTRAINT" \
+    --project="$PROJECT_ID" \
+    --effective \
+    --format=json > "$OUTPUT_DIR/effective-policy-after.json"
+
+  if ! policy_is_exact_allow_all "$OUTPUT_DIR/project-policy-after.json"; then
+    echo "ERROR: el override persistente final no es exactamente allowAll=true." >&2
+    exit 8
+  fi
+  if ! effective_policy_allows_all "$OUTPUT_DIR/effective-policy-after.json"; then
+    echo "ERROR: la política efectiva final no permite al exportador." >&2
+    exit 9
+  fi
+fi
+
+gcloud projects get-iam-policy "$PROJECT_ID" \
+  --format=json > "$OUTPUT_DIR/project-iam-after.json"
+
+if [[ "$MODE" != "rollback" ]]; then
+  for role in roles/bigquery.jobUser roles/bigquery.dataEditor; do
+    if ! jq -e --arg role "$role" --arg member "$EXPORT_MEMBER" '
+      any(.bindings[]?; .role == $role and ((.members // []) | index($member) != null))
+    ' "$OUTPUT_DIR/project-iam-after.json" >/dev/null; then
+      echo "ERROR: falta $role para $EXPORT_MEMBER después de la corrección." >&2
+      exit 10
+    fi
+  done
+fi
+
+jq -r --arg member "$REPORTER_MEMBER" '
+  [.bindings[]? | select((.members // []) | index($member) != null) | .role] | unique[]
+' "$OUTPUT_DIR/project-iam-after.json" > "$OUTPUT_DIR/ga4-reporter-project-roles.txt"
+
+DATASET_EXISTS=false
+if bq --project_id="$PROJECT_ID" show --format=prettyjson \
+  "$PROJECT_ID:$DATASET_ID" > "$OUTPUT_DIR/dataset.json" 2> "$OUTPUT_DIR/dataset.err"; then
+  DATASET_EXISTS=true
+fi
+
+TABLES=(ExportLog searchdata_url_impression searchdata_site_impression)
+TABLE_SUMMARY="$OUTPUT_DIR/table-summary.tsv"
+printf 'table\texists\tnum_rows\ttarget_date_rows\tmax_data_date\n' > "$TABLE_SUMMARY"
+
+for table in "${TABLES[@]}"; do
+  table_json="$OUTPUT_DIR/table-${table}.json"
+  query_json="$OUTPUT_DIR/query-${table}.json"
+  if [[ "$DATASET_EXISTS" == "true" ]] && \
+    bq --project_id="$PROJECT_ID" show --format=prettyjson \
+      "$PROJECT_ID:$DATASET_ID.$table" > "$table_json" 2> "$OUTPUT_DIR/table-${table}.err"; then
+    num_rows="$(jq -r '.numRows // "0"' "$table_json")"
+    target_rows="unknown"
+    max_date="unknown"
+    if bq --project_id="$PROJECT_ID" query \
+      --quiet \
+      --use_legacy_sql=false \
+      --format=json \
+      "SELECT COUNTIF(data_date = DATE('${TARGET_DATE}')) AS target_date_rows, CAST(MAX(data_date) AS STRING) AS max_data_date FROM \`${PROJECT_ID}.${DATASET_ID}.${table}\`" \
+      > "$query_json" 2> "$OUTPUT_DIR/query-${table}.err"; then
+      target_rows="$(jq -r '.[0].target_date_rows // "0"' "$query_json")"
+      max_date="$(jq -r '.[0].max_data_date // "null"' "$query_json")"
+    fi
+    printf '%s\ttrue\t%s\t%s\t%s\n' "$table" "$num_rows" "$target_rows" "$max_date" >> "$TABLE_SUMMARY"
+  else
+    printf '%s\tfalse\t0\t0\tnull\n' "$table" >> "$TABLE_SUMMARY"
+  fi
+done
+
+{
+  echo "# GSC BigQuery domain fix"
+  echo
+  echo "- Project: \`$PROJECT_ID\` (\`$PROJECT_NUMBER\`)"
+  echo "- Dataset: \`$DATASET_ID\`"
+  echo "- Mode: \`$MODE\`"
+  echo "- Constraint: \`$CONSTRAINT\`"
+  echo "- Export principal: \`$EXPORT_MEMBER\`"
+  echo "- Target data date: \`$TARGET_DATE\`"
+  echo "- Dataset exists: \`$DATASET_EXISTS\`"
+  echo
+  echo '```tsv'
+  cat "$TABLE_SUMMARY"
+  echo '```'
+  echo
+  echo "The policy correction is complete when the effective project policy is allowAll=true and both required BigQuery roles are present. Search Console can populate rows only on its next retry; zero rows immediately after the fix are not treated as a policy failure."
+} > "$OUTPUT_DIR/summary.md"
+
+cat "$OUTPUT_DIR/summary.md"


### PR DESCRIPTION
## Diagnóstico

Search Console creó el dataset `searchconsole` y sus tres tablas, pero las exportaciones de `2026-08-18` fallaron porque la política heredada `iam.allowedPolicyMemberDomains` bloquea al principal administrado por Google `search-console-data-export@system.gserviceaccount.com` cuando intenta escribir o modificar IAM en BigQuery.

## Alcance

Este lote no toca la web, Pages, Worker, catálogo, checkout, Merchant ni publicidad. Corre desde una rama aislada y modifica exclusivamente el proyecto analítico:

- proyecto: `amado-libros-analytics`;
- project number esperado: `667747565315`;
- dataset observado: `searchconsole`;
- constraint: `iam.allowedPolicyMemberDomains`.

## Corrección

- toma snapshots de política efectiva, política local e IAM;
- aborta si ya existe una política de proyecto distinta;
- crea un override persistente **sólo en el proyecto**, con `inheritFromParent: false` y `allowAll: true`;
- espera y verifica la propagación efectiva;
- garantiza únicamente los dos roles oficiales del exportador:
  - `roles/bigquery.jobUser`;
  - `roles/bigquery.dataEditor`;
- consulta `ExportLog`, `searchdata_url_impression` y `searchdata_site_impression`;
- mide específicamente la fecha `2026-08-18`;
- genera evidencia descargable de política, IAM y BigQuery.

## Guardas

- nunca escribe una política a nivel organización;
- nunca sobrescribe una política local desconocida;
- rollback sólo elimina un override que coincida exactamente con el creado por este lote;
- no borra dataset ni tablas;
- no retira todavía roles elevados del reporter: eso se hace sólo después de confirmar filas exportadas;
- no considera cero filas inmediatas como fallo del fix, porque Search Console debe ejecutar su próximo reintento.

## Ejecución

El workflow se dispara sólo al hacer push sobre `agent/gsc-bigquery-domain-fix`; no requiere merge a `main` y no dispara deploy productivo de la web.

## Diff

- workflow aislado de reparación;
- script idempotente apply/verify/rollback;
- tests de alcance, WIF, roles, no borrado y rollback conservador.

Producción web queda intacta.