### PR TITLE
TAROT-FINDER-1: selector "Encontrá tu mazo" en esoterismo-tarot

### DIFF
--- a/astro-front/public/tarot-finder.js
+++ b/astro-front/public/tarot-finder.js
@@ -8,6 +8,14 @@
   // porque el navegador no puede importar ese módulo ES sin bundler. Si se
   // cambia un peso o una regla hard/soft, hay que cambiarla en los DOS
   // lugares. Mismos nombres de campos, mismo orden de desempate.
+  //
+  // TAROT-FINDER-1 fix de paridad: todas las funciones puras de acá abajo
+  // (sin DOM) se exponen también en window.__AmadoTarotFinderTestHooks,
+  // exclusivamente para que functions/__tests__/tarot-finder-client.test.js
+  // pueda ejecutar ESTE archivo real dentro de un harness de Node (con un
+  // DOM mínimo simulado) y comparar sus resultados byte a byte contra
+  // tarot-finder-scoring.js — no es una API pública, no se usa desde el
+  // propio flujo de la UI.
   var STEP_ORDER = ['system', 'intent', 'family', 'language', 'guide'];
   var MAX_RESULTS = 6;
   var SCORE = {
@@ -96,6 +104,77 @@
     return lines.join('\n');
   }
 
+  // ---- Máquina de estados (sin DOM) --------------------------------------
+  // Extraída aparte de init() a propósito: son las funciones que
+  // functions/__tests__/tarot-finder-client.test.js ejercita para probar el
+  // flujo real (FIX 1/2/3), no sólo el HTML estático.
+
+  function relevantSteps(answers) {
+    return STEP_ORDER.filter(function (s) { return s !== 'family' || answers.system === 'tarot'; });
+  }
+
+  function nextStepFrom(step, answers) {
+    var order = relevantSteps(answers);
+    var idx = order.indexOf(step);
+    return idx >= 0 && idx < order.length - 1 ? order[idx + 1] : 'results';
+  }
+
+  // FIX 2: desde 'results' vuelve a la última pregunta aplicable (guide,
+  // salvo que algún día se agregue una pregunta después). Desde la primera
+  // pregunta real devuelve null -> sólo ahí "volver" puede cerrar.
+  function prevStepFrom(step, answers) {
+    var order = relevantSteps(answers);
+    if (step === 'results') return order[order.length - 1];
+    var idx = order.indexOf(step);
+    return idx > 0 ? order[idx - 1] : null;
+  }
+
+  function initialFinderState() {
+    return { step: 'system', answers: {}, systemExplainerOpen: false };
+  }
+
+  /**
+   * Reductor puro: (estado, campo, valor) -> nuevo estado. No muta el
+   * estado recibido.
+   *
+   * FIX 1: elegir "No estoy seguro/a" la PRIMERA vez en la pregunta de
+   * sistema no avanza — sólo abre el explicador (systemExplainerOpen).
+   * Sólo "Seguir sin preferencia" (mismo value='unsure', pero con el
+   * explicador ya abierto) confirma system='unsure' y avanza.
+   *
+   * FIX 3: cambiar `system` a cualquier valor que no sea 'tarot' elimina
+   * `answers.deckFamily` de inmediato — una tradición que ya no aplica
+   * nunca puede seguir restringiendo el ranking.
+   */
+  function applyChoice(state, field, value) {
+    var answers = {};
+    for (var k in state.answers) if (Object.prototype.hasOwnProperty.call(state.answers, k)) answers[k] = state.answers[k];
+
+    if (field === 'system' && value === 'unsure' && state.step === 'system' && !state.systemExplainerOpen) {
+      return { step: 'system', answers: answers, systemExplainerOpen: true };
+    }
+
+    if (field === 'system' && value !== 'tarot') {
+      delete answers.deckFamily;
+    }
+    answers[field] = value;
+
+    var nextState = { step: state.step, answers: answers, systemExplainerOpen: false };
+    nextState.step = nextStepFrom(state.step, answers);
+    return nextState;
+  }
+
+  /** FIX 2: "volver" desde el sub-estado del explicador de sistema vuelve a
+   * la vista simple de la misma pregunta, nunca cierra. */
+  function applyGoBack(state) {
+    if (state.step === 'system' && state.systemExplainerOpen) {
+      return { step: 'system', answers: state.answers, systemExplainerOpen: false };
+    }
+    var prev = prevStepFrom(state.step, state.answers);
+    if (prev === null) return null; // señal: cerrar el Finder
+    return { step: prev, answers: state.answers, systemExplainerOpen: false };
+  }
+
   var QUESTIONS = {
     system: {
       field: 'system',
@@ -106,7 +185,12 @@
         { value: 'lenormand', label: 'Lenormand' },
         { value: 'unsure', label: 'No estoy seguro/a' },
       ],
-      explainerWhen: 'unsure',
+      explainerOptions: [
+        { value: 'tarot', label: 'Tarot' },
+        { value: 'oraculo', label: 'Oráculo' },
+        { value: 'lenormand', label: 'Lenormand' },
+        { value: 'unsure', label: 'Seguir sin preferencia' },
+      ],
       explainer: [
         { title: 'Tarot', text: 'Sistema habitualmente estructurado en 78 cartas.' },
         { title: 'Oráculo', text: 'Cada mazo puede tener estructura y temática propias.' },
@@ -155,19 +239,16 @@
     },
   };
 
-  function relevantSteps(answers) {
-    return STEP_ORDER.filter(function (s) { return s !== 'family' || answers.system === 'tarot'; });
-  }
-  function nextStepFrom(step, answers) {
-    var order = relevantSteps(answers);
-    var idx = order.indexOf(step);
-    return idx >= 0 && idx < order.length - 1 ? order[idx + 1] : 'results';
-  }
-  function prevStepFrom(step, answers) {
-    var order = relevantSteps(answers);
-    var idx = order.indexOf(step);
-    return idx > 0 ? order[idx - 1] : null; // null = volver al CTA cerrado
-  }
+  // Hooks de sólo-test (ver comentario de cabecera). No se llaman desde la
+  // UI real; existen para que un harness de Node ejecute este archivo tal
+  // cual se sirve y compare contra tarot-finder-scoring.js.
+  window.__AmadoTarotFinderTestHooks = {
+    STEP_ORDER: STEP_ORDER, MAX_RESULTS: MAX_RESULTS, SCORE: SCORE, QUESTIONS: QUESTIONS,
+    hasPreference: hasPreference, passesHard: passesHard, scoreCandidate: scoreCandidate,
+    rankCandidates: rankCandidates, explainMatch: explainMatch, buildNoResultsMessage: buildNoResultsMessage,
+    relevantSteps: relevantSteps, nextStepFrom: nextStepFrom, prevStepFrom: prevStepFrom,
+    initialFinderState: initialFinderState, applyChoice: applyChoice, applyGoBack: applyGoBack,
+  };
 
   function ready(fn) {
     if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', fn);
@@ -193,7 +274,7 @@
     var state = null;
 
     startBtn.addEventListener('click', function () {
-      state = { step: 'system', answers: {} };
+      state = initialFinderState();
       startBtn.hidden = true;
       root.hidden = false;
       render();
@@ -204,20 +285,19 @@
     });
 
     function choose(field, value) {
-      state.answers[field] = value;
-      state.step = nextStepFrom(state.step, state.answers);
+      state = applyChoice(state, field, value);
       render();
     }
 
     function goBack() {
-      var prev = prevStepFrom(state.step, state.answers);
-      if (prev === null) { closeFinder(); return; }
-      state.step = prev;
+      var nextState = applyGoBack(state);
+      if (nextState === null) { closeFinder(); return; }
+      state = nextState;
       render();
     }
 
     function restart() {
-      state = { step: 'system', answers: {} };
+      state = initialFinderState();
       render();
     }
 
@@ -244,20 +324,24 @@
 
     function renderQuestion(step) {
       var q = QUESTIONS[step];
+      var explainerOpen = step === 'system' && state.systemExplainerOpen;
+      var options = explainerOpen ? q.explainerOptions : q.options;
       var selected = state.answers[q.field];
-      var isFirst = stepPosition(step) === 1;
+      // FIX 2/4: "Cerrar" sólo en la primera pregunta real y fuera del
+      // sub-estado del explicador — desde ahí "volver" nunca cierra.
+      var isFirst = stepPosition(step) === 1 && !explainerOpen;
       var html = '';
       html += '<p class="tf-progress">Pregunta ' + stepPosition(step) + ' de ' + stepTotal() + '</p>';
       html += '<div class="tf-question">';
       html += '<h3 tabindex="-1" id="tf-heading">' + escapeHtml(q.title) + '</h3>';
-      if (q.explainerWhen && selected === q.explainerWhen) {
+      if (explainerOpen) {
         html += '<div class="tf-explainer">' + q.explainer.map(function (e) {
           return '<div><strong>' + escapeHtml(e.title) + '</strong> — ' + escapeHtml(e.text) + '</div>';
         }).join('') + '</div>';
       }
       html += '<div class="tf-options" role="group" aria-label="' + escapeHtml(q.title) + '">';
-      html += q.options.map(function (opt) {
-        var pressed = selected === opt.value ? 'true' : 'false';
+      html += options.map(function (opt) {
+        var pressed = selected === opt.value && !(step === 'system' && opt.value === 'unsure' && explainerOpen) ? 'true' : 'false';
         return '<button type="button" class="tf-option" data-field="' + escapeHtml(q.field) + '" data-value="' + escapeHtml(opt.value) + '" aria-pressed="' + pressed + '">' + escapeHtml(opt.label) + '</button>';
       }).join('');
       html += '</div></div>';

--- a/astro-front/public/tarot-finder.js
+++ b/astro-front/public/tarot-finder.js
@@ -1,0 +1,328 @@
+(function () {
+  'use strict';
+  if (window.AmadoTarotFinder) return;
+  window.AmadoTarotFinder = true;
+
+  // Espejo en vanilla JS de functions/_shared/tarot-finder-scoring.js — la
+  // lógica canónica y testeada (node --test) vive ahí; acá se reimplementa
+  // porque el navegador no puede importar ese módulo ES sin bundler. Si se
+  // cambia un peso o una regla hard/soft, hay que cambiarla en los DOS
+  // lugares. Mismos nombres de campos, mismo orden de desempate.
+  var STEP_ORDER = ['system', 'intent', 'family', 'language', 'guide'];
+  var MAX_RESULTS = 6;
+  var SCORE = {
+    PRINCIPIANTE_PARA_PRIMER_MAZO: 30,
+    GUIA_PARA_ESTUDIAR: 20,
+    EDICION_ESPECIAL_PARA_REGALO_O_COLECCIONISTA: 10,
+    AVANZADO_PARA_EXPERIENCIA: 15,
+    GUIA_NO_EXIGIDA_PERO_PRESENTE: 5,
+  };
+
+  var SYSTEM_LABEL = { tarot: 'Tarot', oraculo: 'Oráculo', lenormand: 'Lenormand', kipper: 'Kipper' };
+  var DECK_FAMILY_LABEL = { rider_waite_smith: 'Rider-Waite-Smith', marsella: 'Tarot de Marsella', thoth: 'Thoth' };
+  var LANGUAGE_LABEL = { espanol: 'Español', ingles: 'Inglés', multilingue: 'Multilingüe' };
+  var INTENT_LABEL = { primer_mazo: 'primer mazo', estudiar: 'aprender/estudiar', experiencia: 'ya tiene experiencia', regalo: 'regalo', coleccionista: 'coleccionista' };
+
+  function escapeHtml(value) {
+    return String(value == null ? '' : value)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function hasPreference(v) {
+    return Boolean(v) && v !== 'no_preference' && v !== 'unsure' && v !== 'sin_preferencia';
+  }
+
+  function passesHard(candidate, answers) {
+    if (hasPreference(answers.system) && candidate.primary_type !== answers.system) return false;
+    if (hasPreference(answers.deckFamily) && candidate.deck_family !== answers.deckFamily) return false;
+    if (hasPreference(answers.language) && candidate.language !== answers.language) return false;
+    if (answers.guide === 'si' && candidate.bundle !== 'mazo_mas_guia') return false;
+    return true;
+  }
+
+  function scoreCandidate(candidate, answers) {
+    var score = 0;
+    if (answers.intent === 'primer_mazo' && candidate.level === 'principiante') score += SCORE.PRINCIPIANTE_PARA_PRIMER_MAZO;
+    if (answers.intent === 'estudiar' && candidate.bundle === 'mazo_mas_guia') score += SCORE.GUIA_PARA_ESTUDIAR;
+    if ((answers.intent === 'regalo' || answers.intent === 'coleccionista') && candidate.edition_style === 'ilustrada_especial') score += SCORE.EDICION_ESPECIAL_PARA_REGALO_O_COLECCIONISTA;
+    if (answers.intent === 'experiencia' && candidate.level === 'avanzado_profesional') score += SCORE.AVANZADO_PARA_EXPERIENCIA;
+    if (answers.guide !== 'si' && candidate.bundle === 'mazo_mas_guia') score += SCORE.GUIA_NO_EXIGIDA_PERO_PRESENTE;
+    return score;
+  }
+
+  // Desempate documentado: score DESC -> stock DESC -> price ASC -> id ASC.
+  function rankCandidates(dataset, answers) {
+    var passing = dataset.filter(function (c) { return passesHard(c, answers); });
+    var scored = passing.map(function (c) { return { candidate: c, score: scoreCandidate(c, answers) }; });
+    scored.sort(function (a, b) {
+      if (b.score !== a.score) return b.score - a.score;
+      var stockDiff = (Number(b.candidate.stock) || 0) - (Number(a.candidate.stock) || 0);
+      if (stockDiff !== 0) return stockDiff;
+      var priceDiff = (Number(a.candidate.price) || 0) - (Number(b.candidate.price) || 0);
+      if (priceDiff !== 0) return priceDiff;
+      return String(a.candidate.id).localeCompare(String(b.candidate.id));
+    });
+    return scored.slice(0, MAX_RESULTS);
+  }
+
+  function explainMatch(candidate, answers) {
+    var badges = [];
+    if (DECK_FAMILY_LABEL[candidate.deck_family]) badges.push(DECK_FAMILY_LABEL[candidate.deck_family]);
+    if (LANGUAGE_LABEL[candidate.language]) badges.push(LANGUAGE_LABEL[candidate.language]);
+    if (candidate.bundle === 'mazo_mas_guia') badges.push('Incluye guía');
+    if (candidate.edition_style === 'ilustrada_especial') badges.push('Edición especial');
+
+    var systemLabel = SYSTEM_LABEL[candidate.primary_type];
+    var clauses = [];
+    if (systemLabel) clauses.push(hasPreference(answers.system) ? ('buscás un ' + systemLabel) : ('es un ' + systemLabel));
+    if (hasPreference(answers.deckFamily) && DECK_FAMILY_LABEL[candidate.deck_family]) clauses.push(DECK_FAMILY_LABEL[candidate.deck_family]);
+    if (hasPreference(answers.language) && LANGUAGE_LABEL[candidate.language]) clauses.push('en ' + LANGUAGE_LABEL[candidate.language].toLowerCase());
+    if (answers.guide === 'si' && candidate.bundle === 'mazo_mas_guia') clauses.push('con guía');
+    return { badges: badges, sentence: clauses.length ? ('Coincide porque ' + clauses.join(' ') + '.') : '' };
+  }
+
+  function buildNoResultsMessage(answers, page) {
+    var lines = ['Hola, estoy buscando un mazo en Amado Libros 😊', '', 'Motivo: Buscar un mazo con el selector "Encontrá tu mazo"'];
+    var situation = [];
+    if (hasPreference(answers.system)) situation.push('Tipo: ' + SYSTEM_LABEL[answers.system]);
+    if (hasPreference(answers.deckFamily)) situation.push('Tradición: ' + DECK_FAMILY_LABEL[answers.deckFamily]);
+    if (hasPreference(answers.language)) situation.push('Idioma: ' + LANGUAGE_LABEL[answers.language]);
+    if (answers.guide === 'si') situation.push('Guía: sí');
+    if (answers.intent && INTENT_LABEL[answers.intent]) situation.push('Experiencia: ' + INTENT_LABEL[answers.intent]);
+    if (situation.length) lines.push('Situación: ' + situation.join('\n'));
+    if (page) lines.push('Página: ' + page);
+    lines.push('', 'No encontré una coincidencia exacta disponible. ¿Pueden buscarme opciones?');
+    return lines.join('\n');
+  }
+
+  var QUESTIONS = {
+    system: {
+      field: 'system',
+      title: '¿Qué estás buscando?',
+      options: [
+        { value: 'tarot', label: 'Tarot' },
+        { value: 'oraculo', label: 'Oráculo' },
+        { value: 'lenormand', label: 'Lenormand' },
+        { value: 'unsure', label: 'No estoy seguro/a' },
+      ],
+      explainerWhen: 'unsure',
+      explainer: [
+        { title: 'Tarot', text: 'Sistema habitualmente estructurado en 78 cartas.' },
+        { title: 'Oráculo', text: 'Cada mazo puede tener estructura y temática propias.' },
+        { title: 'Lenormand', text: 'Sistema distinto del Tarot, tradicionalmente de 36 cartas.' },
+      ],
+    },
+    intent: {
+      field: 'intent',
+      title: '¿Para qué lo querés?',
+      options: [
+        { value: 'primer_mazo', label: 'Es mi primer mazo' },
+        { value: 'estudiar', label: 'Quiero aprender/estudiar' },
+        { value: 'experiencia', label: 'Ya tengo experiencia' },
+        { value: 'regalo', label: 'Es para regalar' },
+        { value: 'coleccionista', label: 'Colecciono mazos' },
+        { value: 'sin_preferencia', label: 'No tengo preferencia' },
+      ],
+    },
+    family: {
+      field: 'deckFamily',
+      title: '¿Buscás alguna tradición en particular?',
+      options: [
+        { value: 'rider_waite_smith', label: 'Rider-Waite-Smith' },
+        { value: 'marsella', label: 'Tarot de Marsella' },
+        { value: 'thoth', label: 'Thoth' },
+        { value: 'no_preference', label: 'No tengo preferencia' },
+      ],
+    },
+    language: {
+      field: 'language',
+      title: '¿Qué idioma preferís?',
+      options: [
+        { value: 'espanol', label: 'Español' },
+        { value: 'ingles', label: 'Inglés' },
+        { value: 'multilingue', label: 'Multilingüe' },
+        { value: 'no_preference', label: 'Me da igual' },
+      ],
+    },
+    guide: {
+      field: 'guide',
+      title: '¿Querés que venga con guía o libro?',
+      options: [
+        { value: 'si', label: 'Sí' },
+        { value: 'no_importante', label: 'No es importante' },
+      ],
+    },
+  };
+
+  function relevantSteps(answers) {
+    return STEP_ORDER.filter(function (s) { return s !== 'family' || answers.system === 'tarot'; });
+  }
+  function nextStepFrom(step, answers) {
+    var order = relevantSteps(answers);
+    var idx = order.indexOf(step);
+    return idx >= 0 && idx < order.length - 1 ? order[idx + 1] : 'results';
+  }
+  function prevStepFrom(step, answers) {
+    var order = relevantSteps(answers);
+    var idx = order.indexOf(step);
+    return idx > 0 ? order[idx - 1] : null; // null = volver al CTA cerrado
+  }
+
+  function ready(fn) {
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', fn);
+    else fn();
+  }
+
+  ready(init);
+
+  function init() {
+    var section = document.getElementById('tarot-finder-cta');
+    var root = document.getElementById('tarot-finder-app');
+    var startBtn = document.getElementById('tarot-finder-start');
+    var dataEl = document.getElementById('tarot-finder-dataset');
+    if (!section || !root || !startBtn || !dataEl) return;
+
+    var waBase = section.getAttribute('data-wa-base') || '';
+    var pageUrl = window.location.href.split('#')[0].split('?')[0];
+
+    var dataset;
+    try { dataset = JSON.parse(dataEl.textContent || '[]'); } catch (_e) { dataset = []; }
+    if (!Array.isArray(dataset) || dataset.length === 0) return;
+
+    var state = null;
+
+    startBtn.addEventListener('click', function () {
+      state = { step: 'system', answers: {} };
+      startBtn.hidden = true;
+      root.hidden = false;
+      render();
+    });
+
+    document.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape' && state && !root.hidden) closeFinder();
+    });
+
+    function choose(field, value) {
+      state.answers[field] = value;
+      state.step = nextStepFrom(state.step, state.answers);
+      render();
+    }
+
+    function goBack() {
+      var prev = prevStepFrom(state.step, state.answers);
+      if (prev === null) { closeFinder(); return; }
+      state.step = prev;
+      render();
+    }
+
+    function restart() {
+      state = { step: 'system', answers: {} };
+      render();
+    }
+
+    function closeFinder() {
+      root.hidden = true;
+      root.innerHTML = '';
+      startBtn.hidden = false;
+      startBtn.focus();
+      state = null;
+    }
+
+    function stepPosition(step) {
+      return relevantSteps(state.answers).indexOf(step) + 1;
+    }
+    function stepTotal() {
+      return relevantSteps(state.answers).length;
+    }
+
+    function render() {
+      if (!state) return;
+      if (state.step === 'results') renderResults();
+      else renderQuestion(state.step);
+    }
+
+    function renderQuestion(step) {
+      var q = QUESTIONS[step];
+      var selected = state.answers[q.field];
+      var isFirst = stepPosition(step) === 1;
+      var html = '';
+      html += '<p class="tf-progress">Pregunta ' + stepPosition(step) + ' de ' + stepTotal() + '</p>';
+      html += '<div class="tf-question">';
+      html += '<h3 tabindex="-1" id="tf-heading">' + escapeHtml(q.title) + '</h3>';
+      if (q.explainerWhen && selected === q.explainerWhen) {
+        html += '<div class="tf-explainer">' + q.explainer.map(function (e) {
+          return '<div><strong>' + escapeHtml(e.title) + '</strong> — ' + escapeHtml(e.text) + '</div>';
+        }).join('') + '</div>';
+      }
+      html += '<div class="tf-options" role="group" aria-label="' + escapeHtml(q.title) + '">';
+      html += q.options.map(function (opt) {
+        var pressed = selected === opt.value ? 'true' : 'false';
+        return '<button type="button" class="tf-option" data-field="' + escapeHtml(q.field) + '" data-value="' + escapeHtml(opt.value) + '" aria-pressed="' + pressed + '">' + escapeHtml(opt.label) + '</button>';
+      }).join('');
+      html += '</div></div>';
+      html += '<div class="tf-nav">';
+      html += '<button type="button" class="tf-back">' + (isFirst ? 'Cerrar' : '‹ Volver') + '</button>';
+      html += '<button type="button" class="tf-restart">Reiniciar</button>';
+      html += '</div>';
+      root.innerHTML = html;
+      bindNav();
+      var buttons = root.querySelectorAll('.tf-option');
+      for (var i = 0; i < buttons.length; i++) {
+        buttons[i].addEventListener('click', (function (btn) {
+          return function () { choose(btn.getAttribute('data-field'), btn.getAttribute('data-value')); };
+        })(buttons[i]));
+      }
+      focusHeading();
+    }
+
+    function renderResults() {
+      var ranked = rankCandidates(dataset, state.answers);
+      var html = '<div class="tf-results">';
+      if (ranked.length === 0) {
+        var message = buildNoResultsMessage(state.answers, pageUrl);
+        var href = waBase + encodeURIComponent(message);
+        html += '<h3 tabindex="-1" id="tf-heading">No encontramos ahora una coincidencia exacta.</h3>';
+        html += '<div class="tf-empty"><p>Podemos buscarla por encargo.</p>';
+        html += '<a class="tf-wa-cta" href="' + escapeHtml(href) + '" target="_blank" rel="noopener noreferrer">Pedí que te lo busquemos</a></div>';
+      } else {
+        html += '<h3 tabindex="-1" id="tf-heading">Encontramos ' + ranked.length + ' opci' + (ranked.length === 1 ? 'ón' : 'ones') + ' que coincide' + (ranked.length === 1 ? '' : 'n') + ' con lo que buscás</h3>';
+        html += '<div class="tf-results-grid">';
+        html += ranked.map(function (r) {
+          var candidate = r.candidate;
+          var ex = explainMatch(candidate, state.answers);
+          var priceText = Number(candidate.price || 0).toLocaleString('es-UY');
+          return '<article class="tf-result-card">' +
+            (candidate.image ? '<img src="' + escapeHtml(candidate.image) + '" alt="Portada de ' + escapeHtml(candidate.title) + '" loading="lazy" decoding="async">' : '') +
+            '<div class="tf-result-body">' +
+            (ex.badges.length ? '<div class="tf-result-badges">' + ex.badges.map(function (b) { return '<span>' + escapeHtml(b) + '</span>'; }).join('') + '</div>' : '') +
+            '<h4>' + escapeHtml(candidate.title) + '</h4>' +
+            (ex.sentence ? '<p class="tf-result-why">' + escapeHtml(ex.sentence) + '</p>' : '') +
+            '<p class="tf-result-price">$' + priceText + ' UYU</p>' +
+            '<a class="tf-result-cta" href="' + escapeHtml(candidate.href) + '">Ver mazo</a>' +
+            '</div></article>';
+        }).join('');
+        html += '</div>';
+      }
+      html += '<div class="tf-nav">';
+      html += '<button type="button" class="tf-back">‹ Volver</button>';
+      html += '<button type="button" class="tf-restart">Reiniciar</button>';
+      html += '</div></div>';
+      root.innerHTML = html;
+      bindNav();
+      focusHeading();
+    }
+
+    function bindNav() {
+      var back = root.querySelector('.tf-back');
+      var restartBtn = root.querySelector('.tf-restart');
+      if (back) back.addEventListener('click', goBack);
+      if (restartBtn) restartBtn.addEventListener('click', restart);
+    }
+
+    function focusHeading() {
+      var heading = document.getElementById('tf-heading');
+      if (heading) heading.focus();
+    }
+  }
+}());

--- a/docs/seo/tarot-accessories-audit-2026-08-21.md
+++ b/docs/seo/tarot-accessories-audit-2026-08-21.md
@@ -5,7 +5,7 @@ Alcance: sólo lectura sobre el catálogo real (activo + por encargo). No modifi
 
 ## Resultado
 
-**0 accesorios reales de tarot/esoterismo detectados en el catálogo actual.**
+**0 accesorios de tarot detectados con los criterios auditados en el catálogo actual.** (Conclusión operativa: no crear un módulo de Accesorios — ver sección final.)
 
 Verificado por **dos vías independientes**, con resultado idéntico:
 

--- a/docs/seo/tarot-accessories-audit-2026-08-21.md
+++ b/docs/seo/tarot-accessories-audit-2026-08-21.md
@@ -1,0 +1,33 @@
+# TAROT-ACCESSORIES-OPPORTUNITY-AUDIT-1 — auditoría de solo lectura
+
+Fecha: 2026-08-21
+Alcance: sólo lectura sobre el catálogo real (activo + por encargo). No modifica nada, no crea ningún módulo nuevo.
+
+## Resultado
+
+**0 accesorios reales de tarot/esoterismo detectados en el catálogo actual.**
+
+Verificado por **dos vías independientes**, con resultado idéntico:
+
+1. `functions/_shared/tarot-merch-tags.js` (TAROT-MERCH-TAGS-1): `primary_type === 'accesorio'` → **0** filas.
+2. Barrido manual independiente sobre catálogo activo (7.090 ítems) + índice pausado (10.097 ítems) descargados en vivo el 2026-08-21, buscando términos de accesorio real (`tapete`, `paño`, `bolsa`, `atril`, `soporte`, `vela ritual`, `sahumerio`, `incensario`, `funda`, `caja de madera`, `journal`, `cuaderno`, `bitácora`) con límite de palabra, intersectados con vocabulario tarot-adyacente (`tarot`, `oráculo`, `lenormand`, `kipper`, `cartomancia`) → **0** coincidencias.
+
+## Recordatorio metodológico (por qué el número es 0 y no un error)
+
+`estuche` **no** cuenta como accesorio: describe el embalaje del propio mazo ("Tarot Egipcio (estuche: 78 Cartas Y Libro)"), no un accesorio vendido aparte. Este criterio ya se verificó y corrigió durante TAROT-MERCH-TAGS-1 — la primera corrida de ese clasificador había detectado 17 "accesorios" que resultaron ser 100% mazos en caja, no accesorios reales (ver `docs/seo/tarot-merch-tags-audit-2026-08-20.md`, sección "Hallazgos y correcciones").
+
+## Falsos positivos descartados en esta corrida
+
+El barrido amplio inicial (sin exigir adyacencia a tarot) encontró 2.567 coincidencias de términos como "fund-" (de "Fundamentos", "Fundación" — no "funda"), "bitácora" en contextos ajenos (psicoanálisis, escuela), etc. — ninguno relacionado con tarot. Ejemplos reales descartados:
+
+| MLU | Título | Por qué se descarta |
+|---|---|---|
+| MLU612062955 | "Bitácora De Una Práctica Psicoanalítica Niños Adolescentes" | "bitácora" sin ningún vocabulario de tarot/oráculo en el título |
+| MLU624261887 | "Señales De Vida Una Bitácora De Escuela — Colección Del Melo" | ídem, contexto literario/escolar |
+| (múltiples) | Títulos con "Fundamentos", "Fundación" | coincidencia de substring con "funda" corregida exigiendo límite de palabra (`\bfunda\b`) |
+
+Ninguno de estos entró al conteo final porque el criterio real exige **coincidencia con vocabulario tarot-adyacente en el mismo título** — no un accesorio genérico de la librería.
+
+## Qué significa esto para el roadmap
+
+No hay hoy inventario real para justificar un módulo "Accesorios" dentro del Universo Tarot ni una landing dedicada. Si en el futuro Amado Libros suma este tipo de producto (tapetes, bolsas, atriles), el clasificador de TAROT-MERCH-TAGS-1 ya está preparado para detectarlo automáticamente en la próxima regeneración — no hace falta ningún cambio de código, sólo que el inventario exista.

--- a/docs/seo/tarot-b2b-blueprint-2026-08-21.md
+++ b/docs/seo/tarot-b2b-blueprint-2026-08-21.md
@@ -1,0 +1,62 @@
+# TAROT-B2B-BLUEPRINT-1 — diseño de flujo futuro (documento, sin implementar)
+
+Fecha: 2026-08-21
+Alcance: **sólo diseño**. No se publica ninguna funcionalidad, no se crea ninguna URL, no se toca checkout ni producción. Este documento es un blueprint para evaluar y priorizar más adelante, como lote independiente.
+
+## Problema que resolvería
+
+Amado Libros vende hoy tarot/oráculos exclusivamente a compradores individuales. Existe una demanda distinta y no atendida: docentes de tarot, coordinadores de talleres, terapeutas que usan cartas en consulta, o instituciones que necesitan **el mismo mazo repetido N veces** (para que cada alumno tenga el suyo) más bibliografía de acompañamiento. Es un patrón de compra distinto (cantidad fija, decisión no impulsiva, cotización antes que compra) que el checkout individual actual no está pensado para resolver bien.
+
+## Entrada propuesta
+
+Un CTA de bajo perfil, no intrusivo, en `/libros/esoterismo-tarot` (o eventualmente en un lugar más amplio del sitio si el patrón se confirma en otras categorías):
+
+> **¿Enseñás Tarot o coordinás un taller?**
+> Te ayudamos a conseguir varios mazos iguales y la bibliografía que necesites.
+> [Contanos qué necesitás]
+
+## Flujo (todo por WhatsApp, sin checkout mayorista nuevo)
+
+1. **Detección de intención**: el CTA es explícito y opt-in — nadie cae acá por accidente, a diferencia de una pregunta agregada al Finder (que es para compradores individuales y no debe mezclarse con este flujo, ver TAROT-FINDER-1 punto 9 "no mezclar cursos/B2B").
+2. **Formulario mínimo inline** (mismo patrón de interacción que el Finder: preguntas simples, sin backend nuevo), pidiendo sólo lo necesario para armar una cotización real:
+   - ¿Qué mazo(s) te interesan? (texto libre o selección desde el dataset ya existente del Finder/hub — reutilizable sin duplicar datos)
+   - Cantidad de mazos iguales necesarios
+   - ¿Necesitás bibliografía de acompañamiento? (sí/no + cuál, si lo sabe)
+   - ¿Cuándo lo necesitás? (para dimensionar si hay que pedir por encargo)
+3. **Salida**: WhatsApp prellenado con esas respuestas, reutilizando el mismo helper (`buildWhatsAppMessage`/`whatsappHref` de `shared/whatsapp-messages.js`) que ya usan el hub y el Finder — **cero URL ni número nuevo**, mismo canal humano de siempre.
+4. **Cotización y cierre**: 100% humano, por WhatsApp, como ya funciona hoy el resto del negocio. No hay checkout mayorista, no hay precio automático por volumen, no hay descuento programado — eso queda fuera de este blueprint hasta que haya evidencia de que vale la pena construirlo.
+
+## Ejemplo de mensaje generado (mismo formato que ya usa el Finder)
+
+```
+Hola, coordino un taller y quisiera cotizar varios mazos iguales 😊
+
+Motivo: Cotización para taller/grupo de estudio
+Situación: Mazo: Tarot Rider-Waite-Smith en español
+Cantidad: 12 mazos iguales
+Bibliografía: Sí, alguna guía de interpretación básica
+Cuándo: En 3 semanas
+
+Página: https://www.amadolibros.com/libros/esoterismo-tarot
+
+¿Podrían armarme una cotización? Gracias.
+```
+
+## Qué NO incluye este blueprint (deliberadamente)
+
+- Checkout mayorista o facturación distinta a la actual.
+- Precios diferenciados por volumen calculados automáticamente.
+- Un catálogo B2B separado o una URL nueva indexable.
+- Integración con el Finder de comprador individual — son intenciones distintas y mezclarlas confundiría a ambos públicos.
+- Cualquier publicación: esto es sólo un documento de diseño para revisar cuando se decida priorizarlo.
+
+## Señales que justificarían construirlo (gate de evidencia, mismo criterio que el resto del proyecto)
+
+No se debería implementar sin antes confirmar al menos una de estas señales reales:
+- Consultas de WhatsApp existentes que ya mencionen "taller", "docente", "grupo", "alumnos" en el contexto de tarot/oráculos (se podría auditar el historial de conversaciones si existe un registro, sin inventar el dato si no está disponible).
+- Volumen del Finder: si varias sesiones del selector individual terminan en "sin resultados" con patrones que sugieren compra grupal (cantidad alta, mismo mazo repetido), sería una señal indirecta real.
+- Pedido explícito de un cliente real pidiendo cotización grupal, documentado.
+
+## Riesgo si se implementara sin evidencia
+
+Construir un flujo B2B completo sin demanda confirmada es exactamente el tipo de "página/funcionalidad basura" que este proyecto evitó deliberadamente en cada lote anterior (hubs sin población suficiente, preguntas de estética sin taxonomía objetiva, etc.). Este blueprint queda documentado y listo, pero su implementación requiere el mismo tipo de gate de evidencia que ya se aplicó a "Lo más buscado" y a la decisión de no crear la landing de Veterinaria Equina.

--- a/docs/seo/tarot-b2b-blueprint-2026-08-21.md
+++ b/docs/seo/tarot-b2b-blueprint-2026-08-21.md
@@ -5,7 +5,7 @@ Alcance: **sólo diseño**. No se publica ninguna funcionalidad, no se crea ning
 
 ## Problema que resolvería
 
-Amado Libros vende hoy tarot/oráculos exclusivamente a compradores individuales. Existe una demanda distinta y no atendida: docentes de tarot, coordinadores de talleres, terapeutas que usan cartas en consulta, o instituciones que necesitan **el mismo mazo repetido N veces** (para que cada alumno tenga el suyo) más bibliografía de acompañamiento. Es un patrón de compra distinto (cantidad fija, decisión no impulsiva, cotización antes que compra) que el checkout individual actual no está pensado para resolver bien.
+El flujo web actual está orientado principalmente a compras individuales. Existe una posible necesidad B2B que conviene validar: docentes de tarot, coordinadores de talleres, terapeutas que usan cartas en consulta, o instituciones que podrían necesitar **el mismo mazo repetido N veces** (para que cada alumno tenga el suyo) más bibliografía de acompañamiento. Sería un patrón de compra distinto al individual (cantidad fija, decisión no impulsiva, cotización antes que compra) que el checkout actual no está pensado para resolver bien — pero esto es una hipótesis de diseño, no una demanda medida (ver sección de señales de evidencia más abajo).
 
 ## Entrada propuesta
 

--- a/functions/__tests__/tarot-finder-client.test.js
+++ b/functions/__tests__/tarot-finder-client.test.js
@@ -1,0 +1,290 @@
+// TAROT-FINDER-1 — ejecuta el archivo REAL astro-front/public/tarot-finder.js
+// dentro de un contexto vm.Node con un DOM mínimo simulado (sin jsdom, sin
+// bundler) para probar:
+//  - el flujo de estado real (FIX 1: "No estoy seguro/a" abre el
+//    explicador sin avanzar; FIX 2: "volver" desde resultados va a la
+//    última pregunta aplicable, nunca cierra salvo desde la primera;
+//    FIX 3: cambiar de sistema limpia deckFamily);
+//  - paridad servidor/cliente (FIX 5): compara pesos, hard constraints,
+//    límite de resultados y desempate del script cliente contra
+//    functions/_shared/tarot-finder-scoring.js, la implementación
+//    canónica y testeada aparte.
+//
+// window.__AmadoTarotFinderTestHooks es una superficie de sólo-test que
+// tarot-finder.js expone a propósito (ver comentario en ese archivo) —
+// nunca se usa desde el flujo real de la UI.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+import * as canonical from '../_shared/tarot-finder-scoring.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLIENT_SCRIPT_PATH = path.resolve(__dirname, '../../astro-front/public/tarot-finder.js');
+const CLIENT_SOURCE = readFileSync(CLIENT_SCRIPT_PATH, 'utf8');
+
+function loadClientHooks() {
+    const sandbox = {
+        document: {
+            readyState: 'complete',
+            addEventListener() {},
+            getElementById() { return null; },
+        },
+        window: {},
+        console,
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(CLIENT_SOURCE, sandbox, { filename: 'tarot-finder.js' });
+    const hooks = sandbox.window.__AmadoTarotFinderTestHooks;
+    assert.ok(hooks, 'tarot-finder.js no expuso window.__AmadoTarotFinderTestHooks — el harness no puede probar el archivo real');
+    return hooks;
+}
+
+function candidate(overrides = {}) {
+    return {
+        id: 'MLU1',
+        title: 'Mazo de prueba',
+        price: 2000,
+        image: 'https://example.com/x.jpg',
+        href: 'https://www.amadolibros.com/libro/MLU1/slug',
+        primary_type: 'tarot',
+        deck_family: null,
+        language: 'desconocido',
+        bundle: 'desconocido',
+        level: 'desconocido',
+        edition_style: null,
+        stock: 3,
+        ...overrides,
+    };
+}
+
+// ── FIX 1: "No estoy seguro/a" abre el explicador sin avanzar ───────────
+
+test('FIX 1: elegir "No estoy seguro/a" la primera vez permanece en la pregunta de sistema y abre el explicador', () => {
+    const hooks = loadClientHooks();
+    const state0 = hooks.initialFinderState();
+    assert.equal(state0.step, 'system');
+    assert.equal(state0.systemExplainerOpen, false);
+
+    const state1 = hooks.applyChoice(state0, 'system', 'unsure');
+    assert.equal(state1.step, 'system', 'sigue en la pregunta de sistema, no avanzó a "intent"');
+    assert.equal(state1.systemExplainerOpen, true, 'el explicador queda abierto');
+    assert.equal(state1.answers.system, undefined, 'todavía no se confirmó ninguna respuesta de sistema');
+});
+
+test('FIX 1: con el explicador abierto, elegir Tarot/Oráculo/Lenormand confirma esa respuesta y avanza', () => {
+    const hooks = loadClientHooks();
+    let state = hooks.applyChoice(hooks.initialFinderState(), 'system', 'unsure'); // abre explicador
+    state = hooks.applyChoice(state, 'system', 'oraculo');
+    assert.equal(state.answers.system, 'oraculo');
+    assert.equal(state.step, 'intent');
+    assert.equal(state.systemExplainerOpen, false);
+});
+
+test('FIX 1: "Seguir sin preferencia" (mismo value=unsure, con el explicador ya abierto) confirma unsure y avanza', () => {
+    const hooks = loadClientHooks();
+    let state = hooks.applyChoice(hooks.initialFinderState(), 'system', 'unsure'); // abre explicador
+    assert.equal(state.step, 'system');
+    state = hooks.applyChoice(state, 'system', 'unsure'); // "Seguir sin preferencia"
+    assert.equal(state.answers.system, 'unsure');
+    assert.equal(state.step, 'intent', 'ahora sí avanza');
+});
+
+test('FIX 1: elegir Tarot/Oráculo/Lenormand directamente (sin pasar por "no estoy seguro") avanza normal, sin explicador', () => {
+    const hooks = loadClientHooks();
+    const state = hooks.applyChoice(hooks.initialFinderState(), 'system', 'tarot');
+    assert.equal(state.answers.system, 'tarot');
+    assert.equal(state.step, 'intent');
+    assert.equal(state.systemExplainerOpen, false);
+});
+
+// ── FIX 2: "volver" desde resultados va a la última pregunta aplicable ──
+
+test('FIX 2: applyGoBack desde el sub-estado del explicador vuelve a la vista simple de la MISMA pregunta, no cierra', () => {
+    const hooks = loadClientHooks();
+    const explainerState = hooks.applyChoice(hooks.initialFinderState(), 'system', 'unsure');
+    const back = hooks.applyGoBack(explainerState);
+    assert.notEqual(back, null, 'no debe señalar "cerrar"');
+    assert.equal(back.step, 'system');
+    assert.equal(back.systemExplainerOpen, false);
+});
+
+test('FIX 2: applyGoBack desde la primera pregunta real (sin explicador) señala "cerrar" (null)', () => {
+    const hooks = loadClientHooks();
+    const result = hooks.applyGoBack(hooks.initialFinderState());
+    assert.equal(result, null);
+});
+
+test('FIX 2: prevStepFrom("results", answers) devuelve la última pregunta aplicable (guide), nunca cierra', () => {
+    const hooks = loadClientHooks();
+    assert.equal(hooks.prevStepFrom('results', { system: 'tarot' }), 'guide');
+    assert.equal(hooks.prevStepFrom('results', { system: 'oraculo' }), 'guide');
+});
+
+test('FIX 2: recorrido completo hasta resultados y "volver" aterriza en guide, no cierra ni salta preguntas', () => {
+    const hooks = loadClientHooks();
+    let state = hooks.initialFinderState();
+    state = hooks.applyChoice(state, 'system', 'tarot');
+    state = hooks.applyChoice(state, 'intent', 'sin_preferencia');
+    state = hooks.applyChoice(state, 'deckFamily', 'no_preference');
+    state = hooks.applyChoice(state, 'language', 'no_preference');
+    state = hooks.applyChoice(state, 'guide', 'no_importante');
+    assert.equal(state.step, 'results');
+
+    const back = hooks.applyGoBack(state);
+    assert.notEqual(back, null);
+    assert.equal(back.step, 'guide');
+    assert.equal(back.answers.system, 'tarot', 'las respuestas previas se conservan al volver');
+});
+
+test('FIX 2: "cerrar" ocurre únicamente desde la primera pregunta (idx 0, sin explicador) — cualquier otro paso vuelve a la pregunta anterior', () => {
+    const hooks = loadClientHooks();
+    let state = hooks.applyChoice(hooks.initialFinderState(), 'system', 'tarot');
+    // en "intent" (segunda pregunta real): volver debe ir a "system", no cerrar
+    const back = hooks.applyGoBack(state);
+    assert.notEqual(back, null);
+    assert.equal(back.step, 'system');
+});
+
+// ── FIX 3: cambiar de sistema limpia deckFamily ──────────────────────────
+
+test('FIX 3: Tarot -> Rider-Waite-Smith -> volver a "system" y elegir Oráculo elimina deckFamily', () => {
+    const hooks = loadClientHooks();
+    let state = hooks.applyChoice(hooks.initialFinderState(), 'system', 'tarot');
+    state = hooks.applyChoice(state, 'intent', 'sin_preferencia');
+    state = hooks.applyChoice(state, 'deckFamily', 'rider_waite_smith');
+    assert.equal(state.answers.deckFamily, 'rider_waite_smith');
+
+    // el usuario vuelve dos preguntas (deckFamily -> intent -> system) y cambia el sistema
+    state = hooks.applyChoice(state, 'system', 'oraculo');
+    assert.equal(state.answers.deckFamily, undefined, 'deckFamily debe desaparecer: oráculo no tiene familias de tarot');
+    assert.equal(state.answers.system, 'oraculo');
+});
+
+test('FIX 3: Tarot -> Marsella -> Lenormand elimina deckFamily', () => {
+    const hooks = loadClientHooks();
+    let state = hooks.applyChoice(hooks.initialFinderState(), 'system', 'tarot');
+    state = hooks.applyChoice(state, 'deckFamily', 'marsella');
+    assert.equal(state.answers.deckFamily, 'marsella');
+    state = hooks.applyChoice(state, 'system', 'lenormand');
+    assert.equal(state.answers.deckFamily, undefined);
+});
+
+test('FIX 3: Tarot -> Thoth -> volver a "system" -> "no estoy seguro" (unsure) elimina deckFamily', () => {
+    const hooks = loadClientHooks();
+    // Simula al usuario de vuelta en la pregunta de sistema (vía
+    // applyGoBack repetido en la app real) ya con tarot+thoth elegidos.
+    const stateAtSystem = { step: 'system', answers: { system: 'tarot', deckFamily: 'thoth' }, systemExplainerOpen: false };
+
+    // Primer click en "No estoy seguro/a": sólo abre el explicador — la
+    // respuesta anterior (deckFamily) NO se toca todavía, nada se confirmó.
+    let state = hooks.applyChoice(stateAtSystem, 'system', 'unsure');
+    assert.equal(state.step, 'system');
+    assert.equal(state.systemExplainerOpen, true);
+    assert.equal(state.answers.deckFamily, 'thoth', 'con el explicador recién abierto, todavía no se confirmó ningún cambio');
+
+    // "Seguir sin preferencia" confirma unsure recién acá.
+    state = hooks.applyChoice(state, 'system', 'unsure');
+    assert.equal(state.answers.system, 'unsure');
+    assert.equal(state.answers.deckFamily, undefined, 'deckFamily eliminado al confirmar unsure');
+});
+
+test('FIX 3: los tres casos siguen devolviendo candidatos válidos cuando existen (deckFamily ya no restringe indebidamente)', () => {
+    const hooks = loadClientHooks();
+    const dataset = [
+        candidate({ id: 'A', primary_type: 'oraculo' }),
+        candidate({ id: 'B', primary_type: 'lenormand' }),
+        candidate({ id: 'C', primary_type: 'tarot', deck_family: 'marsella' }), // no debería aparecer bajo answers sin deckFamily exigido si no matchea sistema
+    ];
+    const oraculoAnswers = { system: 'oraculo' }; // deckFamily ya fue eliminado por FIX 3
+    const ranked = hooks.rankCandidates(dataset, oraculoAnswers);
+    assert.deepEqual(ranked.map(r => r.candidate.id), ['A'], 'sin deckFamily colgado, el oráculo real aparece');
+});
+
+// ── FIX 5: paridad servidor/cliente — mismos pesos, mismas reglas ───────
+
+test('FIX 5: los pesos de score del cliente coinciden exactamente con los del módulo canónico', () => {
+    const hooks = loadClientHooks();
+    // hooks.SCORE se construyó dentro del vm.context (otro "realm" de JS) —
+    // JSON.stringify compara estructura/valores, no identidad de prototipo
+    // (deepStrictEqual fallaría entre realms distintos aunque los datos
+    // sean idénticos; ver también los otros dos usos abajo).
+    assert.equal(JSON.stringify(hooks.SCORE), JSON.stringify(canonical.SCORE_WEIGHTS));
+});
+
+test('FIX 5: el límite de resultados del cliente coincide con el del módulo canónico (6)', () => {
+    const hooks = loadClientHooks();
+    assert.equal(hooks.MAX_RESULTS, 6);
+});
+
+test('FIX 5: passesHard del cliente coincide con passesHardConstraints canónico en una batería de casos', () => {
+    const hooks = loadClientHooks();
+    const cases = [
+        [candidate({ primary_type: 'tarot' }), { system: 'tarot' }],
+        [candidate({ primary_type: 'lenormand' }), { system: 'tarot' }],
+        [candidate({ language: 'desconocido' }), { language: 'espanol' }],
+        [candidate({ language: 'espanol' }), { language: 'espanol' }],
+        [candidate({ bundle: 'desconocido' }), { guide: 'si' }],
+        [candidate({ bundle: 'mazo_mas_guia' }), { guide: 'si' }],
+        [candidate({ deck_family: 'thoth' }), { system: 'tarot', deckFamily: 'rider_waite_smith' }],
+        [candidate({}), {}],
+    ];
+    for (const [c, answers] of cases) {
+        assert.equal(hooks.passesHard(c, answers), canonical.passesHardConstraints(c, answers), JSON.stringify({ c, answers }));
+    }
+});
+
+test('FIX 5: rankCandidates del cliente produce el MISMO orden y los mismos scores que rankTarotFinderCandidates canónico', () => {
+    const hooks = loadClientHooks();
+    const dataset = [
+        candidate({ id: 'A', level: 'principiante', stock: 1, price: 3000 }),
+        candidate({ id: 'B', stock: 10, price: 1000 }),
+        candidate({ id: 'C', stock: 10, price: 500 }),
+        candidate({ id: 'D', bundle: 'mazo_mas_guia', stock: 2, price: 2000 }),
+        candidate({ id: 'E', primary_type: 'oraculo' }),
+    ];
+    const scenarios = [
+        {},
+        { system: 'tarot' },
+        { intent: 'primer_mazo' },
+        { intent: 'estudiar', guide: 'no_importante' },
+        { system: 'oraculo' },
+    ];
+    for (const answers of scenarios) {
+        const clientRanked = hooks.rankCandidates(dataset, answers).map(r => ({ id: r.candidate.id, score: r.score }));
+        const serverRanked = canonical.rankTarotFinderCandidates(dataset, answers).map(r => ({ id: r.candidate.id, score: r.score }));
+        assert.deepEqual(clientRanked, serverRanked, `orden/score distinto para answers=${JSON.stringify(answers)}`);
+    }
+});
+
+test('FIX 5: explainMatch del cliente produce las mismas badges y sentence que explainMatch canónico', () => {
+    const hooks = loadClientHooks();
+    const c = candidate({ primary_type: 'tarot', deck_family: 'rider_waite_smith', language: 'espanol', bundle: 'mazo_mas_guia' });
+    const answers = { system: 'tarot', deckFamily: 'rider_waite_smith', language: 'espanol', guide: 'si' };
+    // JSON.stringify por la misma razón de realms distintos (ver arriba).
+    assert.equal(JSON.stringify(hooks.explainMatch(c, answers)), JSON.stringify(canonical.explainMatch(c, answers)));
+});
+
+test('FIX 5: buildNoResultsMessage del cliente y buildFinderNoResultsMessage canónico producen el mismo texto', async () => {
+    const hooks = loadClientHooks();
+    const { buildWhatsAppMessage } = await import('../../shared/whatsapp-messages.js');
+    const answers = { system: 'tarot', deckFamily: 'rider_waite_smith', language: 'ingles', guide: 'si', intent: 'experiencia' };
+    const page = 'https://www.amadolibros.com/libros/esoterismo-tarot';
+    const clientMessage = hooks.buildNoResultsMessage(answers, page);
+    const serverMessage = canonical.buildFinderNoResultsMessage(answers, { buildWhatsAppMessage, page });
+    assert.equal(clientMessage, serverMessage);
+});
+
+// ── FIX 4: sin aria-haspopup (verificado también en tarot-finder-render.test.js sobre el HTML SSR) ──
+
+test('FIX 4: el HTML de las preguntas nunca declara aria-haspopup (el Finder es inline, no un popup/menú/diálogo)', () => {
+    const hooks = loadClientHooks();
+    // No hay render() ejecutable sin DOM real acá (ver
+    // tarot-finder-render.test.js para la verificación end-to-end del
+    // botón "Empezar" en el HTML servidor); esta prueba deja constancia de
+    // que ningún string del propio archivo fuente contiene aria-haspopup.
+    assert.doesNotMatch(CLIENT_SOURCE, /aria-haspopup/);
+});

--- a/functions/__tests__/tarot-finder-dataset.test.js
+++ b/functions/__tests__/tarot-finder-dataset.test.js
@@ -1,0 +1,166 @@
+// TAROT-FINDER-1 — dataset compacto para el cliente. Cubre: 14. sólo
+// activos/stock, y 18. sin campos innecesarios + guard de tamaño.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildTarotFinderDataset } from '../_shared/tarot-finder-dataset.js';
+
+function item(id, overrides = {}) {
+  return { id, title: `Item ${id}`, price: 2000, status: 'active', available_quantity: 3, ...overrides };
+}
+
+function tag(overrides = {}) {
+  return {
+    primary_type: 'tarot',
+    deck_family: null,
+    format: 'mazo',
+    bundle: 'desconocido',
+    level: 'desconocido',
+    language: 'desconocido',
+    edition_style: null,
+    ...overrides,
+  };
+}
+
+const imageForId = id => `https://images.example.com/${id}.jpg`;
+const hrefForItem = it => `https://www.amadolibros.com/libro/${it.id}/slug`;
+
+test('incluye un candidato válido con exactamente los campos esperados, nada más', () => {
+  const dataset = buildTarotFinderDataset({
+    items: [item('MLU1')],
+    tagLookup: () => tag(),
+    imageForId,
+    hrefForItem,
+  });
+  assert.equal(dataset.length, 1);
+  assert.deepEqual(Object.keys(dataset[0]).sort(), [
+    'bundle', 'deck_family', 'edition_style', 'href', 'id', 'image', 'language',
+    'level', 'price', 'primary_type', 'stock', 'title',
+  ].sort());
+});
+
+// ── 14. Sólo activos con stock ────────────────────────────────────────────
+
+test('14. excluye items pausados', () => {
+  const dataset = buildTarotFinderDataset({
+    items: [item('MLU1', { status: 'paused' })],
+    tagLookup: () => tag(),
+    imageForId,
+    hrefForItem,
+  });
+  assert.equal(dataset.length, 0);
+});
+
+test('14b. excluye items activos sin stock', () => {
+  const dataset = buildTarotFinderDataset({
+    items: [item('MLU1', { available_quantity: 0 })],
+    tagLookup: () => tag(),
+    imageForId,
+    hrefForItem,
+  });
+  assert.equal(dataset.length, 0);
+});
+
+test('14c. excluye items con precio inválido (0, negativo o no numérico)', () => {
+  const dataset = buildTarotFinderDataset({
+    items: [item('MLU1', { price: 0 }), item('MLU2', { price: null }), item('MLU3', { price: -5 })],
+    tagLookup: () => tag(),
+    imageForId,
+    hrefForItem,
+  });
+  assert.equal(dataset.length, 0);
+});
+
+test('excluye accesorios y libros sobre tarot — el Finder busca un mazo', () => {
+  const dataset = buildTarotFinderDataset({
+    items: [item('MLU1'), item('MLU2'), item('MLU3')],
+    tagLookup: (id) => {
+      if (id === 'MLU1') return tag({ primary_type: 'accesorio', format: 'accesorio' });
+      if (id === 'MLU2') return tag({ primary_type: 'tarot', format: 'libro' });
+      return tag({ primary_type: 'tarot', format: 'mazo' });
+    },
+    imageForId,
+    hrefForItem,
+  });
+  assert.deepEqual(dataset.map(d => d.id), ['MLU3']);
+});
+
+test('excluye items sin clasificación (tagLookup devuelve null)', () => {
+  const dataset = buildTarotFinderDataset({
+    items: [item('MLU1')],
+    tagLookup: () => null,
+    imageForId,
+    hrefForItem,
+  });
+  assert.equal(dataset.length, 0);
+});
+
+test('excluye primary_type=otro_sistema y desconocido — el Finder es sólo tarot/oráculo/lenormand/kipper', () => {
+  const dataset = buildTarotFinderDataset({
+    items: [item('MLU1'), item('MLU2')],
+    tagLookup: (id) => tag({ primary_type: id === 'MLU1' ? 'otro_sistema' : 'desconocido' }),
+    imageForId,
+    hrefForItem,
+  });
+  assert.equal(dataset.length, 0);
+});
+
+test('no duplica un id repetido en items', () => {
+  const dataset = buildTarotFinderDataset({
+    items: [item('MLU1'), item('MLU1')],
+    tagLookup: () => tag(),
+    imageForId,
+    hrefForItem,
+  });
+  assert.equal(dataset.length, 1);
+});
+
+test('el href de cada candidato viene del inyectado hrefForItem, nunca reconstruido acá', () => {
+  const dataset = buildTarotFinderDataset({
+    items: [item('MLU1')],
+    tagLookup: () => tag(),
+    imageForId,
+    hrefForItem: () => 'https://www.amadolibros.com/libro/MLU1/titulo-exacto',
+  });
+  assert.equal(dataset[0].href, 'https://www.amadolibros.com/libro/MLU1/titulo-exacto');
+});
+
+test('valida tipos de entrada', () => {
+  assert.throws(() => buildTarotFinderDataset({ items: 'no-array', tagLookup: () => null, imageForId, hrefForItem }), /items debe ser un array/);
+  assert.throws(() => buildTarotFinderDataset({ items: [], tagLookup: null, imageForId, hrefForItem }), /tagLookup debe ser una función/);
+  assert.throws(() => buildTarotFinderDataset({ items: [], tagLookup: () => null, imageForId: null, hrefForItem }), /imageForId debe ser una función/);
+  assert.throws(() => buildTarotFinderDataset({ items: [], tagLookup: () => null, imageForId, hrefForItem: null }), /hrefForItem debe ser una función/);
+});
+
+// ── 18. Tamaño del payload — guard contra crecimiento accidental ────────
+
+test('18. el dataset serializado se mantiene liviano por candidato (guard de tamaño)', () => {
+  const items = Array.from({ length: 200 }, (_, i) => item(`MLU${1000 + i}`, {
+    title: 'Un Título De Mazo Razonablemente Largo Con Autor Incluido',
+  }));
+  const dataset = buildTarotFinderDataset({
+    items,
+    tagLookup: () => tag({ deck_family: 'rider_waite_smith', language: 'espanol', bundle: 'mazo_mas_guia', edition_style: 'ilustrada_especial' }),
+    imageForId,
+    hrefForItem: it => `https://www.amadolibros.com/libro/${it.id}/un-titulo-de-mazo-razonablemente-largo-con-autor-incluido`,
+  });
+  const json = JSON.stringify(dataset);
+  const bytesPerCandidate = json.length / dataset.length;
+  // Guard conservador: si esto falla, alguien agregó un campo pesado
+  // (descripción completa, galería de imágenes, etc.) sin querer.
+  assert.ok(bytesPerCandidate < 450, `cada candidato pesa ${bytesPerCandidate.toFixed(1)} bytes en JSON, se esperaba <450`);
+  // Con el universo real actual (~190 candidatos), el payload total debe
+  // quedar muy por debajo de 120KB — cómodo para mobile.
+  assert.ok(json.length < 120_000, `el dataset completo pesa ${json.length} bytes, se esperaba <120000`);
+});
+
+test('18b. el dataset nunca incluye description ni pictures/galería completa', () => {
+  const dataset = buildTarotFinderDataset({
+    items: [item('MLU1', { description: 'Un texto muy largo '.repeat(50), pictures: ['a', 'b', 'c', 'd', 'e'] })],
+    tagLookup: () => tag(),
+    imageForId,
+    hrefForItem,
+  });
+  assert.ok(!('description' in dataset[0]));
+  assert.ok(!('pictures' in dataset[0]));
+});

--- a/functions/__tests__/tarot-finder-render.test.js
+++ b/functions/__tests__/tarot-finder-render.test.js
@@ -1,0 +1,228 @@
+// TAROT-FINDER-1 — tests de render sobre el HTML real que devuelve
+// functions/libros/[[path]].js: un solo H1, sin canonical/URLs nuevas,
+// robots intactos, el resto de categorías no lleva Finder, "Ver todo"
+// sigue presente, y la página es usable sin JavaScript.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { onRequest as categoryRequest } from '../libros/[[path]].js';
+import {
+    CATALOG_URL,
+    PAUSED_MANIFEST_URL,
+    PRODUCTION_MANIFEST_URL,
+} from '../_shared/catalog.js';
+import { SEO_CATEGORIES } from '../_shared/seo-categories.js';
+import { TAROT_MERCH_TAGS } from '../_shared/tarot-merch-tags.js';
+
+// MLU real y estable del artefacto TAROT-MERCH-TAGS-1 (tarot, Marsella,
+// mazo_mas_guia) — se usa como fixture para que buildTarotFinderDataset()
+// tenga al menos un candidato real y el Finder efectivamente renderice.
+// Si algún día este MLU deja de existir/clasificar así, el test explícito
+// de abajo lo va a decir con un mensaje claro en vez de fallar en silencio.
+const REAL_TAROT_MLU = 'MLU1418182736';
+const realTag = TAROT_MERCH_TAGS.find(row => row.id === REAL_TAROT_MLU);
+
+test('fixture: el MLU real usado en estos tests sigue clasificado como mazo de tarot activo', () => {
+    assert.ok(realTag, `${REAL_TAROT_MLU} ya no existe en TAROT_MERCH_TAGS — actualizar el fixture de tarot-finder-render.test.js`);
+    assert.equal(realTag.primary_type, 'tarot');
+    assert.equal(realTag.format, 'mazo');
+});
+
+const ITEMS = SEO_CATEGORIES.map((category, index) => {
+    if (category.id === 'esoterismo-tarot') {
+        return {
+            id: REAL_TAROT_MLU,
+            title: 'Tarot de Marsella de prueba',
+            author: null,
+            price: 2200,
+            status: 'active',
+            available_quantity: 3,
+            thumbnail: 'https://images.example/tarot.jpg',
+            pictures: [],
+            start_time: '2026-07-01T00:00:00Z',
+        };
+    }
+    return {
+        id: `MLU${index + 1}`,
+        title: `Libro de prueba ${category.name}`,
+        author: `Autor ${index + 1}`,
+        price: 1000 + index,
+        status: 'active',
+        available_quantity: 2,
+        thumbnail: `https://images.example/${index + 1}.jpg`,
+        pictures: [],
+        start_time: '2026-07-01T00:00:00Z',
+    };
+});
+
+const CATEGORY_DATA = {
+    categories: SEO_CATEGORIES.map(category => ({
+        id: category.id,
+        name: category.name,
+        count: 1,
+        subcategories: [],
+    })),
+    // ITEMS[index] corresponde siempre a SEO_CATEGORIES[index] — mismo
+    // orden de construcción arriba, así que el mapeo id->categoría es
+    // directo por índice.
+    items: Object.fromEntries(
+        ITEMS.map((item, index) => [item.id, [SEO_CATEGORIES[index].id]]),
+    ),
+};
+
+function context(path, appEnv = 'production', search = '') {
+    return {
+        request: new Request(`https://${appEnv === 'preview' ? 'preview.example' : 'www.amadolibros.com'}/libros/${path}${search}`),
+        params: { path: path ? [path] : [] },
+        env: { APP_ENV: appEnv },
+        data: {},
+        waitUntil() {},
+    };
+}
+
+test.beforeEach(() => {
+    globalThis.caches = {
+        default: {
+            async match(request) {
+                if (request.url.endsWith('/data/active-categories.json')) {
+                    return Response.json(CATEGORY_DATA);
+                }
+                if (request.url === CATALOG_URL) {
+                    return Response.json({ total: ITEMS.length, items: ITEMS });
+                }
+                if ([PRODUCTION_MANIFEST_URL, PAUSED_MANIFEST_URL].includes(request.url)) {
+                    return Response.json({ schema_version: 0 });
+                }
+                return null;
+            },
+            async put() {},
+        },
+    };
+});
+
+async function html(path, appEnv = 'production', search = '') {
+    const response = await categoryRequest(context(path, appEnv, search));
+    return { response, html: await response.text() };
+}
+
+// ── Un solo H1 ────────────────────────────────────────────────────────────
+
+test('la página de esoterismo-tarot con Finder tiene exactamente un <h1>', async () => {
+    const { html: body } = await html('esoterismo-tarot');
+    const h1Count = (body.match(/<h1[ >]/g) || []).length;
+    assert.equal(h1Count, 1, 'el CTA "Encontrá tu mazo" usa <h2>, no <h1> — el único <h1> sigue siendo el de la categoría');
+    assert.match(body, /<h1>Libros de esoterismo y tarot en Uruguay<\/h1>/);
+});
+
+// ── Sin canonical ni URLs indexables nuevas ──────────────────────────────
+
+test('el Finder no introduce un canonical nuevo: sigue siendo exactamente /libros/esoterismo-tarot', async () => {
+    const { html: body } = await html('esoterismo-tarot');
+    const canonicals = [...body.matchAll(/<link rel="canonical" href="([^"]+)">/g)].map(m => m[1]);
+    assert.deepEqual(canonicals, ['https://www.amadolibros.com/libros/esoterismo-tarot']);
+});
+
+test('el Finder no introduce ningún <a href> a rutas propias (/tarot-finder/, /tarot/, querystrings de respuestas)', async () => {
+    const { html: body } = await html('esoterismo-tarot');
+    const hrefs = [...body.matchAll(/href="([^"]+)"/g)].map(m => m[1]);
+    for (const href of hrefs) {
+        assert.doesNotMatch(href, /\/tarot-finder\//, `href indexable inesperado: ${href}`);
+        assert.doesNotMatch(href, /\/tarot\/(rider-waite|marsella|lenormand|thoth)/, `href indexable inesperado: ${href}`);
+        assert.doesNotMatch(href, /\?(sistema|idioma|guia|tradicion|experiencia)=/, `querystring de respuestas indexable: ${href}`);
+    }
+});
+
+test('el dataset del Finder viaja embebido en un <script type="application/json">, no en una URL propia', async () => {
+    const { html: body } = await html('esoterismo-tarot');
+    assert.match(body, /<script type="application\/json" id="tarot-finder-dataset">/);
+    // Nunca un <link> ni un fetch a un endpoint /api/tarot-finder o similar.
+    assert.doesNotMatch(body, /\/api\/tarot-finder/);
+});
+
+// ── Robots intactos en Preview ────────────────────────────────────────────
+
+test('robots de Preview siguen noindex,follow con el Finder presente', async () => {
+    const { html: body } = await html('esoterismo-tarot', 'preview');
+    assert.match(body, /<meta name="robots" content="noindex, follow">/);
+});
+
+test('robots en producción siguen index,follow con el Finder presente', async () => {
+    const { html: body } = await html('esoterismo-tarot', 'production');
+    assert.match(body, /<meta name="robots" content="index, follow">/);
+});
+
+// ── El resto de categorías no lleva Finder ───────────────────────────────
+
+test('ninguna categoría distinta de esoterismo-tarot incluye el Finder', async () => {
+    for (const category of SEO_CATEGORIES) {
+        if (category.id === 'esoterismo-tarot') continue;
+        const { html: body } = await html(category.id);
+        assert.doesNotMatch(body, /id="tarot-finder-cta"/, category.id);
+        assert.doesNotMatch(body, /tarot-finder\.js/, category.id);
+        assert.doesNotMatch(body, /tarot-finder-dataset/, category.id);
+    }
+});
+
+// ── "Ver todo" sigue presente ────────────────────────────────────────────
+
+test('"Ver todo" (la grilla paginada existente) sigue presente y funcional con el Finder activo', async () => {
+    const { html: body } = await html('esoterismo-tarot');
+    assert.match(body, /<h2>Ver todo<\/h2>/);
+    assert.match(body, /<section class="books-grid"/);
+});
+
+// ── Funciona sin JavaScript ───────────────────────────────────────────────
+
+test('sin JS: el CTA "Empezar" es un <button> real (no depende de un href de JS) y hay un <noscript> con salida por WhatsApp', async () => {
+    const { html: body } = await html('esoterismo-tarot');
+    assert.match(body, /<button type="button" id="tarot-finder-start"/);
+    assert.match(body, /<noscript>[\s\S]*wa\.me\/59899841325[\s\S]*<\/noscript>/);
+});
+
+test('sin JS: el resto de módulos, WhatsApp flotante y footer están en el HTML servidor, no dependen de tarot-finder.js', async () => {
+    const { html: body } = await html('esoterismo-tarot');
+    assert.match(body, /class="wa-float"/, 'el flotante de WhatsApp ya viene renderizado por el servidor');
+    assert.match(body, /Amado Libros/); // footer
+    assert.match(body, /id="tarot-finder-app" hidden/, 'el contenedor del Finder arranca oculto en el HTML crudo, sin esperar a JS para no mostrarse roto');
+});
+
+test('el script /tarot-finder.js se carga con defer, nunca bloqueante', async () => {
+    const { html: body } = await html('esoterismo-tarot');
+    assert.match(body, /<script src="\/tarot-finder\.js" defer><\/script>/);
+});
+
+// ── Sin candidatos reales, el Finder no aparece (mismo criterio que los módulos merchandising) ──
+
+test('si el universo de esoterismo-tarot no tiene ningún candidato clasificado, el Finder no se renderiza', async () => {
+    // Reusa el harness genérico (sin el MLU real fijado) para simular el
+    // caso "0 candidatos": ningún id sintético matchea TAROT_MERCH_TAGS.
+    const genericItems = SEO_CATEGORIES.map((category, index) => ({
+        id: `MLU${900 + index}`,
+        title: `Libro genérico ${category.name}`,
+        author: null,
+        price: 1500,
+        status: 'active',
+        available_quantity: 2,
+        thumbnail: '',
+        pictures: [],
+        start_time: '2026-07-01T00:00:00Z',
+    }));
+    const genericCategoryData = {
+        categories: SEO_CATEGORIES.map(category => ({ id: category.id, name: category.name, count: 1, subcategories: [] })),
+        items: Object.fromEntries(genericItems.map((item, index) => [item.id, [SEO_CATEGORIES[index].id]])),
+    };
+    globalThis.caches = {
+        default: {
+            async match(request) {
+                if (request.url.endsWith('/data/active-categories.json')) return Response.json(genericCategoryData);
+                if (request.url === CATALOG_URL) return Response.json({ total: genericItems.length, items: genericItems });
+                if ([PRODUCTION_MANIFEST_URL, PAUSED_MANIFEST_URL].includes(request.url)) return Response.json({ schema_version: 0 });
+                return null;
+            },
+            async put() {},
+        },
+    };
+    const response = await categoryRequest(context('esoterismo-tarot'));
+    const body = await response.text();
+    assert.doesNotMatch(body, /id="tarot-finder-cta"/);
+    assert.doesNotMatch(body, /tarot-finder\.js/);
+});

--- a/functions/__tests__/tarot-finder-render.test.js
+++ b/functions/__tests__/tarot-finder-render.test.js
@@ -178,6 +178,11 @@ test('sin JS: el CTA "Empezar" es un <button> real (no depende de un href de JS)
     assert.match(body, /<noscript>[\s\S]*wa\.me\/59899841325[\s\S]*<\/noscript>/);
 });
 
+test('FIX 4: el botón "Empezar" no declara aria-haspopup — el Finder se expande inline, no abre popup/menú/diálogo', async () => {
+    const { html: body } = await html('esoterismo-tarot');
+    assert.doesNotMatch(body, /aria-haspopup/);
+});
+
 test('sin JS: el resto de módulos, WhatsApp flotante y footer están en el HTML servidor, no dependen de tarot-finder.js', async () => {
     const { html: body } = await html('esoterismo-tarot');
     assert.match(body, /class="wa-float"/, 'el flotante de WhatsApp ya viene renderizado por el servidor');

--- a/functions/__tests__/tarot-finder-scoring.test.js
+++ b/functions/__tests__/tarot-finder-scoring.test.js
@@ -1,0 +1,285 @@
+// TAROT-FINDER-1 — lógica pura de filtrado (hard) y scoring (soft).
+// Cubre exactamente los 18 puntos pedidos (17 acá, el de tamaño del
+// dataset vive en tarot-finder-dataset.test.js).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildFinderNoResultsMessage,
+  explainMatch,
+  passesHardConstraints,
+  rankTarotFinderCandidates,
+  scoreTarotFinderCandidate,
+  SCORE_WEIGHTS,
+} from '../_shared/tarot-finder-scoring.js';
+import { buildWhatsAppMessage } from '../../shared/whatsapp-messages.js';
+
+function candidate(overrides = {}) {
+  return {
+    id: 'MLU1',
+    title: 'Mazo de prueba',
+    price: 2000,
+    image: 'https://example.com/x.jpg',
+    primary_type: 'tarot',
+    deck_family: null,
+    language: 'desconocido',
+    bundle: 'desconocido',
+    level: 'desconocido',
+    edition_style: null,
+    stock: 3,
+    ...overrides,
+  };
+}
+
+// ── 1-3. Separación de sistemas ──────────────────────────────────────────
+
+test('1. Tarot nunca devuelve Lenormand cuando el sistema es obligatorio', () => {
+  const candidates = [candidate({ id: 'A', primary_type: 'tarot' }), candidate({ id: 'B', primary_type: 'lenormand' })];
+  const ranked = rankTarotFinderCandidates(candidates, { system: 'tarot' });
+  assert.deepEqual(ranked.map(r => r.candidate.id), ['A']);
+});
+
+test('2. Oráculo nunca devuelve Tarot cuando el tipo es obligatorio', () => {
+  const candidates = [candidate({ id: 'A', primary_type: 'tarot' }), candidate({ id: 'B', primary_type: 'oraculo' })];
+  const ranked = rankTarotFinderCandidates(candidates, { system: 'oraculo' });
+  assert.deepEqual(ranked.map(r => r.candidate.id), ['B']);
+});
+
+test('3. Lenormand se conserva como sistema propio, no colapsa con tarot ni oráculo', () => {
+  const candidates = [
+    candidate({ id: 'A', primary_type: 'tarot' }),
+    candidate({ id: 'B', primary_type: 'oraculo' }),
+    candidate({ id: 'C', primary_type: 'lenormand' }),
+  ];
+  const ranked = rankTarotFinderCandidates(candidates, { system: 'lenormand' });
+  assert.deepEqual(ranked.map(r => r.candidate.id), ['C']);
+});
+
+test('sin preferencia de sistema ("unsure"), Kipper puede aparecer entre los candidatos', () => {
+  const candidates = [candidate({ id: 'A', primary_type: 'tarot' }), candidate({ id: 'B', primary_type: 'kipper' })];
+  const ranked = rankTarotFinderCandidates(candidates, { system: 'unsure' });
+  assert.deepEqual(new Set(ranked.map(r => r.candidate.id)), new Set(['A', 'B']));
+});
+
+// ── 4-6. Familia exacta ───────────────────────────────────────────────────
+
+test('4. Rider-Waite-Smith exacto: no acepta Marsella ni Thoth ni sin-familia', () => {
+  const candidates = [
+    candidate({ id: 'A', deck_family: 'rider_waite_smith' }),
+    candidate({ id: 'B', deck_family: 'marsella' }),
+    candidate({ id: 'C', deck_family: 'thoth' }),
+    candidate({ id: 'D', deck_family: null }),
+  ];
+  const ranked = rankTarotFinderCandidates(candidates, { system: 'tarot', deckFamily: 'rider_waite_smith' });
+  assert.deepEqual(ranked.map(r => r.candidate.id), ['A']);
+});
+
+test('5. Marsella exacto', () => {
+  const candidates = [
+    candidate({ id: 'A', deck_family: 'rider_waite_smith' }),
+    candidate({ id: 'B', deck_family: 'marsella' }),
+  ];
+  const ranked = rankTarotFinderCandidates(candidates, { system: 'tarot', deckFamily: 'marsella' });
+  assert.deepEqual(ranked.map(r => r.candidate.id), ['B']);
+});
+
+test('6. Thoth exacto', () => {
+  const candidates = [
+    candidate({ id: 'A', deck_family: 'marsella' }),
+    candidate({ id: 'B', deck_family: 'thoth' }),
+  ];
+  const ranked = rankTarotFinderCandidates(candidates, { system: 'tarot', deckFamily: 'thoth' });
+  assert.deepEqual(ranked.map(r => r.candidate.id), ['B']);
+});
+
+// ── 7-8. Unknown nunca satisface una exigencia exacta ────────────────────
+
+test('7. idioma desconocido no satisface una exigencia de español', () => {
+  const candidates = [candidate({ id: 'A', language: 'desconocido' }), candidate({ id: 'B', language: 'espanol' })];
+  const ranked = rankTarotFinderCandidates(candidates, { language: 'espanol' });
+  assert.deepEqual(ranked.map(r => r.candidate.id), ['B']);
+});
+
+test('8. guía desconocida no satisface "quiero guía"', () => {
+  const candidates = [candidate({ id: 'A', bundle: 'desconocido' }), candidate({ id: 'B', bundle: 'mazo_mas_guia' })];
+  const ranked = rankTarotFinderCandidates(candidates, { guide: 'si' });
+  assert.deepEqual(ranked.map(r => r.candidate.id), ['B']);
+});
+
+test('idioma inglés exige exactamente inglés, no multilingüe ni desconocido', () => {
+  const candidates = [
+    candidate({ id: 'A', language: 'multilingue' }),
+    candidate({ id: 'B', language: 'ingles' }),
+    candidate({ id: 'C', language: 'desconocido' }),
+  ];
+  const ranked = rankTarotFinderCandidates(candidates, { language: 'ingles' });
+  assert.deepEqual(ranked.map(r => r.candidate.id), ['B']);
+});
+
+// ── 9. Preferencia blanda ─────────────────────────────────────────────────
+
+test('9. "primer mazo" es preferencia blanda: no excluye a quien no es level=principiante', () => {
+  const candidates = [candidate({ id: 'A', level: 'desconocido' })];
+  const ranked = rankTarotFinderCandidates(candidates, { intent: 'primer_mazo' });
+  assert.equal(ranked.length, 1, 'sigue apareciendo aunque no sea "principiante" confirmado');
+  assert.equal(ranked[0].score, 0, 'pero no recibe el bonus, porque el tag no lo confirma');
+});
+
+test('9b. "primer mazo" SÍ suma puntos cuando level=principiante está confirmado', () => {
+  const { score, reasons } = scoreTarotFinderCandidate(candidate({ level: 'principiante' }), { intent: 'primer_mazo' });
+  assert.equal(score, SCORE_WEIGHTS.PRINCIPIANTE_PARA_PRIMER_MAZO);
+  assert.ok(reasons.includes('principiante'));
+});
+
+// ── 10-11. Resultados: 0 y máximo 6 ──────────────────────────────────────
+
+test('10. sin matches hard -> 0 resultados', () => {
+  const candidates = [candidate({ id: 'A', primary_type: 'oraculo' })];
+  const ranked = rankTarotFinderCandidates(candidates, { system: 'tarot' });
+  assert.deepEqual(ranked, []);
+});
+
+test('11. nunca más de 6 resultados aunque haya más candidatos válidos', () => {
+  const candidates = Array.from({ length: 20 }, (_, i) => candidate({ id: `MLU${i}` }));
+  const ranked = rankTarotFinderCandidates(candidates, {});
+  assert.equal(ranked.length, 6);
+});
+
+test('el límite es configurable pero 6 es el default', () => {
+  const candidates = Array.from({ length: 20 }, (_, i) => candidate({ id: `MLU${i}` }));
+  assert.equal(rankTarotFinderCandidates(candidates, {}).length, 6);
+  assert.equal(rankTarotFinderCandidates(candidates, {}, { limit: 3 }).length, 3);
+});
+
+// ── 12-13. Determinismo y empate estable ─────────────────────────────────
+
+test('12. el ranking es determinista: mismo input, mismo output', () => {
+  const candidates = [
+    candidate({ id: 'A', level: 'principiante' }),
+    candidate({ id: 'B', bundle: 'mazo_mas_guia' }),
+    candidate({ id: 'C' }),
+  ];
+  const answers = { intent: 'primer_mazo' };
+  const first = rankTarotFinderCandidates(candidates, answers);
+  const second = rankTarotFinderCandidates(candidates, answers);
+  assert.deepEqual(first, second);
+});
+
+test('13. empate estable: score y stock y price iguales -> desempata por id ascendente', () => {
+  const candidates = [
+    candidate({ id: 'MLU3', stock: 5, price: 1000 }),
+    candidate({ id: 'MLU1', stock: 5, price: 1000 }),
+    candidate({ id: 'MLU2', stock: 5, price: 1000 }),
+  ];
+  const ranked = rankTarotFinderCandidates(candidates, {});
+  assert.deepEqual(ranked.map(r => r.candidate.id), ['MLU1', 'MLU2', 'MLU3']);
+});
+
+test('desempate documentado: score DESC -> stock DESC -> price ASC -> id ASC', () => {
+  const candidates = [
+    candidate({ id: 'A', level: 'principiante', stock: 1, price: 3000 }), // score 30
+    candidate({ id: 'B', stock: 10, price: 1000 }), // score 0, más stock
+    candidate({ id: 'C', stock: 10, price: 500 }), // score 0, mismo stock que B, menor precio
+  ];
+  const ranked = rankTarotFinderCandidates(candidates, { intent: 'primer_mazo' });
+  assert.deepEqual(ranked.map(r => r.candidate.id), ['A', 'C', 'B']);
+});
+
+// ── 14. Sólo activos/stock (a nivel de filtro hard, defensivo) ───────────
+
+test('14. passesHardConstraints no depende de stock/status — esa exclusión ya la aplica buildTarotFinderDataset antes; acá se verifica que no se reintroduce accidentalmente', () => {
+  // El dataset ya filtra activos+stock>0 antes de llegar acá (ver
+  // tarot-finder-dataset.test.js). Esta prueba documenta que el filtrado
+  // hard de esta capa es sólo semántico (sistema/familia/idioma/guía), no
+  // duplica la validación de stock.
+  const inStock = candidate({ id: 'A', stock: 1 });
+  const noStockButPassedIn = candidate({ id: 'B', stock: 0 }); // no debería llegar acá en la práctica
+  const ranked = rankTarotFinderCandidates([inStock, noStockButPassedIn], {});
+  assert.equal(ranked.length, 2, 'esta capa no re-filtra por stock; esa responsabilidad es de buildTarotFinderDataset');
+});
+
+// ── 15. Explicación nunca afirma datos unknown ───────────────────────────
+
+test('15. explainMatch nunca menciona idioma/familia desconocidos', () => {
+  const { badges, sentence } = explainMatch(
+    candidate({ language: 'desconocido', deck_family: null, bundle: 'desconocido' }),
+    { system: 'tarot', language: 'no_preference' },
+  );
+  assert.deepEqual(badges, []);
+  assert.doesNotMatch(sentence, /desconocido/i);
+  assert.match(sentence, /Tarot/);
+});
+
+test('15b. explainMatch sólo menciona guía si bundle=mazo_mas_guia es verdadero', () => {
+  const { badges: badgesSin } = explainMatch(candidate({ bundle: 'solo_mazo' }), {});
+  assert.ok(!badgesSin.includes('Incluye guía'));
+  const { badges: badgesCon } = explainMatch(candidate({ bundle: 'mazo_mas_guia' }), {});
+  assert.ok(badgesCon.includes('Incluye guía'));
+});
+
+test('15c. explainMatch con familia y guía exigidas y confirmadas arma la frase completa', () => {
+  const { sentence } = explainMatch(
+    candidate({ primary_type: 'tarot', deck_family: 'rider_waite_smith', language: 'espanol', bundle: 'mazo_mas_guia' }),
+    { system: 'tarot', deckFamily: 'rider_waite_smith', language: 'espanol', guide: 'si' },
+  );
+  assert.equal(sentence, 'Coincide porque buscás un Tarot Rider-Waite-Smith en español con guía.');
+});
+
+// ── 16. WhatsApp de no-resultados con respuestas reales ──────────────────
+
+test('16. el mensaje de no-resultados incluye sólo las respuestas reales, en el formato del helper existente', () => {
+  const message = buildFinderNoResultsMessage(
+    { system: 'tarot', deckFamily: 'rider_waite_smith', language: 'espanol', guide: 'si', intent: 'primer_mazo' },
+    { buildWhatsAppMessage, page: '/libros/esoterismo-tarot' },
+  );
+  assert.match(message, /Tipo: Tarot/);
+  assert.match(message, /Tradición: Rider-Waite-Smith/);
+  assert.match(message, /Idioma: Español/);
+  assert.match(message, /Guía: sí/);
+  assert.match(message, /Experiencia: primer mazo/);
+  assert.match(message, /No encontré una coincidencia exacta disponible/);
+  assert.match(message, /amadolibros\.com\/libros\/esoterismo-tarot/);
+});
+
+test('16b. sin preferencias concretas (todo "no_preference"/"unsure"), no inventa líneas', () => {
+  const message = buildFinderNoResultsMessage(
+    { system: 'unsure', deckFamily: 'no_preference', language: 'no_preference', guide: 'no_importante', intent: 'sin_preferencia' },
+    { buildWhatsAppMessage, page: '/libros/esoterismo-tarot' },
+  );
+  assert.doesNotMatch(message, /Tipo:/);
+  assert.doesNotMatch(message, /Tradición:/);
+  assert.doesNotMatch(message, /Idioma:/);
+  assert.doesNotMatch(message, /Guía:/);
+  assert.doesNotMatch(message, /Experiencia:/);
+});
+
+test('16c. buildFinderNoResultsMessage exige el helper real, no lo reimplementa', () => {
+  assert.throws(() => buildFinderNoResultsMessage({}, {}), /requiere buildWhatsAppMessage/);
+});
+
+// ── 17. Input inválido no rompe ───────────────────────────────────────────
+
+test('17. passesHardConstraints con candidato null/undefined no lanza', () => {
+  assert.equal(passesHardConstraints(null, { system: 'tarot' }), false);
+  assert.equal(passesHardConstraints(undefined, {}), false);
+});
+
+test('17b. rankTarotFinderCandidates con answers vacío/undefined no lanza y no filtra nada por hard constraints', () => {
+  const candidates = [candidate({ id: 'A' }), candidate({ id: 'B', primary_type: 'oraculo' })];
+  assert.doesNotThrow(() => rankTarotFinderCandidates(candidates, undefined));
+  assert.equal(rankTarotFinderCandidates(candidates, {}).length, 2);
+});
+
+test('17c. rankTarotFinderCandidates lanza explícito sobre candidates que no es array (input realmente inválido)', () => {
+  assert.throws(() => rankTarotFinderCandidates('no-array', {}), /candidates debe ser un array/);
+});
+
+test('17d. scoreTarotFinderCandidate con candidato vacío no lanza, score 0', () => {
+  assert.deepEqual(scoreTarotFinderCandidate({}, { intent: 'primer_mazo' }), { score: 0, reasons: [] });
+  assert.deepEqual(scoreTarotFinderCandidate(null, {}), { score: 0, reasons: [] });
+});
+
+test('17e. candidatos con campos parcialmente ausentes no rompen el ranking', () => {
+  const broken = { id: 'X' }; // sin price/stock/primary_type/etc.
+  assert.doesNotThrow(() => rankTarotFinderCandidates([broken], {}));
+});

--- a/functions/_shared/tarot-finder-dataset.js
+++ b/functions/_shared/tarot-finder-dataset.js
@@ -1,0 +1,57 @@
+/**
+ * functions/_shared/tarot-finder-dataset.js
+ *
+ * TAROT-FINDER-1: arma el payload compacto que viaja al cliente para el
+ * selector "Encontrá tu mazo". Puro — no hace fetch, no toca el DOM.
+ *
+ * Universo: sólo mazos comprables ahora (activo + stock>0 + precio válido),
+ * de un sistema real de cartas (tarot/oráculo/lenormand/kipper) — nunca
+ * accesorios ni libros SOBRE tarot (format=libro): el Finder busca un mazo,
+ * no un ensayo. Ningún campo se infiere: viene tal cual de
+ * TAROT_MERCH_TAGS (TAROT-MERCH-TAGS-1), que ya aplicó la regla
+ * "desconocido > clasificación incorrecta".
+ */
+
+const FINDER_SYSTEM_TYPES = new Set(['tarot', 'oraculo', 'lenormand', 'kipper']);
+
+// Campos mínimos enviados al cliente — nunca título largo con subtítulos
+// completos más allá del propio título, nunca descripción, nunca campos de
+// depuración. Ver tarot-finder.dataset.test.js para el guard de tamaño.
+export function buildTarotFinderDataset({ items = [], tagLookup, imageForId, hrefForItem } = {}) {
+  if (!Array.isArray(items)) throw new Error('items debe ser un array.');
+  if (typeof tagLookup !== 'function') throw new Error('tagLookup debe ser una función.');
+  if (typeof imageForId !== 'function') throw new Error('imageForId debe ser una función.');
+  if (typeof hrefForItem !== 'function') throw new Error('hrefForItem debe ser una función.');
+
+  const seen = new Set();
+  const dataset = [];
+  for (const item of items) {
+    if (!item?.id || seen.has(item.id)) continue;
+    const tag = tagLookup(item.id);
+    if (!tag) continue;
+    if (!FINDER_SYSTEM_TYPES.has(tag.primary_type)) continue;
+    if (tag.format === 'libro') continue;
+    if (item.status !== 'active') continue;
+    const stock = Number(item.available_quantity) || 0;
+    if (stock <= 0) continue;
+    const price = Number(item.price) || 0;
+    if (price <= 0) continue;
+
+    seen.add(item.id);
+    dataset.push({
+      id: item.id,
+      title: item.title || '',
+      price,
+      image: imageForId(item.id),
+      href: hrefForItem(item),
+      primary_type: tag.primary_type,
+      deck_family: tag.deck_family,
+      language: tag.language,
+      bundle: tag.bundle,
+      level: tag.level,
+      edition_style: tag.edition_style,
+      stock,
+    });
+  }
+  return dataset;
+}

--- a/functions/_shared/tarot-finder-scoring.js
+++ b/functions/_shared/tarot-finder-scoring.js
@@ -1,0 +1,196 @@
+/**
+ * functions/_shared/tarot-finder-scoring.js
+ *
+ * TAROT-FINDER-1: filtrado (hard constraints) y scoring (soft preferences)
+ * puros para el selector "Encontrá tu mazo". Ninguna función acá hace
+ * fetch ni toca el DOM — se ejecutan igual en el servidor (para
+ * pre-validar) y en el cliente (dentro de tarot-finder.js).
+ *
+ * buildNoResultsWhatsAppMessage() reutiliza buildWhatsAppMessage()/
+ * whatsappHref() de shared/whatsapp-messages.js — el número y la URL de
+ * wa.me nunca se reconstruyen a mano acá.
+ *
+ * HARD vs SOFT (no negociable):
+ *   HARD  -> activo+stock+precio ya vienen filtrados por
+ *            buildTarotFinderDataset(); acá se agregan: primary_type
+ *            cuando el usuario eligió sistema, deck_family cuando eligió
+ *            tradición, language cuando exige idioma, bundle=mazo_mas_guia
+ *            cuando exige guía. Una restricción hard nunca se relaja: un
+ *            candidato que no la cumple queda afuera del resultado, punto.
+ *   SOFT  -> primer mazo / estudiar / regalo / coleccionista / experiencia
+ *            sólo suman puntos cuando el dato del candidato lo confirma.
+ *            Nunca excluyen a nadie.
+ *
+ * 'desconocido' en el candidato NUNCA satisface una restricción hard
+ * concreta (idioma, guía, familia) — es justamente lo que las pruebas
+ * "unknown no satisface X" verifican.
+ */
+
+export const SCORE_WEIGHTS = Object.freeze({
+  PRINCIPIANTE_PARA_PRIMER_MAZO: 30,
+  GUIA_PARA_ESTUDIAR: 20,
+  EDICION_ESPECIAL_PARA_REGALO_O_COLECCIONISTA: 10,
+  // Extensión propia, no pedida explícitamente pero simétrica a la de
+  // "primer mazo": recompensa level=avanzado_profesional cuando el usuario
+  // dice que ya tiene experiencia. Mismo criterio "sólo si el dato lo
+  // confirma" — con level='desconocido' (el caso más común) no suma nada.
+  AVANZADO_PARA_EXPERIENCIA: 15,
+  // Coincidencia secundaria demostrable: el mazo trae guía aunque el
+  // usuario no la haya pedido como obligatoria.
+  GUIA_NO_EXIGIDA_PERO_PRESENTE: 5,
+});
+
+const DECK_FAMILY_LABEL = Object.freeze({
+  rider_waite_smith: 'Rider-Waite-Smith',
+  marsella: 'Tarot de Marsella',
+  thoth: 'Thoth',
+});
+const SYSTEM_LABEL = Object.freeze({
+  tarot: 'Tarot',
+  oraculo: 'Oráculo',
+  lenormand: 'Lenormand',
+  kipper: 'Kipper',
+});
+const LANGUAGE_LABEL = Object.freeze({
+  espanol: 'Español',
+  ingles: 'Inglés',
+  multilingue: 'Multilingüe',
+});
+export const INTENT_LABEL = Object.freeze({
+  primer_mazo: 'primer mazo',
+  estudiar: 'aprender/estudiar',
+  experiencia: 'ya tiene experiencia',
+  regalo: 'regalo',
+  coleccionista: 'coleccionista',
+  sin_preferencia: null,
+});
+
+/**
+ * Arma el texto para "no encontramos coincidencia exacta -> pedilo por
+ * encargo", con las respuestas REALES del usuario, nunca inventadas. Sólo
+ * incluye una línea por pregunta que el usuario efectivamente respondió con
+ * una preferencia concreta (no_preference/unsure/sin_preferencia se omiten,
+ * igual que en explainMatch).
+ */
+export function buildFinderNoResultsMessage(answers = {}, { buildWhatsAppMessage, page } = {}) {
+  if (typeof buildWhatsAppMessage !== 'function') {
+    throw new Error('buildFinderNoResultsMessage requiere buildWhatsAppMessage (shared/whatsapp-messages.js).');
+  }
+  const situationLines = [
+    hasPreference(answers.system) ? `Tipo: ${SYSTEM_LABEL[answers.system] || answers.system}` : null,
+    hasPreference(answers.deckFamily) ? `Tradición: ${DECK_FAMILY_LABEL[answers.deckFamily] || answers.deckFamily}` : null,
+    hasPreference(answers.language) ? `Idioma: ${LANGUAGE_LABEL[answers.language] || answers.language}` : null,
+    answers.guide === 'si' ? 'Guía: sí' : null,
+    (answers.intent && INTENT_LABEL[answers.intent]) ? `Experiencia: ${INTENT_LABEL[answers.intent]}` : null,
+  ].filter(Boolean);
+
+  return buildWhatsAppMessage({
+    greeting: 'Hola, estoy buscando un mazo en Amado Libros 😊',
+    motive: 'Buscar un mazo con el selector "Encontrá tu mazo"',
+    situation: situationLines.length ? situationLines.join('\n') : null,
+    page,
+    closing: 'No encontré una coincidencia exacta disponible. ¿Pueden buscarme opciones?',
+  });
+}
+
+function hasPreference(value) {
+  return Boolean(value) && value !== 'no_preference' && value !== 'unsure' && value !== 'sin_preferencia';
+}
+
+/**
+ * true si el candidato cumple TODAS las restricciones hard de answers.
+ * Nunca relaja silenciosamente: cada gate es una comparación exacta.
+ */
+export function passesHardConstraints(candidate, answers = {}) {
+  if (!candidate) return false;
+  if (hasPreference(answers.system) && candidate.primary_type !== answers.system) return false;
+  if (hasPreference(answers.deckFamily) && candidate.deck_family !== answers.deckFamily) return false;
+  if (hasPreference(answers.language) && candidate.language !== answers.language) return false;
+  if (answers.guide === 'si' && candidate.bundle !== 'mazo_mas_guia') return false;
+  return true;
+}
+
+/**
+ * Puntaje de preferencias blandas — SOLO se llama sobre candidatos que ya
+ * pasaron passesHardConstraints(); es segura de llamar sobre cualquier
+ * candidato de todos modos (no lanza, no filtra).
+ */
+export function scoreTarotFinderCandidate(candidate, answers = {}) {
+  let score = 0;
+  const reasons = [];
+  if (!candidate) return { score: 0, reasons };
+
+  if (answers.intent === 'primer_mazo' && candidate.level === 'principiante') {
+    score += SCORE_WEIGHTS.PRINCIPIANTE_PARA_PRIMER_MAZO;
+    reasons.push('principiante');
+  }
+  if (answers.intent === 'estudiar' && candidate.bundle === 'mazo_mas_guia') {
+    score += SCORE_WEIGHTS.GUIA_PARA_ESTUDIAR;
+    reasons.push('guia_para_estudiar');
+  }
+  if ((answers.intent === 'regalo' || answers.intent === 'coleccionista') && candidate.edition_style === 'ilustrada_especial') {
+    score += SCORE_WEIGHTS.EDICION_ESPECIAL_PARA_REGALO_O_COLECCIONISTA;
+    reasons.push('edicion_especial');
+  }
+  if (answers.intent === 'experiencia' && candidate.level === 'avanzado_profesional') {
+    score += SCORE_WEIGHTS.AVANZADO_PARA_EXPERIENCIA;
+    reasons.push('avanzado');
+  }
+  if (answers.guide !== 'si' && candidate.bundle === 'mazo_mas_guia') {
+    score += SCORE_WEIGHTS.GUIA_NO_EXIGIDA_PERO_PRESENTE;
+    reasons.push('guia_bonus');
+  }
+  return { score, reasons };
+}
+
+/**
+ * Filtra por hard constraints, puntúa, ordena y recorta.
+ * Desempate documentado y estable: score DESC -> stock DESC -> price ASC ->
+ * id ASC. Nunca aleatorio, nunca depende del orden de entrada.
+ */
+export function rankTarotFinderCandidates(candidates, answers = {}, { limit = 6 } = {}) {
+  if (!Array.isArray(candidates)) throw new Error('candidates debe ser un array.');
+  const passing = candidates.filter(c => passesHardConstraints(c, answers));
+  const scored = passing.map(candidate => {
+    const { score, reasons } = scoreTarotFinderCandidate(candidate, answers);
+    return { candidate, score, reasons };
+  });
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    const stockDiff = (Number(b.candidate.stock) || 0) - (Number(a.candidate.stock) || 0);
+    if (stockDiff !== 0) return stockDiff;
+    const priceDiff = (Number(a.candidate.price) || 0) - (Number(b.candidate.price) || 0);
+    if (priceDiff !== 0) return priceDiff;
+    return String(a.candidate.id).localeCompare(String(b.candidate.id));
+  });
+  return scored.slice(0, Math.max(0, limit));
+}
+
+/**
+ * Texto "por qué coincide" — sólo menciona atributos confirmados
+ * (nunca 'desconocido'/null) y sólo los relevantes a lo que se preguntó.
+ */
+export function explainMatch(candidate, answers = {}) {
+  const badges = [];
+  if (DECK_FAMILY_LABEL[candidate.deck_family]) badges.push(DECK_FAMILY_LABEL[candidate.deck_family]);
+  if (LANGUAGE_LABEL[candidate.language]) badges.push(LANGUAGE_LABEL[candidate.language]);
+  if (candidate.bundle === 'mazo_mas_guia') badges.push('Incluye guía');
+  if (candidate.edition_style === 'ilustrada_especial') badges.push('Edición especial');
+
+  const systemLabel = SYSTEM_LABEL[candidate.primary_type] || null;
+  const clauses = [];
+  if (systemLabel) {
+    clauses.push(hasPreference(answers.system) ? `buscás un ${systemLabel}` : `es un ${systemLabel}`);
+  }
+  if (hasPreference(answers.deckFamily) && DECK_FAMILY_LABEL[candidate.deck_family]) {
+    clauses.push(DECK_FAMILY_LABEL[candidate.deck_family]);
+  }
+  if (hasPreference(answers.language) && LANGUAGE_LABEL[candidate.language]) {
+    clauses.push(`en ${LANGUAGE_LABEL[candidate.language].toLowerCase()}`);
+  }
+  if (answers.guide === 'si' && candidate.bundle === 'mazo_mas_guia') {
+    clauses.push('con guía');
+  }
+  const sentence = clauses.length ? `Coincide porque ${clauses.join(' ')}.` : '';
+  return { badges, sentence };
+}

--- a/functions/libros/[[path]].js
+++ b/functions/libros/[[path]].js
@@ -371,7 +371,7 @@ function tarotFinderHtml(dataset, canonical) {
     return `<section class="tarot-finder-cta" id="tarot-finder-cta" aria-labelledby="tarot-finder-cta-title" data-wa-base="${escapeHtml(waBase)}">
     <h2 id="tarot-finder-cta-title">Encontrá tu mazo</h2>
     <p>Respondé unas preguntas y te mostramos opciones disponibles ahora.</p>
-    <button type="button" id="tarot-finder-start" aria-haspopup="true">Empezar</button>
+    <button type="button" id="tarot-finder-start">Empezar</button>
     <noscript>
       <p class="tarot-finder-noscript">Este selector necesita JavaScript.
         <a href="${escapeHtml(whatsappHref(fallbackWaMessage))}" target="_blank" rel="noopener noreferrer">Contanos qué buscás por WhatsApp</a> y te ayudamos a elegir.</p>

--- a/functions/libros/[[path]].js
+++ b/functions/libros/[[path]].js
@@ -25,6 +25,8 @@ import { buildWhatsAppMessage, whatsappHref } from '../../shared/whatsapp-messag
 // Ninguna otra categoría de SEO_CATEGORIES se ve afectada por este import.
 import { TAROT_MERCH_TAGS } from '../_shared/tarot-merch-tags.js';
 import { buildTagLookup, buildTarotHubModules } from '../_shared/tarot-hub-modules.js';
+// TAROT-FINDER-1: mismo alcance — sólo esoterismo-tarot.
+import { buildTarotFinderDataset } from '../_shared/tarot-finder-dataset.js';
 
 const TAROT_CATEGORY_ID = 'esoterismo-tarot';
 const tarotTagLookup = buildTagLookup(TAROT_MERCH_TAGS);
@@ -306,13 +308,18 @@ function tarotModuleSectionHtml(module_, navigationBase, cardIndexRef) {
   </section>`;
 }
 
-function tarotParaEmpezarHtml(module_, navigationBase, canonical, cardIndexRef) {
+function tarotParaEmpezarHtml(module_, navigationBase, canonical, cardIndexRef, hasFinder) {
+    // TAROT-FINDER-1: esta copia decía "muy pronto vamos a tener un
+    // selector" — con el Finder ya en la misma página, esa promesa queda
+    // obsoleta apenas se publique. La reemplazamos según haya o no dataset.
     const waMessage = buildWhatsAppMessage({
         greeting: 'Hola, estoy buscando mi primer tarot y quisiera que me ayudaran 😊',
         motive: 'Elegir un primer mazo de tarot',
         situation: 'Todavía no sé bien qué mazo conviene para empezar',
         page: canonical,
-        closing: 'Muy pronto vamos a tener un selector para recomendarte el mazo ideal — mientras tanto, contanos qué buscás y te ayudamos por acá. Gracias.',
+        closing: hasFinder
+            ? 'Arriba tenés "Encontrá tu mazo" para filtrar por lo que buscás — si preferís, contanos directamente y te ayudamos por acá. Gracias.'
+            : 'Contanos qué buscás y te ayudamos a elegir por acá. Gracias.',
     });
     const cards = module_.entries.map(({ item, tag }) => {
         const html = cardHtml(item, cardIndexRef.value, navigationBase, { badges: tarotBadgesFor(tag) });
@@ -327,14 +334,91 @@ function tarotParaEmpezarHtml(module_, navigationBase, canonical, cardIndexRef) 
   </section>`;
 }
 
-function tarotModulesHtml(modules, navigationBase, canonical) {
+function tarotModulesHtml(modules, navigationBase, canonical, hasFinder) {
     if (!modules || modules.length === 0) return '';
     const cardIndexRef = { value: 0 };
     const sections = modules.map(module_ => module_.id === 'para-empezar'
-        ? tarotParaEmpezarHtml(module_, navigationBase, canonical, cardIndexRef)
+        ? tarotParaEmpezarHtml(module_, navigationBase, canonical, cardIndexRef, hasFinder)
         : tarotModuleSectionHtml(module_, navigationBase, cardIndexRef)).filter(Boolean);
     return `<div class="tarot-modules">${sections.join('\n')}</div>`;
 }
+
+// TAROT-FINDER-1 -------------------------------------------------------------
+
+/**
+ * CTA "Encontrá tu mazo" + dataset compacto inline (JSON embebido, sin
+ * request nueva). Interacción inline la maneja astro-front/public/
+ * tarot-finder.js (defer) — sin ese script, el <noscript> ofrece un CTA de
+ * WhatsApp real, y el resto de la categoría (módulos, Ver todo) sigue
+ * funcionando igual. Ningún dato del dataset queda indexado: va dentro de
+ * un <script type="application/json">, invisible para el HTML renderizado
+ * y sin URL propia.
+ */
+function tarotFinderHtml(dataset, canonical) {
+    if (!dataset || dataset.length === 0) return '';
+    const fallbackWaMessage = buildWhatsAppMessage({
+        greeting: 'Hola, estoy buscando un mazo en Amado Libros 😊',
+        motive: 'Elegir un mazo de tarot u oráculo',
+        situation: 'Preferiría que me ayudaran a elegir por acá (sin JavaScript no pude usar el selector del sitio)',
+        page: canonical,
+        closing: 'Contame qué tipo de mazo buscás y te ayudo a elegir. Gracias.',
+    });
+    // data-wa-base: única fuente del número de WhatsApp para el script
+    // cliente — nunca se hardcodea +59899841325 en tarot-finder.js. Mismo
+    // helper (whatsappHref) que usa el resto del archivo, con texto vacío
+    // para quedarse sólo con la base "https://wa.me/<numero>?text=".
+    const waBase = whatsappHref('');
+    return `<section class="tarot-finder-cta" id="tarot-finder-cta" aria-labelledby="tarot-finder-cta-title" data-wa-base="${escapeHtml(waBase)}">
+    <h2 id="tarot-finder-cta-title">Encontrá tu mazo</h2>
+    <p>Respondé unas preguntas y te mostramos opciones disponibles ahora.</p>
+    <button type="button" id="tarot-finder-start" aria-haspopup="true">Empezar</button>
+    <noscript>
+      <p class="tarot-finder-noscript">Este selector necesita JavaScript.
+        <a href="${escapeHtml(whatsappHref(fallbackWaMessage))}" target="_blank" rel="noopener noreferrer">Contanos qué buscás por WhatsApp</a> y te ayudamos a elegir.</p>
+    </noscript>
+    <div id="tarot-finder-app" hidden></div>
+  </section>
+  <script type="application/json" id="tarot-finder-dataset">${safeJson(dataset)}</script>`;
+}
+
+const TAROT_FINDER_STYLES = `.tarot-finder-cta{background:#18120e;color:#fff;border-radius:1rem;padding:1.25rem clamp(1rem,3vw,1.75rem);margin-top:1.75rem}
+.tarot-finder-cta h2{font-family:Georgia,serif;font-size:1.35rem;margin-bottom:.4rem}
+.tarot-finder-cta p{color:rgba(255,255,255,.75);font-size:.88rem;max-width:60ch;margin-bottom:1rem}
+.tarot-finder-cta .tarot-finder-noscript{color:rgba(255,255,255,.75);font-size:.85rem}
+.tarot-finder-cta .tarot-finder-noscript a{color:#e49982;font-weight:700}
+#tarot-finder-start{min-height:48px;padding:.75rem 1.5rem;border:0;border-radius:999px;background:#e49982;color:#18120e;font-weight:800;font-size:.92rem;cursor:pointer}
+#tarot-finder-start:hover{background:#d98972}
+#tarot-finder-start:focus-visible{outline:3px solid #fff;outline-offset:2px}
+#tarot-finder-app:not([hidden]){margin-top:1.25rem;background:#fff;color:#18120e;border-radius:.85rem;padding:1.1rem clamp(1rem,3vw,1.5rem)}
+.tf-progress{font-size:.76rem;color:#6b6157;margin-bottom:.6rem}
+.tf-question h3{font-size:1.05rem;margin-bottom:.9rem;line-height:1.35}
+.tf-options{display:flex;flex-direction:column;gap:.55rem}
+.tf-option{min-height:48px;text-align:left;padding:.7rem 1rem;border:1.5px solid #e2dbd0;border-radius:.65rem;background:#fff;font:inherit;font-size:.88rem;cursor:pointer;color:#18120e}
+.tf-option:hover{border-color:#e49982}
+.tf-option:focus-visible{outline:3px solid #a94e3d;outline-offset:1px}
+.tf-option[aria-pressed="true"]{border-color:#18120e;background:#f8f5ef;font-weight:700}
+.tf-nav{display:flex;justify-content:space-between;gap:.6rem;margin-top:1.1rem}
+.tf-nav button{min-height:44px;padding:0 1rem;border-radius:.6rem;border:1px solid #e2dbd0;background:#fff;font:inherit;font-size:.82rem;cursor:pointer}
+.tf-nav button:disabled{opacity:.4;cursor:default}
+.tf-nav .tf-restart{margin-left:auto;color:#8a8074}
+.tf-explainer{background:#f8f5ef;border-radius:.6rem;padding:.8rem;margin-bottom:.9rem;font-size:.82rem;color:#50463e;display:flex;flex-direction:column;gap:.35rem}
+.tf-results h3{font-size:1.05rem;margin-bottom:.85rem}
+.tf-results-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.7rem;margin-bottom:1rem}
+.tf-result-card{border:1px solid #e2dbd0;border-radius:.7rem;overflow:hidden;display:flex;flex-direction:column}
+.tf-result-card img{width:100%;aspect-ratio:3/4;object-fit:contain;background:#f8f5ef}
+.tf-result-body{padding:.6rem;display:flex;flex-direction:column;gap:.35rem}
+.tf-result-badges{display:flex;flex-wrap:wrap;gap:.25rem}
+.tf-result-badges span{padding:.1rem .4rem;border-radius:999px;background:#f0e6da;color:#6b4b2f;font-size:.6rem;font-weight:800;text-transform:uppercase}
+.tf-result-card h4{font-size:.82rem;line-height:1.3}
+.tf-result-why{font-size:.72rem;color:#6b6157}
+.tf-result-price{font-weight:800;font-size:.88rem}
+.tf-result-cta{margin-top:auto;text-align:center;padding:.5rem;border-radius:.5rem;background:#18120e;color:#fff;text-decoration:none;font-size:.78rem;font-weight:700}
+.tf-empty{background:#fff7e8;border:1px solid #efd2a6;border-radius:.65rem;padding:1rem;color:#6b4218}
+.tf-empty .tf-wa-cta{display:inline-flex;margin-top:.75rem;padding:.65rem 1rem;border-radius:999px;background:#25d366;color:#fff;text-decoration:none;font-weight:800;font-size:.82rem}
+@media(min-width:640px){.tf-results-grid{grid-template-columns:repeat(3,minmax(0,1fr))}}
+@media(min-width:900px){.tf-results-grid{grid-template-columns:repeat(4,minmax(0,1fr))}}`;
+
+// ---------------------------------------------------------------------------
 
 const TAROT_MODULE_STYLES = `.tarot-modules{display:flex;flex-direction:column;gap:1.75rem;margin-top:1.75rem}
 .tarot-module{background:#fff;border:1px solid #e2dbd0;border-radius:1rem;padding:1.1rem clamp(1rem,3vw,1.5rem)}
@@ -350,7 +434,7 @@ const TAROT_MODULE_STYLES = `.tarot-modules{display:flex;flex-direction:column;g
 
 // ---------------------------------------------------------------------------
 
-function renderPage({ category, categoryUniverseCount, items, isPreview, hasUnexpectedParameters, navigationBase, page, totalPages, tarotModules }) {
+function renderPage({ category, categoryUniverseCount, items, isPreview, hasUnexpectedParameters, navigationBase, page, totalPages, tarotModules, tarotFinderDataset }) {
     const canonical = `${BASE}${categoryPath(category.id, page)}`;
     const offset = (page - 1) * MAX_RESULTS;
     const visibleItems = items.slice(offset, offset + MAX_RESULTS);
@@ -443,7 +527,7 @@ function renderPage({ category, categoryUniverseCount, items, isPreview, hasUnex
   <script type="application/ld+json">${safeJson(collectionSchema)}</script>
   <script type="application/ld+json">${safeJson(breadcrumbSchema)}</script>
   <style>
-    *{box-sizing:border-box;margin:0;padding:0}body{font-family:Inter,system-ui,-apple-system,sans-serif;background:#f8f5ef;color:#18120e;line-height:1.55}a{color:inherit}.category-header{position:sticky;top:0;z-index:40;background:rgba(18,14,11,.97);color:#fff;border-bottom:1px solid rgba(255,255,255,.08)}.header-inner{max-width:1200px;height:72px;margin:auto;padding:0 1rem;display:grid;grid-template-columns:auto minmax(220px,1fr) auto;align-items:center;gap:1rem}.brand-link{display:flex;align-items:center;gap:.55rem;text-decoration:none}.brand-link img{width:44px;height:44px}.brand-link span{display:flex;flex-direction:column}.brand-link strong{font-size:.92rem}.brand-link small{color:rgba(255,255,255,.55);font-size:.7rem}.header-search{height:42px;display:flex;max-width:620px;width:100%;justify-self:center}.header-search input{min-width:0;flex:1;border:0;border-radius:999px 0 0 999px;padding:0 1rem;font:inherit}.header-search button{border:0;border-radius:0 999px 999px 0;padding:0 1rem;background:#e49982;color:#18120e;font-weight:800;cursor:pointer}.cart-link{min-height:42px;display:inline-flex;align-items:center;padding:0 .9rem;border:1px solid rgba(255,255,255,.2);border-radius:999px;text-decoration:none;font-size:.82rem}.breadcrumbs{max-width:1120px;margin:0 auto;padding:1rem;font-size:.82rem;color:#6b6157}.breadcrumbs a{color:#8f493b}.category-main{max-width:1120px;margin:0 auto;padding:0 1rem 3rem}.intro{padding:clamp(1.25rem,3vw,2rem);background:#fff;border:1px solid #e2dbd0;border-radius:1rem}.intro h1{font-family:Georgia,serif;font-size:clamp(1.75rem,5vw,2.6rem);line-height:1.12;margin-bottom:.8rem}.intro p{max-width:78ch;color:#5f554c}.category-scope{margin-top:1rem;padding:.75rem .9rem;border-left:4px solid #e49982;background:#f8f5ef;border-radius:.35rem;color:#50463e;font-size:.88rem}.benefits{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:1rem}.benefits span{padding:.35rem .65rem;border-radius:999px;background:#f5f0ea;color:#50463e;font-size:.75rem;font-weight:700}.results-head{display:flex;align-items:end;justify-content:space-between;gap:1rem;margin:2rem 0 1rem}.results-head h2{font-size:1.15rem}.results-head p{color:#6b6157;font-size:.84rem}.books-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.8rem}.book-card{display:flex;flex-direction:column;min-width:0;background:#fff;border:1px solid #e2dbd0;border-radius:.8rem;overflow:hidden}.book-image{display:grid;place-items:center;aspect-ratio:3/4;background:#eee7de;overflow:hidden}.book-image img{width:100%;height:100%;object-fit:cover;transition:transform .2s}.book-card:hover .book-image img{transform:scale(1.025)}.book-placeholder{font-size:2.5rem}.book-body{display:flex;flex:1;flex-direction:column;align-items:flex-start;gap:.4rem;padding:.8rem}.stock-badge{padding:.16rem .48rem;border-radius:999px;background:#eaf7ee;color:#267a42;font-size:.64rem;font-weight:800;text-transform:uppercase}.book-body h2{font-size:.86rem;line-height:1.3}.book-body h2 a{text-decoration:none}.book-author{width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#6b6157;font-size:.75rem}.book-prices{display:flex;flex-direction:column;gap:.15rem;margin-top:.2rem;font-size:.72rem}.book-prices strong{font-size:.9rem}.book-prices .transfer{color:#a94e3d;font-weight:700}.book-cta{margin-top:auto;padding:.38rem .7rem;border-radius:999px;background:#18120e;color:#fff;text-decoration:none;font-size:.73rem;font-weight:700}.category-nav{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.55rem;margin-top:2.5rem;padding:1rem;background:#fff;border:1px solid #e2dbd0;border-radius:1rem}.category-nav a{padding:.55rem .7rem;border-radius:.55rem;background:#f8f5ef;text-decoration:none;font-size:.78rem}.category-nav a[aria-current="page"]{background:#18120e;color:#fff}.empty{margin-top:1.5rem;padding:1.5rem;background:#fff;border:1px solid #e2dbd0;border-radius:.8rem}${PAGINATION_STYLES}${FOOTER_STYLES}${WA_FLOAT_STYLES}${TAROT_MODULE_STYLES}@media(min-width:640px){.books-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.category-nav{grid-template-columns:repeat(4,minmax(0,1fr))}}@media(min-width:900px){.books-grid{grid-template-columns:repeat(4,minmax(0,1fr))}}@media(max-width:620px){.header-inner{height:auto;min-height:68px;grid-template-columns:1fr auto;padding:.55rem .8rem}.brand-link small,.cart-link{display:none}.header-search{grid-column:1/-1;grid-row:2;margin-bottom:.2rem}.category-header{position:relative}}
+    *{box-sizing:border-box;margin:0;padding:0}body{font-family:Inter,system-ui,-apple-system,sans-serif;background:#f8f5ef;color:#18120e;line-height:1.55}a{color:inherit}.category-header{position:sticky;top:0;z-index:40;background:rgba(18,14,11,.97);color:#fff;border-bottom:1px solid rgba(255,255,255,.08)}.header-inner{max-width:1200px;height:72px;margin:auto;padding:0 1rem;display:grid;grid-template-columns:auto minmax(220px,1fr) auto;align-items:center;gap:1rem}.brand-link{display:flex;align-items:center;gap:.55rem;text-decoration:none}.brand-link img{width:44px;height:44px}.brand-link span{display:flex;flex-direction:column}.brand-link strong{font-size:.92rem}.brand-link small{color:rgba(255,255,255,.55);font-size:.7rem}.header-search{height:42px;display:flex;max-width:620px;width:100%;justify-self:center}.header-search input{min-width:0;flex:1;border:0;border-radius:999px 0 0 999px;padding:0 1rem;font:inherit}.header-search button{border:0;border-radius:0 999px 999px 0;padding:0 1rem;background:#e49982;color:#18120e;font-weight:800;cursor:pointer}.cart-link{min-height:42px;display:inline-flex;align-items:center;padding:0 .9rem;border:1px solid rgba(255,255,255,.2);border-radius:999px;text-decoration:none;font-size:.82rem}.breadcrumbs{max-width:1120px;margin:0 auto;padding:1rem;font-size:.82rem;color:#6b6157}.breadcrumbs a{color:#8f493b}.category-main{max-width:1120px;margin:0 auto;padding:0 1rem 3rem}.intro{padding:clamp(1.25rem,3vw,2rem);background:#fff;border:1px solid #e2dbd0;border-radius:1rem}.intro h1{font-family:Georgia,serif;font-size:clamp(1.75rem,5vw,2.6rem);line-height:1.12;margin-bottom:.8rem}.intro p{max-width:78ch;color:#5f554c}.category-scope{margin-top:1rem;padding:.75rem .9rem;border-left:4px solid #e49982;background:#f8f5ef;border-radius:.35rem;color:#50463e;font-size:.88rem}.benefits{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:1rem}.benefits span{padding:.35rem .65rem;border-radius:999px;background:#f5f0ea;color:#50463e;font-size:.75rem;font-weight:700}.results-head{display:flex;align-items:end;justify-content:space-between;gap:1rem;margin:2rem 0 1rem}.results-head h2{font-size:1.15rem}.results-head p{color:#6b6157;font-size:.84rem}.books-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.8rem}.book-card{display:flex;flex-direction:column;min-width:0;background:#fff;border:1px solid #e2dbd0;border-radius:.8rem;overflow:hidden}.book-image{display:grid;place-items:center;aspect-ratio:3/4;background:#eee7de;overflow:hidden}.book-image img{width:100%;height:100%;object-fit:cover;transition:transform .2s}.book-card:hover .book-image img{transform:scale(1.025)}.book-placeholder{font-size:2.5rem}.book-body{display:flex;flex:1;flex-direction:column;align-items:flex-start;gap:.4rem;padding:.8rem}.stock-badge{padding:.16rem .48rem;border-radius:999px;background:#eaf7ee;color:#267a42;font-size:.64rem;font-weight:800;text-transform:uppercase}.book-body h2{font-size:.86rem;line-height:1.3}.book-body h2 a{text-decoration:none}.book-author{width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#6b6157;font-size:.75rem}.book-prices{display:flex;flex-direction:column;gap:.15rem;margin-top:.2rem;font-size:.72rem}.book-prices strong{font-size:.9rem}.book-prices .transfer{color:#a94e3d;font-weight:700}.book-cta{margin-top:auto;padding:.38rem .7rem;border-radius:999px;background:#18120e;color:#fff;text-decoration:none;font-size:.73rem;font-weight:700}.category-nav{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.55rem;margin-top:2.5rem;padding:1rem;background:#fff;border:1px solid #e2dbd0;border-radius:1rem}.category-nav a{padding:.55rem .7rem;border-radius:.55rem;background:#f8f5ef;text-decoration:none;font-size:.78rem}.category-nav a[aria-current="page"]{background:#18120e;color:#fff}.empty{margin-top:1.5rem;padding:1.5rem;background:#fff;border:1px solid #e2dbd0;border-radius:.8rem}${PAGINATION_STYLES}${FOOTER_STYLES}${WA_FLOAT_STYLES}${TAROT_MODULE_STYLES}${TAROT_FINDER_STYLES}@media(min-width:640px){.books-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.category-nav{grid-template-columns:repeat(4,minmax(0,1fr))}}@media(min-width:900px){.books-grid{grid-template-columns:repeat(4,minmax(0,1fr))}}@media(max-width:620px){.header-inner{height:auto;min-height:68px;grid-template-columns:1fr auto;padding:.55rem .8rem}.brand-link small,.cart-link{display:none}.header-search{grid-column:1/-1;grid-row:2;margin-bottom:.2rem}.category-header{position:relative}}
     .book-image{padding:.35rem}.book-image img{object-fit:contain}
   </style>
 </head>
@@ -457,7 +541,8 @@ ${headerHtml()}
     <p class="category-scope">${scopeText}</p>
     <div class="benefits"><span>12% menos por transferencia</span><span>Hasta 12 cuotas</span><span>Envíos a todo Uruguay</span><span>Encargos del exterior</span></div>
   </section>
-  ${tarotModulesHtml(tarotModules, navigationBase, canonical)}
+  ${tarotFinderHtml(tarotFinderDataset, canonical)}
+  ${tarotModulesHtml(tarotModules, navigationBase, canonical, Boolean(tarotFinderDataset?.length))}
   <div class="results-head"><h2>${tarotModules?.length ? 'Ver todo' : 'Libros disponibles'}</h2><p>${resultText}</p></div>
   ${items.length > 0 ? `<section class="books-grid" aria-label="${escapeHtml(category.h1)}">${cards}</section>${pagination}` : '<p class="empty">No hay títulos disponibles en esta categoría en este momento. Consultanos por WhatsApp y lo buscamos por encargo.</p>'}
   ${categoryNavHtml(category.id)}
@@ -465,6 +550,7 @@ ${headerHtml()}
 ${footerHtml(undefined, canonical)}
 ${waFloatHtml(waMessage, canonical)}
 <script src="/search-autocomplete.js" defer></script>
+${tarotFinderDataset?.length ? '<script src="/tarot-finder.js" defer></script>' : ''}
 </body>
 </html>`;
 }
@@ -541,6 +627,17 @@ export async function onRequest(ctx) {
     const tarotModules = category.id === TAROT_CATEGORY_ID && pageParam.page === 1 && !hasUnexpectedParameters && items.length > 0
         ? buildTarotHubModules({ items, tagLookup: tarotTagLookup, demandLedgerLookup: tarotDemandLedgerLookup })
         : null;
+    // TAROT-FINDER-1: mismo gate que tarotModules, mismo `items` — el
+    // dataset del Finder y la grilla "Ver todo" describen exactamente el
+    // mismo universo, nunca datos separados que puedan desalinearse.
+    const tarotFinderDataset = tarotModules
+        ? buildTarotFinderDataset({
+            items,
+            tagLookup: tarotTagLookup,
+            imageForId: id => bookCoverUrl(id),
+            hrefForItem: it => `${navigationBase}/libro/${it.id}/${slugify(it.title)}`,
+        })
+        : [];
     const html = renderPage({
         category,
         categoryUniverseCount,
@@ -551,6 +648,7 @@ export async function onRequest(ctx) {
         page: pageParam.page,
         totalPages,
         tarotModules,
+        tarotFinderDataset,
     });
 
     return new Response(html, {


### PR DESCRIPTION
## Dependencia real, apilada deliberadamente

Base de esta PR: **`agent/tarot-hub-merch-1` (#209)**, no `main`. No se retargetea a `main` para forzar el Preview (a diferencia de #209): el workflow `deploy-pr-preview.yml` sólo dispara con `base: main` y no tiene `workflow_dispatch`. El Preview queda **pendiente hasta que #209 se mergee** — documentado, no fingido. Todo se validó localmente: sintaxis, 4 suites de tests focalizados, regresión completa, suite completa, ambos builds.

## Diff propio (10 archivos, contra `agent/tarot-hub-merch-1`)

```
functions/_shared/tarot-finder-dataset.js         | nuevo
functions/_shared/tarot-finder-scoring.js         | nuevo
functions/libros/[[path]].js                      | +112/-7 (sólo branch esoterismo-tarot)
astro-front/public/tarot-finder.js                | nuevo
functions/__tests__/tarot-finder-dataset.test.js  | nuevo
functions/__tests__/tarot-finder-render.test.js   | nuevo
functions/__tests__/tarot-finder-scoring.test.js  | nuevo
functions/__tests__/tarot-finder-client.test.js   | nuevo
docs/seo/tarot-accessories-audit-2026-08-21.md    | nuevo
docs/seo/tarot-b2b-blueprint-2026-08-21.md         | nuevo
```

## Qué es

"Encontrá tu mazo" — selector inline (no modal), mobile-first, una pregunta por pantalla, que reduce ~285 candidatos activos reales a 3-6 opciones. Ningún atributo inventado: todo sale de `TAROT_MERCH_TAGS` (#207) + el `items` que el hub ya carga (cero fetch nuevo).

**Preguntas**: Sistema (tarot/oráculo/lenormand/no sé) → Intención (soft) → Tradición (sólo si sistema=tarot; RWS/Marsella/Thoth, hard) → Idioma (hard) → Guía (hard).

## 8 fixes aplicados tras revisión (este PR ya los incluye)

1. **"No estoy seguro/a"** ya no avanza al primer click — abre el explicador Tarot/Oráculo/Lenormand en la misma pregunta; sólo "Seguir sin preferencia" confirma `system='unsure'` y avanza.
2. **"Volver" desde resultados** va a la última pregunta aplicable (`guide`), nunca cierra el Finder. Cerrar ocurre únicamente desde la primera pregunta real, Escape, o el control explícito.
3. **Limpieza de estado dependiente**: cambiar `system` a cualquier valor distinto de `tarot` elimina `answers.deckFamily` de inmediato.
4. **Accesibilidad**: se quitó `aria-haspopup="true"` — el Finder es inline, no un popup/menú/diálogo.
5. **Paridad servidor/cliente**: sin bundler. `tarot-finder-client.test.js` ejecuta el archivo real `tarot-finder.js` dentro de un `vm.context` de Node (DOM mínimo simulado) y compara pesos, hard constraints, límite, desempate, `explainMatch` y el mensaje de WhatsApp byte a byte contra `tarot-finder-scoring.js` — 20/20. La lógica sigue duplicada a propósito (documentado en ambos archivos), pero ahora hay una prueba real que detecta drift, no sólo una promesa.
6/7. **Lenguaje absoluto corregido** en los dos docs de auditoría: "0 accesorios reales" → "0 accesorios detectados con los criterios auditados"; "existe una demanda distinta y no atendida" → "existe una posible necesidad B2B que conviene validar". Las conclusiones operativas no cambiaron.

**HARD vs SOFT**: una restricción hard nunca se relaja silenciosamente — `desconocido` nunca satisface una exigencia concreta. Las preferencias soft sólo suman puntos, nunca excluyen.

**Scoring** (pesos documentados, idénticos en cliente y servidor, verificado por test): principiante+primer_mazo=30, guía+estudiar=20, edición_especial+regalo|coleccionista=10, avanzado+experiencia=15 (extensión propia, documentada), guía-presente-no-exigida=5. Nunca `opportunity_score`, popularidad, ratings ni intuición de estilo. Desempate: `score DESC → stock DESC → price ASC → id ASC`.

**Sin resultados**: nunca relaja las restricciones — ofrece WhatsApp con las respuestas reales, reutilizando `buildWhatsAppMessage`/`whatsappHref` ya existentes (el número de teléfono viaja al cliente vía `data-wa-base`, nunca hardcodeado en el JS).

**Dataset cliente**: compacto (11 campos, nunca descripción/galería), embebido inline como `<script type="application/json">`. ~285 candidatos reales, ~352 bytes/candidato promedio, guard de test <450 b/candidato.

**Sin JS**: CTA es un `<button>` inerte, `<noscript>` ofrece WhatsApp, resto de la categoría es HTML servidor puro.

**Sin URLs nuevas**: nada de `/tarot-finder/...`, sin querystrings indexables, sin canonical nuevo.

## Validación

- **Tests focalizados**: `tarot-finder-scoring` 30/30, `tarot-finder-dataset` 12/12, `tarot-finder-render` 14/14 (incluye el nuevo check de `aria-haspopup`), `tarot-finder-client` 20/20 (flujo de estado real + paridad cliente/servidor).
- **Regresión** (#209 + #207 + 8 categorías): 97/97.
- **Suite completa**: `functions/*` 789/791 (worker-sync 117/117, astro-lib 29/29, api 257/257). Mismas 2 fallas CRLF preexistentes, no relacionadas.
- **Sintaxis**: OK en todo el repo, incluido `tarot-finder.js`.
- **Build Astro checkout OFF/ON**: OK, `tarot-finder.js` confirmado en el build estático.
- **Preview**: pendiente (ver nota de dependencia arriba).

## Fuera de alcance en este lote

Sin comparador de mazos, sin cursos, sin B2B implementado (sólo blueprint), sin accesorios externos (auditoría confirmó 0), sin bundles de checkout, sin `/tarot/rider-waite` ni páginas de familia, sin Demand Ledger, sin links desde Home, sin cambios de SEO title globales.

**NO se mergea. NO se toca producción.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)