### PR TITLE
SEO: detector seguro de candidatos a consolidación de ediciones

### DIFF
--- a/docs/seo/edition-consolidation-candidates-1.md
+++ b/docs/seo/edition-consolidation-candidates-1.md
@@ -34,6 +34,14 @@ node scripts/seo/edition-consolidation-candidates.mjs catalog.json report.json
 
 El reporte incluye estadísticas, grupos, representante propuesto, fuentes candidatas y motivos de revisión/rechazo. El resultado es determinista para el mismo input.
 
+## Evidencia que justifica este diseño
+
+El baseline reproducido del 2026-08-08 encontró 3.164 grupos por ISBN, pero sólo 211 `same_book` bajo la regla estricta y 2.953 `isbn_inconsistent`. Compartir ISBN, por sí solo, no autoriza una consolidación.
+
+La evidencia de Search Console del 2026-07-21 al 2026-08-17 muestra además consultas repartidas entre dos URLs en algunos pares históricamente `same_book`, por ejemplo Headway Elementary 5th Edition Audio CD, Memento Mori y Obesidad de Virginia Busnelli. También muestra consultas repartidas sobre pares con el mismo ISBN pero identidad textual inconsistente, como Daat, Maase Bereshit y Estrategias de enseñanza; esos contraejemplos deben permanecer fuera de la automatización.
+
+El detalle y los MLU están preservados en `docs/seo/edition-consolidation-pilot-evidence-2026-08-20.md`.
+
 ## No incluido
 
 - no cambia canonicals;
@@ -42,4 +50,14 @@ El reporte incluye estadísticas, grupos, representante propuesto, fuentes candi
 - no toca Mercado Libre;
 - no modifica precio, stock, carrito ni checkout.
 
-El paso siguiente, sujeto a aprobación, es correr este detector sobre un snapshot fresco del catálogo, revisar manualmente un piloto pequeño y recién entonces diseñar la capa reversible de canonical.
+## Siguiente gate
+
+Antes de cualquier canonical:
+
+1. correr este detector sobre un snapshot fresco del catálogo;
+2. revisar manualmente un piloto pequeño;
+3. comprobar que el representante sigue 200, indexable y con canonical propio;
+4. aplicar primero canonical reversible;
+5. reservar 301 para pares humano-verificados.
+
+Producción no se toca en este PR.

--- a/docs/seo/edition-consolidation-candidates-1.md
+++ b/docs/seo/edition-consolidation-candidates-1.md
@@ -48,9 +48,9 @@ El workflow público volvió a correr el 2026-08-20 sobre el catálogo vigente (
 - 209 grupos `same_book` bajo la regla estricta histórica;
 - 2.928 grupos `isbn_inconsistent`.
 
-La evidencia de Search Console del 2026-07-21 al 2026-08-17 muestra además consultas repartidas entre dos URLs en algunos pares históricamente `same_book`, por ejemplo Headway Elementary 5th Edition Audio CD, Memento Mori y Obesidad de Virginia Busnelli. La revalidación estructural fresca confirmó que los tres pares siguen activos con stock y permanecen `same_book` bajo el baseline histórico; sin embargo Memento Mori usa el autor genérico `Varios autores`, así que el detector nuevo debe degradarlo a `manual_review`, no a candidato automático.
+La evidencia de Search Console del 2026-07-21 al 2026-08-17 muestra además consultas repartidas entre dos URLs en algunos pares históricamente `same_book`, por ejemplo Headway Elementary 5th Edition Audio CD, Memento Mori y Obesidad de Virginia Busnelli. La revalidación estructural fresca confirmó que los tres pares siguen activos con stock y permanecen `same_book` bajo el baseline histórico; sin embargo Memento Mori usa el autor genérico `Varios autores`, así que el detector nuevo lo degrada a `manual_review`, no a candidato automático.
 
-El baseline histórico no contiene `condition`; por eso ni Headway ni Obesidad quedan autorizados para canonical todavía. La siguiente revalidación debe ejecutarse con el detector nuevo sobre un snapshot completo que incluya condición y el resto de los atributos disponibles.
+El baseline histórico no contiene `condition`; por eso ni Headway ni Obesidad quedan autorizados para canonical todavía. Son los **dos candidatos automáticos potenciales** que deben pasar primero por el detector nuevo sobre un snapshot completo que incluya condición y el resto de atributos disponibles.
 
 También hay consultas repartidas sobre pares con el mismo ISBN pero identidad textual inconsistente, como Daat, Maase Bereshit y Estrategias de enseñanza; esos contraejemplos deben permanecer fuera de la automatización.
 

--- a/docs/seo/edition-consolidation-candidates-1.md
+++ b/docs/seo/edition-consolidation-candidates-1.md
@@ -1,0 +1,45 @@
+# SEO-EDITION-CONSOLIDATION-CANDIDATES-1
+
+Objetivo: detectar pares/grupos de publicaciones activas que podrían representar la misma edición, sin aplicar todavía `rel=canonical`, 301 ni exclusiones de sitemap.
+
+## Regla conservadora
+
+Un grupo sólo queda como `canonical_candidate` cuando todos sus miembros cumplen simultáneamente:
+
+- publicación activa con stock;
+- ISBN válido y normalizado al mismo GTIN;
+- misma condición (`new` o `used`);
+- título normalizado idéntico;
+- autor normalizado presente e idéntico.
+
+Si falta autor o condición, el grupo queda `manual_review`. Si título o autor entran en conflicto, queda `do_not_consolidate`.
+
+El detector no usa similitud semántica, no corrige ISBN y no agrupa ítems sin ISBN válido.
+
+## Representante
+
+Dentro de un grupo de alta confianza se propone un representante determinista:
+
+1. mayor stock;
+2. a igualdad de stock, menor precio válido;
+3. a igualdad, menor ID MLU.
+
+Esto mantiene el criterio alineado con la lógica comercial ya usada en el feed de Merchant, sin tocar todavía las fichas.
+
+## Ejecución
+
+```bash
+node scripts/seo/edition-consolidation-candidates.mjs catalog.json report.json
+```
+
+El reporte incluye estadísticas, grupos, representante propuesto, fuentes candidatas y motivos de revisión/rechazo. El resultado es determinista para el mismo input.
+
+## No incluido
+
+- no cambia canonicals;
+- no crea redirects;
+- no modifica sitemap;
+- no toca Mercado Libre;
+- no modifica precio, stock, carrito ni checkout.
+
+El paso siguiente, sujeto a aprobación, es correr este detector sobre un snapshot fresco del catálogo, revisar manualmente un piloto pequeño y recién entonces diseñar la capa reversible de canonical.

--- a/docs/seo/edition-consolidation-candidates-1.md
+++ b/docs/seo/edition-consolidation-candidates-1.md
@@ -48,7 +48,9 @@ El workflow público volvió a correr el 2026-08-20 sobre el catálogo vigente (
 - 209 grupos `same_book` bajo la regla estricta histórica;
 - 2.928 grupos `isbn_inconsistent`.
 
-La evidencia de Search Console del 2026-07-21 al 2026-08-17 muestra además consultas repartidas entre dos URLs en algunos pares históricamente `same_book`, por ejemplo Headway Elementary 5th Edition Audio CD, Memento Mori y Obesidad de Virginia Busnelli. La revalidación fresca confirmó que los tres pares siguen activos con stock y permanecen `same_book` bajo el baseline histórico; sin embargo Memento Mori usa el autor genérico `Varios autores`, así que el detector nuevo debe degradarlo a `manual_review`, no a candidato automático.
+La evidencia de Search Console del 2026-07-21 al 2026-08-17 muestra además consultas repartidas entre dos URLs en algunos pares históricamente `same_book`, por ejemplo Headway Elementary 5th Edition Audio CD, Memento Mori y Obesidad de Virginia Busnelli. La revalidación estructural fresca confirmó que los tres pares siguen activos con stock y permanecen `same_book` bajo el baseline histórico; sin embargo Memento Mori usa el autor genérico `Varios autores`, así que el detector nuevo debe degradarlo a `manual_review`, no a candidato automático.
+
+El baseline histórico no contiene `condition`; por eso ni Headway ni Obesidad quedan autorizados para canonical todavía. La siguiente revalidación debe ejecutarse con el detector nuevo sobre un snapshot completo que incluya condición y el resto de los atributos disponibles.
 
 También hay consultas repartidas sobre pares con el mismo ISBN pero identidad textual inconsistente, como Daat, Maase Bereshit y Estrategias de enseñanza; esos contraejemplos deben permanecer fuera de la automatización.
 
@@ -66,10 +68,11 @@ El detalle y los MLU están preservados en `docs/seo/edition-consolidation-pilot
 
 Antes de cualquier canonical:
 
-1. correr este detector sobre un snapshot fresco del catálogo;
-2. revisar manualmente un piloto pequeño;
-3. comprobar que el representante sigue 200, indexable y con canonical propio;
-4. aplicar primero canonical reversible;
-5. reservar 301 para pares humano-verificados.
+1. correr este detector sobre un snapshot fresco y completo del catálogo;
+2. confirmar `condition` y los demás atributos comerciales disponibles;
+3. revisar manualmente un piloto pequeño;
+4. comprobar que el representante sigue 200, indexable y con canonical propio;
+5. aplicar primero canonical reversible;
+6. reservar 301 para pares humano-verificados.
 
 Producción no se toca en este PR.

--- a/docs/seo/edition-consolidation-candidates-1.md
+++ b/docs/seo/edition-consolidation-candidates-1.md
@@ -10,7 +10,9 @@ Un grupo sólo queda como `canonical_candidate` cuando todos sus miembros cumple
 - ISBN válido y normalizado al mismo GTIN;
 - misma condición (`new` o `used`);
 - título normalizado idéntico;
-- autor normalizado presente e idéntico.
+- autor normalizado presente, idéntico y no genérico.
+
+Autores como `Varios autores`, `VV. AA.`, `Anónimo`, `No aplica` o equivalentes ya no habilitan canonical automático aunque coincidan entre publicaciones: el grupo queda `manual_review` con motivo `author_generic`.
 
 Si falta autor o condición, el grupo queda `manual_review`. Si título o autor entran en conflicto, queda `do_not_consolidate`.
 
@@ -38,7 +40,17 @@ El reporte incluye estadísticas, grupos, representante propuesto, fuentes candi
 
 El baseline reproducido del 2026-08-08 encontró 3.164 grupos por ISBN, pero sólo 211 `same_book` bajo la regla estricta y 2.953 `isbn_inconsistent`. Compartir ISBN, por sí solo, no autoriza una consolidación.
 
-La evidencia de Search Console del 2026-07-21 al 2026-08-17 muestra además consultas repartidas entre dos URLs en algunos pares históricamente `same_book`, por ejemplo Headway Elementary 5th Edition Audio CD, Memento Mori y Obesidad de Virginia Busnelli. También muestra consultas repartidas sobre pares con el mismo ISBN pero identidad textual inconsistente, como Daat, Maase Bereshit y Estrategias de enseñanza; esos contraejemplos deben permanecer fuera de la automatización.
+El workflow público volvió a correr el 2026-08-20 sobre el catálogo vigente (generado a las 23:47:33Z) y midió:
+
+- 7.090 activos con stock;
+- 3.137 grupos con ISBN repetido;
+- 6.285 listings dentro de esos grupos;
+- 209 grupos `same_book` bajo la regla estricta histórica;
+- 2.928 grupos `isbn_inconsistent`.
+
+La evidencia de Search Console del 2026-07-21 al 2026-08-17 muestra además consultas repartidas entre dos URLs en algunos pares históricamente `same_book`, por ejemplo Headway Elementary 5th Edition Audio CD, Memento Mori y Obesidad de Virginia Busnelli. La revalidación fresca confirmó que los tres pares siguen activos con stock y permanecen `same_book` bajo el baseline histórico; sin embargo Memento Mori usa el autor genérico `Varios autores`, así que el detector nuevo debe degradarlo a `manual_review`, no a candidato automático.
+
+También hay consultas repartidas sobre pares con el mismo ISBN pero identidad textual inconsistente, como Daat, Maase Bereshit y Estrategias de enseñanza; esos contraejemplos deben permanecer fuera de la automatización.
 
 El detalle y los MLU están preservados en `docs/seo/edition-consolidation-pilot-evidence-2026-08-20.md`.
 

--- a/docs/seo/edition-consolidation-pilot-evidence-2026-08-20.md
+++ b/docs/seo/edition-consolidation-pilot-evidence-2026-08-20.md
@@ -1,0 +1,78 @@
+# SEO-EDITION-CONSOLIDATION-1 — evidencia para piloto
+
+Fecha: 2026-08-20
+
+Este documento no autoriza redirects ni canonicals. Reúne evidencia histórica y de Search Console para decidir qué pares deben revalidarse contra el catálogo vigente antes de cualquier cambio indexable.
+
+## Baseline estructural preservado (2026-08-08)
+
+El artifact público `seo-baseline-public-2026-08-08` registró:
+
+- 7.123 items activos analizados;
+- 3.164 grupos con ISBN repetido;
+- 6.341 listings dentro de esos grupos;
+- sólo 211 grupos `same_book` bajo la regla estricta del audit;
+- 2.953 grupos `isbn_inconsistent`.
+
+Conclusión: compartir ISBN no basta para consolidar. La gran mayoría de los grupos por ISBN presentan diferencias de título/autor y deben rechazarse o pasar por revisión.
+
+## Evidencia GSC actual de canibalización útil para priorizar
+
+Ventana GSC: 2026-07-21 a 2026-08-17.
+
+### Candidatos fuertes: misma obra en baseline + query dividida entre dos URLs
+
+1. `Headway Elementary 5th Edition Audio CD`
+   - ISBN histórico: `9780194527552`
+   - MLU: `MLU648794507`, `MLU715787398`
+   - baseline: `same_book`
+   - query GSC `headway elementary 5th edition audio`: 2 impresiones, repartidas 1/1 entre ambas URLs, posición 8/8.
+
+2. `Memento Mori - Recuerda Tu Muerte`
+   - ISBN histórico: `9798294067946`
+   - MLU: `MLU834746174`, `MLU1420573720`
+   - baseline: `same_book`
+   - query GSC `memento mori`: 2 impresiones, repartidas 1/1 entre ambas URLs.
+
+3. `Obesidad — Virginia Busnelli`
+   - ISBN histórico: `9789500217262`
+   - MLU: `MLU1067876690`, `MLU677997343`
+   - baseline: `same_book`
+   - query GSC `obesidad virginia busnelli`: 2 impresiones, repartidas 1/1 entre ambas URLs.
+
+Estos tres pares son buenos candidatos para la primera revalidación fresca porque combinan identidad estricta histórica y evidencia de que Google está repartiendo impresiones entre dos URLs.
+
+## Contraejemplos que justifican el detector conservador
+
+Los siguientes pares comparten ISBN en el baseline, pero fueron clasificados `isbn_inconsistent`; no deben consolidarse automáticamente aunque Search Console muestre dos URLs para la misma query:
+
+- `Daat: El Conocimiento` — `MLU661209812` / `MLU660998018` — ISBN `9789874816016`;
+- `Maase Bereshit` — `MLU635157654` / `MLU652668348` — ISBN `9789872360368`;
+- `Estrategias de enseñanza` — `MLU631153278` / `MLU631813403` — ISBN `9789870602125`;
+- `Anastasia` — `MLU679607330` / `MLU679658240` — ISBN `9788461615063`;
+- `La Nobleza Negra` — `MLU690319456` / `MLU691609938` — ISBN `9798854798280`;
+- `Sod 22` — `MLU628130108` / `MLU617694745` — ISBN `9789872360351`.
+
+El detector nuevo debe mantener estos casos fuera de `canonical_candidate` salvo que una verificación posterior demuestre identidad completa con reglas más fuertes que el ISBN solo.
+
+## Gate antes de canonical
+
+Para cada candidato del piloto hay que volver a verificar, sobre snapshot fresco:
+
+1. ambos MLU siguen activos y con stock;
+2. ISBN válido idéntico;
+3. misma condición;
+4. título normalizado idéntico bajo la regla del detector;
+5. autor normalizado idéntico y no genérico;
+6. ninguna diferencia de edición, idioma, formato u otro atributo comercial disponible;
+7. representante elegido de forma determinista;
+8. la URL representante responde 200, indexable y con canonical propio.
+
+Si cualquiera falla, no se canonicaliza.
+
+## Alcance recomendado del piloto
+
+- empezar por los 3 pares con evidencia GSC anterior;
+- ampliar hasta 20–30 pares sólo después de correr el detector contra el snapshot vigente y revisar manualmente la muestra;
+- canonical reversible primero;
+- 301 queda fuera de este lote y sigue reservado a pares humano-verificados.

--- a/docs/seo/edition-consolidation-pilot-evidence-2026-08-20.md
+++ b/docs/seo/edition-consolidation-pilot-evidence-2026-08-20.md
@@ -2,7 +2,7 @@
 
 Fecha: 2026-08-20
 
-Este documento no autoriza redirects ni canonicals. Reúne evidencia histórica y de Search Console para decidir qué pares deben revalidarse contra el catálogo vigente antes de cualquier cambio indexable.
+Este documento no autoriza redirects ni canonicals. Reúne evidencia histórica, una re-ejecución estructural fresca y Search Console para decidir qué pares deben revalidarse antes de cualquier cambio indexable.
 
 ## Baseline estructural preservado (2026-08-08)
 
@@ -16,31 +16,56 @@ El artifact público `seo-baseline-public-2026-08-08` registró:
 
 Conclusión: compartir ISBN no basta para consolidar. La gran mayoría de los grupos por ISBN presentan diferencias de título/autor y deben rechazarse o pasar por revisión.
 
+## Revalidación estructural fresca (2026-08-20)
+
+El workflow `SEO baseline public audit` volvió a ejecutar el reporte contra el catálogo vigente. Artifact generado a `2026-08-20T23:47:33.733Z`:
+
+- 7.090 activos con stock;
+- 3.137 grupos con ISBN repetido;
+- 6.285 listings dentro de esos grupos;
+- 209 grupos `same_book` bajo la regla estricta histórica;
+- 2.928 grupos `isbn_inconsistent`;
+- active-index: 7.088 items; sólo 2 IDs aparecen únicamente en `catalog.json` y 0 únicamente en el índice.
+
+Los tres pares priorizados por GSC siguen activos con stock y continúan en grupos `same_book` bajo el baseline fresco.
+
 ## Evidencia GSC actual de canibalización útil para priorizar
 
 Ventana GSC: 2026-07-21 a 2026-08-17.
 
-### Candidatos fuertes: misma obra en baseline + query dividida entre dos URLs
+### Candidatos para revalidación
 
 1. `Headway Elementary 5th Edition Audio CD`
-   - ISBN histórico: `9780194527552`
+   - ISBN: `9780194527552`
    - MLU: `MLU648794507`, `MLU715787398`
-   - baseline: `same_book`
+   - baseline fresco: `same_book`
+   - títulos actuales idénticos: `Headway Elementary (5th.edition) - Audio Cd`
+   - autores actuales idénticos: `Soars, John`
+   - stock actual observado en el baseline: 2 / 2
    - query GSC `headway elementary 5th edition audio`: 2 impresiones, repartidas 1/1 entre ambas URLs, posición 8/8.
+   - estado: candidato fuerte para la siguiente revalidación del detector, todavía sin canonical aplicado.
 
-2. `Memento Mori - Recuerda Tu Muerte`
-   - ISBN histórico: `9798294067946`
-   - MLU: `MLU834746174`, `MLU1420573720`
-   - baseline: `same_book`
-   - query GSC `memento mori`: 2 impresiones, repartidas 1/1 entre ambas URLs.
-
-3. `Obesidad — Virginia Busnelli`
-   - ISBN histórico: `9789500217262`
+2. `Obesidad — Virginia Busnelli`
+   - ISBN: `9789500217262`
    - MLU: `MLU1067876690`, `MLU677997343`
-   - baseline: `same_book`
+   - baseline fresco: `same_book`
+   - títulos actuales idénticos: `Obesidad Virginia Busnelli Guía Médica Para Bajar De Peso`
+   - autores actuales idénticos: `Virginia Busnelli`
+   - stock actual observado en el baseline: 3 / 3
    - query GSC `obesidad virginia busnelli`: 2 impresiones, repartidas 1/1 entre ambas URLs.
+   - estado: candidato fuerte para la siguiente revalidación del detector, todavía sin canonical aplicado.
 
-Estos tres pares son buenos candidatos para la primera revalidación fresca porque combinan identidad estricta histórica y evidencia de que Google está repartiendo impresiones entre dos URLs.
+3. `Memento Mori - Recuerda Tu Muerte`
+   - ISBN: `9798294067946`
+   - MLU: `MLU834746174`, `MLU1420573720`
+   - baseline fresco: `same_book`
+   - títulos actuales idénticos;
+   - autor actual en ambos: `Varios autores`;
+   - stock actual observado en el baseline: 1 / 1;
+   - query GSC `memento mori`: 2 impresiones, repartidas 1/1 entre ambas URLs.
+   - estado: **manual_review**, no candidato automático. El autor es genérico y no aporta evidencia de identidad. El detector fue endurecido para emitir `author_generic` en este caso.
+
+Por tanto, el primer piloto automático ya no son tres pares: son **dos pares fuertes** (Headway y Obesidad). Memento queda como caso humano-verificado si se quisiera consolidar después.
 
 ## Contraejemplos que justifican el detector conservador
 
@@ -72,7 +97,8 @@ Si cualquiera falla, no se canonicaliza.
 
 ## Alcance recomendado del piloto
 
-- empezar por los 3 pares con evidencia GSC anterior;
-- ampliar hasta 20–30 pares sólo después de correr el detector contra el snapshot vigente y revisar manualmente la muestra;
+- empezar por Headway y Obesidad;
+- Memento sólo mediante revisión humana por autor genérico;
+- ampliar hasta 20–30 pares únicamente después de correr el detector contra el snapshot vigente y revisar manualmente la muestra;
 - canonical reversible primero;
 - 301 queda fuera de este lote y sigue reservado a pares humano-verificados.

--- a/docs/seo/edition-consolidation-pilot-evidence-2026-08-20.md
+++ b/docs/seo/edition-consolidation-pilot-evidence-2026-08-20.md
@@ -27,7 +27,7 @@ El workflow `SEO baseline public audit` volvió a ejecutar el reporte contra el 
 - 2.928 grupos `isbn_inconsistent`;
 - active-index: 7.088 items; sólo 2 IDs aparecen únicamente en `catalog.json` y 0 únicamente en el índice.
 
-Los tres pares priorizados por GSC siguen activos con stock y continúan en grupos `same_book` bajo el baseline fresco.
+Los tres pares priorizados por GSC siguen activos con stock y continúan en grupos `same_book` bajo el baseline fresco. Este reporte histórico no incluye `condition`, por lo que **todavía no autoriza canonical automático**: la condición debe confirmarse con el detector nuevo sobre el snapshot completo antes de cualquier cambio indexable.
 
 ## Evidencia GSC actual de canibalización útil para priorizar
 
@@ -65,7 +65,7 @@ Ventana GSC: 2026-07-21 a 2026-08-17.
    - query GSC `memento mori`: 2 impresiones, repartidas 1/1 entre ambas URLs.
    - estado: **manual_review**, no candidato automático. El autor es genérico y no aporta evidencia de identidad. El detector fue endurecido para emitir `author_generic` en este caso.
 
-Por tanto, el primer piloto automático ya no son tres pares: son **dos pares fuertes** (Headway y Obesidad). Memento queda como caso humano-verificado si se quisiera consolidar después.
+Por tanto, el primer piloto automático potencial ya no son tres pares: son **dos pares fuertes para revalidar** (Headway y Obesidad). Memento queda como caso humano-verificado si se quisiera consolidar después. Ninguno se canonicaliza hasta que el detector nuevo confirme también `condition` y el resto de los gates.
 
 ## Contraejemplos que justifican el detector conservador
 
@@ -97,7 +97,7 @@ Si cualquiera falla, no se canonicaliza.
 
 ## Alcance recomendado del piloto
 
-- empezar por Headway y Obesidad;
+- empezar por Headway y Obesidad sólo si el detector completo confirma todos los gates;
 - Memento sólo mediante revisión humana por autor genérico;
 - ampliar hasta 20–30 pares únicamente después de correr el detector contra el snapshot vigente y revisar manualmente la muestra;
 - canonical reversible primero;

--- a/functions/__tests__/edition-consolidation-candidates.test.js
+++ b/functions/__tests__/edition-consolidation-candidates.test.js
@@ -1,0 +1,158 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  analyzeEditionClusters,
+  normalizeComparableText,
+  pickCanonicalRepresentative,
+  stableReportJson,
+} from '../../scripts/seo/edition-consolidation-candidates.mjs';
+
+const ISBN_A = '9788412027082';
+const ISBN_B = '9780194316002';
+
+function item(id, overrides = {}) {
+  return {
+    id,
+    title: 'Reflexiones sobre vivir en compasión',
+    author: 'Autor Ejemplo',
+    isbn: ISBN_A,
+    condition: 'new',
+    status: 'active',
+    available_quantity: 1,
+    price: 1500,
+    ...overrides,
+  };
+}
+
+test('normaliza texto sin borrar palabras significativas', () => {
+  assert.equal(
+    normalizeComparableText('  María Montessori: Psicogeometría  '),
+    'maria montessori psicogeometria',
+  );
+});
+
+test('detecta como alta confianza mismo ISBN, título, autor y condición', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100', { available_quantity: 1, price: 1600 }),
+    item('MLU101', { available_quantity: 3, price: 1700 }),
+  ]);
+
+  assert.equal(report.stats.high_confidence_groups, 1);
+  assert.equal(report.stats.canonical_candidate_sources, 1);
+  assert.deepEqual(report.clusters[0], {
+    gtin: ISBN_A,
+    condition: 'new',
+    confidence: 'high',
+    recommended_action: 'canonical_candidate',
+    reasons: [],
+    representative_id: 'MLU101',
+    source_ids: ['MLU100'],
+    member_ids: ['MLU100', 'MLU101'],
+    normalized_title: 'reflexiones sobre vivir en compasion',
+    normalized_author: 'autor ejemplo',
+  });
+});
+
+test('el representante usa stock, luego precio y luego id como desempate', () => {
+  const chosen = pickCanonicalRepresentative([
+    item('MLU102', { available_quantity: 2, price: 1500 }),
+    item('MLU101', { available_quantity: 2, price: 1400 }),
+    item('MLU100', { available_quantity: 1, price: 1000 }),
+  ]);
+  assert.equal(chosen.id, 'MLU101');
+
+  const tie = pickCanonicalRepresentative([
+    item('MLU102', { available_quantity: 2, price: 1400 }),
+    item('MLU101', { available_quantity: 2, price: 1400 }),
+  ]);
+  assert.equal(tie.id, 'MLU101');
+});
+
+test('títulos incompatibles bloquean consolidación automática', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100'),
+    item('MLU101', { title: 'Un libro completamente distinto' }),
+  ]);
+  assert.equal(report.clusters[0].confidence, 'reject');
+  assert.equal(report.clusters[0].recommended_action, 'do_not_consolidate');
+  assert.deepEqual(report.clusters[0].source_ids, []);
+  assert.ok(report.clusters[0].reasons.includes('title_conflict'));
+});
+
+test('autores incompatibles bloquean consolidación automática', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100'),
+    item('MLU101', { author: 'Otra Persona' }),
+  ]);
+  assert.equal(report.clusters[0].confidence, 'reject');
+  assert.ok(report.clusters[0].reasons.includes('author_conflict'));
+});
+
+test('autor faltante obliga a revisión humana aunque el resto coincida', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100'),
+    item('MLU101', { author: null }),
+  ]);
+  assert.equal(report.clusters[0].confidence, 'review');
+  assert.equal(report.clusters[0].recommended_action, 'manual_review');
+  assert.deepEqual(report.clusters[0].source_ids, []);
+  assert.ok(report.clusters[0].reasons.includes('author_missing'));
+});
+
+test('condición desconocida no habilita canonical automático', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100', { condition: null }),
+    item('MLU101', { condition: null }),
+  ]);
+  assert.equal(report.clusters[0].confidence, 'review');
+  assert.ok(report.clusters[0].reasons.includes('condition_unknown'));
+});
+
+test('new y used nunca se agrupan entre sí', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100', { condition: 'new' }),
+    item('MLU101', { condition: 'used' }),
+  ]);
+  assert.equal(report.stats.duplicate_groups, 0);
+});
+
+test('ISBN inválido no participa en clusters', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100', { isbn: '1234' }),
+    item('MLU101', { isbn: '1234' }),
+  ]);
+  assert.equal(report.stats.valid_isbn_items, 0);
+  assert.equal(report.stats.duplicate_groups, 0);
+});
+
+test('pausados y activos sin stock quedan fuera del detector', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100', { status: 'paused', available_quantity: 0 }),
+    item('MLU101', { available_quantity: 0 }),
+    item('MLU102', { isbn: ISBN_B }),
+    item('MLU103', { isbn: ISBN_B }),
+  ]);
+  assert.equal(report.stats.active_in_stock_items, 2);
+  assert.equal(report.stats.duplicate_groups, 1);
+});
+
+test('el resultado es determinista aunque cambie el orden de entrada', () => {
+  const a = [
+    item('MLU102', { available_quantity: 2 }),
+    item('MLU100', { available_quantity: 1 }),
+    item('MLU101', { available_quantity: 2 }),
+  ];
+  const b = [a[1], a[2], a[0]];
+  assert.equal(
+    stableReportJson(analyzeEditionClusters(a)),
+    stableReportJson(analyzeEditionClusters(b)),
+  );
+});
+
+test('no muta los ítems de entrada', () => {
+  const items = [item('MLU100'), item('MLU101')];
+  const before = JSON.stringify(items);
+  analyzeEditionClusters(items);
+  assert.equal(JSON.stringify(items), before);
+});

--- a/functions/__tests__/edition-consolidation-candidates.test.js
+++ b/functions/__tests__/edition-consolidation-candidates.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
   analyzeEditionClusters,
+  isGenericAuthor,
   normalizeComparableText,
   pickCanonicalRepresentative,
   stableReportJson,
@@ -30,6 +31,13 @@ test('normaliza texto sin borrar palabras significativas', () => {
     normalizeComparableText('  María Montessori: Psicogeometría  '),
     'maria montessori psicogeometria',
   );
+});
+
+test('reconoce autores genéricos después de normalizar', () => {
+  for (const value of ['Varios autores', 'VV. AA.', 'Anónimo', 'No aplica', 'Various Authors']) {
+    assert.equal(isGenericAuthor(value), true, value);
+  }
+  assert.equal(isGenericAuthor('Virginia Busnelli'), false);
 });
 
 test('detecta como alta confianza mismo ISBN, título, autor y condición', () => {
@@ -98,6 +106,17 @@ test('autor faltante obliga a revisión humana aunque el resto coincida', () => 
   assert.equal(report.clusters[0].recommended_action, 'manual_review');
   assert.deepEqual(report.clusters[0].source_ids, []);
   assert.ok(report.clusters[0].reasons.includes('author_missing'));
+});
+
+test('autor genérico no habilita canonical automático', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100', { author: 'Varios autores' }),
+    item('MLU101', { author: 'Varios autores' }),
+  ]);
+  assert.equal(report.clusters[0].confidence, 'review');
+  assert.equal(report.clusters[0].recommended_action, 'manual_review');
+  assert.deepEqual(report.clusters[0].source_ids, []);
+  assert.ok(report.clusters[0].reasons.includes('author_generic'));
 });
 
 test('condición desconocida no habilita canonical automático', () => {

--- a/functions/__tests__/edition-consolidation-candidates.test.js
+++ b/functions/__tests__/edition-consolidation-candidates.test.js
@@ -22,6 +22,9 @@ function item(id, overrides = {}) {
     status: 'active',
     available_quantity: 1,
     price: 1500,
+    catalog_listing: null,
+    catalog_product_id: null,
+    bibliographic: null,
     ...overrides,
   };
 }
@@ -48,17 +51,105 @@ test('detecta como alta confianza mismo ISBN, título, autor y condición', () =
 
   assert.equal(report.stats.high_confidence_groups, 1);
   assert.equal(report.stats.canonical_candidate_sources, 1);
-  assert.deepEqual(report.clusters[0], {
-    gtin: ISBN_A,
-    condition: 'new',
-    confidence: 'high',
-    recommended_action: 'canonical_candidate',
-    reasons: [],
-    representative_id: 'MLU101',
-    source_ids: ['MLU100'],
-    member_ids: ['MLU100', 'MLU101'],
-    normalized_title: 'reflexiones sobre vivir en compasion',
-    normalized_author: 'autor ejemplo',
+  assert.equal(report.clusters[0].origin_type, 'bibliographic_only');
+  assert.equal(report.clusters[0].representative_id, 'MLU101');
+  assert.deepEqual(report.clusters[0].source_ids, ['MLU100']);
+  assert.deepEqual(report.clusters[0].normalized_bibliographic, {
+    edition: null,
+    language: null,
+    format: null,
+  });
+});
+
+test('clasifica publicación común + publicación catálogo con mismo catalog_product_id', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100', { catalog_listing: false, catalog_product_id: 'MLU-PROD-1' }),
+    item('MLU101', { catalog_listing: true, catalog_product_id: 'mlu-prod-1' }),
+  ]);
+  const cluster = report.clusters[0];
+  assert.equal(cluster.confidence, 'high');
+  assert.equal(cluster.origin_type, 'ml_common_plus_catalog');
+  assert.deepEqual(cluster.catalog_product_ids, ['MLU-PROD-1']);
+  assert.deepEqual(cluster.catalog_listing_values, [false, true]);
+  assert.equal(report.stats.ml_common_plus_catalog_groups, 1);
+});
+
+test('mismo catalog_product_id sin mezcla common/catalog queda separado como same_ml_catalog_product', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100', { catalog_listing: true, catalog_product_id: 'MLU-PROD-1' }),
+    item('MLU101', { catalog_listing: true, catalog_product_id: 'MLU-PROD-1' }),
+  ]);
+  assert.equal(report.clusters[0].origin_type, 'same_ml_catalog_product');
+  assert.equal(report.stats.same_ml_catalog_product_groups, 1);
+});
+
+test('catalog_product_id distintos bloquean consolidación automática', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100', { catalog_product_id: 'MLU-PROD-1' }),
+    item('MLU101', { catalog_product_id: 'MLU-PROD-2' }),
+  ]);
+  const cluster = report.clusters[0];
+  assert.equal(cluster.confidence, 'reject');
+  assert.equal(cluster.origin_type, 'catalog_product_conflict');
+  assert.ok(cluster.reasons.includes('catalog_product_conflict'));
+  assert.equal(report.stats.catalog_product_conflict_groups, 1);
+});
+
+test('catalog_product_id presente sólo en parte del grupo exige revisión humana', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100', { catalog_product_id: 'MLU-PROD-1' }),
+    item('MLU101', { catalog_product_id: null }),
+  ]);
+  assert.equal(report.clusters[0].confidence, 'review');
+  assert.equal(report.clusters[0].origin_type, 'catalog_product_partial');
+  assert.ok(report.clusters[0].reasons.includes('catalog_product_partial'));
+});
+
+test('catalog_listing=true sin catalog_product_id exige revisión humana', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100', { catalog_listing: true }),
+    item('MLU101', { catalog_listing: false }),
+  ]);
+  assert.equal(report.clusters[0].confidence, 'review');
+  assert.equal(report.clusters[0].origin_type, 'catalog_listing_without_product_id');
+  assert.ok(report.clusters[0].reasons.includes('catalog_listing_without_product_id'));
+});
+
+test('edición, idioma o formato contradictorios bloquean consolidación automática', () => {
+  const cases = [
+    ['edition', '1ª edición', '2ª edición'],
+    ['language', 'Español', 'Inglés'],
+    ['format', 'Tapa blanda', 'Tapa dura'],
+  ];
+  for (const [field, a, b] of cases) {
+    const report = analyzeEditionClusters([
+      item('MLU100', { bibliographic: { [field]: a } }),
+      item('MLU101', { bibliographic: { [field]: b } }),
+    ]);
+    assert.equal(report.clusters[0].confidence, 'reject', field);
+    assert.ok(report.clusters[0].reasons.includes(`${field}_conflict`), field);
+  }
+});
+
+test('dato bibliográfico presente sólo en parte del grupo exige revisión', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100', { bibliographic: { language: 'Español' } }),
+    item('MLU101', { bibliographic: null }),
+  ]);
+  assert.equal(report.clusters[0].confidence, 'review');
+  assert.ok(report.clusters[0].reasons.includes('language_partial'));
+});
+
+test('datos bibliográficos iguales refuerzan identidad sin bloquear', () => {
+  const report = analyzeEditionClusters([
+    item('MLU100', { bibliographic: { edition: '1ª', language: 'Español', format: 'Tapa blanda' } }),
+    item('MLU101', { bibliographic: { edition: '1ª', language: 'Español', format: 'Tapa blanda' } }),
+  ]);
+  assert.equal(report.clusters[0].confidence, 'high');
+  assert.deepEqual(report.clusters[0].normalized_bibliographic, {
+    edition: '1a',
+    language: 'espanol',
+    format: 'tapa blanda',
   });
 });
 
@@ -158,9 +249,9 @@ test('pausados y activos sin stock quedan fuera del detector', () => {
 
 test('el resultado es determinista aunque cambie el orden de entrada', () => {
   const a = [
-    item('MLU102', { available_quantity: 2 }),
-    item('MLU100', { available_quantity: 1 }),
-    item('MLU101', { available_quantity: 2 }),
+    item('MLU102', { available_quantity: 2, catalog_listing: false, catalog_product_id: 'MLU-PROD-1' }),
+    item('MLU100', { available_quantity: 1, catalog_listing: true, catalog_product_id: 'MLU-PROD-1' }),
+    item('MLU101', { available_quantity: 2, catalog_listing: false, catalog_product_id: 'MLU-PROD-1' }),
   ];
   const b = [a[1], a[2], a[0]];
   assert.equal(

--- a/scripts/seo/edition-consolidation-candidates.mjs
+++ b/scripts/seo/edition-consolidation-candidates.mjs
@@ -25,6 +25,14 @@ export function normalizeComparableText(value) {
     .trim();
 }
 
+function normalizeEditionIdentity(value) {
+  return normalizeComparableText(
+    String(value || '')
+      .replace(/ª/g, 'a')
+      .replace(/º/g, 'o'),
+  ).replace(/\b(\d+)\s+([ao])\b/g, '$1$2');
+}
+
 export function isGenericAuthor(value) {
   return GENERIC_AUTHORS.has(normalizeComparableText(value));
 }
@@ -53,7 +61,12 @@ function uniqueSorted(values) {
 }
 
 function analyzeOptionalIdentityField(group, field, reasons) {
-  const normalized = group.map(item => normalizeComparableText(item?.bibliographic?.[field]));
+  const normalized = group.map(item => {
+    const value = item?.bibliographic?.[field];
+    return field === 'edition'
+      ? normalizeEditionIdentity(value)
+      : normalizeComparableText(value);
+  });
   const values = uniqueSorted(normalized);
   const presentCount = normalized.filter(Boolean).length;
 
@@ -278,12 +291,14 @@ async function runCli() {
   };
 
   const output = stableReportJson(report);
-  if (outputPath) await fs.writeFile(outputPath, output, 'utf8');
-  else process.stdout.write(output);
+  if (outputPath) {
+    await fs.writeFile(outputPath, output, 'utf8');
+  } else {
+    process.stdout.write(output);
+  }
 }
 
-const isDirectRun = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
-if (isDirectRun) {
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   runCli().catch(error => {
     console.error(error?.stack || error);
     process.exitCode = 1;

--- a/scripts/seo/edition-consolidation-candidates.mjs
+++ b/scripts/seo/edition-consolidation-candidates.mjs
@@ -1,0 +1,192 @@
+import fs from 'node:fs/promises';
+import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { normalizeIsbnToGtin } from '../../functions/feed.xml.js';
+
+export const REPORT_SCHEMA_VERSION = 1;
+
+export function normalizeComparableText(value) {
+  return String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLocaleLowerCase('es')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizeCondition(value) {
+  const condition = String(value || '').trim().toLowerCase();
+  return condition === 'new' || condition === 'used' ? condition : 'unknown';
+}
+
+function validCandidateItem(item) {
+  return Boolean(
+    item &&
+    /^MLU\d+$/.test(String(item.id || '')) &&
+    String(item.title || '').trim() &&
+    item.status === 'active' &&
+    Number(item.available_quantity) > 0
+  );
+}
+
+export function pickCanonicalRepresentative(group) {
+  if (!Array.isArray(group) || group.length === 0) return null;
+  return [...group].sort((a, b) => {
+    const qtyA = Number(a.available_quantity) || 0;
+    const qtyB = Number(b.available_quantity) || 0;
+    if (qtyB !== qtyA) return qtyB - qtyA;
+
+    const rawPriceA = Number(a.price);
+    const rawPriceB = Number(b.price);
+    const priceA = Number.isFinite(rawPriceA) && rawPriceA > 0 ? rawPriceA : Number.POSITIVE_INFINITY;
+    const priceB = Number.isFinite(rawPriceB) && rawPriceB > 0 ? rawPriceB : Number.POSITIVE_INFINITY;
+    if (priceA !== priceB) return priceA - priceB;
+
+    const idA = String(a.id || '');
+    const idB = String(b.id || '');
+    return idA < idB ? -1 : idA > idB ? 1 : 0;
+  })[0];
+}
+
+function analyzeGroup(gtin, condition, group) {
+  const normalizedTitles = group.map(item => normalizeComparableText(item.title));
+  const normalizedAuthors = group.map(item => normalizeComparableText(item.author));
+  const titleValues = [...new Set(normalizedTitles.filter(Boolean))].sort();
+  const authorValues = [...new Set(normalizedAuthors.filter(Boolean))].sort();
+
+  const allTitlesPresent = normalizedTitles.every(Boolean);
+  const allAuthorsPresent = normalizedAuthors.every(Boolean);
+  const reasons = [];
+
+  if (!allTitlesPresent) reasons.push('title_missing');
+  else if (titleValues.length !== 1) reasons.push('title_conflict');
+
+  if (!allAuthorsPresent) reasons.push('author_missing');
+  else if (authorValues.length !== 1) reasons.push('author_conflict');
+
+  if (condition === 'unknown') reasons.push('condition_unknown');
+
+  const hasIdentityConflict = reasons.includes('title_conflict') || reasons.includes('author_conflict');
+  const confidence = reasons.length === 0
+    ? 'high'
+    : hasIdentityConflict
+      ? 'reject'
+      : 'review';
+
+  const representative = pickCanonicalRepresentative(group);
+  const sortedIds = group.map(item => item.id).sort();
+  const sourceIds = representative
+    ? sortedIds.filter(id => id !== representative.id)
+    : [];
+
+  return {
+    gtin,
+    condition,
+    confidence,
+    recommended_action: confidence === 'high'
+      ? 'canonical_candidate'
+      : confidence === 'review'
+        ? 'manual_review'
+        : 'do_not_consolidate',
+    reasons,
+    representative_id: representative?.id || null,
+    source_ids: confidence === 'high' ? sourceIds : [],
+    member_ids: sortedIds,
+    normalized_title: titleValues.length === 1 ? titleValues[0] : null,
+    normalized_author: authorValues.length === 1 && allAuthorsPresent ? authorValues[0] : null,
+  };
+}
+
+export function analyzeEditionClusters(items) {
+  const input = Array.isArray(items) ? items : [];
+  const groups = new Map();
+  let activeInStockItems = 0;
+  let validIsbnItems = 0;
+
+  for (const item of input) {
+    if (!validCandidateItem(item)) continue;
+    activeInStockItems += 1;
+
+    const isbn = normalizeIsbnToGtin(item.isbn);
+    if (!isbn.valid || !isbn.gtin) continue;
+    validIsbnItems += 1;
+
+    const condition = normalizeCondition(item.condition);
+    const key = `${isbn.gtin}|${condition}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(item);
+  }
+
+  const confidenceOrder = { high: 0, review: 1, reject: 2 };
+  const clusters = [];
+  for (const [key, group] of groups.entries()) {
+    if (group.length < 2) continue;
+    const separator = key.lastIndexOf('|');
+    const gtin = key.slice(0, separator);
+    const condition = key.slice(separator + 1);
+    clusters.push(analyzeGroup(gtin, condition, group));
+  }
+
+  clusters.sort((a, b) =>
+    (confidenceOrder[a.confidence] - confidenceOrder[b.confidence]) ||
+    a.gtin.localeCompare(b.gtin) ||
+    a.condition.localeCompare(b.condition)
+  );
+
+  const high = clusters.filter(cluster => cluster.confidence === 'high');
+  const review = clusters.filter(cluster => cluster.confidence === 'review');
+  const reject = clusters.filter(cluster => cluster.confidence === 'reject');
+
+  return {
+    schema_version: REPORT_SCHEMA_VERSION,
+    stats: {
+      input_items: input.length,
+      active_in_stock_items: activeInStockItems,
+      valid_isbn_items: validIsbnItems,
+      duplicate_groups: clusters.length,
+      high_confidence_groups: high.length,
+      review_groups: review.length,
+      rejected_groups: reject.length,
+      canonical_candidate_sources: high.reduce((sum, cluster) => sum + cluster.source_ids.length, 0),
+    },
+    clusters,
+  };
+}
+
+export function stableReportJson(report) {
+  return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+async function runCli() {
+  const [, , inputPath, outputPath] = process.argv;
+  if (!inputPath) {
+    throw new Error('Uso: node scripts/seo/edition-consolidation-candidates.mjs <catalog.json> [report.json]');
+  }
+
+  const raw = await fs.readFile(inputPath);
+  const parsed = JSON.parse(raw.toString('utf8'));
+  const items = Array.isArray(parsed) ? parsed : parsed?.items;
+  if (!Array.isArray(items)) {
+    throw new Error('El input debe ser un array o un objeto con items[].');
+  }
+
+  const report = analyzeEditionClusters(items);
+  report.source = {
+    file: inputPath,
+    sha256: crypto.createHash('sha256').update(raw).digest('hex'),
+    updated_at: typeof parsed?.updated_at === 'string' ? parsed.updated_at : null,
+  };
+
+  const output = stableReportJson(report);
+  if (outputPath) await fs.writeFile(outputPath, output, 'utf8');
+  else process.stdout.write(output);
+}
+
+const isDirectRun = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isDirectRun) {
+  runCli().catch(error => {
+    console.error(error?.stack || error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/seo/edition-consolidation-candidates.mjs
+++ b/scripts/seo/edition-consolidation-candidates.mjs
@@ -5,6 +5,16 @@ import { normalizeIsbnToGtin } from '../../functions/feed.xml.js';
 
 export const REPORT_SCHEMA_VERSION = 1;
 
+const GENERIC_AUTHORS = new Set([
+  'anonimo',
+  'anonymous',
+  'no aplica',
+  'sin autor',
+  'varios autores',
+  'various authors',
+  'vv aa',
+]);
+
 export function normalizeComparableText(value) {
   return String(value || '')
     .normalize('NFD')
@@ -13,6 +23,10 @@ export function normalizeComparableText(value) {
     .replace(/[^a-z0-9]+/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
+}
+
+export function isGenericAuthor(value) {
+  return GENERIC_AUTHORS.has(normalizeComparableText(value));
 }
 
 function normalizeCondition(value) {
@@ -64,6 +78,7 @@ function analyzeGroup(gtin, condition, group) {
 
   if (!allAuthorsPresent) reasons.push('author_missing');
   else if (authorValues.length !== 1) reasons.push('author_conflict');
+  else if (isGenericAuthor(authorValues[0])) reasons.push('author_generic');
 
   if (condition === 'unknown') reasons.push('condition_unknown');
 

--- a/scripts/seo/edition-consolidation-candidates.mjs
+++ b/scripts/seo/edition-consolidation-candidates.mjs
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { normalizeIsbnToGtin } from '../../functions/feed.xml.js';
 
-export const REPORT_SCHEMA_VERSION = 1;
+export const REPORT_SCHEMA_VERSION = 2;
 
 const GENERIC_AUTHORS = new Set([
   'anonimo',
@@ -34,6 +34,10 @@ function normalizeCondition(value) {
   return condition === 'new' || condition === 'used' ? condition : 'unknown';
 }
 
+function normalizeCatalogProductId(value) {
+  return String(value || '').trim().toUpperCase();
+}
+
 function validCandidateItem(item) {
   return Boolean(
     item &&
@@ -42,6 +46,57 @@ function validCandidateItem(item) {
     item.status === 'active' &&
     Number(item.available_quantity) > 0
   );
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values.filter(Boolean))].sort();
+}
+
+function analyzeOptionalIdentityField(group, field, reasons) {
+  const normalized = group.map(item => normalizeComparableText(item?.bibliographic?.[field]));
+  const values = uniqueSorted(normalized);
+  const presentCount = normalized.filter(Boolean).length;
+
+  if (values.length > 1) reasons.push(`${field}_conflict`);
+  else if (values.length === 1 && presentCount !== group.length) reasons.push(`${field}_partial`);
+
+  return values.length === 1 ? values[0] : null;
+}
+
+function analyzeCatalogIdentity(group, reasons) {
+  const rawIds = group.map(item => normalizeCatalogProductId(item.catalog_product_id));
+  const catalogProductIds = uniqueSorted(rawIds);
+  const listingValues = [...new Set(
+    group
+      .map(item => typeof item.catalog_listing === 'boolean' ? item.catalog_listing : null)
+      .filter(value => value !== null)
+  )].sort();
+  const presentCount = rawIds.filter(Boolean).length;
+
+  let originType = 'bibliographic_only';
+
+  if (catalogProductIds.length > 1) {
+    reasons.push('catalog_product_conflict');
+    originType = 'catalog_product_conflict';
+  } else if (catalogProductIds.length === 1) {
+    if (presentCount !== group.length) {
+      reasons.push('catalog_product_partial');
+      originType = 'catalog_product_partial';
+    } else if (listingValues.includes(true) && listingValues.includes(false)) {
+      originType = 'ml_common_plus_catalog';
+    } else {
+      originType = 'same_ml_catalog_product';
+    }
+  } else if (group.some(item => item.catalog_listing === true)) {
+    reasons.push('catalog_listing_without_product_id');
+    originType = 'catalog_listing_without_product_id';
+  }
+
+  return {
+    origin_type: originType,
+    catalog_product_ids: catalogProductIds,
+    catalog_listing_values: listingValues,
+  };
 }
 
 export function pickCanonicalRepresentative(group) {
@@ -66,8 +121,8 @@ export function pickCanonicalRepresentative(group) {
 function analyzeGroup(gtin, condition, group) {
   const normalizedTitles = group.map(item => normalizeComparableText(item.title));
   const normalizedAuthors = group.map(item => normalizeComparableText(item.author));
-  const titleValues = [...new Set(normalizedTitles.filter(Boolean))].sort();
-  const authorValues = [...new Set(normalizedAuthors.filter(Boolean))].sort();
+  const titleValues = uniqueSorted(normalizedTitles);
+  const authorValues = uniqueSorted(normalizedAuthors);
 
   const allTitlesPresent = normalizedTitles.every(Boolean);
   const allAuthorsPresent = normalizedAuthors.every(Boolean);
@@ -82,7 +137,22 @@ function analyzeGroup(gtin, condition, group) {
 
   if (condition === 'unknown') reasons.push('condition_unknown');
 
-  const hasIdentityConflict = reasons.includes('title_conflict') || reasons.includes('author_conflict');
+  const normalizedBibliographic = {
+    edition: analyzeOptionalIdentityField(group, 'edition', reasons),
+    language: analyzeOptionalIdentityField(group, 'language', reasons),
+    format: analyzeOptionalIdentityField(group, 'format', reasons),
+  };
+  const catalogIdentity = analyzeCatalogIdentity(group, reasons);
+
+  const hasIdentityConflict = reasons.some(reason => [
+    'title_conflict',
+    'author_conflict',
+    'edition_conflict',
+    'language_conflict',
+    'format_conflict',
+    'catalog_product_conflict',
+  ].includes(reason));
+
   const confidence = reasons.length === 0
     ? 'high'
     : hasIdentityConflict
@@ -105,11 +175,15 @@ function analyzeGroup(gtin, condition, group) {
         ? 'manual_review'
         : 'do_not_consolidate',
     reasons,
+    origin_type: catalogIdentity.origin_type,
+    catalog_product_ids: catalogIdentity.catalog_product_ids,
+    catalog_listing_values: catalogIdentity.catalog_listing_values,
     representative_id: representative?.id || null,
     source_ids: confidence === 'high' ? sourceIds : [],
     member_ids: sortedIds,
     normalized_title: titleValues.length === 1 ? titleValues[0] : null,
     normalized_author: authorValues.length === 1 && allAuthorsPresent ? authorValues[0] : null,
+    normalized_bibliographic: normalizedBibliographic,
   };
 }
 
@@ -145,6 +219,7 @@ export function analyzeEditionClusters(items) {
 
   clusters.sort((a, b) =>
     (confidenceOrder[a.confidence] - confidenceOrder[b.confidence]) ||
+    a.origin_type.localeCompare(b.origin_type) ||
     a.gtin.localeCompare(b.gtin) ||
     a.condition.localeCompare(b.condition)
   );
@@ -152,6 +227,10 @@ export function analyzeEditionClusters(items) {
   const high = clusters.filter(cluster => cluster.confidence === 'high');
   const review = clusters.filter(cluster => cluster.confidence === 'review');
   const reject = clusters.filter(cluster => cluster.confidence === 'reject');
+  const byOrigin = clusters.reduce((acc, cluster) => {
+    acc[cluster.origin_type] = (acc[cluster.origin_type] || 0) + 1;
+    return acc;
+  }, {});
 
   return {
     schema_version: REPORT_SCHEMA_VERSION,
@@ -164,6 +243,11 @@ export function analyzeEditionClusters(items) {
       review_groups: review.length,
       rejected_groups: reject.length,
       canonical_candidate_sources: high.reduce((sum, cluster) => sum + cluster.source_ids.length, 0),
+      origin_groups: byOrigin,
+      ml_common_plus_catalog_groups: byOrigin.ml_common_plus_catalog || 0,
+      same_ml_catalog_product_groups: byOrigin.same_ml_catalog_product || 0,
+      bibliographic_only_groups: byOrigin.bibliographic_only || 0,
+      catalog_product_conflict_groups: byOrigin.catalog_product_conflict || 0,
     },
     clusters,
   };

--- a/scripts/seo/edition-consolidation-candidates.mjs
+++ b/scripts/seo/edition-consolidation-candidates.mjs
@@ -291,14 +291,12 @@ async function runCli() {
   };
 
   const output = stableReportJson(report);
-  if (outputPath) {
-    await fs.writeFile(outputPath, output, 'utf8');
-  } else {
-    process.stdout.write(output);
-  }
+  if (outputPath) await fs.writeFile(outputPath, output, 'utf8');
+  else process.stdout.write(output);
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+const isDirectRun = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isDirectRun) {
   runCli().catch(error => {
     console.error(error?.stack || error);
     process.exitCode = 1;


### PR DESCRIPTION
## Objetivo

Preparar `SEO-EDITION-CONSOLIDATION-1` sin tocar todavía canonicals, redirects ni sitemap.

## Qué agrega

- detector determinista de grupos activos con mismo ISBN válido + misma condición;
- sólo marca `canonical_candidate` cuando título y autor normalizados coinciden de forma exacta y completa;
- autores genéricos (`Varios autores`, `VV. AA.`, `Anónimo`, `No aplica`, equivalentes) → `manual_review` con `author_generic`;
- si falta autor/condición → `manual_review`;
- si título o autor entran en conflicto → `do_not_consolidate`;
- representante propuesto por mayor stock → menor precio → menor MLU;
- salida JSON reproducible para auditoría sobre snapshots frescos;
- documentación de alcance, rollback y evidencia de piloto.

## Evidencia incorporada

Baseline histórico 2026-08-08:
- 3.164 grupos con ISBN repetido;
- 211 `same_book`;
- 2.953 `isbn_inconsistent`.

Rerun estructural fresco 2026-08-20 (artifact generado 23:47:33Z):
- 7.090 activos con stock;
- 3.137 grupos con ISBN repetido;
- 6.285 listings duplicados;
- 209 `same_book`;
- 2.928 `isbn_inconsistent`.

GSC 2026-07-21 → 2026-08-17 confirma impresiones repartidas entre dos URLs en tres pares históricamente `same_book`:
- Headway Elementary 5th Edition Audio CD;
- Obesidad — Virginia Busnelli;
- Memento Mori.

Tras endurecer la regla de autor, Memento Mori queda fuera del piloto automático porque ambos listings usan `Varios autores`. Los dos candidatos automáticos potenciales para la siguiente revalidación son Headway y Obesidad, pero **todavía no se canonicaliza ninguno**: el baseline histórico no contiene `condition`, así que el detector nuevo debe correr sobre un snapshot completo antes de cualquier cambio indexable.

También se preservan contraejemplos con mismo ISBN pero identidad inconsistente (Daat, Maase Bereshit, Estrategias de enseñanza, Anastasia, La Nobleza Negra, Sod 22) para bloquear consolidaciones automáticas dudosas.

Detalle: `docs/seo/edition-consolidation-pilot-evidence-2026-08-20.md`.

## Riesgo

Muy bajo: sólo detector, tests y documentación. No modifica ninguna ruta ni comportamiento productivo.

NO incluido:
- `rel=canonical`;
- 301;
- exclusión de sitemap;
- cambios en Mercado Libre;
- cambios de precio, stock, carrito o checkout.

## Validación

- tests focalizados originales: 12/12;
- nuevos tests: autores genéricos quedan fuera de canonical automático;
- CI/Preview/SEO baseline se vuelven a ejecutar sobre el head endurecido;
- el rerun anterior del Preview quedó verde después de la carrera de propagación inicial.

## Siguiente paso

Esperar checks del head actual. Después, correr el detector sobre snapshot completo/fresco para confirmar `condition` y demás atributos de Headway y Obesidad. Sólo si pasan todos los gates, proponer un piloto de canonical reversible en Preview. 301 sigue fuera de alcance.

No mergear ni tocar Producción sin aprobación explícita.