### PR TITLE
TAROT-HUB-MERCH-1: módulos merchandising en /libros/esoterismo-tarot

### DIFF
--- a/functions/__tests__/tarot-hub-modules.test.js
+++ b/functions/__tests__/tarot-hub-modules.test.js
@@ -169,7 +169,9 @@ test('sin ninguna novedad real, el módulo no aparece', () => {
   assert.equal(modules.find(m => m.id === 'novedades'), undefined);
 });
 
-// ── Lo más buscado: sólo con señal real del Demand Ledger ────────────────
+// ── Lo más buscado: demanda real de Search Console (impressions/clicks),
+// NUNCA opportunity_score — ese campo mide oportunidad SEO/CTR, no volumen
+// de búsqueda, y queda reservado para priorización interna. ─────────────
 
 test('sin demandLedgerLookup (DEMAND-LEDGER-1 no mergeado todavía), lo-mas-buscado nunca aparece', () => {
   const modules = buildTarotHubModules({
@@ -180,27 +182,86 @@ test('sin demandLedgerLookup (DEMAND-LEDGER-1 no mergeado todavía), lo-mas-busc
   assert.equal(modules.find(m => m.id === 'mas-buscado'), undefined);
 });
 
-test('con demandLedgerLookup presente pero sin ningún score positivo, tampoco aparece (nunca placeholder)', () => {
+test('muchas impresiones (>= umbral) -> el producto aparece en lo-mas-buscado', () => {
   const modules = buildTarotHubModules({
     items: [item('MLU1')],
     tagLookup: lookupFrom([tag('MLU1')]),
-    demandLedgerLookup: () => ({ opportunity_score: null, score_reason: 'impresiones insuficientes' }),
+    demandLedgerLookup: () => ({ impressions: 50, clicks: 3 }),
+  });
+  const masBuscado = modules.find(m => m.id === 'mas-buscado');
+  assert.ok(masBuscado);
+  assert.equal(masBuscado.entries[0].item.id, 'MLU1');
+});
+
+test('pocas impresiones (< umbral) -> el producto NO aparece, sin importar los clicks', () => {
+  const modules = buildTarotHubModules({
+    items: [item('MLU1')],
+    tagLookup: lookupFrom([tag('MLU1')]),
+    demandLedgerLookup: () => ({ impressions: 9, clicks: 8 }), // 9 < 10, por debajo del umbral
   });
   assert.equal(modules.find(m => m.id === 'mas-buscado'), undefined);
 });
 
-test('con al menos un score positivo real, lo-mas-buscado aparece ordenado por score desc', () => {
-  const items = ['MLU1', 'MLU2'].map(id => item(id));
-  const tags = [tag('MLU1'), tag('MLU2')];
-  const demand = { MLU1: { opportunity_score: 1.2 }, MLU2: { opportunity_score: 5.6 } };
+test('sin evidencia de demanda (demandLedgerLookup devuelve null), tampoco aparece (nunca placeholder)', () => {
+  const modules = buildTarotHubModules({
+    items: [item('MLU1')],
+    tagLookup: lookupFrom([tag('MLU1')]),
+    demandLedgerLookup: () => null,
+  });
+  assert.equal(modules.find(m => m.id === 'mas-buscado'), undefined);
+});
+
+test('orden por impressions descendente', () => {
+  const items = ['MLU1', 'MLU2', 'MLU3'].map(id => item(id));
+  const tags = [tag('MLU1'), tag('MLU2'), tag('MLU3')];
+  const demand = {
+    MLU1: { impressions: 20, clicks: 1 },
+    MLU2: { impressions: 80, clicks: 1 },
+    MLU3: { impressions: 40, clicks: 1 },
+  };
   const modules = buildTarotHubModules({
     items, tagLookup: lookupFrom(tags),
     demandLedgerLookup: id => demand[id] || null,
   });
   const masBuscado = modules.find(m => m.id === 'mas-buscado');
+  assert.deepEqual(masBuscado.entries.map(e => e.item.id), ['MLU2', 'MLU3', 'MLU1']);
+});
+
+test('empate en impressions -> desempata por clicks descendente', () => {
+  const items = ['MLU1', 'MLU2'].map(id => item(id));
+  const tags = [tag('MLU1'), tag('MLU2')];
+  const demand = {
+    MLU1: { impressions: 30, clicks: 2 },
+    MLU2: { impressions: 30, clicks: 7 },
+  };
+  const modules = buildTarotHubModules({
+    items, tagLookup: lookupFrom(tags),
+    demandLedgerLookup: id => demand[id] || null,
+  });
+  const masBuscado = modules.find(m => m.id === 'mas-buscado');
+  assert.deepEqual(masBuscado.entries.map(e => e.item.id), ['MLU2', 'MLU1']);
+});
+
+test('opportunity_score alto con pocas impresiones NO convierte el producto en "más buscado"', () => {
+  const modules = buildTarotHubModules({
+    items: [item('MLU1')],
+    tagLookup: lookupFrom([tag('MLU1')]),
+    // opportunity_score alto es irrelevante acá: impressions=3 está muy por
+    // debajo del umbral de 10, así que el módulo debe quedar ausente.
+    demandLedgerLookup: () => ({ impressions: 3, clicks: 0, opportunity_score: 99.9 }),
+  });
+  assert.equal(modules.find(m => m.id === 'mas-buscado'), undefined);
+});
+
+test('con impressions suficientes, un opportunity_score bajo o null no impide que aparezca', () => {
+  const modules = buildTarotHubModules({
+    items: [item('MLU1')],
+    tagLookup: lookupFrom([tag('MLU1')]),
+    demandLedgerLookup: () => ({ impressions: 25, clicks: 1, opportunity_score: null }),
+  });
+  const masBuscado = modules.find(m => m.id === 'mas-buscado');
   assert.ok(masBuscado);
-  assert.equal(masBuscado.entries[0].item.id, 'MLU2'); // mayor score primero
-  assert.equal(masBuscado.entries[1].item.id, 'MLU1');
+  assert.equal(masBuscado.entries[0].item.id, 'MLU1');
 });
 
 // ── Volvió a estar disponible: sólo con evidencia histórica real ────────

--- a/functions/__tests__/tarot-hub-modules.test.js
+++ b/functions/__tests__/tarot-hub-modules.test.js
@@ -1,0 +1,253 @@
+// TAROT-HUB-MERCH-1 — selección determinista de módulos merchandising.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildTagLookup, buildTarotHubModules } from '../_shared/tarot-hub-modules.js';
+
+function item(id, overrides = {}) {
+  return { id, title: `Item ${id}`, price: 1000, available_quantity: 1, ...overrides };
+}
+
+function tag(id, overrides = {}) {
+  return {
+    id,
+    primary_type: 'tarot',
+    deck_family: null,
+    format: 'mazo',
+    bundle: 'desconocido',
+    level: 'desconocido',
+    language: 'desconocido',
+    edition_style: null,
+    is_new_arrival: false,
+    is_restocked: false,
+    needs_review: false,
+    duplicate_mlu_ids: [id],
+    ...overrides,
+  };
+}
+
+function lookupFrom(tags) {
+  return buildTagLookup(tags);
+}
+
+test('buildTagLookup resuelve por cualquier MLU duplicado, no sólo por el representante', () => {
+  const tags = [tag('MLU1', { duplicate_mlu_ids: ['MLU1', 'MLU2', 'MLU3'] })];
+  const lookup = buildTagLookup(tags);
+  assert.equal(lookup('MLU1').id, 'MLU1');
+  assert.equal(lookup('MLU2').id, 'MLU1');
+  assert.equal(lookup('MLU3').id, 'MLU1');
+  assert.equal(lookup('MLU9'), null);
+});
+
+test('un item sin tag (no clasificado) simplemente no participa de ningún módulo', () => {
+  const modules = buildTarotHubModules({
+    items: [item('MLU1')],
+    tagLookup: () => null,
+  });
+  // "Para empezar" siempre está presente como módulo editorial, el resto no.
+  assert.equal(modules.length, 1);
+  assert.equal(modules[0].id, 'para-empezar');
+  assert.equal(modules[0].hasProducts, false);
+});
+
+// ── Para empezar: 3-6, o sólo texto ──────────────────────────────────────
+
+test('para-empezar con 3 o más coincidencias muestra hasta 6 productos', () => {
+  const items = ['MLU1', 'MLU2', 'MLU3', 'MLU4', 'MLU5', 'MLU6', 'MLU7'].map(id => item(id));
+  const tags = items.map(i => tag(i.id, { level: 'principiante' }));
+  const modules = buildTarotHubModules({ items, tagLookup: lookupFrom(tags) });
+  const paraEmpezar = modules.find(m => m.id === 'para-empezar');
+  assert.equal(paraEmpezar.hasProducts, true);
+  assert.equal(paraEmpezar.entries.length, 6); // cap en 6, no 7
+});
+
+test('para-empezar con exactamente 3 coincidencias muestra los 3', () => {
+  const items = ['MLU1', 'MLU2', 'MLU3'].map(id => item(id));
+  const tags = items.map(i => tag(i.id, { level: 'principiante' }));
+  const modules = buildTarotHubModules({ items, tagLookup: lookupFrom(tags) });
+  const paraEmpezar = modules.find(m => m.id === 'para-empezar');
+  assert.equal(paraEmpezar.hasProducts, true);
+  assert.equal(paraEmpezar.entries.length, 3);
+});
+
+test('para-empezar con menos de 3 coincidencias queda sin productos (sólo editorial)', () => {
+  const items = ['MLU1', 'MLU2'].map(id => item(id));
+  const tags = items.map(i => tag(i.id, { level: 'principiante' }));
+  const modules = buildTarotHubModules({ items, tagLookup: lookupFrom(tags) });
+  const paraEmpezar = modules.find(m => m.id === 'para-empezar');
+  assert.equal(paraEmpezar.hasProducts, false);
+  assert.equal(paraEmpezar.entries.length, 0);
+});
+
+test('para-empezar sin ninguna coincidencia sigue presente (nunca se elimina el módulo del todo)', () => {
+  const modules = buildTarotHubModules({
+    items: [item('MLU1')],
+    tagLookup: lookupFrom([tag('MLU1', { level: 'desconocido' })]),
+  });
+  const paraEmpezar = modules.find(m => m.id === 'para-empezar');
+  assert.ok(paraEmpezar);
+  assert.equal(paraEmpezar.hasProducts, false);
+});
+
+// ── Módulos que se ocultan completamente si no hay productos ────────────
+
+test('oraculos, clasicos y lenormand-kipper no aparecen si no hay ningún producto que matchee', () => {
+  const modules = buildTarotHubModules({
+    items: [item('MLU1')],
+    tagLookup: lookupFrom([tag('MLU1', { primary_type: 'tarot', deck_family: null, format: 'mazo' })]),
+  });
+  assert.equal(modules.find(m => m.id === 'oraculos'), undefined);
+  assert.equal(modules.find(m => m.id === 'clasicos'), undefined);
+  assert.equal(modules.find(m => m.id === 'lenormand-kipper'), undefined);
+});
+
+test('oraculos aparece cuando hay al menos un oráculo', () => {
+  const modules = buildTarotHubModules({
+    items: [item('MLU1')],
+    tagLookup: lookupFrom([tag('MLU1', { primary_type: 'oraculo' })]),
+  });
+  const oraculos = modules.find(m => m.id === 'oraculos');
+  assert.ok(oraculos);
+  assert.equal(oraculos.entries.length, 1);
+});
+
+test('clasicos agrupa cualquier deck_family (RWS, Marsella, Thoth) en un solo módulo', () => {
+  const items = ['MLU1', 'MLU2', 'MLU3'].map(id => item(id));
+  const tags = [
+    tag('MLU1', { deck_family: 'rider_waite_smith' }),
+    tag('MLU2', { deck_family: 'marsella' }),
+    tag('MLU3', { deck_family: 'thoth' }),
+  ];
+  const modules = buildTarotHubModules({ items, tagLookup: lookupFrom(tags) });
+  const clasicos = modules.find(m => m.id === 'clasicos');
+  assert.equal(clasicos.entries.length, 3);
+});
+
+test('lenormand y kipper conviven en un módulo pero cada fila conserva su primary_type real (no se colapsan)', () => {
+  const items = ['MLU1', 'MLU2'].map(id => item(id));
+  const tags = [tag('MLU1', { primary_type: 'lenormand' }), tag('MLU2', { primary_type: 'kipper' })];
+  const modules = buildTarotHubModules({ items, tagLookup: lookupFrom(tags) });
+  const module_ = modules.find(m => m.id === 'lenormand-kipper');
+  assert.equal(module_.entries.length, 2);
+  assert.equal(module_.entries.find(e => e.item.id === 'MLU1').tag.primary_type, 'lenormand');
+  assert.equal(module_.entries.find(e => e.item.id === 'MLU2').tag.primary_type, 'kipper');
+});
+
+test('para-profundizar sólo incluye format=libro, nunca mazos', () => {
+  const items = ['MLU1', 'MLU2'].map(id => item(id));
+  const tags = [tag('MLU1', { format: 'libro' }), tag('MLU2', { format: 'mazo' })];
+  const modules = buildTarotHubModules({ items, tagLookup: lookupFrom(tags) });
+  const paraProfundizar = modules.find(m => m.id === 'para-profundizar');
+  assert.equal(paraProfundizar.entries.length, 1);
+  assert.equal(paraProfundizar.entries[0].item.id, 'MLU1');
+});
+
+test('format=desconocido (36% del universo real) no entra a para-profundizar ni a ningún módulo que requiera formato', () => {
+  const modules = buildTarotHubModules({
+    items: [item('MLU1')],
+    tagLookup: lookupFrom([tag('MLU1', { format: 'desconocido', primary_type: 'tarot' })]),
+  });
+  assert.equal(modules.find(m => m.id === 'para-profundizar'), undefined);
+});
+
+// ── Novedades: sólo start_time real ──────────────────────────────────────
+
+test('novedades sólo incluye is_new_arrival=true (ya resuelto en el artefacto por start_time real)', () => {
+  const items = ['MLU1', 'MLU2'].map(id => item(id));
+  const tags = [tag('MLU1', { is_new_arrival: true }), tag('MLU2', { is_new_arrival: false })];
+  const modules = buildTarotHubModules({ items, tagLookup: lookupFrom(tags) });
+  const novedades = modules.find(m => m.id === 'novedades');
+  assert.equal(novedades.entries.length, 1);
+  assert.equal(novedades.entries[0].item.id, 'MLU1');
+});
+
+test('sin ninguna novedad real, el módulo no aparece', () => {
+  const modules = buildTarotHubModules({
+    items: [item('MLU1')],
+    tagLookup: lookupFrom([tag('MLU1', { is_new_arrival: false })]),
+  });
+  assert.equal(modules.find(m => m.id === 'novedades'), undefined);
+});
+
+// ── Lo más buscado: sólo con señal real del Demand Ledger ────────────────
+
+test('sin demandLedgerLookup (DEMAND-LEDGER-1 no mergeado todavía), lo-mas-buscado nunca aparece', () => {
+  const modules = buildTarotHubModules({
+    items: [item('MLU1')],
+    tagLookup: lookupFrom([tag('MLU1')]),
+    // demandLedgerLookup no provisto -> default siempre null
+  });
+  assert.equal(modules.find(m => m.id === 'mas-buscado'), undefined);
+});
+
+test('con demandLedgerLookup presente pero sin ningún score positivo, tampoco aparece (nunca placeholder)', () => {
+  const modules = buildTarotHubModules({
+    items: [item('MLU1')],
+    tagLookup: lookupFrom([tag('MLU1')]),
+    demandLedgerLookup: () => ({ opportunity_score: null, score_reason: 'impresiones insuficientes' }),
+  });
+  assert.equal(modules.find(m => m.id === 'mas-buscado'), undefined);
+});
+
+test('con al menos un score positivo real, lo-mas-buscado aparece ordenado por score desc', () => {
+  const items = ['MLU1', 'MLU2'].map(id => item(id));
+  const tags = [tag('MLU1'), tag('MLU2')];
+  const demand = { MLU1: { opportunity_score: 1.2 }, MLU2: { opportunity_score: 5.6 } };
+  const modules = buildTarotHubModules({
+    items, tagLookup: lookupFrom(tags),
+    demandLedgerLookup: id => demand[id] || null,
+  });
+  const masBuscado = modules.find(m => m.id === 'mas-buscado');
+  assert.ok(masBuscado);
+  assert.equal(masBuscado.entries[0].item.id, 'MLU2'); // mayor score primero
+  assert.equal(masBuscado.entries[1].item.id, 'MLU1');
+});
+
+// ── Volvió a estar disponible: sólo con evidencia histórica real ────────
+
+test('sin ningún is_restocked=true real, el módulo no aparece (nunca se inventa reposición)', () => {
+  const modules = buildTarotHubModules({
+    items: [item('MLU1')],
+    tagLookup: lookupFrom([tag('MLU1', { is_restocked: false })]),
+  });
+  assert.equal(modules.find(m => m.id === 'volvio-disponible'), undefined);
+});
+
+test('con evidencia real de reposición, el módulo aparece', () => {
+  const modules = buildTarotHubModules({
+    items: [item('MLU1')],
+    tagLookup: lookupFrom([tag('MLU1', { is_restocked: true })]),
+  });
+  assert.ok(modules.find(m => m.id === 'volvio-disponible'));
+});
+
+// ── Tope por módulo — nunca cargar el universo completo ──────────────────
+
+test('cada módulo con productos respeta el tope de 12 tarjetas aunque haya más candidatos', () => {
+  const ids = Array.from({ length: 20 }, (_, i) => `MLU${i + 1}`);
+  const items = ids.map(id => item(id));
+  const tags = ids.map(id => tag(id, { primary_type: 'oraculo' }));
+  const modules = buildTarotHubModules({ items, tagLookup: lookupFrom(tags) });
+  const oraculos = modules.find(m => m.id === 'oraculos');
+  assert.equal(oraculos.entries.length, 12);
+  assert.equal(oraculos.totalCount, 20); // el total real se conserva para mostrar "ver más"
+});
+
+// ── Validación de entrada y determinismo ─────────────────────────────────
+
+test('buildTarotHubModules valida tipos de entrada', () => {
+  assert.throws(() => buildTarotHubModules({ items: 'no-array', tagLookup: () => null }), /items debe ser un array/);
+  assert.throws(() => buildTarotHubModules({ items: [], tagLookup: null }), /tagLookup debe ser una función/);
+});
+
+test('buildTarotHubModules es determinista', () => {
+  const items = ['MLU1', 'MLU2', 'MLU3'].map(id => item(id));
+  const tags = [
+    tag('MLU1', { primary_type: 'oraculo' }),
+    tag('MLU2', { deck_family: 'marsella' }),
+    tag('MLU3', { primary_type: 'lenormand' }),
+  ];
+  const first = buildTarotHubModules({ items, tagLookup: lookupFrom(tags) });
+  const second = buildTarotHubModules({ items, tagLookup: lookupFrom(tags) });
+  assert.deepEqual(first, second);
+});

--- a/functions/_shared/tarot-hub-modules.js
+++ b/functions/_shared/tarot-hub-modules.js
@@ -19,6 +19,15 @@ const PARA_EMPEZAR_MIN = 3;
 const PARA_EMPEZAR_MAX = 6;
 const MODULE_DISPLAY_CAP = 12; // tope de tarjetas por módulo — nunca cargar el universo completo de una
 
+// "Lo más buscado" mide DEMANDA real de búsqueda (impresiones de Search
+// Console), no oportunidad SEO. opportunity_score del Demand Ledger es una
+// señal de priorización interna (CTR observado vs. esperado para esa
+// posición) — un producto puede tener opportunity_score alto con muy pocas
+// impresiones (justo lo que lo hace poco confiable como señal de "lo más
+// buscado"), o impresiones altas con opportunity_score bajo/null porque su
+// CTR ya es bueno. Por eso este módulo nunca lee opportunity_score.
+const MAS_BUSCADO_MIN_IMPRESSIONS = 10;
+
 /**
  * Arma un lookup id->fila de TAROT_MERCH_TAGS que también resuelve por
  * cualquiera de los MLU duplicados absorbidos en la deduplicación del
@@ -54,10 +63,20 @@ export function buildTarotHubModules({ items = [], tagLookup, demandLedgerLookup
   const paraProfundizar = tagged.filter(e => e.tag.format === 'libro');
   const novedades = tagged.filter(e => e.tag.is_new_arrival === true);
   const volvioDisponible = tagged.filter(e => e.tag.is_restocked === true);
+  // Demanda real: impressions como señal principal (umbral mínimo de
+  // evidencia antes de mostrar nada), clicks como desempate. Nunca
+  // opportunity_score — ver comentario de MAS_BUSCADO_MIN_IMPRESSIONS.
   const masBuscado = tagged
     .map(e => ({ ...e, demand: demandLedgerLookup(e.item.id) }))
-    .filter(e => e.demand && Number(e.demand.opportunity_score) > 0)
-    .sort((a, b) => b.demand.opportunity_score - a.demand.opportunity_score);
+    .filter(e => e.demand && Number(e.demand.impressions) >= MAS_BUSCADO_MIN_IMPRESSIONS)
+    .sort((a, b) => {
+      const impressionsA = Number(a.demand.impressions) || 0;
+      const impressionsB = Number(b.demand.impressions) || 0;
+      if (impressionsA !== impressionsB) return impressionsB - impressionsA;
+      const clicksA = Number(a.demand.clicks) || 0;
+      const clicksB = Number(b.demand.clicks) || 0;
+      return clicksB - clicksA;
+    });
 
   const modules = [];
 

--- a/functions/_shared/tarot-hub-modules.js
+++ b/functions/_shared/tarot-hub-modules.js
@@ -1,0 +1,126 @@
+/**
+ * functions/_shared/tarot-hub-modules.js
+ *
+ * TAROT-HUB-MERCH-1: selección determinista de qué módulos merchandising
+ * mostrar en /libros/esoterismo-tarot y con qué productos, a partir del
+ * artefacto de TAROT-MERCH-TAGS-1 (functions/_shared/tarot-merch-tags.js).
+ *
+ * Puro: no hace fetch, no renderiza HTML. functions/libros/[[path]].js sólo
+ * llama a buildTarotHubModules() con los items ya resueltos (los mismos que
+ * ya calcula la ruta hoy — ningún fetch adicional) y un lookup de tags.
+ *
+ * REGLA: un módulo con menos productos que su mínimo requerido no se
+ * muestra con productos — o se oculta del todo, o (sólo "Para empezar")
+ * queda como texto editorial sin grilla. Nunca se rellena con productos que
+ * no cumplen el criterio del módulo.
+ */
+
+const PARA_EMPEZAR_MIN = 3;
+const PARA_EMPEZAR_MAX = 6;
+const MODULE_DISPLAY_CAP = 12; // tope de tarjetas por módulo — nunca cargar el universo completo de una
+
+/**
+ * Arma un lookup id->fila de TAROT_MERCH_TAGS que también resuelve por
+ * cualquiera de los MLU duplicados absorbidos en la deduplicación del
+ * artefacto (no sólo el representante) — necesario porque la grilla del
+ * hub dedupea con su propio criterio (dedupeCategoryResults) y puede haber
+ * elegido un representante distinto al de TAROT-MERCH-TAGS-1 para el mismo
+ * título.
+ */
+export function buildTagLookup(tarotMerchTags) {
+  const byAnyId = new Map();
+  for (const row of tarotMerchTags) {
+    for (const id of row.duplicate_mlu_ids || [row.id]) byAnyId.set(id, row);
+  }
+  return id => byAnyId.get(String(id || '').toUpperCase()) || null;
+}
+
+function cap(list) {
+  return list.slice(0, MODULE_DISPLAY_CAP);
+}
+
+export function buildTarotHubModules({ items = [], tagLookup, demandLedgerLookup = () => null } = {}) {
+  if (!Array.isArray(items)) throw new Error('items debe ser un array.');
+  if (typeof tagLookup !== 'function') throw new Error('tagLookup debe ser una función.');
+
+  const tagged = items
+    .map(item => ({ item, tag: tagLookup(item.id) }))
+    .filter(entry => entry.tag != null);
+
+  const paraEmpezar = tagged.filter(e => e.tag.level === 'principiante');
+  const oraculos = tagged.filter(e => e.tag.primary_type === 'oraculo');
+  const clasicos = tagged.filter(e => e.tag.deck_family != null);
+  const lenormandKipper = tagged.filter(e => e.tag.primary_type === 'lenormand' || e.tag.primary_type === 'kipper');
+  const paraProfundizar = tagged.filter(e => e.tag.format === 'libro');
+  const novedades = tagged.filter(e => e.tag.is_new_arrival === true);
+  const volvioDisponible = tagged.filter(e => e.tag.is_restocked === true);
+  const masBuscado = tagged
+    .map(e => ({ ...e, demand: demandLedgerLookup(e.item.id) }))
+    .filter(e => e.demand && Number(e.demand.opportunity_score) > 0)
+    .sort((a, b) => b.demand.opportunity_score - a.demand.opportunity_score);
+
+  const modules = [];
+
+  // "Para empezar" es el único módulo que se mantiene visible incluso sin
+  // productos (decisión aprobada): microexplicación + entrada futura al
+  // Finder, sin inventar una grilla que no cumple el mínimo confiable.
+  modules.push({
+    id: 'para-empezar',
+    title: 'Para empezar',
+    kind: 'editorial-mini',
+    entries: paraEmpezar.length >= PARA_EMPEZAR_MIN ? cap(paraEmpezar.slice(0, PARA_EMPEZAR_MAX)) : [],
+    hasProducts: paraEmpezar.length >= PARA_EMPEZAR_MIN,
+  });
+
+  if (oraculos.length > 0) {
+    modules.push({ id: 'oraculos', title: 'Oráculos', kind: 'grid', entries: cap(oraculos), totalCount: oraculos.length });
+  }
+
+  if (clasicos.length > 0) {
+    modules.push({ id: 'clasicos', title: 'Clásicos', kind: 'grid-badged', entries: cap(clasicos), totalCount: clasicos.length });
+  }
+
+  if (lenormandKipper.length > 0) {
+    modules.push({
+      id: 'lenormand-kipper',
+      title: 'Lenormand y Kipper',
+      kind: 'grid-badged',
+      entries: cap(lenormandKipper),
+      totalCount: lenormandKipper.length,
+    });
+  }
+
+  if (paraProfundizar.length > 0) {
+    modules.push({
+      id: 'para-profundizar',
+      title: 'Para profundizar',
+      kind: 'grid',
+      entries: cap(paraProfundizar),
+      totalCount: paraProfundizar.length,
+    });
+  }
+
+  if (novedades.length > 0) {
+    modules.push({ id: 'novedades', title: 'Novedades', kind: 'grid', entries: cap(novedades), totalCount: novedades.length });
+  }
+
+  // Sin señal real (Demand Ledger sin filas de score>0 para este universo
+  // todavía, o lookup ausente porque DEMAND-LEDGER-1 no está mergeado) ->
+  // el módulo directamente no se agrega. Nunca placeholder, nunca "próximamente".
+  if (masBuscado.length > 0) {
+    modules.push({ id: 'mas-buscado', title: 'Lo más buscado', kind: 'grid', entries: cap(masBuscado), totalCount: masBuscado.length });
+  }
+
+  // Mismo criterio: sin evidencia histórica de reposición, no se agrega.
+  if (volvioDisponible.length > 0) {
+    modules.push({
+      id: 'volvio-disponible',
+      title: 'Volvió a estar disponible',
+      kind: 'grid',
+      entries: cap(volvioDisponible),
+      totalCount: volvioDisponible.length,
+    });
+  }
+
+  return modules;
+}

--- a/functions/libros/[[path]].js
+++ b/functions/libros/[[path]].js
@@ -33,7 +33,10 @@ const tarotTagLookup = buildTagLookup(TAROT_MERCH_TAGS);
 // implementado y probado (ver tarot-hub-modules.test.js) pero sin datos
 // reales hasta que ese lote se integre — devolver null es honesto, no un
 // placeholder. Reemplazar este no-op por un import real de
-// opportunityForProductId() cuando #206 esté en main.
+// opportunityForProductId() cuando #206 esté en main — esa fila trae
+// impressions/clicks (lo que "Lo más buscado" realmente usa) además de
+// opportunity_score, que buildTarotHubModules() ignora a propósito: mide
+// oportunidad SEO/CTR, no volumen de búsqueda.
 const tarotDemandLedgerLookup = () => null;
 
 const MAX_RESULTS = 48;

--- a/functions/libros/[[path]].js
+++ b/functions/libros/[[path]].js
@@ -20,7 +20,21 @@ import {
     CARD_IMAGE_SIZES,
     responsiveImage,
 } from '../_shared/cloudflare-images.js';
-import { buildWhatsAppMessage } from '../../shared/whatsapp-messages.js';
+import { buildWhatsAppMessage, whatsappHref } from '../../shared/whatsapp-messages.js';
+// TAROT-HUB-MERCH-1: sólo se usa cuando category.id === 'esoterismo-tarot'.
+// Ninguna otra categoría de SEO_CATEGORIES se ve afectada por este import.
+import { TAROT_MERCH_TAGS } from '../_shared/tarot-merch-tags.js';
+import { buildTagLookup, buildTarotHubModules } from '../_shared/tarot-hub-modules.js';
+
+const TAROT_CATEGORY_ID = 'esoterismo-tarot';
+const tarotTagLookup = buildTagLookup(TAROT_MERCH_TAGS);
+// DEMAND-LEDGER-1 (PR #206) todavía no está mergeado a main: no hay
+// functions/_shared/demand-ledger.js en esta rama. "Lo más buscado" queda
+// implementado y probado (ver tarot-hub-modules.test.js) pero sin datos
+// reales hasta que ese lote se integre — devolver null es honesto, no un
+// placeholder. Reemplazar este no-op por un import real de
+// opportunityForProductId() cuando #206 esté en main.
+const tarotDemandLedgerLookup = () => null;
 
 const MAX_RESULTS = 48;
 const PAGE_PARAM_RE = /^[1-9][0-9]{0,6}$/;
@@ -168,7 +182,32 @@ function categoryNavHtml(currentId) {
 </nav>`;
 }
 
-function cardHtml(item, index, navigationBase) {
+// TAROT-HUB-MERCH-1: etiquetas cortas de merchandising para las tarjetas de
+// los módulos "Clásicos" y "Lenormand y Kipper". Sólo texto/estilo — no
+// afectan precio, stock, carrito ni checkout. deck_family/bundle/
+// edition_style vienen ya resueltos por TAROT-MERCH-TAGS-1; nunca se infiere
+// nada acá.
+const TAROT_DECK_FAMILY_LABEL = {
+    rider_waite_smith: 'Rider-Waite-Smith',
+    marsella: 'Marsella',
+    thoth: 'Thoth',
+};
+const TAROT_PRIMARY_TYPE_LABEL = {
+    lenormand: 'Lenormand',
+    kipper: 'Kipper',
+};
+
+function tarotBadgesFor(tag) {
+    if (!tag) return [];
+    const badges = [];
+    if (TAROT_PRIMARY_TYPE_LABEL[tag.primary_type]) badges.push(TAROT_PRIMARY_TYPE_LABEL[tag.primary_type]);
+    if (TAROT_DECK_FAMILY_LABEL[tag.deck_family]) badges.push(TAROT_DECK_FAMILY_LABEL[tag.deck_family]);
+    if (tag.bundle === 'mazo_mas_guia') badges.push('+ Guía');
+    if (tag.edition_style === 'ilustrada_especial') badges.push('Edición especial');
+    return badges;
+}
+
+function cardHtml(item, index, navigationBase, { badges = [], forceLazy = false } = {}) {
     const href = `${navigationBase}/libro/${item.id}/${slugify(item.title)}`;
     const source = navigationBase === BASE
         ? bookCoverUrl(item.id)
@@ -187,14 +226,22 @@ function cardHtml(item, index, navigationBase) {
     const responsiveAttrs = image.srcset
         ? ` srcset="${escapeHtml(image.srcset)}" sizes="${escapeHtml(image.sizes)}"`
         : '';
+    // "fuera del primer viewport" (TAROT-HUB-MERCH-1): la grilla "Ver todo"
+    // de esoterismo-tarot ya no es lo primero de la página cuando hay
+    // módulos merchandising arriba — forceLazy la saca del criterio index<6.
+    const eager = !forceLazy && index < 6;
     const imageHtml = image.src
-        ? `<img src="${escapeHtml(image.src)}"${responsiveAttrs} alt="Portada de ${title}" loading="${index < 6 ? 'eager' : 'lazy'}" decoding="async" width="280" height="420">`
+        ? `<img src="${escapeHtml(image.src)}"${responsiveAttrs} alt="Portada de ${title}" loading="${eager ? 'eager' : 'lazy'}" decoding="async" width="280" height="420">`
         : '<span class="book-placeholder" aria-hidden="true">📚</span>';
+    const badgesHtml = badges.length
+        ? `<div class="tarot-badges">${badges.map(b => `<span class="tarot-badge">${escapeHtml(b)}</span>`).join('')}</div>`
+        : '';
 
     return `<article class="book-card">
   <a class="book-image" href="${escapeHtml(href)}">${imageHtml}</a>
   <div class="book-body">
     <span class="stock-badge">Disponible</span>
+    ${badgesHtml}
     <h2><a href="${escapeHtml(href)}">${title}</a></h2>
     ${author}
     ${price > 0 ? `<div class="book-prices">
@@ -224,7 +271,83 @@ ${faviconHeadHtml()}
     });
 }
 
-function renderPage({ category, categoryUniverseCount, items, isPreview, hasUnexpectedParameters, navigationBase, page, totalPages }) {
+// TAROT-HUB-MERCH-1 ---------------------------------------------------------
+
+const TAROT_MODULE_INTRO = {
+    'para-empezar': '¿Es tu primer tarot? Estos mazos tienen guía o instructivo pensado para quien recién empieza.',
+    oraculos: 'Mazos de oráculo disponibles ahora — un sistema distinto del tarot, con su propia lógica de lectura.',
+    clasicos: 'Las barajas clásicas del tarot: Rider-Waite-Smith, Marsella y Thoth, cuando el mazo lo indica.',
+    'lenormand-kipper': 'Lenormand y Kipper son sistemas de cartomancia propios, distintos entre sí y del tarot — se muestran juntos por temática, nunca mezclados en la clasificación.',
+    'para-profundizar': 'Libros para estudiar tarot y oráculos en profundidad — teoría, historia e interpretación, no mazos.',
+    novedades: 'Altas recientes en esta categoría.',
+    'mas-buscado': 'Fichas con más demanda real de búsqueda en esta categoría.',
+    'volvio-disponible': 'Títulos que volvieron a tener stock.',
+};
+
+function tarotModuleSectionHtml(module_, navigationBase, cardIndexRef) {
+    if (module_.entries.length === 0) return '';
+    const cards = module_.entries.map(({ item, tag }) => {
+        const badges = module_.kind === 'grid-badged' ? tarotBadgesFor(tag) : [];
+        const html = cardHtml(item, cardIndexRef.value, navigationBase, { badges });
+        cardIndexRef.value += 1;
+        return html;
+    }).join('\n');
+    const moreNote = module_.totalCount > module_.entries.length
+        ? `<p class="tarot-module-more">Mostrando ${module_.entries.length} de ${module_.totalCount} — el resto está en “Ver todo” más abajo.</p>`
+        : '';
+    return `<section class="tarot-module" id="tarot-${escapeHtml(module_.id)}" aria-labelledby="tarot-${escapeHtml(module_.id)}-title">
+    <h2 id="tarot-${escapeHtml(module_.id)}-title">${escapeHtml(module_.title)}</h2>
+    <p class="tarot-module-intro">${escapeHtml(TAROT_MODULE_INTRO[module_.id] || '')}</p>
+    <div class="tarot-module-grid">${cards}</div>
+    ${moreNote}
+  </section>`;
+}
+
+function tarotParaEmpezarHtml(module_, navigationBase, canonical, cardIndexRef) {
+    const waMessage = buildWhatsAppMessage({
+        greeting: 'Hola, estoy buscando mi primer tarot y quisiera que me ayudaran 😊',
+        motive: 'Elegir un primer mazo de tarot',
+        situation: 'Todavía no sé bien qué mazo conviene para empezar',
+        page: canonical,
+        closing: 'Muy pronto vamos a tener un selector para recomendarte el mazo ideal — mientras tanto, contanos qué buscás y te ayudamos por acá. Gracias.',
+    });
+    const cards = module_.entries.map(({ item, tag }) => {
+        const html = cardHtml(item, cardIndexRef.value, navigationBase, { badges: tarotBadgesFor(tag) });
+        cardIndexRef.value += 1;
+        return html;
+    }).join('\n');
+    return `<section class="tarot-module tarot-module-editorial" id="tarot-para-empezar" aria-labelledby="tarot-para-empezar-title">
+    <h2 id="tarot-para-empezar-title">Para empezar</h2>
+    <p class="tarot-module-intro">${escapeHtml(TAROT_MODULE_INTRO['para-empezar'])}</p>
+    ${module_.hasProducts ? `<div class="tarot-module-grid">${cards}</div>` : ''}
+    <a class="tarot-wa-cta" href="${escapeHtml(whatsappHref(waMessage))}" target="_blank" rel="noopener noreferrer">Contanos qué buscás por WhatsApp</a>
+  </section>`;
+}
+
+function tarotModulesHtml(modules, navigationBase, canonical) {
+    if (!modules || modules.length === 0) return '';
+    const cardIndexRef = { value: 0 };
+    const sections = modules.map(module_ => module_.id === 'para-empezar'
+        ? tarotParaEmpezarHtml(module_, navigationBase, canonical, cardIndexRef)
+        : tarotModuleSectionHtml(module_, navigationBase, cardIndexRef)).filter(Boolean);
+    return `<div class="tarot-modules">${sections.join('\n')}</div>`;
+}
+
+const TAROT_MODULE_STYLES = `.tarot-modules{display:flex;flex-direction:column;gap:1.75rem;margin-top:1.75rem}
+.tarot-module{background:#fff;border:1px solid #e2dbd0;border-radius:1rem;padding:1.1rem clamp(1rem,3vw,1.5rem)}
+.tarot-module h2{font-family:Georgia,serif;font-size:1.25rem;margin-bottom:.35rem}
+.tarot-module-intro{color:#6b6157;font-size:.85rem;max-width:70ch;margin-bottom:.9rem}
+.tarot-module-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.7rem}
+.tarot-module-more{margin-top:.75rem;font-size:.78rem;color:#8a8074}
+.tarot-badges{display:flex;flex-wrap:wrap;gap:.3rem}
+.tarot-badge{padding:.14rem .5rem;border-radius:999px;background:#f0e6da;color:#6b4b2f;font-size:.62rem;font-weight:800;text-transform:uppercase;letter-spacing:.02em}
+.tarot-module-editorial .tarot-wa-cta{display:inline-flex;margin-top:.9rem;padding:.65rem 1rem;border-radius:999px;background:#25d366;color:#fff;text-decoration:none;font-weight:800;font-size:.82rem}
+@media(min-width:640px){.tarot-module-grid{grid-template-columns:repeat(3,minmax(0,1fr))}}
+@media(min-width:900px){.tarot-module-grid{grid-template-columns:repeat(4,minmax(0,1fr))}}`;
+
+// ---------------------------------------------------------------------------
+
+function renderPage({ category, categoryUniverseCount, items, isPreview, hasUnexpectedParameters, navigationBase, page, totalPages, tarotModules }) {
     const canonical = `${BASE}${categoryPath(category.id, page)}`;
     const offset = (page - 1) * MAX_RESULTS;
     const visibleItems = items.slice(offset, offset + MAX_RESULTS);
@@ -264,7 +387,12 @@ function renderPage({ category, categoryUniverseCount, items, isPreview, hasUnex
         : totalPages > 1
             ? `Mostrando ${rangeFrom}–${rangeTo} de ${items.length} libros disponibles`
             : `${items.length} libro${items.length === 1 ? '' : 's'} disponible${items.length === 1 ? '' : 's'}`;
-    const cards = visibleItems.map((item, index) => cardHtml(item, index, navigationBase)).join('\n');
+    // TAROT-HUB-MERCH-1: cuando hay módulos merchandising arriba, esta
+    // grilla ya no es lo primero de la página — forceLazy evita eager-load
+    // de imágenes fuera del primer viewport.
+    const cards = visibleItems
+        .map((item, index) => cardHtml(item, index, navigationBase, { forceLazy: Boolean(tarotModules?.length) }))
+        .join('\n');
     const robots = isPreview || hasUnexpectedParameters || items.length === 0
         ? 'noindex, follow'
         : 'index, follow';
@@ -302,7 +430,7 @@ function renderPage({ category, categoryUniverseCount, items, isPreview, hasUnex
   <script type="application/ld+json">${safeJson(collectionSchema)}</script>
   <script type="application/ld+json">${safeJson(breadcrumbSchema)}</script>
   <style>
-    *{box-sizing:border-box;margin:0;padding:0}body{font-family:Inter,system-ui,-apple-system,sans-serif;background:#f8f5ef;color:#18120e;line-height:1.55}a{color:inherit}.category-header{position:sticky;top:0;z-index:40;background:rgba(18,14,11,.97);color:#fff;border-bottom:1px solid rgba(255,255,255,.08)}.header-inner{max-width:1200px;height:72px;margin:auto;padding:0 1rem;display:grid;grid-template-columns:auto minmax(220px,1fr) auto;align-items:center;gap:1rem}.brand-link{display:flex;align-items:center;gap:.55rem;text-decoration:none}.brand-link img{width:44px;height:44px}.brand-link span{display:flex;flex-direction:column}.brand-link strong{font-size:.92rem}.brand-link small{color:rgba(255,255,255,.55);font-size:.7rem}.header-search{height:42px;display:flex;max-width:620px;width:100%;justify-self:center}.header-search input{min-width:0;flex:1;border:0;border-radius:999px 0 0 999px;padding:0 1rem;font:inherit}.header-search button{border:0;border-radius:0 999px 999px 0;padding:0 1rem;background:#e49982;color:#18120e;font-weight:800;cursor:pointer}.cart-link{min-height:42px;display:inline-flex;align-items:center;padding:0 .9rem;border:1px solid rgba(255,255,255,.2);border-radius:999px;text-decoration:none;font-size:.82rem}.breadcrumbs{max-width:1120px;margin:0 auto;padding:1rem;font-size:.82rem;color:#6b6157}.breadcrumbs a{color:#8f493b}.category-main{max-width:1120px;margin:0 auto;padding:0 1rem 3rem}.intro{padding:clamp(1.25rem,3vw,2rem);background:#fff;border:1px solid #e2dbd0;border-radius:1rem}.intro h1{font-family:Georgia,serif;font-size:clamp(1.75rem,5vw,2.6rem);line-height:1.12;margin-bottom:.8rem}.intro p{max-width:78ch;color:#5f554c}.category-scope{margin-top:1rem;padding:.75rem .9rem;border-left:4px solid #e49982;background:#f8f5ef;border-radius:.35rem;color:#50463e;font-size:.88rem}.benefits{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:1rem}.benefits span{padding:.35rem .65rem;border-radius:999px;background:#f5f0ea;color:#50463e;font-size:.75rem;font-weight:700}.results-head{display:flex;align-items:end;justify-content:space-between;gap:1rem;margin:2rem 0 1rem}.results-head h2{font-size:1.15rem}.results-head p{color:#6b6157;font-size:.84rem}.books-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.8rem}.book-card{display:flex;flex-direction:column;min-width:0;background:#fff;border:1px solid #e2dbd0;border-radius:.8rem;overflow:hidden}.book-image{display:grid;place-items:center;aspect-ratio:3/4;background:#eee7de;overflow:hidden}.book-image img{width:100%;height:100%;object-fit:cover;transition:transform .2s}.book-card:hover .book-image img{transform:scale(1.025)}.book-placeholder{font-size:2.5rem}.book-body{display:flex;flex:1;flex-direction:column;align-items:flex-start;gap:.4rem;padding:.8rem}.stock-badge{padding:.16rem .48rem;border-radius:999px;background:#eaf7ee;color:#267a42;font-size:.64rem;font-weight:800;text-transform:uppercase}.book-body h2{font-size:.86rem;line-height:1.3}.book-body h2 a{text-decoration:none}.book-author{width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#6b6157;font-size:.75rem}.book-prices{display:flex;flex-direction:column;gap:.15rem;margin-top:.2rem;font-size:.72rem}.book-prices strong{font-size:.9rem}.book-prices .transfer{color:#a94e3d;font-weight:700}.book-cta{margin-top:auto;padding:.38rem .7rem;border-radius:999px;background:#18120e;color:#fff;text-decoration:none;font-size:.73rem;font-weight:700}.category-nav{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.55rem;margin-top:2.5rem;padding:1rem;background:#fff;border:1px solid #e2dbd0;border-radius:1rem}.category-nav a{padding:.55rem .7rem;border-radius:.55rem;background:#f8f5ef;text-decoration:none;font-size:.78rem}.category-nav a[aria-current="page"]{background:#18120e;color:#fff}.empty{margin-top:1.5rem;padding:1.5rem;background:#fff;border:1px solid #e2dbd0;border-radius:.8rem}${PAGINATION_STYLES}${FOOTER_STYLES}${WA_FLOAT_STYLES}@media(min-width:640px){.books-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.category-nav{grid-template-columns:repeat(4,minmax(0,1fr))}}@media(min-width:900px){.books-grid{grid-template-columns:repeat(4,minmax(0,1fr))}}@media(max-width:620px){.header-inner{height:auto;min-height:68px;grid-template-columns:1fr auto;padding:.55rem .8rem}.brand-link small,.cart-link{display:none}.header-search{grid-column:1/-1;grid-row:2;margin-bottom:.2rem}.category-header{position:relative}}
+    *{box-sizing:border-box;margin:0;padding:0}body{font-family:Inter,system-ui,-apple-system,sans-serif;background:#f8f5ef;color:#18120e;line-height:1.55}a{color:inherit}.category-header{position:sticky;top:0;z-index:40;background:rgba(18,14,11,.97);color:#fff;border-bottom:1px solid rgba(255,255,255,.08)}.header-inner{max-width:1200px;height:72px;margin:auto;padding:0 1rem;display:grid;grid-template-columns:auto minmax(220px,1fr) auto;align-items:center;gap:1rem}.brand-link{display:flex;align-items:center;gap:.55rem;text-decoration:none}.brand-link img{width:44px;height:44px}.brand-link span{display:flex;flex-direction:column}.brand-link strong{font-size:.92rem}.brand-link small{color:rgba(255,255,255,.55);font-size:.7rem}.header-search{height:42px;display:flex;max-width:620px;width:100%;justify-self:center}.header-search input{min-width:0;flex:1;border:0;border-radius:999px 0 0 999px;padding:0 1rem;font:inherit}.header-search button{border:0;border-radius:0 999px 999px 0;padding:0 1rem;background:#e49982;color:#18120e;font-weight:800;cursor:pointer}.cart-link{min-height:42px;display:inline-flex;align-items:center;padding:0 .9rem;border:1px solid rgba(255,255,255,.2);border-radius:999px;text-decoration:none;font-size:.82rem}.breadcrumbs{max-width:1120px;margin:0 auto;padding:1rem;font-size:.82rem;color:#6b6157}.breadcrumbs a{color:#8f493b}.category-main{max-width:1120px;margin:0 auto;padding:0 1rem 3rem}.intro{padding:clamp(1.25rem,3vw,2rem);background:#fff;border:1px solid #e2dbd0;border-radius:1rem}.intro h1{font-family:Georgia,serif;font-size:clamp(1.75rem,5vw,2.6rem);line-height:1.12;margin-bottom:.8rem}.intro p{max-width:78ch;color:#5f554c}.category-scope{margin-top:1rem;padding:.75rem .9rem;border-left:4px solid #e49982;background:#f8f5ef;border-radius:.35rem;color:#50463e;font-size:.88rem}.benefits{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:1rem}.benefits span{padding:.35rem .65rem;border-radius:999px;background:#f5f0ea;color:#50463e;font-size:.75rem;font-weight:700}.results-head{display:flex;align-items:end;justify-content:space-between;gap:1rem;margin:2rem 0 1rem}.results-head h2{font-size:1.15rem}.results-head p{color:#6b6157;font-size:.84rem}.books-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.8rem}.book-card{display:flex;flex-direction:column;min-width:0;background:#fff;border:1px solid #e2dbd0;border-radius:.8rem;overflow:hidden}.book-image{display:grid;place-items:center;aspect-ratio:3/4;background:#eee7de;overflow:hidden}.book-image img{width:100%;height:100%;object-fit:cover;transition:transform .2s}.book-card:hover .book-image img{transform:scale(1.025)}.book-placeholder{font-size:2.5rem}.book-body{display:flex;flex:1;flex-direction:column;align-items:flex-start;gap:.4rem;padding:.8rem}.stock-badge{padding:.16rem .48rem;border-radius:999px;background:#eaf7ee;color:#267a42;font-size:.64rem;font-weight:800;text-transform:uppercase}.book-body h2{font-size:.86rem;line-height:1.3}.book-body h2 a{text-decoration:none}.book-author{width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#6b6157;font-size:.75rem}.book-prices{display:flex;flex-direction:column;gap:.15rem;margin-top:.2rem;font-size:.72rem}.book-prices strong{font-size:.9rem}.book-prices .transfer{color:#a94e3d;font-weight:700}.book-cta{margin-top:auto;padding:.38rem .7rem;border-radius:999px;background:#18120e;color:#fff;text-decoration:none;font-size:.73rem;font-weight:700}.category-nav{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.55rem;margin-top:2.5rem;padding:1rem;background:#fff;border:1px solid #e2dbd0;border-radius:1rem}.category-nav a{padding:.55rem .7rem;border-radius:.55rem;background:#f8f5ef;text-decoration:none;font-size:.78rem}.category-nav a[aria-current="page"]{background:#18120e;color:#fff}.empty{margin-top:1.5rem;padding:1.5rem;background:#fff;border:1px solid #e2dbd0;border-radius:.8rem}${PAGINATION_STYLES}${FOOTER_STYLES}${WA_FLOAT_STYLES}${TAROT_MODULE_STYLES}@media(min-width:640px){.books-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.category-nav{grid-template-columns:repeat(4,minmax(0,1fr))}}@media(min-width:900px){.books-grid{grid-template-columns:repeat(4,minmax(0,1fr))}}@media(max-width:620px){.header-inner{height:auto;min-height:68px;grid-template-columns:1fr auto;padding:.55rem .8rem}.brand-link small,.cart-link{display:none}.header-search{grid-column:1/-1;grid-row:2;margin-bottom:.2rem}.category-header{position:relative}}
     .book-image{padding:.35rem}.book-image img{object-fit:contain}
   </style>
 </head>
@@ -316,7 +444,8 @@ ${headerHtml()}
     <p class="category-scope">${scopeText}</p>
     <div class="benefits"><span>12% menos por transferencia</span><span>Hasta 12 cuotas</span><span>Envíos a todo Uruguay</span><span>Encargos del exterior</span></div>
   </section>
-  <div class="results-head"><h2>Libros disponibles</h2><p>${resultText}</p></div>
+  ${tarotModulesHtml(tarotModules, navigationBase, canonical)}
+  <div class="results-head"><h2>${tarotModules?.length ? 'Ver todo' : 'Libros disponibles'}</h2><p>${resultText}</p></div>
   ${items.length > 0 ? `<section class="books-grid" aria-label="${escapeHtml(category.h1)}">${cards}</section>${pagination}` : '<p class="empty">No hay títulos disponibles en esta categoría en este momento. Consultanos por WhatsApp y lo buscamos por encargo.</p>'}
   ${categoryNavHtml(category.id)}
 </main>
@@ -392,6 +521,13 @@ export async function onRequest(ctx) {
     }
     const isPreview = ctx.env?.APP_ENV === 'preview';
     const navigationBase = isPreview ? requestUrl.origin : BASE;
+    // TAROT-HUB-MERCH-1: módulos merchandising sólo en la vista limpia
+    // (página 1, sin parámetros inesperados) de esoterismo-tarot, y sólo si
+    // hay algo que mostrar. Reutiliza `items` — ya calculado arriba, cero
+    // fetch adicional. Ninguna otra categoría pasa por este branch.
+    const tarotModules = category.id === TAROT_CATEGORY_ID && pageParam.page === 1 && !hasUnexpectedParameters && items.length > 0
+        ? buildTarotHubModules({ items, tagLookup: tarotTagLookup, demandLedgerLookup: tarotDemandLedgerLookup })
+        : null;
     const html = renderPage({
         category,
         categoryUniverseCount,
@@ -401,6 +537,7 @@ export async function onRequest(ctx) {
         navigationBase,
         page: pageParam.page,
         totalPages,
+        tarotModules,
     });
 
     return new Response(html, {

--- a/functions/libros/[[path]].js
+++ b/functions/libros/[[path]].js
@@ -399,9 +399,19 @@ function renderPage({ category, categoryUniverseCount, items, isPreview, hasUnex
     const pageTitle = page > 1 ? `${category.title} — Página ${page}` : category.title;
     const pageDescription = page > 1 ? `${category.description} Página ${page} de ${totalPages}.` : category.description;
     const pagination = paginationHtml({ categoryId: category.id, page, totalPages });
-    const scopeText = Number.isFinite(categoryUniverseCount) && categoryUniverseCount > items.length
-        ? `<strong>${items.length} título${items.length === 1 ? '' : 's'} disponible${items.length === 1 ? '' : 's'} ahora.</strong> Los ${categoryUniverseCount} títulos informados en la portada incluyen disponibles y libros que podemos buscar por encargo.`
-        : `<strong>${items.length} título${items.length === 1 ? '' : 's'} disponible${items.length === 1 ? '' : 's'} ahora.</strong> También buscamos ediciones agotadas o difíciles de conseguir por encargo.`;
+    // TAROT-HUB-MERCH-1: copy inequívoco para esoterismo-tarot — "314 título(s)
+    // informados en la portada" se podía leer como stock inmediato, que no es
+    // lo que dice. El número visible es siempre el de items.length (dinámico,
+    // nunca hardcodeado); el universo por-encargo mayor se nombra sin cifra
+    // propia, sólo cuando existe realmente. El resto de las categorías
+    // conserva el texto original, sin cambios.
+    const scopeText = category.id === TAROT_CATEGORY_ID
+        ? (Number.isFinite(categoryUniverseCount) && categoryUniverseCount > items.length
+            ? `<strong>${items.length} disponible${items.length === 1 ? '' : 's'} ahora</strong> · más títulos disponibles por encargo`
+            : `<strong>${items.length} disponible${items.length === 1 ? '' : 's'} ahora</strong>`)
+        : (Number.isFinite(categoryUniverseCount) && categoryUniverseCount > items.length
+            ? `<strong>${items.length} título${items.length === 1 ? '' : 's'} disponible${items.length === 1 ? '' : 's'} ahora.</strong> Los ${categoryUniverseCount} títulos informados en la portada incluyen disponibles y libros que podemos buscar por encargo.`
+            : `<strong>${items.length} título${items.length === 1 ? '' : 's'} disponible${items.length === 1 ? '' : 's'} ahora.</strong> También buscamos ediciones agotadas o difíciles de conseguir por encargo.`);
     const waMessage = buildWhatsAppMessage({
         greeting: 'Hola, estoy buscando un libro en Amado Libros y quisiera que me ayudaran 😊',
         motive: 'Consultar por un libro de esta categoría',


### PR DESCRIPTION
## Estado

**#207 (TAROT-MERCH-TAGS-1) ya está mergeado a `main`** (squash `090e88ee6d45f16841ce739f8e10bb5914a8dd83`). Esta rama se reconstruyó limpia sobre ese `main` — el diff contra `main` queda limitado exactamente a 3 archivos:

```
functions/__tests__/tarot-hub-modules.test.js
functions/_shared/tarot-hub-modules.js
functions/libros/[[path]].js
```

Ninguna otra categoría de `seo-categories.js` se toca.

## Qué agrega

`/libros/esoterismo-tarot` tiene módulos merchandising reales, poblados con `TAROT_MERCH_TAGS` (ya en `main`). Sin URLs nuevas: mismo canonical, misma paginación, mismo allowlist.

## Módulos — orden mobile-first y qué renderiza con datos reales hoy

| # | Módulo | Regla | Render hoy |
|---|---|---|---|
| 1 | **Para empezar** | 3–6 con `level=principiante`; si <3, sólo microexplicación + WhatsApp, sin rellenar | Actualmente **0 productos** en vivo (el catálogo drifea desde que se generó el artefacto) — el módulo se degrada correctamente a sólo texto + CTA, tal como exige la regla |
| 2 | **Oráculos** | cualquier `primary_type=oraculo` | ✅ ~12 de 38 (tope de tarjeta) |
| 3 | **Clásicos** | `deck_family` no nulo (RWS/Marsella/Thoth) | ✅ badges reales por tarjeta; Thoth va como badge, no carrusel propio (volumen bajo) |
| 4 | **Lenormand y Kipper** | juntos visualmente, `primary_type` real por badge | ✅ nunca colapsados semánticamente (verificado con tarjetas reales cuyo título comercial dice "Tarot..." pero se agrupan como Lenormand) |
| 5 | **Para profundizar** | `format=libro` | ✅ separados de los mazos |
| 6 | **Novedades** | `is_new_arrival` (start_time real) | ✅ |
| 7 | **Lo más buscado** | `impressions >= 10` del Demand Ledger (impressions DESC, clicks DESC) — **nunca `opportunity_score`**, que mide oportunidad SEO/CTR, no volumen de búsqueda | ❌ no renderiza — DEMAND-LEDGER-1 (#206) todavía no está mergeado, el lookup es un no-op documentado |
| 8 | **Volvió a estar disponible** | `is_restocked=true`, sólo con evidencia histórica real | ❌ no renderiza — 0 evidencia real hoy (ventana histórica corta) |
| 9 | **Ver todo** | grilla paginada existente | ✅ sin cambios de comportamiento salvo `forceLazy` |

Ediciones especiales y Mazo+guía son badges sobre la tarjeta, no carruseles propios (volumen insuficiente).

## Hero

`314 disponibles ahora · más títulos disponibles por encargo` — reemplaza una frase que se podía leer como stock inmediato ("Los 1267 títulos informados en la portada..."). El número visible es siempre dinámico (`items.length`), nunca hardcodeado. Sólo para `esoterismo-tarot`; las otras 7 categorías no cambian.

## "Lo más buscado": corregido a demanda real, no oportunidad SEO

Versión anterior de este PR usaba `opportunity_score > 0` como criterio — incorrecto: ese campo mide CTR observado vs. esperado para una posición (útil para priorizar qué title/meta atacar), no cuánta gente busca algo. Un producto puede tener `opportunity_score` alto con 2-3 impresiones (ruido de muestra chica), o impresiones altas con `opportunity_score` bajo porque su CTR ya es bueno.

Corregido a: `impressions >= 10` como umbral mínimo de evidencia, orden `impressions DESC → clicks DESC`, sin leer `opportunity_score` en ningún punto de `buildTarotHubModules()`. Sin datos suficientes, el módulo sigue ausente — mismo comportamiento visual que antes, porque #206 sigue sin mergear.

## Preservado sin cambios

Canonical, robots, paginación, precios, transferencia, carrito, checkout, `Product`/`Book`/`Offer` de fichas. Sólo `CollectionPage`/`ItemList`/`BreadcrumbList` como ya existía.

## Validación

- **Tests focalizados**: `tarot-hub-modules.test.js` — **27/27** (incluye los 5 casos pedidos para "Lo más buscado": impresiones altas aparece, impresiones bajas no aparece, orden por impresiones, empate por clicks, `opportunity_score` alto con pocas impresiones NO convierte en "más buscado").
- **Regresión de las 8 categorías**: **26/26**.
- **Suite completa**: `functions/*` 713/715 (worker-sync 117/117, astro-front/lib 29/29, api 257/257). Mismas 2 fallas CRLF preexistentes, no relacionadas.
- **Build Astro checkout OFF/ON**: OK.
- **Preview**: verde (CI + deploy + commerce audit `pass`, 0 críticos).

## Alcance estricto

No crea `/libros/oraculos`, `/libros/lenormand`, `/libros/rider-waite` ni `/libros/marsella`. No implementa `TAROT-FINDER-1`. No mezcla cursos, B2B ni accesorios externos.

**NO se mergea. NO se toca producción.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)