### PR TITLE
SEO/CX: ampliar fichas vidriera a 3000 y limpiar títulos

### DIFF
--- a/functions/__tests__/automatic-product-showcase.test.js
+++ b/functions/__tests__/automatic-product-showcase.test.js
@@ -53,13 +53,20 @@ function rendered(item = book(), relatedBooks = []) {
   return renderPage(item, SLUG, false, '', '', relatedBooks);
 }
 
+function schemas(html) {
+  return [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+    .map(match => JSON.parse(match[1]));
+}
+
 function productSchema(html) {
-  for (const match of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
-    const schema = JSON.parse(match[1]);
+  return schemas(html).find(schema => {
     const types = Array.isArray(schema['@type']) ? schema['@type'] : [schema['@type']];
-    if (types.includes('Book') && schema.sku === PRODUCT_ID) return schema;
-  }
-  return null;
+    return types.includes('Book') && schema.sku === PRODUCT_ID;
+  }) || null;
+}
+
+function breadcrumbSchema(html) {
+  return schemas(html).find(schema => schema['@type'] === 'BreadcrumbList') || null;
 }
 
 test('extrae del HTML SSR únicamente datos reales de la publicación', () => {
@@ -146,6 +153,64 @@ test('convierte una ficha activa en vidriera sin tocar precio, stock ni acciones
   assert.match(schema.description, /evaluación clínica/);
   assert.equal(schema.review, undefined);
   assert.equal(schema.aggregateRating, undefined);
+});
+
+test('limpia H1, title, snippet, breadcrumb y schema sin alterar el título comercial del carrito', () => {
+  const rawTitle = 'Manual De Emdr Y Procesos De Terapia Familiar, De Louise Shapiro. Editorial Ediciones Pléyades En Español';
+  const item = book({
+    title: rawTitle,
+    author: 'Francine Shapiro, Florence W. Kaslow y Louise Maxfield',
+    publisher: 'Ediciones Pléyades',
+    bibliographic: {
+      subtitle: null,
+      language: 'Español',
+      format: 'Tapa blanda',
+      edition: null,
+      publication_year: null,
+      genre: 'Psicoterapia familiar',
+      collection: null,
+      translator: null,
+    },
+  });
+  const canonical = `https://www.amadolibros.com/libro/${PRODUCT_ID}/${SLUG}`;
+  const html = enrichAutomaticProductShowcaseHtml(rendered(item), PRODUCT_ID);
+  const schema = productSchema(html);
+  const breadcrumb = breadcrumbSchema(html);
+
+  assert.match(html, /<h1>Manual de EMDR y Procesos de Terapia Familiar<\/h1>/);
+  assert.match(html, /<title>Manual de EMDR y Procesos de Terapia Familiar \| Amado Libros<\/title>/);
+  assert.match(html, /<meta property="og:title" content="Manual de EMDR y Procesos de Terapia Familiar \| Amado Libros">/);
+  assert.match(html, /<meta name="twitter:title" content="Manual de EMDR y Procesos de Terapia Familiar \| Amado Libros">/);
+  assert.match(html, /<meta name="description" content="Comprá Manual de EMDR y Procesos de Terapia Familiar de Francine Shapiro/);
+  assert.match(html, /<nav>[\s\S]*?<span>Manual de EMDR y Procesos de Terapia Familiar<\/span>/);
+  assert.match(html, new RegExp(`data-title="${rawTitle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
+  assert.match(html, new RegExp(`<link rel="canonical" href="${canonical}">`));
+
+  assert.equal(schema.name, 'Manual de EMDR y Procesos de Terapia Familiar');
+  assert.equal(schema.alternateName, rawTitle);
+  assert.equal(schema.offers.price, '1990');
+  assert.equal(schema.offers.availability, 'https://schema.org/InStock');
+  assert.equal(breadcrumb.itemListElement.at(-1).name, 'Manual de EMDR y Procesos de Terapia Familiar');
+});
+
+test('la limpieza no cambia el slug ni el enlace original de Mercado Libre', () => {
+  const rawTitle = 'Psicoterapia Centrada En La Transferenci: 213 Biblioteca De Psicología';
+  const html = enrichAutomaticProductShowcaseHtml(rendered(book({
+    title: rawTitle,
+    bibliographic: {
+      subtitle: null,
+      language: 'Español',
+      format: 'Tapa blanda',
+      edition: null,
+      publication_year: null,
+      genre: 'Psicología',
+      collection: 'Biblioteca De Psicología',
+    },
+  })), PRODUCT_ID);
+
+  assert.match(html, /<h1>Psicoterapia Centrada en la Transferenci<\/h1>/);
+  assert.match(html, new RegExp(`https://www\\.amadolibros\\.com/libro/${PRODUCT_ID}/${SLUG}`));
+  assert.match(html, /https:\/\/articulo\.mercadolibre\.com\.uy\/MLU-123456789/);
 });
 
 test('la vidriera aparece antes de los libros relacionados', () => {

--- a/functions/__tests__/book-display-title.test.js
+++ b/functions/__tests__/book-display-title.test.js
@@ -1,0 +1,111 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildBookSeoTitle,
+  deriveBookDisplayTitle,
+} from '../_shared/book-display-title.js';
+
+function item(title, overrides = {}) {
+  return {
+    title,
+    author: 'Autora Real',
+    publisher: 'Editorial Real',
+    bibliographic: {
+      format: 'Tapa blanda',
+      language: 'Español',
+      edition: '2.ª edición',
+      publication_year: '2020',
+      collection: 'Biblioteca de Psicología',
+    },
+    ...overrides,
+  };
+}
+
+test('retira autoría genérica, editorial, formato, idioma y año del sufijo comercial', () => {
+  const raw = 'Terapia Psicodinamica Para La Patologia De La Personalidad, De Vv. Aa.. Editorial Ddb, Tapa Blanda En Español, 2020';
+  const result = deriveBookDisplayTitle(item(raw, {
+    author: 'Eve Caligor, Otto F. Kernberg, John F. Clarkin y Frank E. Yeomans',
+    publisher: 'DDB',
+  }));
+
+  assert.equal(result.rawTitle, raw);
+  assert.equal(result.title, 'Terapia Psicodinamica para la Patologia de la Personalidad');
+  assert.equal(result.changed, true);
+  assert.equal(result.reason, 'metadata-suffix');
+  assert.ok(result.removedParts.some(value => /Editorial Ddb/i.test(value)));
+  assert.ok(result.removedParts.some(value => /2020/.test(value)));
+});
+
+test('limpia la ficha observada de EMDR y conserva la sigla', () => {
+  const raw = 'Manual De Emdr Y Procesos De Terapia Familiar, De Louise Shapiro. Editorial Ediciones Pléyades En Español';
+  const result = deriveBookDisplayTitle(item(raw, {
+    author: 'Francine Shapiro, Florence W. Kaslow y Louise Maxfield',
+    publisher: 'Ediciones Pléyades',
+  }));
+
+  assert.equal(result.title, 'Manual de EMDR y Procesos de Terapia Familiar');
+  assert.ok(result.removedParts.length >= 2);
+});
+
+test('mueve número y colección fuera del título sin cortar el título de obra', () => {
+  const result = deriveBookDisplayTitle(item(
+    'Psicoterapia Centrada En La Transferenci: 213 Biblioteca De Psicología',
+  ));
+
+  assert.equal(result.title, 'Psicoterapia Centrada en la Transferenci');
+  assert.deepEqual(result.removedParts, ['213 Biblioteca De Psicología']);
+});
+
+test('conserva subtítulos legítimos después de dos puntos', () => {
+  const raw = 'El Hombre En Busca De Sentido: Un Psicólogo En Un Campo De Concentración';
+  const result = deriveBookDisplayTitle(item(raw, {
+    bibliographic: {},
+  }));
+
+  assert.equal(result.title, 'El Hombre en Busca de Sentido: un Psicólogo en un Campo de Concentración');
+  assert.equal(result.removedParts.length, 0);
+});
+
+test('no interpreta De Profundis ni una frase interna con de como autoría', () => {
+  assert.equal(deriveBookDisplayTitle(item('De Profundis', { bibliographic: {} })).title, 'De Profundis');
+  assert.equal(
+    deriveBookDisplayTitle(item('La Librería De Los Finales Felices', { bibliographic: {} })).title,
+    'La Librería de los Finales Felices',
+  );
+});
+
+test('normaliza conectores y siglas sin reescribir las palabras de la obra', () => {
+  assert.equal(
+    deriveBookDisplayTitle(item('Harry Potter Y La Piedra Filosofal', { bibliographic: {} })).title,
+    'Harry Potter y la Piedra Filosofal',
+  );
+  assert.equal(
+    deriveBookDisplayTitle(item('Manual Tcc Para Tdah', { bibliographic: {} })).title,
+    'Manual TCC para TDAH',
+  );
+});
+
+test('no muta el título fuente y genera un title SEO de máximo 70 caracteres', () => {
+  const source = item(
+    'Manual De Emdr Y Procesos De Terapia Familiar, De Louise Shapiro. Editorial Ediciones Pléyades En Español',
+    { publisher: 'Ediciones Pléyades' },
+  );
+  const before = source.title;
+  const display = deriveBookDisplayTitle(source);
+  const seoTitle = buildBookSeoTitle(display.title);
+
+  assert.equal(source.title, before);
+  assert.ok(seoTitle.length <= 70);
+  assert.match(seoTitle, / \| Amado Libros$/);
+});
+
+test('rechaza una poda que dejaría un candidato irrazonablemente corto', () => {
+  const raw = 'De Luz, De Ana María Pérez';
+  const result = deriveBookDisplayTitle(item(raw, {
+    author: 'Ana María Pérez',
+    bibliographic: {},
+  }));
+
+  assert.equal(result.title, raw);
+});

--- a/functions/__tests__/showcase-cohort.test.js
+++ b/functions/__tests__/showcase-cohort.test.js
@@ -4,8 +4,12 @@ import assert from 'node:assert/strict';
 import {
   fetchShowcaseCohort,
   isProductInShowcaseCohort,
+  LEGACY_SHOWCASE_COHORT_LIMIT,
   normalizeShowcaseCohort,
   resetShowcaseCohortMemoryForTests,
+  SHOWCASE_COHORT_LIMIT,
+  SHOWCASE_COHORT_V1_URL,
+  SHOWCASE_COHORT_V2_URL,
   SHOWCASE_PREVIEW_SAMPLE_IDS,
 } from '../_shared/showcase-cohort.js';
 
@@ -28,57 +32,73 @@ function installCache() {
   return writes;
 }
 
-test('acepta una cohorte compacta, única y limitada a 1000 MLU', () => {
-  const ids = Array.from({ length: 1000 }, (_, index) => `MLU${100000000 + index}`);
-  const cohort = normalizeShowcaseCohort({
-    schema_version: 1,
+function payload(schemaVersion, count) {
+  const ids = Array.from({ length: count }, (_, index) => `MLU${100000000 + index}`);
+  return {
+    schema_version: schemaVersion,
     generated_at: '2026-08-20T12:00:00.000Z',
     catalog_version: '2026-08-20T12:00:00.000Z',
     total: ids.length,
     ids,
-  });
+  };
+}
 
-  assert.ok(cohort);
-  assert.equal(cohort.total, 1000);
-  assert.equal(cohort.ids.size, 1000);
-  assert.equal(cohort.ids.has(ids[999]), true);
-  assert.equal(cohort.source, 'r2');
+test('acepta v2 con hasta 3000 MLU y v1 con hasta 1000', () => {
+  const v2 = normalizeShowcaseCohort(payload(2, 3000));
+  const v1 = normalizeShowcaseCohort(payload(1, 1000));
+
+  assert.equal(SHOWCASE_COHORT_LIMIT, 3000);
+  assert.equal(LEGACY_SHOWCASE_COHORT_LIMIT, 1000);
+  assert.ok(v2);
+  assert.equal(v2.total, 3000);
+  assert.equal(v2.ids.size, 3000);
+  assert.equal(v2.source, 'r2-v2');
+  assert.ok(v1);
+  assert.equal(v1.total, 1000);
+  assert.equal(v1.source, 'r2-v1');
 });
 
-test('rechaza duplicados, IDs inválidos, total cruzado y más de 1000', () => {
+test('rechaza versión desconocida, duplicados, IDs inválidos, total cruzado y límites excedidos', () => {
   assert.equal(normalizeShowcaseCohort({
-    schema_version: 1,
+    schema_version: 3,
+    total: 1,
+    ids: ['MLU1'],
+  }), null);
+  assert.equal(normalizeShowcaseCohort({
+    schema_version: 2,
     total: 2,
     ids: ['MLU1', 'MLU1'],
   }), null);
   assert.equal(normalizeShowcaseCohort({
-    schema_version: 1,
+    schema_version: 2,
     total: 1,
     ids: ['ABC1'],
   }), null);
   assert.equal(normalizeShowcaseCohort({
-    schema_version: 1,
+    schema_version: 2,
     total: 2,
     ids: ['MLU1'],
   }), null);
-  assert.equal(normalizeShowcaseCohort({
-    schema_version: 1,
-    total: 1001,
-    ids: Array.from({ length: 1001 }, (_, index) => `MLU${index + 1}`),
-  }), null);
+  assert.equal(normalizeShowcaseCohort(payload(1, 1001)), null);
+  assert.equal(normalizeShowcaseCohort(payload(2, 3001)), null);
 });
 
-test('Preview usa una muestra controlada si la cohorte todavía no existe', async () => {
+test('Preview usa una muestra controlada sólo si faltan v2 y v1', async () => {
   const originalFetch = globalThis.fetch;
   const originalCaches = globalThis.caches;
   installCache();
-  globalThis.fetch = async () => new Response('ausente', { status: 404 });
+  const urls = [];
+  globalThis.fetch = async url => {
+    urls.push(String(url));
+    return new Response('ausente', { status: 404 });
+  };
   resetShowcaseCohortMemoryForTests();
 
   try {
     const preview = await fetchShowcaseCohort(context('preview'));
     assert.equal(preview.source, 'preview-fallback');
     assert.deepEqual([...preview.ids], SHOWCASE_PREVIEW_SAMPLE_IDS);
+    assert.deepEqual(urls, [SHOWCASE_COHORT_V2_URL, SHOWCASE_COHORT_V1_URL]);
     assert.equal(
       await isProductInShowcaseCohort(context('preview'), SHOWCASE_PREVIEW_SAMPLE_IDS[0]),
       true,
@@ -90,15 +110,20 @@ test('Preview usa una muestra controlada si la cohorte todavía no existe', asyn
   }
 });
 
-test('Producción nunca usa la muestra de Preview si falta el archivo', async () => {
+test('Producción nunca usa la muestra de Preview si faltan ambos archivos', async () => {
   const originalFetch = globalThis.fetch;
   const originalCaches = globalThis.caches;
   installCache();
-  globalThis.fetch = async () => new Response('ausente', { status: 404 });
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls++;
+    return new Response('ausente', { status: 404 });
+  };
   resetShowcaseCohortMemoryForTests();
 
   try {
     assert.equal(await fetchShowcaseCohort(context('production')), null);
+    assert.equal(calls, 2);
   } finally {
     globalThis.fetch = originalFetch;
     globalThis.caches = originalCaches;
@@ -106,27 +131,64 @@ test('Producción nunca usa la muestra de Preview si falta el archivo', async ()
   }
 });
 
-test('lee R2, normaliza la cohorte y permite consultar pertenencia por ID', async () => {
+test('prefiere v2, la cachea y permite consultar pertenencia por ID', async () => {
   const originalFetch = globalThis.fetch;
   const originalCaches = globalThis.caches;
   const writes = installCache();
-  globalThis.fetch = async () => Response.json({
-    schema_version: 1,
-    generated_at: '2026-08-20T12:00:00.000Z',
-    catalog_version: '2026-08-20T12:00:00.000Z',
-    total: 3,
-    ids: ['MLU10', 'MLU20', 'MLU30'],
-  });
+  const calls = [];
+  globalThis.fetch = async url => {
+    calls.push(String(url));
+    return Response.json({
+      schema_version: 2,
+      generated_at: '2026-08-20T12:00:00.000Z',
+      catalog_version: '2026-08-20T12:00:00.000Z',
+      total: 3,
+      ids: ['MLU10', 'MLU20', 'MLU30'],
+    });
+  };
   resetShowcaseCohortMemoryForTests();
 
   try {
     const ctx = context('production');
     const cohort = await fetchShowcaseCohort(ctx);
-    assert.equal(cohort.source, 'r2');
+    assert.equal(cohort.source, 'r2-v2');
     assert.equal(cohort.ids.has('MLU20'), true);
+    assert.deepEqual(calls, [SHOWCASE_COHORT_V2_URL]);
     assert.equal(writes.length, 1);
     assert.equal(await isProductInShowcaseCohort(ctx, 'mlu20'), true);
     assert.equal(await isProductInShowcaseCohort(ctx, 'MLU99'), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.caches = originalCaches;
+    resetShowcaseCohortMemoryForTests();
+  }
+});
+
+test('si v2 falta o es inválida, conserva la cohorte v1 de rollback', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalCaches = globalThis.caches;
+  const writes = installCache();
+  const calls = [];
+  globalThis.fetch = async url => {
+    const value = String(url);
+    calls.push(value);
+    if (value === SHOWCASE_COHORT_V2_URL) return new Response('ausente', { status: 404 });
+    return Response.json({
+      schema_version: 1,
+      generated_at: '2026-08-20T12:00:00.000Z',
+      catalog_version: '2026-08-20T12:00:00.000Z',
+      total: 2,
+      ids: ['MLU11', 'MLU22'],
+    });
+  };
+  resetShowcaseCohortMemoryForTests();
+
+  try {
+    const cohort = await fetchShowcaseCohort(context('production'));
+    assert.equal(cohort.source, 'r2-v1');
+    assert.deepEqual([...cohort.ids], ['MLU11', 'MLU22']);
+    assert.deepEqual(calls, [SHOWCASE_COHORT_V2_URL, SHOWCASE_COHORT_V1_URL]);
+    assert.equal(writes.length, 1);
   } finally {
     globalThis.fetch = originalFetch;
     globalThis.caches = originalCaches;

--- a/functions/__tests__/showcase-ranking.test.js
+++ b/functions/__tests__/showcase-ranking.test.js
@@ -2,7 +2,9 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   assignShowcaseRanking,
+  DEFAULT_SHOWCASE_LIMIT,
   isShowcaseEligible,
+  LEGACY_SHOWCASE_LIMIT,
   normalizeValidIsbn,
   rankShowcaseItems,
   showcaseEditionKey,
@@ -33,7 +35,28 @@ test('normaliza ISBN válidos y rechaza checksums falsos', () => {
   assert.equal(normalizeValidIsbn('1234567890128'), null);
 });
 
-test('selecciona exactamente mil ediciones y asigna rango continuo', () => {
+test('el límite nuevo es 3000 y conserva el límite legado de 1000', () => {
+  assert.equal(DEFAULT_SHOWCASE_LIMIT, 3000);
+  assert.equal(LEGACY_SHOWCASE_LIMIT, 1000);
+});
+
+test('selecciona hasta 3000 ediciones por defecto y asigna rango continuo', () => {
+  const items = Array.from({ length: 3200 }, (_, index) => item(index));
+  const metrics = assignShowcaseRanking(items);
+  const selected = items.filter(entry => entry.showcase_rank);
+
+  assert.equal(metrics.schema_version, 2);
+  assert.equal(metrics.limit, 3000);
+  assert.equal(metrics.selected_items, 3000);
+  assert.equal(selected.length, 3000);
+  assert.deepEqual(
+    selected.map(entry => entry.showcase_rank).sort((a, b) => a - b),
+    Array.from({ length: 3000 }, (_, index) => index + 1),
+  );
+  assert.equal(items.filter(entry => entry.showcase_rank == null).length, 200);
+});
+
+test('permite generar explícitamente una selección legado de 1000', () => {
   const items = Array.from({ length: 1200 }, (_, index) => item(index));
   const metrics = assignShowcaseRanking(items, { limit: 1000 });
   const selected = items.filter(entry => entry.showcase_rank);
@@ -44,7 +67,6 @@ test('selecciona exactamente mil ediciones y asigna rango continuo', () => {
     selected.map(entry => entry.showcase_rank).sort((a, b) => a - b),
     Array.from({ length: 1000 }, (_, index) => index + 1),
   );
-  assert.equal(items.filter(entry => entry.showcase_rank == null).length, 200);
 });
 
 test('excluye pausados, sin stock, moneda no UYU y objetos sin señal de libro', () => {
@@ -131,14 +153,50 @@ test('clasifica el nivel de contenido sin inventarlo', () => {
   assert.equal(levels.get(item(3).id), 'bibliographic');
 });
 
+test('asigna display_title derivado sin mutar el título fuente y mide la limpieza', () => {
+  const rawTitle = 'Manual De Emdr Y Procesos De Terapia Familiar, De Louise Shapiro. Editorial Ediciones Pléyades En Español';
+  const dirty = item(1, {
+    title: rawTitle,
+    author: 'Francine Shapiro, Florence W. Kaslow y Louise Maxfield',
+    publisher: 'Ediciones Pléyades',
+    bibliographic: { language: 'Español', format: 'Tapa blanda' },
+  });
+  const cleanItem = item(2, { title: 'El arte de leer' });
+  const metrics = assignShowcaseRanking([dirty, cleanItem], { limit: 2 });
+
+  assert.equal(dirty.title, rawTitle);
+  assert.equal(dirty.showcase_display_title, 'Manual de EMDR y Procesos de Terapia Familiar');
+  assert.equal(dirty.showcase_title_changed, true);
+  assert.equal(cleanItem.showcase_display_title, 'El arte de leer');
+  assert.equal(metrics.selected_title_cleaned, 1);
+  assert.equal(metrics.selected_title_over_70_before, 1);
+  assert.equal(metrics.selected_title_over_70_after, 0);
+});
+
+test('expone distribución editorial, descriptiva y bibliográfica en data_quality', () => {
+  const values = [
+    item(1, { description: 'a'.repeat(500) }),
+    item(2, { description: 'a'.repeat(120) }),
+    item(3, { description: null }),
+  ];
+  const metrics = assignShowcaseRanking(values, { limit: 3 });
+
+  assert.equal(metrics.selected_editorial, 1);
+  assert.equal(metrics.selected_descriptive, 1);
+  assert.equal(metrics.selected_bibliographic, 1);
+  assert.equal(metrics.selected_items, 3);
+});
+
 test('una nueva corrida limpia marcas viejas antes de reasignar', () => {
   const items = [item(1), item(2), item(3)];
   assignShowcaseRanking(items, { limit: 3 });
   assert.ok(items.every(entry => entry.showcase_rank));
+  assert.ok(items.every(entry => entry.showcase_display_title));
 
   assignShowcaseRanking(items, { limit: 1, priorityIds: [items[2].id] });
   assert.equal(items.filter(entry => entry.showcase_rank).length, 1);
   assert.equal(items[2].showcase_rank, 1);
   assert.equal(items[0].showcase_rank, undefined);
   assert.equal(items[1].showcase_score, undefined);
+  assert.equal(items[0].showcase_display_title, undefined);
 });

--- a/functions/_shared/book-display-title.js
+++ b/functions/_shared/book-display-title.js
@@ -1,0 +1,235 @@
+// FICHAS-VIDRIERA-3000-QUALITY: título visible derivado de forma conservadora.
+// Nunca modifica el título fuente, el slug ni el canonical. Sólo retira sufijos
+// comerciales que pueden identificarse como autor/editorial/formato/idioma/año.
+
+const LOWERCASE_WORDS = new Set([
+  'a', 'al', 'con', 'contra', 'de', 'del', 'desde', 'durante', 'e', 'el', 'en',
+  'entre', 'hacia', 'hasta', 'la', 'las', 'los', 'o', 'para', 'por', 'según',
+  'sin', 'sobre', 'tras', 'u', 'un', 'una', 'unas', 'unos', 'y',
+]);
+
+const ACRONYMS = new Map([
+  ['adn', 'ADN'],
+  ['a4', 'A4'],
+  ['b1', 'B1'],
+  ['cie', 'CIE'],
+  ['dsm', 'DSM'],
+  ['emdr', 'EMDR'],
+  ['isbn', 'ISBN'],
+  ['nvi', 'NVI'],
+  ['ntv', 'NTV'],
+  ['rvr', 'RVR'],
+  ['tcc', 'TCC'],
+  ['tdah', 'TDAH'],
+  ['toc', 'TOC'],
+  ['ux', 'UX'],
+]);
+
+const GENERIC_AUTHOR_LABELS = new Set([
+  'anonimo', 'anónimo', 'autor', 'autores', 'varios', 'varios autores',
+  'vv aa', 'vv. aa.', 'vv aa.', 'vv. aa', 'sin autor', 's a', 's/a',
+]);
+
+const METADATA_PREFIX_RE = /^(?:de\s+|autor(?:a|es)?\s*:?|editorial\b|editado\s+por\b|tapa\s+(?:blanda|dura)\b|encuadernaci[oó]n\b|formato\b|idioma\b|en\s+(?:espa[nñ]ol|ingl[eé]s|portugu[eé]s|franc[eé]s|italiano|alem[aá]n)\b|colecci[oó]n\b|serie\b|biblioteca\b|(?:1[89]|20)\d{2}$|\d+[.ªºa]?\s*edici[oó]n\b)/iu;
+const COLLECTION_SUFFIX_RE = /^\d{1,4}\s+(?:biblioteca|colecci[oó]n|serie)\b/iu;
+const PAREN_METADATA_RE = /\s*\(([^()]*)\)\s*$/u;
+
+function clean(value) {
+  return String(value ?? '')
+    .replace(/[\u00a0\s]+/gu, ' ')
+    .replace(/\s+([,.;:!?])/gu, '$1')
+    .replace(/([,;:]){2,}/gu, '$1')
+    .replace(/\.{2,}$/u, '.')
+    .trim();
+}
+
+function normalizedText(value) {
+  return clean(value)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLocaleLowerCase('es')
+    .replace(/[“”"'`´]/gu, '')
+    .replace(/[^a-z0-9]+/gu, ' ')
+    .trim();
+}
+
+function bibliography(item) {
+  return item?.bibliographic && typeof item.bibliographic === 'object' && !Array.isArray(item.bibliographic)
+    ? item.bibliographic
+    : {};
+}
+
+function authorKeys(value) {
+  const source = clean(value);
+  if (!source) return new Set();
+  const parts = [
+    source,
+    ...source.split(/\s*(?:,|\by\b|&|\/|;)\s*/iu),
+  ].map(normalizedText).filter(Boolean);
+  return new Set(parts);
+}
+
+function exactMetadataKeys(item) {
+  const book = bibliography(item);
+  const values = [
+    item?.publisher,
+    book.format,
+    book.language,
+    book.edition,
+    book.publication_year,
+    book.collection,
+  ].map(normalizedText).filter(Boolean);
+  return new Set(values);
+}
+
+function stripLabel(value) {
+  return normalizedText(value)
+    .replace(/^(?:editorial|editado por|formato|idioma|coleccion|serie|biblioteca|edicion)\s+/u, '')
+    .trim();
+}
+
+function isAuthorMetadata(segment, item) {
+  const key = normalizedText(segment);
+  if (!key) return false;
+  const authors = authorKeys(item?.author);
+  const withoutLabel = key.replace(/^(?:de|autor|autora|autores)\s+/u, '').trim();
+  if (GENERIC_AUTHOR_LABELS.has(key) || GENERIC_AUTHOR_LABELS.has(withoutLabel)) return true;
+  if (authors.has(key) || authors.has(withoutLabel)) return true;
+
+  // Sólo se acepta un "de Nombre Apellido" no exacto cuando aparece como
+  // segmento separado y tiene aspecto de persona, no como parte del título.
+  if (/^de\s+[\p{L}. '-]{3,80}$/iu.test(clean(segment))) {
+    const words = withoutLabel.split(/\s+/u).filter(Boolean);
+    return words.length >= 2 && words.length <= 8;
+  }
+  return false;
+}
+
+function isMetadataSegment(segment, item) {
+  const value = clean(segment).replace(/[.;]+$/u, '').trim();
+  const key = normalizedText(value);
+  if (!key) return false;
+  if (isAuthorMetadata(value, item)) return true;
+
+  const exact = exactMetadataKeys(item);
+  if (exact.has(key) || exact.has(stripLabel(key))) return true;
+  if (METADATA_PREFIX_RE.test(value)) return true;
+
+  const book = bibliography(item);
+  const year = normalizedText(book.publication_year);
+  if (year && new RegExp(`(?:^|\\s)${year}(?:$|\\s)`, 'u').test(key)) return true;
+
+  const publisher = normalizedText(item?.publisher);
+  if (publisher && key.startsWith('editorial ') && key.includes(publisher)) return true;
+
+  return false;
+}
+
+function prepareSeparators(title) {
+  return clean(title)
+    .replace(/,\s+(?=(?:de\s+|autor(?:a|es)?\s*:?|editorial\b|tapa\b|formato\b|idioma\b|en\s+(?:espa[nñ]ol|ingl[eé]s|portugu[eé]s|franc[eé]s|italiano|alem[aá]n)\b|colecci[oó]n\b|serie\b|biblioteca\b|(?:1[89]|20)\d{2}\b|\d+[.ªºa]?\s*edici[oó]n\b))/giu, ' | ')
+    .replace(/\.\s+(?=(?:editorial\b|tapa\b|formato\b|idioma\b|en\s+(?:espa[nñ]ol|ingl[eé]s|portugu[eé]s|franc[eé]s|italiano|alem[aá]n)\b|colecci[oó]n\b|serie\b|biblioteca\b|(?:1[89]|20)\d{2}\b))/giu, ' | ')
+    .replace(/\s+[–—-]\s+(?=(?:de\s+|editorial\b|tapa\b|formato\b|idioma\b|en\s+(?:espa[nñ]ol|ingl[eé]s|portugu[eé]s|franc[eé]s|italiano|alem[aá]n)\b|(?:1[89]|20)\d{2}\b))/giu, ' | ');
+}
+
+function normalizeWordCase(title) {
+  const pieces = clean(title).split(/(\s+|[-–—/:])/u);
+  let wordIndex = 0;
+  return pieces.map(piece => {
+    if (!piece || /^(?:\s+|[-–—/:])$/u.test(piece)) return piece;
+    const key = normalizedText(piece);
+    const acronym = ACRONYMS.get(key);
+    if (acronym) {
+      wordIndex++;
+      return acronym;
+    }
+    const output = wordIndex > 0 && LOWERCASE_WORDS.has(key)
+      ? piece.toLocaleLowerCase('es')
+      : piece;
+    wordIndex++;
+    return output;
+  }).join('');
+}
+
+function safeCandidate(rawTitle, candidate) {
+  const raw = clean(rawTitle);
+  const value = clean(candidate).replace(/[|,;:.-]+$/u, '').trim();
+  if (value.length < 4) return raw;
+  if (value.length < Math.min(12, Math.ceil(raw.length * 0.22))) return raw;
+  return value;
+}
+
+export function deriveBookDisplayTitle(item = {}) {
+  const rawTitle = clean(item?.title);
+  if (!rawTitle) {
+    return Object.freeze({
+      rawTitle: '',
+      title: '',
+      changed: false,
+      removedParts: Object.freeze([]),
+      reason: 'empty',
+    });
+  }
+
+  const removedParts = [];
+  let candidate = rawTitle;
+
+  // Sufijos parentéticos puramente comerciales: “(tapa blanda, español, 2020)”.
+  const parenthetical = candidate.match(PAREN_METADATA_RE);
+  if (parenthetical && isMetadataSegment(parenthetical[1], item)) {
+    removedParts.unshift(clean(parenthetical[1]));
+    candidate = candidate.slice(0, parenthetical.index).trim();
+  }
+
+  const segments = prepareSeparators(candidate)
+    .split(/\s*\|\s*/u)
+    .map(clean)
+    .filter(Boolean);
+  while (segments.length > 1 && isMetadataSegment(segments.at(-1), item)) {
+    removedParts.unshift(segments.pop());
+  }
+  candidate = segments.join(' | ');
+
+  // Colección/número trasladado al bloque bibliográfico, nunca se elimina un
+  // subtítulo normal luego de dos puntos.
+  const colonIndex = candidate.lastIndexOf(':');
+  if (colonIndex > 3) {
+    const suffix = clean(candidate.slice(colonIndex + 1));
+    const collection = normalizedText(bibliography(item).collection);
+    const suffixKey = normalizedText(suffix);
+    if (COLLECTION_SUFFIX_RE.test(suffix) || (collection && suffixKey === collection)) {
+      removedParts.unshift(suffix);
+      candidate = candidate.slice(0, colonIndex);
+    }
+  }
+
+  candidate = safeCandidate(rawTitle, candidate);
+  const displayTitle = normalizeWordCase(candidate);
+  const changed = displayTitle !== rawTitle;
+
+  return Object.freeze({
+    rawTitle,
+    title: displayTitle,
+    changed,
+    removedParts: Object.freeze(removedParts),
+    reason: removedParts.length ? 'metadata-suffix' : changed ? 'case-normalization' : 'unchanged',
+  });
+}
+
+function shortenByWord(value, maxLength) {
+  const text = clean(value);
+  if (text.length <= maxLength) return text;
+  const sliced = text.slice(0, Math.max(1, maxLength - 1)).replace(/\s+\S*$/u, '').trim();
+  return `${sliced || text.slice(0, maxLength - 1)}…`;
+}
+
+export function buildBookSeoTitle(displayTitle, {
+  brand = 'Amado Libros',
+  maxLength = 70,
+} = {}) {
+  const title = clean(displayTitle);
+  if (!title) return brand;
+  const separator = ' | ';
+  const available = Math.max(20, maxLength - brand.length - separator.length);
+  return `${shortenByWord(title, available)}${separator}${brand}`;
+}

--- a/functions/_shared/book-display-title.js
+++ b/functions/_shared/book-display-title.js
@@ -160,7 +160,7 @@ function normalizeWordCase(title) {
 function safeCandidate(rawTitle, candidate) {
   const raw = clean(rawTitle);
   const value = clean(candidate).replace(/[|,;:.-]+$/u, '').trim();
-  if (value.length < 4) return raw;
+  if (value.length < 8) return raw;
   if (value.length < Math.min(12, Math.ceil(raw.length * 0.22))) return raw;
   return value;
 }

--- a/functions/_shared/book-display-title.js
+++ b/functions/_shared/book-display-title.js
@@ -30,6 +30,7 @@ const GENERIC_AUTHOR_LABELS = new Set([
   'vv aa', 'vv. aa.', 'vv aa.', 'vv. aa', 'sin autor', 's a', 's/a',
 ]);
 
+const NAME_CONNECTORS = new Set(['de', 'del', 'la', 'las', 'los', 'y']);
 const METADATA_PREFIX_RE = /^(?:de\s+|autor(?:a|es)?\s*:?|editorial\b|editado\s+por\b|tapa\s+(?:blanda|dura)\b|encuadernaci[oó]n\b|formato\b|idioma\b|en\s+(?:espa[nñ]ol|ingl[eé]s|portugu[eé]s|franc[eé]s|italiano|alem[aá]n)\b|colecci[oó]n\b|serie\b|biblioteca\b|(?:1[89]|20)\d{2}$|\d+[.ªºa]?\s*edici[oó]n\b)/iu;
 const COLLECTION_SUFFIX_RE = /^\d{1,4}\s+(?:biblioteca|colecci[oó]n|serie)\b/iu;
 const PAREN_METADATA_RE = /\s*\(([^()]*)\)\s*$/u;
@@ -88,6 +89,15 @@ function stripLabel(value) {
     .trim();
 }
 
+function looksLikePersonName(value) {
+  const source = clean(value).replace(/^de\s+/iu, '').trim();
+  const words = source.split(/\s+/u).filter(Boolean);
+  const significant = words.filter(word => !NAME_CONNECTORS.has(normalizedText(word)));
+  if (significant.length < 2 || significant.length > 7) return false;
+  return significant.every(word =>
+    /^[\p{Lu}][\p{L}.'’\-]*$/u.test(word) || /^[\p{Lu}]\.$/u.test(word));
+}
+
 function isAuthorMetadata(segment, item) {
   const key = normalizedText(segment);
   if (!key) return false;
@@ -97,12 +107,8 @@ function isAuthorMetadata(segment, item) {
   if (authors.has(key) || authors.has(withoutLabel)) return true;
 
   // Sólo se acepta un "de Nombre Apellido" no exacto cuando aparece como
-  // segmento separado y tiene aspecto de persona, no como parte del título.
-  if (/^de\s+[\p{L}. '-]{3,80}$/iu.test(clean(segment))) {
-    const words = withoutLabel.split(/\s+/u).filter(Boolean);
-    return words.length >= 2 && words.length <= 8;
-  }
-  return false;
+  // segmento separado y sus palabras tienen aspecto inequívoco de nombre.
+  return /^de\s+/iu.test(clean(segment)) && looksLikePersonName(segment);
 }
 
 function isMetadataSegment(segment, item) {
@@ -203,16 +209,23 @@ export function deriveBookDisplayTitle(item = {}) {
     }
   }
 
-  candidate = safeCandidate(rawTitle, candidate);
-  const displayTitle = normalizeWordCase(candidate);
+  const candidateBeforeSafety = clean(candidate);
+  const safe = safeCandidate(rawTitle, candidateBeforeSafety);
+  const rejectedRemoval = removedParts.length > 0 && safe === rawTitle && candidateBeforeSafety !== rawTitle;
+  const effectiveRemovedParts = rejectedRemoval ? [] : removedParts;
+  const displayTitle = rejectedRemoval ? rawTitle : normalizeWordCase(safe);
   const changed = displayTitle !== rawTitle;
 
   return Object.freeze({
     rawTitle,
     title: displayTitle,
     changed,
-    removedParts: Object.freeze(removedParts),
-    reason: removedParts.length ? 'metadata-suffix' : changed ? 'case-normalization' : 'unchanged',
+    removedParts: Object.freeze(effectiveRemovedParts),
+    reason: effectiveRemovedParts.length
+      ? 'metadata-suffix'
+      : changed
+        ? 'case-normalization'
+        : 'unchanged',
   });
 }
 

--- a/functions/_shared/showcase-cohort.js
+++ b/functions/_shared/showcase-cohort.js
@@ -1,8 +1,11 @@
 import { R2_BASE } from './catalog.js';
 import { perfNow, recordPerf } from './perf.js';
 
-export const SHOWCASE_COHORT_URL = `${R2_BASE}/showcase/v1/cohort.json`;
-export const SHOWCASE_COHORT_LIMIT = 1000;
+export const SHOWCASE_COHORT_V2_URL = `${R2_BASE}/showcase/v2/cohort.json`;
+export const SHOWCASE_COHORT_V1_URL = `${R2_BASE}/showcase/v1/cohort.json`;
+export const SHOWCASE_COHORT_URL = SHOWCASE_COHORT_V2_URL;
+export const LEGACY_SHOWCASE_COHORT_LIMIT = 1000;
+export const SHOWCASE_COHORT_LIMIT = 3000;
 
 // Sólo permite comprobar el renderer en un Preview anterior al primer sync que
 // publique la cohorte. Producción jamás usa esta lista de respaldo.
@@ -23,28 +26,36 @@ function validProductId(value) {
   return /^MLU\d+$/.test(String(value || '').toUpperCase());
 }
 
+function limitForSchema(schemaVersion) {
+  if (schemaVersion === 2) return SHOWCASE_COHORT_LIMIT;
+  if (schemaVersion === 1) return LEGACY_SHOWCASE_COHORT_LIMIT;
+  return 0;
+}
+
 export function normalizeShowcaseCohort(payload) {
-  if (!payload || payload.schema_version !== 1 || !Array.isArray(payload.ids)) return null;
+  const schemaVersion = Number(payload?.schema_version);
+  const limit = limitForSchema(schemaVersion);
+  if (!limit || !Array.isArray(payload?.ids)) return null;
   const ids = payload.ids.map(value => String(value || '').toUpperCase());
-  if (ids.length < 1 || ids.length > SHOWCASE_COHORT_LIMIT) return null;
+  if (ids.length < 1 || ids.length > limit) return null;
   if (ids.some(id => !validProductId(id))) return null;
   if (new Set(ids).size !== ids.length) return null;
   if (Number(payload.total) !== ids.length) return null;
 
   return {
-    schema_version: 1,
+    schema_version: schemaVersion,
     generated_at: typeof payload.generated_at === 'string' ? payload.generated_at : null,
     catalog_version: typeof payload.catalog_version === 'string' ? payload.catalog_version : null,
     total: ids.length,
     ids: new Set(ids),
-    source: 'r2',
+    source: `r2-v${schemaVersion}`,
   };
 }
 
 function previewFallback(context) {
   if (context?.env?.APP_ENV !== 'preview') return null;
   return {
-    schema_version: 1,
+    schema_version: 2,
     generated_at: null,
     catalog_version: null,
     total: SHOWCASE_PREVIEW_SAMPLE_IDS.length,
@@ -53,26 +64,26 @@ function previewFallback(context) {
   };
 }
 
-async function fetchCohort(context) {
+async function fetchCohortUrl(context, url, timingSuffix) {
   const cache = caches.default;
-  const cacheKey = new Request(SHOWCASE_COHORT_URL);
+  const cacheKey = new Request(url);
   const readStartedAt = perfNow();
   const cacheStartedAt = perfNow();
   let response = await cache.match(cacheKey);
-  recordPerf(context, 'showcase_cohort_cache', cacheStartedAt, {
+  recordPerf(context, `showcase_cohort_${timingSuffix}_cache`, cacheStartedAt, {
     cache: response ? 'hit' : 'miss',
   });
 
   if (!response) {
     const originStartedAt = perfNow();
-    const fetched = await fetch(SHOWCASE_COHORT_URL);
-    recordPerf(context, 'showcase_cohort_origin', originStartedAt);
-    if (!fetched.ok) return previewFallback(context);
+    const fetched = await fetch(url);
+    recordPerf(context, `showcase_cohort_${timingSuffix}_origin`, originStartedAt);
+    if (!fetched.ok) return null;
     response = new Response(fetched.body, {
       status: fetched.status,
       headers: {
         'Content-Type': 'application/json',
-        'Cache-Control': 'public, max-age=3600',
+        'Cache-Control': 'public, max-age=300',
       },
     });
     if (typeof context?.waitUntil === 'function') {
@@ -83,15 +94,29 @@ async function fetchCohort(context) {
   try {
     const bodyStartedAt = perfNow();
     const body = await response.arrayBuffer();
-    recordPerf(context, 'showcase_cohort_body', bodyStartedAt, { bytes: body.byteLength });
-    recordPerf(context, 'showcase_cohort_read', readStartedAt, { bytes: body.byteLength });
+    recordPerf(context, `showcase_cohort_${timingSuffix}_body`, bodyStartedAt, {
+      bytes: body.byteLength,
+    });
+    recordPerf(context, `showcase_cohort_${timingSuffix}_read`, readStartedAt, {
+      bytes: body.byteLength,
+    });
     const parseStartedAt = perfNow();
     const payload = JSON.parse(new TextDecoder().decode(body));
-    recordPerf(context, 'showcase_cohort_parse', parseStartedAt);
-    return normalizeShowcaseCohort(payload) || previewFallback(context);
+    recordPerf(context, `showcase_cohort_${timingSuffix}_parse`, parseStartedAt);
+    return normalizeShowcaseCohort(payload);
   } catch {
-    return previewFallback(context);
+    return null;
   }
+}
+
+async function fetchCohort(context) {
+  // Rollout sin ventana rota: Pages nuevo intenta v2 (3.000) y conserva v1
+  // (1.000) como fallback. Un rollback de Pages también sigue leyendo v1.
+  const current = await fetchCohortUrl(context, SHOWCASE_COHORT_V2_URL, 'v2');
+  if (current) return current;
+
+  const legacy = await fetchCohortUrl(context, SHOWCASE_COHORT_V1_URL, 'v1');
+  return legacy || previewFallback(context);
 }
 
 export async function fetchShowcaseCohort(context) {

--- a/functions/_shared/showcase-ranking.js
+++ b/functions/_shared/showcase-ranking.js
@@ -1,7 +1,10 @@
-// FICHAS-VIDRIERA-1000: selección comercial determinista de ediciones activas.
-// No inventa demanda ni contenido. Ordena únicamente señales reales del catálogo.
+// FICHAS-VIDRIERA-3000-QUALITY: selección comercial determinista de ediciones
+// activas. No inventa demanda ni contenido y deriva un título visible reversible.
 
-export const DEFAULT_SHOWCASE_LIMIT = 1000;
+import { deriveBookDisplayTitle } from './book-display-title.js';
+
+export const LEGACY_SHOWCASE_LIMIT = 1000;
+export const DEFAULT_SHOWCASE_LIMIT = 3000;
 
 const GENERIC_AUTHORS = new Set([
   'anónimo',
@@ -166,7 +169,8 @@ export function scoreShowcaseItem(item, { priorityIds = [] } = {}) {
   const bibliography = fieldCount(item?.bibliographic);
   const dimensions = fieldCount(item?.dimensions);
   const stock = Math.max(0, Number(item?.available_quantity) || 0);
-  const title = clean(item?.title);
+  const rawTitle = clean(item?.title);
+  const displayTitle = deriveBookDisplayTitle(item).title;
   let score = 0;
 
   if (priorities.has(clean(item.id).toUpperCase())) score += 2200;
@@ -193,13 +197,15 @@ export function scoreShowcaseItem(item, { priorityIds = [] } = {}) {
   if (normalizedText(item?.condition) === 'new') score += 40;
   score += Math.min(100, Math.round(Math.log2(stock + 1) * 25));
 
-  if (title.length >= 8 && title.length <= 150) score += 30;
-  if (/Ã|Â|â|�/.test(title)) score -= 250;
+  if (displayTitle.length >= 8 && displayTitle.length <= 90) score += 30;
+  if (rawTitle.length > 100 && displayTitle.length <= 70) score += 10;
+  if (/Ã|Â|â|�/.test(rawTitle)) score -= 250;
 
   return score;
 }
 
 function candidateFor(item, priorityIds) {
+  const display = deriveBookDisplayTitle(item);
   return {
     item,
     id: clean(item.id).toUpperCase(),
@@ -208,6 +214,10 @@ function candidateFor(item, priorityIds) {
     description: descriptionLength(item),
     pictures: pictureCount(item),
     startedAt: validDate(item.start_time),
+    displayTitle: display.title,
+    titleChanged: display.changed,
+    rawTitleLength: display.rawTitle.length,
+    displayTitleLength: display.title.length,
   };
 }
 
@@ -267,6 +277,8 @@ export function assignShowcaseRanking(items = [], options = {}) {
     delete item.showcase_rank;
     delete item.showcase_score;
     delete item.showcase_content_level;
+    delete item.showcase_display_title;
+    delete item.showcase_title_changed;
   }
 
   const ranked = rankShowcaseItems(items, options);
@@ -274,6 +286,8 @@ export function assignShowcaseRanking(items = [], options = {}) {
     candidate.item.showcase_rank = candidate.rank;
     candidate.item.showcase_score = candidate.score;
     candidate.item.showcase_content_level = candidate.contentLevel;
+    candidate.item.showcase_display_title = candidate.displayTitle;
+    candidate.item.showcase_title_changed = candidate.titleChanged;
   }
 
   const selectedWithDescription = ranked.selected
@@ -282,9 +296,21 @@ export function assignShowcaseRanking(items = [], options = {}) {
     .filter(candidate => Boolean(normalizeValidIsbn(candidate.item.isbn))).length;
   const selectedWithMultipleImages = ranked.selected
     .filter(candidate => candidate.pictures >= 2).length;
+  const selectedEditorial = ranked.selected
+    .filter(candidate => candidate.contentLevel === 'editorial').length;
+  const selectedDescriptive = ranked.selected
+    .filter(candidate => candidate.contentLevel === 'descriptive').length;
+  const selectedBibliographic = ranked.selected
+    .filter(candidate => candidate.contentLevel === 'bibliographic').length;
+  const selectedTitleCleaned = ranked.selected
+    .filter(candidate => candidate.titleChanged).length;
+  const selectedTitleOver70Before = ranked.selected
+    .filter(candidate => candidate.rawTitleLength > 70).length;
+  const selectedTitleOver70After = ranked.selected
+    .filter(candidate => candidate.displayTitleLength > 70).length;
 
   return {
-    schema_version: 1,
+    schema_version: 2,
     limit: Math.max(0, Math.floor(Number(options.limit ?? DEFAULT_SHOWCASE_LIMIT) || 0)),
     eligible_items: ranked.eligibleItems,
     unique_editions: ranked.uniqueEditions,
@@ -293,6 +319,12 @@ export function assignShowcaseRanking(items = [], options = {}) {
     selected_with_description: selectedWithDescription,
     selected_with_isbn: selectedWithIsbn,
     selected_with_multiple_images: selectedWithMultipleImages,
+    selected_editorial: selectedEditorial,
+    selected_descriptive: selectedDescriptive,
+    selected_bibliographic: selectedBibliographic,
+    selected_title_cleaned: selectedTitleCleaned,
+    selected_title_over_70_before: selectedTitleOver70Before,
+    selected_title_over_70_after: selectedTitleOver70After,
     highest_score: ranked.selected[0]?.score ?? null,
     lowest_score: ranked.selected.at(-1)?.score ?? null,
   };

--- a/functions/_shared/showcase-title-quality.js
+++ b/functions/_shared/showcase-title-quality.js
@@ -1,0 +1,67 @@
+// FICHAS-VIDRIERA-3000-QUALITY: aplica el título derivado al renderer automático
+// sin cambiar el título fuente, el slug, el canonical ni los datos del carrito.
+
+import {
+  buildBookSeoTitle,
+  deriveBookDisplayTitle,
+} from './book-display-title.js';
+import {
+  isGenericAuthor,
+  normalizeValidIsbn,
+} from './showcase-ranking.js';
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function shortenByWord(value, maxLength) {
+  const text = clean(value);
+  if (text.length <= maxLength) return text;
+  const sliced = text.slice(0, Math.max(1, maxLength - 1)).replace(/\s+\S*$/u, '').trim();
+  return `${sliced || text.slice(0, maxLength - 1)}…`;
+}
+
+function replaceExact(value, rawTitle, displayTitle) {
+  if (typeof value !== 'string' || !rawTitle || rawTitle === displayTitle) return value;
+  return value.split(rawTitle).join(displayTitle);
+}
+
+function buildMetaDescription(item, displayTitle) {
+  const author = !isGenericAuthor(item?.author) ? clean(item.author) : null;
+  const isbn = normalizeValidIsbn(item?.isbn);
+  const identity = `Comprá ${displayTitle}${author ? ` de ${author}` : ''} en Uruguay.`;
+  const edition = isbn ? ` ISBN ${isbn}.` : '';
+  return shortenByWord(
+    `${identity}${edition} Consultá stock, 12% menos por transferencia, cuotas y envíos a todo el país.`,
+    170,
+  );
+}
+
+export function applyShowcaseTitleQuality(config, item) {
+  if (!config || typeof config !== 'object' || !item || typeof item !== 'object') return config;
+  const display = deriveBookDisplayTitle(item);
+  if (!display.title) return config;
+
+  const summary = Array.isArray(config.summary)
+    ? config.summary.map(value => replaceExact(value, display.rawTitle, display.title))
+    : config.summary;
+  const schemaDescription = replaceExact(
+    config.schemaDescription,
+    display.rawTitle,
+    display.title,
+  );
+
+  return {
+    ...config,
+    h1: display.title,
+    rawTitle: display.rawTitle,
+    titleChanged: display.changed,
+    titleReason: display.reason,
+    removedTitleParts: [...display.removedParts],
+    seoTitle: buildBookSeoTitle(display.title),
+    introHeading: replaceExact(config.introHeading, display.rawTitle, display.title),
+    summary,
+    schemaDescription,
+    metaDescription: buildMetaDescription(item, display.title),
+  };
+}

--- a/functions/libro/_middleware.js
+++ b/functions/libro/_middleware.js
@@ -142,11 +142,6 @@ function enrichCatalogBreadcrumbSchema(html) {
   });
 }
 
-// SEO-ACTIVE-CATALOG-BREADCRUMB: las fichas realmente disponibles recuperan
-// un enlace HTML rastreable hacia /catalogo y el mismo nivel en BreadcrumbList.
-// No se aplica a pausadas: la cohorte SEO conserva su rama específica
-// Inicio → Libros por encargo → ficha, y las pausadas fuera de cohorte no se
-// mezclan en este lote.
 export function enrichActiveCatalogBreadcrumbHtml(html) {
   const source = String(html || '');
   if (!source.includes(ACTIVE_PAGE_MARKER)) return source;
@@ -191,17 +186,10 @@ export function enrichByRequestProductHtml(html, productId) {
   const source = String(html || '');
   const hasGenericOrderCopy = source.includes(ORDER_BOX_GENERIC_COPY);
   const hasLeadTime = source.includes('class="order-lead-time"');
-
-  // El copy exacto de la caja es la señal de una ficha pausada. Las fichas
-  // activas en moneda no-UYU también usan .order-box, pero tienen otro texto:
-  // nunca deben recibir el plazo de un encargo.
   const isPausedPage = (hasGenericOrderCopy || hasLeadTime) &&
     !source.includes('class="badge in-stock"');
   if (!isPausedPage) return source;
 
-  // CX-POR-ENCARGO-ALL: el plazo aprobado es una condición operativa común,
-  // no una regla SEO. Se muestra en toda ficha pausada válida, aunque sea
-  // noindex, sin alterar precio, Offer, canonical, robots ni disponibilidad.
   let result = hasGenericOrderCopy
     ? source.replace(ORDER_BOX_GENERIC_COPY, ORDER_BOX_LEAD_TIME_COPY)
     : source;
@@ -212,9 +200,6 @@ export function enrichByRequestProductHtml(html, productId) {
   const hubPage = orderHubPageForProductId(productId);
   if (!hubPage || result.includes('class="order-hub-links"')) return result;
 
-  // La cohorte es estática durante el lote SEO, pero un título puede volver a
-  // stock antes de regenerarla. La guarda isPausedPage evita etiquetar como
-  // "por encargo" una ficha que ya volvió a estar disponible.
   result = result.replace(
     BREADCRUMB_RE,
     `<nav>\n  <a href="/">Inicio</a> ›\n  <a href="${ORDER_HUB_PATH}">Libros por encargo</a> ›\n  <span>`,
@@ -363,15 +348,15 @@ function replaceDescriptionMeta(html, config) {
   const safeDescription = escapeHtml(config.metaDescription);
   return html
     .replace(
-      /<meta name="description" content="[^"]*">/,
+      /<meta\s+name="description"\s+content="[^"]*">/,
       `<meta name="description" content="${safeDescription}">`,
     )
     .replace(
-      /<meta property="og:description" content="[^"]*">/,
+      /<meta\s+property="og:description"\s+content="[^"]*">/,
       `<meta property="og:description" content="${safeDescription}">`,
     )
     .replace(
-      /<meta name="twitter:description" content="[^"]*">/,
+      /<meta\s+name="twitter:description"\s+content="[^"]*">/,
       `<meta name="twitter:description" content="${safeDescription}">`,
     );
 }
@@ -381,11 +366,11 @@ function replaceTitleMeta(html, config) {
   return html
     .replace(/<title>[\s\S]*?<\/title>/, `<title>${safeTitle}</title>`)
     .replace(
-      /<meta property="og:title" content="[^"]*">/,
+      /<meta\s+property="og:title"\s+content="[^"]*">/,
       `<meta property="og:title" content="${safeTitle}">`,
     )
     .replace(
-      /<meta name="twitter:title" content="[^"]*">/,
+      /<meta\s+name="twitter:title"\s+content="[^"]*">/,
       `<meta name="twitter:title" content="${safeTitle}">`,
     );
 }
@@ -428,9 +413,6 @@ export function enrichAutomaticProductShowcaseHtml(html, productId) {
   return result;
 }
 
-// FICHAS-VIDRIERA-1: capa editorial visible para un MLU/ISBN exacto. Usa la
-// publicación de Mercado Libre como fuente de precio, stock, condición,
-// imágenes y CTA, y agrega sólo contenido original + bibliografía verificada.
 export function enrichProductShowcaseHtml(html, productId) {
   const source = String(html || '');
   const config = PRODUCT_SHOWCASE_OVERRIDES[productId];
@@ -452,11 +434,6 @@ export function enrichProductShowcaseHtml(html, productId) {
   return result;
 }
 
-// SEO-PRODUCT-SCHEMA-1: Google exige que Product tenga al menos una señal
-// elegible para fragmentos de producto (Offer, review o aggregateRating).
-// Las fichas sin oferta real no deben fingir precio, disponibilidad ni reseñas:
-// conservan toda la semántica bibliográfica como Book y dejan de declarar
-// Product hasta que exista una señal elegible real.
 export function normalizeProductSnippetSchemaHtml(html) {
   const source = String(html || '');
   return source.replace(JSON_LD_RE, (full, rawJson) => {
@@ -510,9 +487,6 @@ export async function onRequest(context) {
     return response;
   }
 
-  // Se inspecciona un clon. Si ninguna transformación aplica, se devuelve la
-  // Response original con body, ETag y headers intactos. Si el HTML cambia,
-  // responseWithBody descarta validators del contenido anterior.
   const html = await response.clone().text();
   const withCatalogBreadcrumb = enrichActiveCatalogBreadcrumbHtml(html);
   const withByRequestCx = enrichByRequestProductHtml(withCatalogBreadcrumb, productId);

--- a/functions/libro/_middleware.js
+++ b/functions/libro/_middleware.js
@@ -10,6 +10,7 @@ import {
 } from '../_shared/order-hub.js';
 import { isProductInShowcaseCohort } from '../_shared/showcase-cohort.js';
 import { PRODUCT_SHOWCASE_OVERRIDES } from '../_shared/product-showcases.js';
+import { applyShowcaseTitleQuality } from '../_shared/showcase-title-quality.js';
 
 const PRODUCT_PATH_RE = /^\/libro\/(MLU\d+)(?:\/|$)/i;
 const BREADCRUMB_RE = /<nav>\s*<a href="\/">Inicio<\/a>\s*›\s*<span>/;
@@ -338,10 +339,21 @@ function enrichAutomaticShowcaseSchema(html, productId, config) {
     } catch {
       return full;
     }
+
+    if (schema?.['@type'] === 'BreadcrumbList' && Array.isArray(schema.itemListElement)) {
+      const current = schema.itemListElement.at(-1);
+      if (current) current.name = config.h1;
+      return `<script type="application/ld+json">${serializeSchema(schema)}</script>`;
+    }
+
     const rawType = schema?.['@type'];
     const types = Array.isArray(rawType) ? rawType : [rawType].filter(Boolean);
     if (!types.includes('Book') || String(schema.sku || '').toUpperCase() !== productId) return full;
 
+    if (config.titleChanged) {
+      schema.name = config.h1;
+      if (!schema.alternateName && config.rawTitle) schema.alternateName = config.rawTitle;
+    }
     schema.description = config.schemaDescription;
     return `<script type="application/ld+json">${serializeSchema(schema)}</script>`;
   });
@@ -364,6 +376,20 @@ function replaceDescriptionMeta(html, config) {
     );
 }
 
+function replaceTitleMeta(html, config) {
+  const safeTitle = escapeHtml(config.seoTitle || `${config.h1} | Amado Libros`);
+  return html
+    .replace(/<title>[\s\S]*?<\/title>/, `<title>${safeTitle}</title>`)
+    .replace(
+      /<meta property="og:title" content="[^"]*">/,
+      `<meta property="og:title" content="${safeTitle}">`,
+    )
+    .replace(
+      /<meta name="twitter:title" content="[^"]*">/,
+      `<meta name="twitter:title" content="${safeTitle}">`,
+    );
+}
+
 function insertShowcaseBeforeRelated(html, block) {
   const index = html.indexOf(RELATED_BOOKS_MARKER);
   if (index >= 0) return `${html.slice(0, index)}${block}\n  ${html.slice(index)}`;
@@ -380,16 +406,19 @@ export function enrichAutomaticProductShowcaseHtml(html, productId) {
   }
 
   const item = productItemFromProductHtml(source, id);
-  const config = buildAutomaticProductShowcase(item);
+  const baseConfig = buildAutomaticProductShowcase(item);
+  const config = applyShowcaseTitleQuality(baseConfig, item);
   if (!config) return source;
 
-  let result = source;
-  if (config.subtitle && !result.includes('class="book-subtitle"')) {
-    result = result.replace(
-      PRODUCT_H1_RE,
-      match => `${match}\n    <p class="book-subtitle">${escapeHtml(config.subtitle)}</p>`,
-    );
-  }
+  let result = source.replace(
+    PRODUCT_H1_RE,
+    `<h1>${escapeHtml(config.h1)}</h1>${config.subtitle ? `\n    <p class="book-subtitle">${escapeHtml(config.subtitle)}</p>` : ''}`,
+  );
+  result = result.replace(
+    PRODUCT_NAV_RE,
+    `$1${escapeHtml(config.h1)}$2`,
+  );
+  result = replaceTitleMeta(result, config);
   result = replaceDescriptionMeta(result, config);
   result = enrichAutomaticShowcaseSchema(result, id, config);
   result = insertShowcaseBeforeRelated(result, renderProductShowcase(config));

--- a/scripts/seo/showcase-live-audit.mjs
+++ b/scripts/seo/showcase-live-audit.mjs
@@ -1,13 +1,20 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { SHOWCASE_PREVIEW_SAMPLE_IDS } from '../../functions/_shared/showcase-cohort.js';
+import {
+  SHOWCASE_COHORT_V1_URL,
+  SHOWCASE_COHORT_V2_URL,
+  SHOWCASE_PREVIEW_SAMPLE_IDS,
+} from '../../functions/_shared/showcase-cohort.js';
 
 const BASE_URL = (process.env.SHOWCASE_BASE_URL || 'https://www.amadolibros.com').replace(/\/$/, '');
 const EXPECT_INDEXABLE = process.env.SHOWCASE_EXPECT_INDEXABLE !== 'false';
 const OUTPUT_DIR = process.env.SHOWCASE_OUTPUT_DIR || 'artifacts/showcase-live';
 const CONCURRENCY = Math.max(1, Math.min(8, Number(process.env.SHOWCASE_CONCURRENCY) || 5));
+const SAMPLE_SIZE = Math.max(3, Math.min(12, Number(process.env.SHOWCASE_SAMPLE_SIZE) || 5));
+const MAX_CANDIDATES = Math.max(SAMPLE_SIZE, Math.min(120, Number(process.env.SHOWCASE_MAX_CANDIDATES) || 60));
 const CURATED_ID = 'MLU633557235';
+const ACTIVE_PAGE_MARKER = 'class="badge in-stock"';
 
 function decodeHtml(value) {
   return String(value || '')
@@ -31,6 +38,10 @@ function canonical(html) {
 
 function h1(html) {
   return decodeHtml(html.match(/<h1>([\s\S]*?)<\/h1>/i)?.[1] || '');
+}
+
+function documentTitle(html) {
+  return decodeHtml(html.match(/<title>([\s\S]*?)<\/title>/i)?.[1] || '');
 }
 
 function section(html, className) {
@@ -68,19 +79,38 @@ function productSchema(html, productId) {
   }) || null;
 }
 
+function breadcrumbSchema(html) {
+  return schemas(html).find(schema => schema?.['@type'] === 'BreadcrumbList') || null;
+}
+
 async function fetchProduct(productId) {
-  const response = await fetch(`${BASE_URL}/libro/${productId}`, {
-    redirect: 'follow',
-    headers: { 'user-agent': 'AmadoLibros-Showcase-Audit/1.0' },
-    signal: AbortSignal.timeout(45_000),
-  });
-  return {
-    productId,
-    status: response.status,
-    finalUrl: response.url,
-    headers: Object.fromEntries(response.headers.entries()),
-    html: await response.text(),
-  };
+  try {
+    const response = await fetch(`${BASE_URL}/libro/${productId}`, {
+      redirect: 'follow',
+      headers: {
+        'user-agent': 'AmadoLibros-Showcase-Audit/2.0',
+        'cache-control': 'no-cache',
+      },
+      signal: AbortSignal.timeout(45_000),
+    });
+    return {
+      productId,
+      status: response.status,
+      finalUrl: response.url,
+      headers: Object.fromEntries(response.headers.entries()),
+      html: await response.text(),
+      fetchError: null,
+    };
+  } catch (error) {
+    return {
+      productId,
+      status: 0,
+      finalUrl: '',
+      headers: {},
+      html: '',
+      fetchError: error.message,
+    };
+  }
 }
 
 async function mapConcurrent(values, mapper) {
@@ -96,22 +126,110 @@ async function mapConcurrent(values, mapper) {
   return results;
 }
 
+function validCohort(payload) {
+  if (![1, 2].includes(Number(payload?.schema_version)) || !Array.isArray(payload?.ids)) return false;
+  if (Number(payload.total) !== payload.ids.length || payload.ids.length < 1) return false;
+  return payload.ids.every(id => /^MLU\d+$/.test(String(id || '').toUpperCase()));
+}
+
+async function fetchCohortCandidateIds() {
+  const attempts = [];
+  for (const [version, url] of [[2, SHOWCASE_COHORT_V2_URL], [1, SHOWCASE_COHORT_V1_URL]]) {
+    try {
+      const response = await fetch(url, {
+        headers: {
+          'user-agent': 'AmadoLibros-Showcase-Audit/2.0',
+          'cache-control': 'no-cache',
+        },
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (!response.ok) {
+        attempts.push({ version, url, status: response.status, valid: false });
+        continue;
+      }
+      const payload = await response.json();
+      const valid = validCohort(payload);
+      attempts.push({ version, url, status: response.status, valid, total: payload?.ids?.length || 0 });
+      if (valid) {
+        return {
+          source: `r2-v${version}`,
+          ids: payload.ids.map(id => String(id).toUpperCase()),
+          attempts,
+        };
+      }
+    } catch (error) {
+      attempts.push({ version, url, status: 0, valid: false, error: error.message });
+    }
+  }
+
+  // Respaldo sólo para un Preview anterior a la primera cohorte. La selección
+  // real de muestras igual hace preflight y nunca convierte un pausado en falla.
+  return {
+    source: 'preview-fallback-ids',
+    ids: [...SHOWCASE_PREVIEW_SAMPLE_IDS],
+    attempts,
+  };
+}
+
+function automaticSampleEligibility(result) {
+  if (result.fetchError) return `fetch: ${result.fetchError}`;
+  if (result.status !== 200) return `HTTP ${result.status}`;
+  if (!result.html.includes(ACTIVE_PAGE_MARKER)) return 'no está activa/con stock';
+  if (!result.html.includes('class="product-showcase"')) return 'no recibió vidriera';
+  if (!result.html.includes('data-action="add-to-cart"')) return 'no es vendible en checkout';
+  const schema = productSchema(result.html, result.productId);
+  const rawTypes = schema?.['@type'];
+  const types = Array.isArray(rawTypes) ? rawTypes : [rawTypes].filter(Boolean);
+  if (!types.includes('Product') || !schema?.offers) return 'no tiene Product + Offer real';
+  return null;
+}
+
+async function selectAutomaticSamples() {
+  const cohort = await fetchCohortCandidateIds();
+  const ids = [...new Set([...cohort.ids, ...SHOWCASE_PREVIEW_SAMPLE_IDS])]
+    .filter(id => id !== CURATED_ID)
+    .slice(0, MAX_CANDIDATES);
+  const selected = [];
+  const skipped = [];
+  const batchSize = Math.max(CONCURRENCY, 8);
+
+  for (let start = 0; start < ids.length && selected.length < SAMPLE_SIZE; start += batchSize) {
+    const batch = ids.slice(start, start + batchSize);
+    const fetched = await mapConcurrent(batch, fetchProduct);
+    for (const result of fetched) {
+      const reason = automaticSampleEligibility(result);
+      if (reason) {
+        skipped.push({ productId: result.productId, reason });
+      } else if (selected.length < SAMPLE_SIZE) {
+        selected.push(result);
+      }
+    }
+  }
+
+  return { cohort, selected, skipped, candidatesChecked: selected.length + skipped.length };
+}
+
 function inspectProduct(result, { curated = false } = {}) {
   const failures = [];
   const html = result.html;
   const showcase = section(html, 'product-showcase');
   const title = h1(html);
+  const seoTitle = documentTitle(html);
   const metaRobots = robots(html);
   const xRobots = String(result.headers['x-robots-tag'] || '').toLowerCase();
   const schema = productSchema(html, result.productId);
+  const breadcrumb = breadcrumbSchema(html);
   const rawTypes = schema?.['@type'];
   const types = Array.isArray(rawTypes) ? rawTypes : [rawTypes].filter(Boolean);
   const priceIndex = html.indexOf('Precio web/tarjeta:');
   const showcaseIndex = html.indexOf('class="product-showcase"');
   const showcaseWords = decodeHtml(showcase).split(/\s+/).filter(Boolean).length;
 
+  if (result.fetchError) failures.push(`fetch: ${result.fetchError}`);
   if (result.status !== 200) failures.push(`HTTP ${result.status}`);
   if (!title) failures.push('H1 vacío');
+  if (!seoTitle) failures.push('title HTML vacío');
+  if (!curated && seoTitle.length > 70) failures.push(`title HTML demasiado largo (${seoTitle.length})`);
   if (!showcase) failures.push('falta .product-showcase');
   if (showcase && showcaseWords < 80) failures.push(`vidriera demasiado breve (${showcaseWords} palabras)`);
   if (!html.includes('class="book-subtitle"')) failures.push('falta subtítulo visible');
@@ -129,6 +247,9 @@ function inspectProduct(result, { curated = false } = {}) {
   if (!schema) failures.push('falta schema Book/Product');
   if (schema && !types.includes('Product')) failures.push('ficha vendible perdió Product');
   if (schema && !schema.offers) failures.push('ficha vendible perdió Offer real');
+  if (schema && title && schema.name !== title) failures.push('schema.name no coincide con H1 limpio');
+  const breadcrumbName = breadcrumb?.itemListElement?.at?.(-1)?.name;
+  if (breadcrumbName && title && breadcrumbName !== title) failures.push('breadcrumb no coincide con H1 limpio');
   if (schema?.review || schema?.aggregateRating) failures.push('apareció review/rating no autorizado');
   if (/class="product-showcase"[\s\S]*?(?:★★★★★|5\/5|rating)/i.test(showcase)) {
     failures.push('la vidriera contiene una calificación no autorizada');
@@ -164,6 +285,8 @@ function inspectProduct(result, { curated = false } = {}) {
     status: result.status,
     finalUrl: result.finalUrl,
     title,
+    documentTitle: seoTitle,
+    documentTitleLength: seoTitle.length,
     canonical: canonical(html),
     robots: metaRobots,
     xRobotsTag: xRobots,
@@ -178,20 +301,31 @@ function inspectProduct(result, { curated = false } = {}) {
 }
 
 async function main() {
-  const ids = [...SHOWCASE_PREVIEW_SAMPLE_IDS, CURATED_ID];
-  const fetched = await mapConcurrent(ids, fetchProduct);
-  const products = fetched.map(result => inspectProduct(result, {
-    curated: result.productId === CURATED_ID,
-  }));
-  const failures = products.flatMap(product =>
-    product.failures.map(failure => `${product.productId}: ${failure}`));
+  const selection = await selectAutomaticSamples();
+  const curatedResult = await fetchProduct(CURATED_ID);
+  const products = [
+    ...selection.selected.map(result => inspectProduct(result)),
+    inspectProduct(curatedResult, { curated: true }),
+  ];
+  const selectionFailures = selection.selected.length < SAMPLE_SIZE
+    ? [`muestras automáticas insuficientes: ${selection.selected.length}/${SAMPLE_SIZE} después de ${selection.candidatesChecked} candidatos`]
+    : [];
+  const failures = [
+    ...selectionFailures,
+    ...products.flatMap(product =>
+      product.failures.map(failure => `${product.productId}: ${failure}`)),
+  ];
   const automatic = products.filter(product => !product.curated);
 
   const report = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     generatedAt: new Date().toISOString(),
     baseUrl: BASE_URL,
     expectIndexable: EXPECT_INDEXABLE,
+    cohortSource: selection.cohort.source,
+    cohortAttempts: selection.cohort.attempts,
+    candidatesChecked: selection.candidatesChecked,
+    skippedCandidates: selection.skipped,
     automaticSamples: automatic.length,
     automaticPassed: automatic.filter(product => product.failures.length === 0).length,
     curatedPassed: products.find(product => product.curated)?.failures.length === 0,
@@ -203,6 +337,9 @@ async function main() {
   const outputPath = path.join(OUTPUT_DIR, 'showcase-live-audit.json');
   await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`);
   console.log(JSON.stringify({
+    cohortSource: report.cohortSource,
+    candidatesChecked: report.candidatesChecked,
+    skipped: report.skippedCandidates.length,
     automaticSamples: report.automaticSamples,
     automaticPassed: report.automaticPassed,
     curatedPassed: report.curatedPassed,

--- a/worker-sync/__tests__/showcase-publish.test.js
+++ b/worker-sync/__tests__/showcase-publish.test.js
@@ -23,7 +23,7 @@ function item(index, overrides = {}) {
   };
 }
 
-function catalog(count = 1200) {
+function catalog(count = 3200) {
   return {
     total: count,
     updated_at: '2026-08-20T12:00:00.000Z',
@@ -31,26 +31,60 @@ function catalog(count = 1200) {
   };
 }
 
-test('prepara exactamente las 1000 mejores ediciones activas', () => {
-  const value = catalog(1200);
+test('prepara 3000 ediciones v2 y conserva las primeras 1000 como cohorte v1', () => {
+  const value = catalog(3200);
   const syncMeta = {};
-  const { cohort, metrics } = prepareShowcaseCatalog(value, syncMeta);
+  const { cohort, legacyCohort, metrics } = prepareShowcaseCatalog(value, syncMeta);
 
-  assert.equal(cohort.schema_version, 1);
-  assert.equal(cohort.total, 1000);
-  assert.equal(cohort.ids.length, 1000);
-  assert.equal(new Set(cohort.ids).size, 1000);
-  assert.equal(metrics.selected_items, 1000);
-  assert.equal(value.items.filter(entry => entry.showcase_rank).length, 1000);
-  assert.equal(value.data_quality.showcase_selection.selected_items, 1000);
-  assert.equal(syncMeta.showcase_selection.selected_items, 1000);
+  assert.equal(cohort.schema_version, 2);
+  assert.equal(cohort.total, 3000);
+  assert.equal(cohort.ids.length, 3000);
+  assert.equal(new Set(cohort.ids).size, 3000);
+  assert.equal(legacyCohort.schema_version, 1);
+  assert.equal(legacyCohort.total, 1000);
+  assert.deepEqual(legacyCohort.ids, cohort.ids.slice(0, 1000));
+  assert.equal(metrics.selected_items, 3000);
+  assert.equal(value.items.filter(entry => entry.showcase_rank).length, 3000);
+  assert.equal(value.data_quality.showcase_selection.selected_items, 3000);
+  assert.equal(syncMeta.showcase_selection.selected_items, 3000);
+  assert.equal(syncMeta.showcase_selection.legacy_selected_items, 1000);
   assert.deepEqual(
     value.items
       .filter(entry => entry.showcase_rank)
       .map(entry => entry.showcase_rank)
       .sort((a, b) => a - b),
-    Array.from({ length: 1000 }, (_, index) => index + 1),
+    Array.from({ length: 3000 }, (_, index) => index + 1),
   );
+});
+
+test('publica métricas de niveles de contenido y limpieza de títulos', () => {
+  const rawTitle = 'Manual De Emdr Y Procesos De Terapia Familiar, De Louise Shapiro. Editorial Ediciones Pléyades En Español';
+  const value = {
+    total: 3,
+    updated_at: '2026-08-20T12:00:00.000Z',
+    items: [
+      item(1, {
+        title: rawTitle,
+        author: 'Francine Shapiro, Florence W. Kaslow y Louise Maxfield',
+        publisher: 'Ediciones Pléyades',
+        description: 'a'.repeat(500),
+        bibliographic: { language: 'Español', format: 'Tapa blanda' },
+      }),
+      item(2, { description: 'b'.repeat(120) }),
+      item(3, { description: null }),
+    ],
+  };
+  const syncMeta = {};
+  const { metrics } = prepareShowcaseCatalog(value, syncMeta);
+
+  assert.equal(metrics.selected_editorial, 1);
+  assert.equal(metrics.selected_descriptive, 1);
+  assert.equal(metrics.selected_bibliographic, 1);
+  assert.equal(metrics.selected_title_cleaned, 1);
+  assert.equal(value.items[0].title, rawTitle);
+  assert.equal(value.items[0].showcase_display_title, 'Manual de EMDR y Procesos de Terapia Familiar');
+  assert.equal(syncMeta.showcase_selection.selected_title_over_70_before, 1);
+  assert.equal(syncMeta.showcase_selection.selected_title_over_70_after, 0);
 });
 
 test('la prioridad editorial verificada gana sin inventar señales de demanda', () => {
@@ -75,8 +109,9 @@ test('la prioridad editorial verificada gana sin inventar señales de demanda', 
     items: [richer, priority],
   };
 
-  const { cohort } = prepareShowcaseCatalog(value);
+  const { cohort, legacyCohort } = prepareShowcaseCatalog(value);
   assert.equal(cohort.ids[0], 'MLU633557235');
+  assert.equal(legacyCohort.ids[0], 'MLU633557235');
   assert.equal(priority.showcase_rank, 1);
 });
 
@@ -100,14 +135,15 @@ test('no incorpora pausados ni repite la misma edición', () => {
     items: [original, representative, paused],
   };
 
-  const { cohort, metrics } = prepareShowcaseCatalog(value);
+  const { cohort, legacyCohort, metrics } = prepareShowcaseCatalog(value);
   assert.deepEqual(cohort.ids, [representative.id]);
+  assert.deepEqual(legacyCohort.ids, [representative.id]);
   assert.equal(metrics.duplicate_editions_excluded, 1);
   assert.equal(paused.showcase_rank, undefined);
   assert.equal(original.showcase_rank, undefined);
 });
 
-test('publica staging, valida readback y promueve catálogo + meta + cohorte como último puntero', async () => {
+test('publica staging, valida readback y promueve v1 antes de v2', async () => {
   const objects = new Map();
   const writes = [];
   const env = {
@@ -124,7 +160,7 @@ test('publica staging, valida readback y promueve catálogo + meta + cohorte com
       },
     },
   };
-  const value = catalog(1005);
+  const value = catalog(3005);
   const syncMeta = { status: 'success' };
 
   await publishToR2(env, value, syncMeta);
@@ -132,41 +168,53 @@ test('publica staging, valida readback y promueve catálogo + meta + cohorte com
   assert.deepEqual(writes.map(write => write.key), [
     'staging/catalog.json',
     'staging/meta.json',
-    'staging/showcase-cohort.json',
+    'staging/showcase-cohort-v1.json',
+    'staging/showcase-cohort-v2.json',
     'catalog.json',
     'meta.json',
     'showcase/v1/cohort.json',
+    'showcase/v2/cohort.json',
   ]);
-  const cohort = JSON.parse(objects.get('showcase/v1/cohort.json'));
+  const v1 = JSON.parse(objects.get('showcase/v1/cohort.json'));
+  const v2 = JSON.parse(objects.get('showcase/v2/cohort.json'));
   const liveCatalog = JSON.parse(objects.get('catalog.json'));
-  assert.equal(cohort.total, 1000);
-  assert.equal(liveCatalog.data_quality.showcase_selection.selected_items, 1000);
-  assert.equal(syncMeta.showcase_selection.selected_items, 1000);
-  assert.equal(writes[5].options.httpMetadata.cacheControl, 'public, max-age=3600');
+  assert.equal(v1.total, 1000);
+  assert.equal(v2.total, 3000);
+  assert.deepEqual(v1.ids, v2.ids.slice(0, 1000));
+  assert.equal(liveCatalog.data_quality.showcase_selection.selected_items, 3000);
+  assert.equal(syncMeta.showcase_selection.selected_items, 3000);
+  assert.equal(writes[6].options.httpMetadata.cacheControl, 'public, max-age=300');
+  assert.equal(writes[7].options.httpMetadata.cacheControl, 'public, max-age=300');
 });
 
-test('si el readback de la cohorte falla no toca ningún archivo live', async () => {
-  const objects = new Map();
-  const writes = [];
-  const env = {
-    CATALOG_R2: {
-      async put(key, body) {
-        writes.push(key);
-        objects.set(key, body);
+test('si el readback de cualquiera de las cohortes falla no toca archivos live', async () => {
+  for (const missingKey of [
+    'staging/showcase-cohort-v1.json',
+    'staging/showcase-cohort-v2.json',
+  ]) {
+    const objects = new Map();
+    const writes = [];
+    const env = {
+      CATALOG_R2: {
+        async put(key, body) {
+          writes.push(key);
+          objects.set(key, body);
+        },
+        async get(key) {
+          if (key === missingKey) return null;
+          const body = objects.get(key);
+          return body == null ? null : { async text() { return body; } };
+        },
       },
-      async get(key) {
-        if (key === 'staging/showcase-cohort.json') return null;
-        const body = objects.get(key);
-        return body == null ? null : { async text() { return body; } };
-      },
-    },
-  };
+    };
 
-  await assert.rejects(
-    publishToR2(env, catalog(10), {}),
-    /showcase-cohort\.json devolvió null/,
-  );
-  assert.equal(writes.includes('showcase/v1/cohort.json'), false);
-  assert.equal(writes.includes('catalog.json'), false);
-  assert.equal(writes.includes('meta.json'), false);
+    await assert.rejects(
+      publishToR2(env, catalog(10), {}),
+      /Readback de cohortes vidriera devolvió null/,
+    );
+    assert.equal(writes.includes('showcase/v1/cohort.json'), false);
+    assert.equal(writes.includes('showcase/v2/cohort.json'), false);
+    assert.equal(writes.includes('catalog.json'), false);
+    assert.equal(writes.includes('meta.json'), false);
+  }
 });

--- a/worker-sync/r2-publish.js
+++ b/worker-sync/r2-publish.js
@@ -1,6 +1,7 @@
 import {
   assignShowcaseRanking,
   DEFAULT_SHOWCASE_LIMIT,
+  LEGACY_SHOWCASE_LIMIT,
 } from '../functions/_shared/showcase-ranking.js';
 import { PRODUCT_SHOWCASE_OVERRIDES } from '../functions/_shared/product-showcases.js';
 import { PRODUCT_SEO_OVERRIDES } from '../functions/_shared/seo-products.js';
@@ -10,12 +11,14 @@ import { VERIFIED_DEMAND_BOOK_IDS } from './verified-demand-bibliography.js';
 /**
  * worker-sync/r2-publish.js
  *
- * Escribe catalog.json, meta.json y la cohorte compacta de fichas vidriera en
+ * Escribe catalog.json, meta.json y cohortes compactas de fichas vidriera en
  * el bucket R2 amadolibros-catalog usando staging → validación → promote.
  */
 
-const SHOWCASE_COHORT_STAGING_KEY = 'staging/showcase-cohort.json';
-const SHOWCASE_COHORT_LIVE_KEY = 'showcase/v1/cohort.json';
+const SHOWCASE_V1_STAGING_KEY = 'staging/showcase-cohort-v1.json';
+const SHOWCASE_V2_STAGING_KEY = 'staging/showcase-cohort-v2.json';
+const SHOWCASE_V1_LIVE_KEY = 'showcase/v1/cohort.json';
+const SHOWCASE_V2_LIVE_KEY = 'showcase/v2/cohort.json';
 const SHOWCASE_PRIORITY_IDS = new Set([
   ...Object.keys(PRODUCT_SHOWCASE_OVERRIDES),
   ...Object.keys(PRODUCT_SEO_OVERRIDES),
@@ -23,12 +26,12 @@ const SHOWCASE_PRIORITY_IDS = new Set([
   ...VERIFIED_DEMAND_BOOK_IDS,
 ]);
 
-function validShowcasePayload(payload) {
+function validShowcasePayload(payload, { schemaVersion, limit }) {
   return payload &&
-    payload.schema_version === 1 &&
+    payload.schema_version === schemaVersion &&
     Number.isInteger(payload.total) &&
     payload.total >= 1 &&
-    payload.total <= DEFAULT_SHOWCASE_LIMIT &&
+    payload.total <= limit &&
     Array.isArray(payload.ids) &&
     payload.ids.length === payload.total &&
     new Set(payload.ids).size === payload.ids.length &&
@@ -36,11 +39,9 @@ function validShowcasePayload(payload) {
 }
 
 /**
- * Marca exactamente las mejores ediciones activas del catálogo y genera un
- * puntero liviano para Pages. La selección usa únicamente campos reales:
- * descripción, ISBN, autoría, editorial, páginas, bibliografía, imágenes,
- * identidad de catálogo y stock. Las oportunidades ya verificadas reciben un
- * bonus explícito, sin consultar conectores de publicidad.
+ * Marca las mejores ediciones activas y genera dos punteros livianos:
+ * - v2: hasta 3.000 fichas, consumida por Pages nuevo;
+ * - v1: primeras 1.000, compatible con Pages anterior y rollback inmediato.
  */
 export function prepareShowcaseCatalog(catalog, syncMeta = null) {
   if (!catalog || !Array.isArray(catalog.items)) {
@@ -64,16 +65,35 @@ export function prepareShowcaseCatalog(catalog, syncMeta = null) {
     .filter(item => Number.isInteger(item.showcase_rank))
     .sort((a, b) => a.showcase_rank - b.showcase_rank)
     .map(item => item.id);
-  const cohort = {
-    schema_version: 1,
+  const common = {
     generated_at: catalog.updated_at,
     catalog_version: catalog.updated_at,
+  };
+  const cohort = {
+    schema_version: 2,
+    ...common,
     total: ids.length,
     ids,
   };
+  const legacyIds = ids.slice(0, LEGACY_SHOWCASE_LIMIT);
+  const legacyCohort = {
+    schema_version: 1,
+    ...common,
+    total: legacyIds.length,
+    ids: legacyIds,
+  };
 
-  if (!validShowcasePayload(cohort)) {
-    throw new Error('[R2] La cohorte vidriera generada no cumple el contrato.');
+  if (!validShowcasePayload(cohort, {
+    schemaVersion: 2,
+    limit: DEFAULT_SHOWCASE_LIMIT,
+  })) {
+    throw new Error('[R2] La cohorte vidriera v2 generada no cumple el contrato.');
+  }
+  if (!validShowcasePayload(legacyCohort, {
+    schemaVersion: 1,
+    limit: LEGACY_SHOWCASE_LIMIT,
+  })) {
+    throw new Error('[R2] La cohorte vidriera v1 de compatibilidad no cumple el contrato.');
   }
 
   if (syncMeta && typeof syncMeta === 'object') {
@@ -81,20 +101,28 @@ export function prepareShowcaseCatalog(catalog, syncMeta = null) {
       schema_version: metrics.schema_version,
       limit: metrics.limit,
       selected_items: metrics.selected_items,
+      legacy_selected_items: legacyCohort.total,
       selected_with_description: metrics.selected_with_description,
       selected_with_isbn: metrics.selected_with_isbn,
       selected_with_multiple_images: metrics.selected_with_multiple_images,
+      selected_editorial: metrics.selected_editorial,
+      selected_descriptive: metrics.selected_descriptive,
+      selected_bibliographic: metrics.selected_bibliographic,
+      selected_title_cleaned: metrics.selected_title_cleaned,
+      selected_title_over_70_before: metrics.selected_title_over_70_before,
+      selected_title_over_70_after: metrics.selected_title_over_70_after,
     };
   }
 
-  return { cohort, metrics };
+  return { cohort, legacyCohort, metrics };
 }
 
 export async function publishToR2(env, catalog, syncMeta) {
-  const { cohort, metrics } = prepareShowcaseCatalog(catalog, syncMeta);
+  const { cohort, legacyCohort, metrics } = prepareShowcaseCatalog(catalog, syncMeta);
   const catalogBody = JSON.stringify(catalog);
   const metaBody = JSON.stringify(syncMeta);
   const cohortBody = JSON.stringify(cohort);
+  const legacyCohortBody = JSON.stringify(legacyCohort);
 
   // ── 1. Escribir staging ────────────────────────────────────────────────────
   await env.CATALOG_R2.put('staging/catalog.json', catalogBody, {
@@ -111,7 +139,14 @@ export async function publishToR2(env, catalog, syncMeta) {
     },
   });
 
-  await env.CATALOG_R2.put(SHOWCASE_COHORT_STAGING_KEY, cohortBody, {
+  await env.CATALOG_R2.put(SHOWCASE_V1_STAGING_KEY, legacyCohortBody, {
+    httpMetadata: {
+      contentType: 'application/json',
+      cacheControl: 'no-store',
+    },
+  });
+
+  await env.CATALOG_R2.put(SHOWCASE_V2_STAGING_KEY, cohortBody, {
     httpMetadata: {
       contentType: 'application/json',
       cacheControl: 'no-store',
@@ -121,26 +156,30 @@ export async function publishToR2(env, catalog, syncMeta) {
   console.log('[R2] Staging escrito. Validando readback...');
 
   // ── 2. Leer de vuelta y validar ────────────────────────────────────────────
-  const [stagingObj, stagingShowcaseObj] = await Promise.all([
+  const [stagingObj, stagingV1Obj, stagingV2Obj] = await Promise.all([
     env.CATALOG_R2.get('staging/catalog.json'),
-    env.CATALOG_R2.get(SHOWCASE_COHORT_STAGING_KEY),
+    env.CATALOG_R2.get(SHOWCASE_V1_STAGING_KEY),
+    env.CATALOG_R2.get(SHOWCASE_V2_STAGING_KEY),
   ]);
   if (!stagingObj) {
     throw new Error('[R2] Readback de staging/catalog.json devolvió null — R2 inconsistente. Abortando promote.');
   }
-  if (!stagingShowcaseObj) {
-    throw new Error('[R2] Readback de staging/showcase-cohort.json devolvió null. Abortando promote.');
+  if (!stagingV1Obj || !stagingV2Obj) {
+    throw new Error('[R2] Readback de cohortes vidriera devolvió null. Abortando promote.');
   }
 
   let parsed;
-  let parsedShowcase;
+  let parsedV1;
+  let parsedV2;
   try {
-    const [catalogText, showcaseText] = await Promise.all([
+    const [catalogText, v1Text, v2Text] = await Promise.all([
       stagingObj.text(),
-      stagingShowcaseObj.text(),
+      stagingV1Obj.text(),
+      stagingV2Obj.text(),
     ]);
     parsed = JSON.parse(catalogText);
-    parsedShowcase = JSON.parse(showcaseText);
+    parsedV1 = JSON.parse(v1Text);
+    parsedV2 = JSON.parse(v2Text);
   } catch (error) {
     throw new Error(`[R2] El staging no es JSON válido: ${error.message}`);
   }
@@ -153,9 +192,23 @@ export async function publishToR2(env, catalog, syncMeta) {
   if (Array.isArray(parsed.items) && typeof parsed.total === 'number' && parsed.items.length !== parsed.total) {
     errs.push(`items.length (${parsed.items.length}) !== total (${parsed.total})`);
   }
-  if (!validShowcasePayload(parsedShowcase)) errs.push('cohorte vidriera inválida');
-  if (validShowcasePayload(parsedShowcase) && parsedShowcase.total !== metrics.selected_items) {
-    errs.push(`cohorte.total (${parsedShowcase.total}) !== selected_items (${metrics.selected_items})`);
+  if (!validShowcasePayload(parsedV1, {
+    schemaVersion: 1,
+    limit: LEGACY_SHOWCASE_LIMIT,
+  })) errs.push('cohorte vidriera v1 inválida');
+  if (!validShowcasePayload(parsedV2, {
+    schemaVersion: 2,
+    limit: DEFAULT_SHOWCASE_LIMIT,
+  })) errs.push('cohorte vidriera v2 inválida');
+  if (parsedV2?.total !== metrics.selected_items) {
+    errs.push(`cohorte v2 total (${parsedV2?.total}) !== selected_items (${metrics.selected_items})`);
+  }
+  if (parsedV1?.total !== Math.min(metrics.selected_items, LEGACY_SHOWCASE_LIMIT)) {
+    errs.push(`cohorte v1 total (${parsedV1?.total}) no coincide con compatibilidad esperada`);
+  }
+  if (Array.isArray(parsedV1?.ids) && Array.isArray(parsedV2?.ids) &&
+      JSON.stringify(parsedV1.ids) !== JSON.stringify(parsedV2.ids.slice(0, parsedV1.ids.length))) {
+    errs.push('cohorte v1 no es prefijo exacto de v2');
   }
 
   if (errs.length > 0) {
@@ -164,14 +217,10 @@ export async function publishToR2(env, catalog, syncMeta) {
 
   console.log(
     `[R2] Validación OK: ${parsed.total} items; ` +
-    `${parsedShowcase.total} fichas vidriera; updated_at: ${parsed.updated_at}`,
+    `${parsedV2.total} fichas v2; ${parsedV1.total} fichas v1; updated_at: ${parsed.updated_at}`,
   );
 
   // ── 3. Promote a live ──────────────────────────────────────────────────────
-  // Primero se publica la fotografía completa y recién al final la cohorte que
-  // la referencia. Si catálogo o meta fallan, Pages conserva la cohorte previa;
-  // si falla el último put, sólo queda el catálogo nuevo con la cohorte anterior,
-  // una degradación segura sin IDs adelantados ni fichas rotas.
   await env.CATALOG_R2.put('catalog.json', catalogBody, {
     httpMetadata: {
       contentType: 'application/json',
@@ -186,19 +235,27 @@ export async function publishToR2(env, catalog, syncMeta) {
     },
   });
 
-  // Puntero/allowlist último: nunca anuncia una edición antes de que el catálogo
-  // completo que la contiene haya quedado publicado.
-  await env.CATALOG_R2.put(SHOWCASE_COHORT_LIVE_KEY, cohortBody, {
+  // Compatibilidad primero: Pages viejo y rollback siempre conservan 1.000.
+  await env.CATALOG_R2.put(SHOWCASE_V1_LIVE_KEY, legacyCohortBody, {
     httpMetadata: {
       contentType: 'application/json',
-      cacheControl: 'public, max-age=3600',
+      cacheControl: 'public, max-age=300',
+    },
+  });
+
+  // v2 último: nunca anuncia una edición antes de catálogo/meta ni deja sin
+  // fallback a Pages. Si este put falla, el sitio conserva la cohorte v1.
+  await env.CATALOG_R2.put(SHOWCASE_V2_LIVE_KEY, cohortBody, {
+    httpMetadata: {
+      contentType: 'application/json',
+      cacheControl: 'public, max-age=300',
     },
   });
 
   const bytes = new TextEncoder().encode(catalogBody).length;
   console.log(
     `[R2] Promote completado: ${catalog.total} items, ` +
-    `${cohort.total} fichas vidriera, ` +
+    `${cohort.total} fichas v2 (${legacyCohort.total} compatibles v1), ` +
     `${(bytes / 1024 / 1024).toFixed(2)} MB, updated_at: ${catalog.updated_at}`,
   );
 }


### PR DESCRIPTION
## Objetivo

Escalar el motor automático aprobado en PR #202 desde hasta 1.000 a hasta 3.000 ediciones activas elegibles y corregir títulos/H1 excesivamente comerciales sin modificar el título fuente, el slug, el canonical ni los datos de compra.

## Cambio implementado

- `DEFAULT_SHOWCASE_LIMIT`: 1.000 → 3.000;
- cohorte R2 v2 de hasta 3.000;
- cohorte v1 de las primeras 1.000 conservada para compatibilidad y rollback;
- Pages intenta v2 y cae a v1 si falta o es inválida;
- publicación staging/readback/promote para catálogo, meta, v1 y v2;
- v2 se publica última;
- limpieza de título determinista, reversible y conservadora;
- H1, title HTML, OG/Twitter title, breadcrumb y `schema.name` usan el título visible derivado;
- `schema.alternateName` conserva el título original cuando cambia;
- carrito, analítica, permalink de Mercado Libre, slug y canonical conservan el título/identidad original;
- métricas de calidad editorial/descriptiva/bibliográfica y before/after de títulos;
- auditoría de Preview selecciona muestras activas desde la cohorte real y salta IDs pausados.

## Guardas

- sólo activos con stock, precio UYU y señales de libro;
- deduplicación por edición + condición;
- no inventa sinopsis, biografías, reseñas ni ratings;
- no cambia precio, stock, Offer, imágenes, carrito, WhatsApp ni Mercado Libre;
- una poda dudosa conserva el título original;
- v1 continúa disponible para rollback;
- Producción no usa fallback de IDs de Preview.

## Validación final

- CI completo: ✅
- Deploy + audit de Preview: ✅
- SEO baseline público: ✅
- PR mergeable: ✅
- Producción: intacta

Correcciones finales incluidas:
- rechazo de podas que dejan títulos excesivamente cortos;
- limpieza efectiva de OG/Twitter con el espaciado real del HTML SSR.

Listo técnicamente para revisión/merge. No fusionar sin aprobación explícita de Producción.