### PR TITLE
GW1+GW2: Radar de Demanda No Satisfecha + Kit de Lista de Lectura

### DIFF
--- a/astro-front/src/pages/lista-de-libros.astro
+++ b/astro-front/src/pages/lista-de-libros.astro
@@ -21,7 +21,7 @@ const jsonLd = {
 
 <BaseLayout
   title="Consultá tu lista de libros | Amado Libros"
-  description="Pegá tu lista de libros del liceo, la facultad o donde sea y te decimos al instante qué tenemos disponible, qué conseguimos por encargo y qué buscamos por vos."
+  description="Pegá tu lista de libros del liceo, la facultad o donde sea y te decimos al instante qué tenemos disponible, qué lo podemos buscar por encargo y qué buscamos por vos."
   canonical="https://www.amadolibros.com/lista-de-libros"
   jsonLd={jsonLd}
 >
@@ -37,7 +37,7 @@ const jsonLd = {
         <h1 id="list-title">Consultá tu lista de libros</h1>
         <p>
           Pegá los títulos, uno por línea (con autor si lo tenés, mejor). Te decimos
-          al instante qué tenemos disponible ahora, qué podemos conseguir por
+          al instante qué tenemos disponible ahora, qué lo podemos buscar por
           encargo, y para el resto armamos un pedido para buscarlo por vos.
         </p>
       </section>
@@ -78,12 +78,14 @@ const jsonLd = {
 <script>
   const STATUS_LABEL = {
     matched_active: 'Disponible ahora',
-    matched_by_encargo: 'Lo conseguimos por encargo',
+    matched_by_encargo: 'Lo podemos buscar por encargo',
+    needs_confirmation: 'Encontramos más de una coincidencia — confirmamos por WhatsApp',
     no_match: 'No lo identificamos — lo buscamos por vos',
   };
   const STATUS_CLASS = {
     matched_active: 'is-active',
     matched_by_encargo: 'is-encargo',
+    needs_confirmation: 'is-needs-confirmation',
     no_match: 'is-no-match',
   };
 
@@ -94,8 +96,12 @@ const jsonLd = {
   const resultsList = document.querySelector('#list-results-items');
   const whatsappCta = document.querySelector('#list-whatsapp-cta');
 
+  // Sin fallback de número hardcodeado: window.AmadoWhatsApp (cargado por
+  // BaseLayout) es la única fuente del número de WhatsApp. Si no está
+  // disponible, no hay CTA de WhatsApp — no duplicamos el número acá.
   function buildWhatsAppMessage(results) {
     const wa = window.AmadoWhatsApp;
+    if (!wa) return null;
     const lines = [
       'Hola, estoy consultando esta lista de libros en Amado Libros 😊',
       '',
@@ -106,10 +112,9 @@ const jsonLd = {
       const label = STATUS_LABEL[r.status] || 'Consultar';
       lines.push(`- ${r.query} — ${label}`);
     });
-    lines.push('', `Página: ${wa ? wa.absolutePage(window.location.href) : window.location.href}`);
+    lines.push('', `Página: ${wa.absolutePage(window.location.href)}`);
     lines.push('', 'Quisiera confirmar precios, tiempos de encargo y coordinar la compra. Gracias.');
-    const text = lines.join('\n');
-    return wa ? wa.href(text) : `https://wa.me/59899841325?text=${encodeURIComponent(text)}`;
+    return wa.href(lines.join('\n'));
   }
 
   async function checkList() {
@@ -136,7 +141,8 @@ const jsonLd = {
       resultsList.replaceChildren(...results.map(r => {
         const li = document.createElement('li');
         li.className = `list-result-item ${STATUS_CLASS[r.status] || ''}`;
-        const title = r.match ? r.match.title : r.query;
+        const candidateTitles = Array.isArray(r.candidates) ? r.candidates.map(c => c.title).join(' / ') : '';
+        const title = r.match ? r.match.title : (candidateTitles || r.query);
         const priceText = r.match && r.match.price ? ` — $${Number(r.match.price).toLocaleString('es-UY')} UYU` : '';
         li.innerHTML = `<span class="list-result-status">${STATUS_LABEL[r.status] || ''}</span>` +
           `<span class="list-result-title"></span>` +
@@ -146,12 +152,17 @@ const jsonLd = {
         return li;
       }));
       resultsSection.hidden = false;
-      whatsappCta.href = buildWhatsAppMessage(results);
+      const waUrl = buildWhatsAppMessage(results);
+      // Si window.AmadoWhatsApp no cargó, ocultamos el CTA en vez de armar
+      // un link con un número duplicado a mano.
+      whatsappCta.hidden = !waUrl;
+      if (waUrl) whatsappCta.href = waUrl;
       statusEl.textContent = '';
       window.gtag?.('event', 'book_list_check_completed', {
         line_count: results.length,
         matched_active: results.filter(r => r.status === 'matched_active').length,
         matched_by_encargo: results.filter(r => r.status === 'matched_by_encargo').length,
+        needs_confirmation: results.filter(r => r.status === 'needs_confirmation').length,
         no_match: results.filter(r => r.status === 'no_match').length,
       });
     } catch (error) {
@@ -323,6 +334,7 @@ const jsonLd = {
 
   .list-result-item.is-active .list-result-status { background: #dcfce7; color: #16a34a; }
   .list-result-item.is-encargo .list-result-status { background: #fff7e8; color: #a94e3d; }
+  .list-result-item.is-needs-confirmation .list-result-status { background: #fef3c7; color: #92400e; }
   .list-result-item.is-no-match .list-result-status { background: #f1f5f9; color: #64748b; }
 
   .list-result-title { color: var(--ink); font-weight: 600; }

--- a/astro-front/src/pages/lista-de-libros.astro
+++ b/astro-front/src/pages/lista-de-libros.astro
@@ -1,0 +1,359 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import WAFloat from '../components/WAFloat.astro';
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  name: 'Consulta de disponibilidad por lista de libros',
+  serviceType: 'Verificación de stock y encargo para varios títulos a la vez',
+  areaServed: { '@type': 'Country', name: 'Uruguay' },
+  provider: {
+    '@type': 'OnlineStore',
+    '@id': 'https://www.amadolibros.com/#bookstore',
+    name: 'Amado Libros',
+    url: 'https://www.amadolibros.com/',
+  },
+};
+---
+
+<BaseLayout
+  title="Consultá tu lista de libros | Amado Libros"
+  description="Pegá tu lista de libros del liceo, la facultad o donde sea y te decimos al instante qué tenemos disponible, qué conseguimos por encargo y qué buscamos por vos."
+  canonical="https://www.amadolibros.com/lista-de-libros"
+  jsonLd={jsonLd}
+>
+  <Header />
+  <main class="list-page">
+    <div class="list-shell">
+      <nav class="breadcrumbs" aria-label="Migas de pan">
+        <a href="/">Inicio</a><span aria-hidden="true">›</span><span>Consultá tu lista</span>
+      </nav>
+
+      <section class="list-intro" aria-labelledby="list-title">
+        <p class="eyebrow">Para listas de liceo, facultad o lo que sea</p>
+        <h1 id="list-title">Consultá tu lista de libros</h1>
+        <p>
+          Pegá los títulos, uno por línea (con autor si lo tenés, mejor). Te decimos
+          al instante qué tenemos disponible ahora, qué podemos conseguir por
+          encargo, y para el resto armamos un pedido para buscarlo por vos.
+        </p>
+      </section>
+
+      <section class="list-form-section" aria-label="Verificar lista">
+        <label for="book-list">Tu lista (un título por línea)</label>
+        <textarea
+          id="book-list"
+          rows="8"
+          maxlength="4000"
+          placeholder={"Cien años de soledad\nEl principito - Saint-Exupéry\n9789871387861"}
+        ></textarea>
+        <div class="list-actions">
+          <button type="button" id="check-list-btn">Verificar</button>
+          <span id="list-status" role="status" aria-live="polite"></span>
+        </div>
+      </section>
+
+      <section id="list-results" class="list-results" hidden aria-labelledby="list-results-title">
+        <h2 id="list-results-title">Resultado</h2>
+        <ul id="list-results-items" class="list-results-items"></ul>
+        <a id="list-whatsapp-cta" class="list-whatsapp-cta" target="_blank" rel="noopener noreferrer">
+          Pedir esta lista por WhatsApp
+        </a>
+      </section>
+
+      <p class="privacy-note">
+        Verificamos tu lista contra nuestro catálogo real. Lo que no identifiquemos queda
+        anotado para que sepamos qué nos están pidiendo — nunca inventamos una coincidencia:
+        si no estamos seguros, te lo decimos y lo buscamos igual por vos.
+      </p>
+    </div>
+  </main>
+  <Footer />
+  <WAFloat />
+</BaseLayout>
+
+<script>
+  const STATUS_LABEL = {
+    matched_active: 'Disponible ahora',
+    matched_by_encargo: 'Lo conseguimos por encargo',
+    no_match: 'No lo identificamos — lo buscamos por vos',
+  };
+  const STATUS_CLASS = {
+    matched_active: 'is-active',
+    matched_by_encargo: 'is-encargo',
+    no_match: 'is-no-match',
+  };
+
+  const textarea = document.querySelector('#book-list');
+  const button = document.querySelector('#check-list-btn');
+  const statusEl = document.querySelector('#list-status');
+  const resultsSection = document.querySelector('#list-results');
+  const resultsList = document.querySelector('#list-results-items');
+  const whatsappCta = document.querySelector('#list-whatsapp-cta');
+
+  function buildWhatsAppMessage(results) {
+    const wa = window.AmadoWhatsApp;
+    const lines = [
+      'Hola, estoy consultando esta lista de libros en Amado Libros 😊',
+      '',
+      'Motivo: Consulta de disponibilidad por lista',
+      'Lista:',
+    ];
+    results.forEach(r => {
+      const label = STATUS_LABEL[r.status] || 'Consultar';
+      lines.push(`- ${r.query} — ${label}`);
+    });
+    lines.push('', `Página: ${wa ? wa.absolutePage(window.location.href) : window.location.href}`);
+    lines.push('', 'Quisiera confirmar precios, tiempos de encargo y coordinar la compra. Gracias.');
+    const text = lines.join('\n');
+    return wa ? wa.href(text) : `https://wa.me/59899841325?text=${encodeURIComponent(text)}`;
+  }
+
+  async function checkList() {
+    const rawLines = textarea.value.split('\n').map(l => l.trim()).filter(Boolean);
+    if (rawLines.length === 0) {
+      statusEl.textContent = 'Escribí al menos un título.';
+      return;
+    }
+    button.disabled = true;
+    statusEl.textContent = 'Verificando…';
+    resultsSection.hidden = true;
+    window.gtag?.('event', 'book_list_check_started', { line_count: rawLines.length });
+
+    try {
+      const response = await fetch('/api/list-lookup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lines: rawLines }),
+      });
+      if (!response.ok) throw new Error('No pudimos verificar la lista.');
+      const data = await response.json();
+      const results = Array.isArray(data.results) ? data.results : [];
+
+      resultsList.replaceChildren(...results.map(r => {
+        const li = document.createElement('li');
+        li.className = `list-result-item ${STATUS_CLASS[r.status] || ''}`;
+        const title = r.match ? r.match.title : r.query;
+        const priceText = r.match && r.match.price ? ` — $${Number(r.match.price).toLocaleString('es-UY')} UYU` : '';
+        li.innerHTML = `<span class="list-result-status">${STATUS_LABEL[r.status] || ''}</span>` +
+          `<span class="list-result-title"></span>` +
+          `<span class="list-result-price"></span>`;
+        li.querySelector('.list-result-title').textContent = title;
+        li.querySelector('.list-result-price').textContent = priceText;
+        return li;
+      }));
+      resultsSection.hidden = false;
+      whatsappCta.href = buildWhatsAppMessage(results);
+      statusEl.textContent = '';
+      window.gtag?.('event', 'book_list_check_completed', {
+        line_count: results.length,
+        matched_active: results.filter(r => r.status === 'matched_active').length,
+        matched_by_encargo: results.filter(r => r.status === 'matched_by_encargo').length,
+        no_match: results.filter(r => r.status === 'no_match').length,
+      });
+    } catch (error) {
+      statusEl.textContent = 'No pudimos verificar la lista. Probá de nuevo en un momento.';
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  button.addEventListener('click', checkList);
+</script>
+
+<style>
+  .list-page {
+    padding: 0 1rem 3.5rem;
+    background:
+      radial-gradient(circle at 85% 8%, rgba(228, 153, 130, 0.13), transparent 32%),
+      var(--bg);
+  }
+
+  .list-shell {
+    width: 100%;
+    max-width: 760px;
+    margin: 0 auto;
+  }
+
+  .breadcrumbs {
+    display: flex;
+    gap: 0.45rem;
+    padding: 1rem 0;
+    color: var(--ink-2);
+    font-size: 0.78rem;
+  }
+
+  .breadcrumbs a { color: var(--salmon-hover); }
+
+  .list-intro {
+    padding: clamp(1.4rem, 5vw, 3rem);
+    border: 1px solid var(--border);
+    border-radius: 1.15rem 1.15rem 0 0;
+    background: var(--ink);
+    color: #fff;
+  }
+
+  .eyebrow {
+    color: var(--salmon);
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+  }
+
+  .list-intro h1 {
+    max-width: 20ch;
+    margin-top: 0.45rem;
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 7vw, 3.2rem);
+    letter-spacing: -0.035em;
+    line-height: 1.06;
+  }
+
+  .list-intro > p:not(.eyebrow) {
+    max-width: 62ch;
+    margin-top: 0.9rem;
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 0.94rem;
+  }
+
+  .list-form-section {
+    display: grid;
+    gap: 0.75rem;
+    padding: clamp(1.2rem, 4vw, 2.3rem);
+    border: 1px solid var(--border);
+    border-top: 0;
+    background: #fff;
+  }
+
+  .list-form-section label {
+    color: var(--ink);
+    font-size: 0.82rem;
+    font-weight: 800;
+  }
+
+  #book-list {
+    width: 100%;
+    min-height: 180px;
+    padding: 0.85rem;
+    border: 1px solid #d7cec3;
+    border-radius: 0.65rem;
+    outline: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font: 500 0.92rem/1.5 var(--font-ui);
+    resize: vertical;
+  }
+
+  #book-list:focus {
+    border-color: var(--salmon-hover);
+    box-shadow: 0 0 0 3px rgba(228, 153, 130, 0.16);
+  }
+
+  .list-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  #check-list-btn {
+    min-height: 50px;
+    padding: 0.75rem 1.5rem;
+    border: 0;
+    border-radius: 0.7rem;
+    background: var(--salmon);
+    color: #18120e;
+    font-size: 0.9rem;
+    font-weight: 800;
+    cursor: pointer;
+  }
+
+  #check-list-btn:hover { background: var(--salmon-hover); }
+  #check-list-btn:disabled { opacity: 0.6; cursor: wait; }
+
+  #list-status {
+    font-size: 0.82rem;
+    color: var(--ink-2);
+  }
+
+  .list-results {
+    padding: clamp(1.2rem, 4vw, 2.3rem);
+    border: 1px solid var(--border);
+    border-top: 0;
+    border-radius: 0 0 1.15rem 1.15rem;
+    background: #fff;
+  }
+
+  .list-results h2 {
+    font-size: 1.05rem;
+    margin-bottom: 0.9rem;
+    color: var(--ink);
+  }
+
+  .list-results-items {
+    display: grid;
+    gap: 0.55rem;
+    padding: 0;
+    margin: 0 0 1.1rem;
+    list-style: none;
+  }
+
+  .list-result-item {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 0.55rem;
+    font-size: 0.85rem;
+  }
+
+  .list-result-status {
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.68rem;
+    font-weight: 800;
+    white-space: nowrap;
+  }
+
+  .list-result-item.is-active .list-result-status { background: #dcfce7; color: #16a34a; }
+  .list-result-item.is-encargo .list-result-status { background: #fff7e8; color: #a94e3d; }
+  .list-result-item.is-no-match .list-result-status { background: #f1f5f9; color: #64748b; }
+
+  .list-result-title { color: var(--ink); font-weight: 600; }
+  .list-result-price { color: var(--ink-2); font-size: 0.8rem; white-space: nowrap; }
+
+  .list-whatsapp-cta {
+    display: inline-flex;
+    min-height: 50px;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border-radius: 0.7rem;
+    background: var(--wa);
+    color: #102516;
+    font-size: 0.9rem;
+    font-weight: 800;
+    text-decoration: none;
+    text-align: center;
+  }
+
+  .list-whatsapp-cta:hover { background: var(--wa-hover); }
+
+  .privacy-note {
+    margin-top: 1rem;
+    color: var(--ink-2);
+    font-size: 0.74rem;
+    line-height: 1.5;
+  }
+
+  @media (min-width: 640px) {
+    .list-actions { flex-wrap: nowrap; }
+  }
+</style>

--- a/astro-front/src/pages/pedir-libro.astro
+++ b/astro-front/src/pages/pedir-libro.astro
@@ -153,6 +153,10 @@ const jsonLd = {
           <a id="catalog-search-link" href="/catalogo">Buscar primero en el catálogo</a>
         </div>
 
+        <p class="field-wide multi-title-note">
+          ¿Tenés varios títulos? <a href="/lista-de-libros">Consultá una lista completa</a>
+        </p>
+
         <p class="privacy-note field-wide">
           Este formulario no guarda datos en la web. Al continuar se abre WhatsApp con la información ordenada para que podamos buscarla manualmente.
         </p>
@@ -411,10 +415,18 @@ const jsonLd = {
 
   .field small,
   .privacy-note,
-  .context-note {
+  .context-note,
+  .multi-title-note {
     color: var(--ink-2);
     font-size: 0.72rem;
     line-height: 1.45;
+  }
+
+  .multi-title-note a {
+    color: var(--salmon-hover);
+    font-weight: 800;
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
   }
 
   .context-note {

--- a/functions/__tests__/catalogo-demand-radar.test.js
+++ b/functions/__tests__/catalogo-demand-radar.test.js
@@ -1,0 +1,186 @@
+// GW1 (Radar de Demanda No Satisfecha) en /catalogo — el registro debe medir
+// si el libro existe en TODO el catálogo elegible, no en la vista filtrada.
+// Un libro real que el usuario dejó afuera con un filtro de categoría o de
+// disponibilidad no es demanda insatisfecha: es un libro que sí tenemos.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+import { onRequest as catalogRequest } from '../catalogo.js';
+import { PAUSED_MANIFEST_URL, PRODUCTION_MANIFEST_URL, R2_BASE } from '../_shared/catalog.js';
+
+const CATALOG = {
+    total: 2,
+    items: [
+        {
+            id: 'MLU1', title: 'El Género En Disputa', author: 'Judith Butler',
+            isbn: '9780415924993', price: 1000, status: 'active', available_quantity: 2,
+            thumbnail: '', pictures: [], permalink: 'https://x/MLU1',
+        },
+        {
+            id: 'MLU5', title: 'Vinilo The Beatles Abbey Road', author: '',
+            isbn: '5', price: 700, status: 'active', available_quantity: 1,
+            thumbnail: '', pictures: [], permalink: 'https://x/MLU5',
+        },
+    ],
+};
+
+const ACTIVE_CATEGORIES = {
+    generated_at: '2026-08-02T00:00:00.000Z',
+    taxonomy_version: 2,
+    rules_version: 8,
+    categories: [
+        { id: 'filosofia-ciencias-sociales', name: 'Filosofía y ciencias sociales', count: 1, subcategories: [] },
+        { id: 'esoterismo-tarot', name: 'Esoterismo y tarot', count: 0, subcategories: [] },
+    ],
+    items: {
+        MLU1: ['filosofia-ciencias-sociales'],
+    },
+};
+
+const PAUSED_MANIFEST = {
+    schema_version: 1,
+    current: {
+        version: 'v1',
+        index_key: 'stock1-preview/index.json',
+        block_prefix: 'stock1-preview/blocks',
+        block_count: 1,
+    },
+};
+
+const PAUSED_INDEX = {
+    schema_version: 1,
+    fields: ['id', 'title', 'author', 'isbn', 'image'],
+    derived_fields: { slug: 'slugify-v1', status: 'paused', block: 'numeric-id-mod-block-count' },
+    block_count: 1,
+    items: [
+        // Sólo existe por encargo — ningún activo lo matchea.
+        ['MLU6', 'Diccionario Inglés Avanzado', 'Autor Encargo', '111', ''],
+    ],
+};
+
+function createD1() {
+    const sqlite = new DatabaseSync(':memory:');
+    sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS demand_radar_unmatched_queries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      normalized_query TEXT NOT NULL,
+      raw_query TEXT NOT NULL,
+      source TEXT NOT NULL CHECK (source IN ('catalogo_search','reading_list')),
+      occurrence_count INTEGER NOT NULL DEFAULT 1,
+      first_seen_at TEXT NOT NULL,
+      last_seen_at TEXT NOT NULL,
+      UNIQUE (normalized_query, source)
+    )`);
+    return {
+        sqlite,
+        prepare(sql) {
+            const statement = sqlite.prepare(sql);
+            return {
+                bind(...args) {
+                    return {
+                        async first() { return statement.get(...args) || null; },
+                        async all() { return { results: statement.all(...args) }; },
+                        async run() {
+                            const result = statement.run(...args);
+                            return { success: true, meta: { changes: Number(result.changes) } };
+                        },
+                    };
+                },
+            };
+        },
+    };
+}
+
+function context(url, { db, waitUntilCalls } = {}) {
+    return {
+        request: new Request(url),
+        params: {},
+        env: { APP_ENV: 'preview', ORDERS_DB: db },
+        waitUntil(promise) {
+            if (waitUntilCalls) waitUntilCalls.push(promise);
+        },
+    };
+}
+
+test.beforeEach(() => {
+    globalThis.caches = {
+        default: {
+            async match(request) {
+                if (request.url === PAUSED_MANIFEST_URL) return Response.json(PAUSED_MANIFEST);
+                if (request.url === PRODUCTION_MANIFEST_URL) return Response.json({ current: null, previous: null });
+                if (request.url === `${R2_BASE}/${PAUSED_MANIFEST.current.index_key}`) {
+                    return Response.json(PAUSED_INDEX);
+                }
+                if (request.url.endsWith('/data/active-categories.json')) {
+                    return Response.json(ACTIVE_CATEGORIES);
+                }
+                return null;
+            },
+            async put() {},
+        },
+    };
+    globalThis.fetch = async () => Response.json(CATALOG);
+});
+
+test.afterEach(() => {
+    delete globalThis.caches;
+    delete globalThis.fetch;
+});
+
+test('existe globalmente (activo) pero la categoría elegida lo excluye → NO registra en el Radar', async () => {
+    const db = createD1();
+    const waitUntilCalls = [];
+    const res = await catalogRequest(context(
+        'https://preview.example/catalogo?q=genero+en+disputa&categoria=esoterismo-tarot',
+        { db, waitUntilCalls },
+    ));
+    assert.equal(res.status, 200);
+    const html = await res.text();
+    assert.doesNotMatch(html, /El Género En Disputa/, 'la vista filtrada efectivamente no lo muestra');
+    await Promise.all(waitUntilCalls);
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 0, 'el libro existe globalmente — no es demanda insatisfecha, sólo quedó fuera del filtro');
+});
+
+test('existe globalmente (por encargo) pero el filtro "disponibles" lo excluye → NO registra en el Radar', async () => {
+    const db = createD1();
+    const waitUntilCalls = [];
+    const res = await catalogRequest(context(
+        'https://preview.example/catalogo?q=diccionario+ingles+avanzado&disponibilidad=disponibles',
+        { db, waitUntilCalls },
+    ));
+    assert.equal(res.status, 200);
+    await Promise.all(waitUntilCalls);
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 0, 'existe por encargo — no es demanda insatisfecha, sólo no está "disponible ahora"');
+});
+
+test('no existe en ningún lado del catálogo elegible → SÍ registra en el Radar', async () => {
+    const db = createD1();
+    const waitUntilCalls = [];
+    const res = await catalogRequest(context(
+        'https://preview.example/catalogo?q=zzzznoexisteenningunaparte',
+        { db, waitUntilCalls },
+    ));
+    assert.equal(res.status, 200);
+    await Promise.all(waitUntilCalls);
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].source, 'catalogo_search');
+    assert.equal(rows[0].raw_query, 'zzzznoexisteenningunaparte');
+});
+
+test('existe globalmente y SIN ningún filtro activo → tampoco registra (totalResults ya sería > 0)', async () => {
+    const db = createD1();
+    const waitUntilCalls = [];
+    const res = await catalogRequest(context(
+        'https://preview.example/catalogo?q=genero+en+disputa',
+        { db, waitUntilCalls },
+    ));
+    assert.equal(res.status, 200);
+    const html = await res.text();
+    assert.match(html, /El Género En Disputa/);
+    await Promise.all(waitUntilCalls);
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 0);
+});

--- a/functions/__tests__/demand-radar.test.js
+++ b/functions/__tests__/demand-radar.test.js
@@ -7,6 +7,7 @@ import {
     ensureDemandRadarSchema,
     matchCatalogLine,
     normalizeQuery,
+    prepareCatalogCandidates,
     recordUnmatchedQuery,
 } from '../_shared/demand-radar.js';
 
@@ -40,6 +41,10 @@ function pausedItem(overrides = {}) {
     return { id: 'MLU2', title: 'El Amor En Los Tiempos Del Cólera', author: 'Gabriel García Márquez', isbn: null, ...overrides };
 }
 
+function prepared({ activeItems = [], pausedItems = [] } = {}) {
+    return prepareCatalogCandidates({ activeItems, pausedItems });
+}
+
 // ── normalizeQuery ────────────────────────────────────────────────────────
 
 test('normalizeQuery: minúsculas, sin acentos, espacios colapsados', () => {
@@ -51,25 +56,17 @@ test('normalizeQuery: minúsculas, sin acentos, espacios colapsados', () => {
 // ── matchCatalogLine: activos ────────────────────────────────────────────
 
 test('matchCatalogLine: título con cobertura fuerte de tokens matchea activo con precio y stock', () => {
-    const result = matchCatalogLine('cien años de soledad', { activeItems: [activeItem()], pausedItems: [] });
+    const result = matchCatalogLine('cien años de soledad', prepared({ activeItems: [activeItem()] }));
     assert.equal(result.status, 'matched_active');
     assert.equal(result.match.id, 'MLU1');
     assert.equal(result.match.price, 1200);
     assert.equal(result.match.stock, 3);
 });
 
-test('matchCatalogLine: activo tiene prioridad sobre por-encargo cuando ambos matchean', () => {
-    const result = matchCatalogLine('cien años de soledad', {
-        activeItems: [activeItem()],
-        pausedItems: [pausedItem({ title: 'Cien Años De Soledad' })],
-    });
-    assert.equal(result.status, 'matched_active');
-});
-
 // ── matchCatalogLine: por encargo ────────────────────────────────────────
 
 test('matchCatalogLine: sin match activo, matchea por-encargo sin precio ni stock (nunca se inventan)', () => {
-    const result = matchCatalogLine('el amor en los tiempos del colera', { activeItems: [], pausedItems: [pausedItem()] });
+    const result = matchCatalogLine('el amor en los tiempos del colera', prepared({ pausedItems: [pausedItem()] }));
     assert.equal(result.status, 'matched_by_encargo');
     assert.equal(result.match.id, 'MLU2');
     assert.equal(result.match.price, null);
@@ -79,10 +76,9 @@ test('matchCatalogLine: sin match activo, matchea por-encargo sin precio ni stoc
 // ── matchCatalogLine: ISBN ────────────────────────────────────────────────
 
 test('matchCatalogLine: ISBN exacto (>=10 dígitos) matchea aunque el título no coincida en texto', () => {
-    const result = matchCatalogLine('978-987-138-786-1', {
+    const result = matchCatalogLine('978-987-138-786-1', prepared({
         activeItems: [activeItem({ id: 'MLU9', title: 'Título Distinto', isbn: '9789871387861' })],
-        pausedItems: [],
-    });
+    }));
     assert.equal(result.status, 'matched_active');
     assert.equal(result.match.id, 'MLU9');
 });
@@ -90,32 +86,128 @@ test('matchCatalogLine: ISBN exacto (>=10 dígitos) matchea aunque el título no
 // ── matchCatalogLine: no_match — nunca inventa una coincidencia dudosa ──
 
 test('matchCatalogLine: sin ningún candidato real, no_match', () => {
-    const result = matchCatalogLine('un libro que no existe en absoluto', { activeItems: [activeItem()], pausedItems: [] });
+    const result = matchCatalogLine('un libro que no existe en absoluto', prepared({ activeItems: [activeItem()] }));
     assert.equal(result.status, 'no_match');
     assert.equal(result.match, null);
 });
 
 test('matchCatalogLine: coincidencia de una sola palabra común NO alcanza (evita falsos positivos)', () => {
-    // "el libro" comparte sólo "libro" con un título que también dice
-    // "libro" en otro contexto — no debe considerarse una coincidencia real.
-    const result = matchCatalogLine('el libro', {
+    const result = matchCatalogLine('el libro', prepared({
         activeItems: [activeItem({ title: 'Un Libro Cualquiera Sobre Otra Cosa Completamente Distinta' })],
-        pausedItems: [],
-    });
+    }));
     assert.equal(result.status, 'no_match');
 });
 
 test('matchCatalogLine: cobertura parcial insuficiente (menos del 80% de los tokens) queda no_match', () => {
-    const result = matchCatalogLine('cien años de soledad y algo mas que no esta', {
-        activeItems: [activeItem()],
-        pausedItems: [],
-    });
+    const result = matchCatalogLine('cien años de soledad y algo mas que no esta', prepared({ activeItems: [activeItem()] }));
     assert.equal(result.status, 'no_match');
 });
 
 test('matchCatalogLine: línea vacía devuelve null (no genera una fila de resultado)', () => {
-    assert.equal(matchCatalogLine('   ', { activeItems: [], pausedItems: [] }), null);
-    assert.equal(matchCatalogLine('', { activeItems: [], pausedItems: [] }), null);
+    assert.equal(matchCatalogLine('   ', prepared({})), null);
+    assert.equal(matchCatalogLine('', prepared({})), null);
+});
+
+// ── matchCatalogLine: el autor refuerza, nunca sustituye ni perjudica ────
+
+test('matchCatalogLine: título solo matchea (referencia)', () => {
+    const result = matchCatalogLine('Cien años de soledad', prepared({ activeItems: [activeItem()] }));
+    assert.equal(result.status, 'matched_active');
+});
+
+test('matchCatalogLine: título + autor CORRECTO también matchea (agregar el autor no debe empeorar la cobertura)', () => {
+    const result = matchCatalogLine('Cien años de soledad Gabriel García Márquez', prepared({ activeItems: [activeItem()] }));
+    assert.equal(result.status, 'matched_active');
+    assert.equal(result.match.id, 'MLU1');
+});
+
+test('matchCatalogLine: mismo título + autor INCORRECTO no matchea (el autor no sustituye evidencia de título)', () => {
+    const result = matchCatalogLine('Cien años de soledad Isabel Allende', prepared({ activeItems: [activeItem()] }));
+    assert.equal(result.status, 'no_match');
+});
+
+test('matchCatalogLine: sólo el nombre del autor (sin ningún token de título) nunca matchea — un autor prolífico es ambiguo por definición', () => {
+    const result = matchCatalogLine('Gabriel García Márquez', prepared({ activeItems: [activeItem()] }));
+    assert.equal(result.status, 'no_match');
+});
+
+// ── matchCatalogLine: ranking determinista + detección de ambigüedad ────
+
+test('matchCatalogLine: empate de precisión entre DOS obras activas distintas → needs_confirmation, nunca una afirmación arbitraria', () => {
+    const itemA = activeItem({ id: 'MLU10', title: 'Poemas', author: 'Autor Uno' });
+    const itemB = activeItem({ id: 'MLU11', title: 'Poemas', author: 'Autor Dos' });
+    const result = matchCatalogLine('poemas', prepared({ activeItems: [itemA, itemB] }));
+    assert.equal(result.status, 'needs_confirmation');
+    assert.equal(result.match, null);
+    assert.equal(result.candidates.length, 2);
+    assert.deepEqual(result.candidates.map(c => c.id).sort(), ['MLU10', 'MLU11']);
+});
+
+test('matchCatalogLine: empate de precisión entre DOS obras por-encargo distintas → needs_confirmation', () => {
+    const itemA = pausedItem({ id: 'MLU20', title: 'Ensayos', author: 'Autor Uno' });
+    const itemB = pausedItem({ id: 'MLU21', title: 'Ensayos', author: 'Autor Dos' });
+    const result = matchCatalogLine('ensayos', prepared({ pausedItems: [itemA, itemB] }));
+    assert.equal(result.status, 'needs_confirmation');
+    assert.equal(result.candidates.length, 2);
+});
+
+test('matchCatalogLine: mismo orden de aparición invertido da el mismo resultado (no depende de la posición en el array)', () => {
+    const itemA = activeItem({ id: 'MLU10', title: 'Poemas', author: 'Autor Uno' });
+    const itemB = activeItem({ id: 'MLU11', title: 'Poemas', author: 'Autor Dos' });
+    const forward = matchCatalogLine('poemas', prepared({ activeItems: [itemA, itemB] }));
+    const reversed = matchCatalogLine('poemas', prepared({ activeItems: [itemB, itemA] }));
+    assert.equal(forward.status, 'needs_confirmation');
+    assert.equal(reversed.status, 'needs_confirmation');
+    assert.deepEqual(forward.candidates.map(c => c.id).sort(), reversed.candidates.map(c => c.id).sort());
+});
+
+// ── matchCatalogLine: activo vs. por-encargo — sólo desempata, no decide ─
+
+test('matchCatalogLine: un activo MEDIOCRE no debe tapar un por-encargo mucho más preciso', () => {
+    // Activa parcial: comparte sólo 2 de 4 tokens del título real buscado.
+    const weakActive = activeItem({ id: 'MLU30', title: 'Eva Luna Historias De Mujeres', author: 'Otro Autor' });
+    // Pausada exacta: coincide 100% con la búsqueda.
+    const exactPaused = pausedItem({ id: 'MLU31', title: 'Eva Luna', author: 'Isabel Allende' });
+    const result = matchCatalogLine('eva luna', prepared({ activeItems: [weakActive], pausedItems: [exactPaused] }));
+    assert.equal(result.status, 'matched_by_encargo', 'la pausada exacta tiene más precisión que la activa parcial');
+    assert.equal(result.match.id, 'MLU31');
+});
+
+test('matchCatalogLine: con precisión IDÉNTICA entre activo y por-encargo, el estado comercial desempata a favor del activo', () => {
+    const active = activeItem({ id: 'MLU40', title: 'Rayuela', author: 'Julio Cortázar' });
+    const paused = pausedItem({ id: 'MLU41', title: 'Rayuela', author: 'Julio Cortázar' });
+    const result = matchCatalogLine('Rayuela Julio Cortázar', prepared({ activeItems: [active], pausedItems: [paused] }));
+    assert.equal(result.status, 'matched_active');
+    assert.equal(result.match.id, 'MLU40');
+});
+
+// ── prepareCatalogCandidates: guard estructural de escala ────────────────
+
+test('prepareCatalogCandidates: pre-tokeniza título y autor una sola vez (estructura reutilizable)', () => {
+    const [candidate] = prepared({ activeItems: [activeItem()] });
+    assert.deepEqual(candidate.titleTokens, ['cien', 'anos', 'de', 'soledad']);
+    assert.ok(candidate.titleTokenSet instanceof Set);
+    assert.deepEqual(candidate.authorTokens, ['gabriel', 'garcia', 'marquez']);
+    assert.ok(candidate.authorTokenSet instanceof Set);
+});
+
+test('matchCatalogLine reutiliza los tokens ya preparados en vez de retokenizar por línea (guard estructural de escala)', () => {
+    const candidates = prepared({ activeItems: [activeItem()] });
+    // Saboteamos deliberadamente los tokens ya preparados: si matchCatalogLine
+    // volviera a tokenizar item.title en cada llamada, este sabotaje no
+    // tendría efecto y el resultado seguiría siendo un match.
+    candidates[0].titleTokens = ['manzana'];
+    candidates[0].titleTokenSet = new Set(['manzana']);
+    const result = matchCatalogLine('cien años de soledad', candidates);
+    assert.equal(result.status, 'no_match', 'si usara item.title en vivo esto matchearía; al no matchear, confirma que usa la caché preparada');
+});
+
+test('matchCatalogLine resuelve 40 líneas contra la misma estructura preparada sin volver a llamar prepareCatalogCandidates', () => {
+    const candidates = prepared({ activeItems: [activeItem()], pausedItems: [pausedItem()] });
+    const lines = Array.from({ length: 40 }, (_, i) => (i % 2 === 0 ? 'cien años de soledad' : 'el amor en los tiempos del colera'));
+    const results = lines.map(line => matchCatalogLine(line, candidates));
+    assert.equal(results.length, 40);
+    assert.ok(results.every(r => r.status === 'matched_active' || r.status === 'matched_by_encargo'));
 });
 
 // ── recordUnmatchedQuery / ensureDemandRadarSchema (D1 real vía sqlite) ──
@@ -124,23 +216,43 @@ test('recordUnmatchedQuery: primera vez inserta con occurrence_count=1', async (
     const db = createD1();
     await ensureDemandRadarSchema(db);
     await recordUnmatchedQuery(db, { rawQuery: 'Rayuela Cortázar', source: 'catalogo_search', appEnv: 'production' });
-    const row = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries WHERE normalized_query = ?').get('rayuela cortazar');
+    const row = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries WHERE normalized_query = ? AND source = ?').get('rayuela cortazar', 'catalogo_search');
     assert.ok(row);
     assert.equal(row.occurrence_count, 1);
     assert.equal(row.raw_query, 'Rayuela Cortázar');
     assert.equal(row.source, 'catalogo_search');
 });
 
-test('recordUnmatchedQuery: repetir la misma búsqueda (normalizada) incrementa el contador, no duplica fila', async () => {
+test('recordUnmatchedQuery: repetir la misma búsqueda (normalizada, misma fuente) incrementa el contador, no duplica fila', async () => {
     const db = createD1();
     await ensureDemandRadarSchema(db);
     await recordUnmatchedQuery(db, { rawQuery: 'rayuela', source: 'catalogo_search' });
-    await recordUnmatchedQuery(db, { rawQuery: 'Rayuela', source: 'autocomplete' });
-    await recordUnmatchedQuery(db, { rawQuery: '  RAYUELA  ', source: 'reading_list' });
+    await recordUnmatchedQuery(db, { rawQuery: 'Rayuela', source: 'catalogo_search' });
+    await recordUnmatchedQuery(db, { rawQuery: '  RAYUELA  ', source: 'catalogo_search' });
     const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
     assert.equal(rows.length, 1);
     assert.equal(rows[0].occurrence_count, 3);
-    assert.equal(rows[0].source, 'reading_list', 'la fuente se actualiza a la del último evento');
+});
+
+test('recordUnmatchedQuery: la MISMA query normalizada en fuentes distintas genera dos filas separadas, sin pisar la atribución de origen', async () => {
+    const db = createD1();
+    await ensureDemandRadarSchema(db);
+    await recordUnmatchedQuery(db, { rawQuery: 'rayuela', source: 'catalogo_search' });
+    await recordUnmatchedQuery(db, { rawQuery: 'rayuela', source: 'reading_list' });
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries ORDER BY source').all();
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].source, 'catalogo_search');
+    assert.equal(rows[0].occurrence_count, 1);
+    assert.equal(rows[1].source, 'reading_list');
+    assert.equal(rows[1].occurrence_count, 1);
+});
+
+test('recordUnmatchedQuery: "autocomplete" ya no es una fuente válida — se ignora silenciosamente', async () => {
+    const db = createD1();
+    await ensureDemandRadarSchema(db);
+    await recordUnmatchedQuery(db, { rawQuery: 'consulta valida', source: 'autocomplete' });
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 0);
 });
 
 test('recordUnmatchedQuery: sin db (undefined), no lanza (llamador siempre puede invocarlo sin binding)', async () => {
@@ -163,4 +275,74 @@ test('recordUnmatchedQuery: recorta a MAX_QUERY_LENGTH sin lanzar con input extr
     const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
     assert.equal(rows.length, 1);
     assert.ok(rows[0].raw_query.length <= 200);
+});
+
+// ── recordUnmatchedQuery: higiene de PII para 'reading_list' ─────────────
+
+test('recordUnmatchedQuery: NO persiste una línea de reading_list que contiene un email', async () => {
+    const db = createD1();
+    await ensureDemandRadarSchema(db);
+    await recordUnmatchedQuery(db, { rawQuery: 'contactame a juan@example.com por el libro', source: 'reading_list' });
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 0);
+});
+
+test('recordUnmatchedQuery: NO persiste una línea de reading_list que contiene una URL', async () => {
+    const db = createD1();
+    await ensureDemandRadarSchema(db);
+    await recordUnmatchedQuery(db, { rawQuery: 'mira este libro en https://ejemplo.com/libro', source: 'reading_list' });
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 0);
+});
+
+test('recordUnmatchedQuery: NO persiste una línea de reading_list que es un teléfono largo (9 dígitos, formato UY móvil)', async () => {
+    const db = createD1();
+    await ensureDemandRadarSchema(db);
+    await recordUnmatchedQuery(db, { rawQuery: '099 123 456', source: 'reading_list' });
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 0);
+});
+
+test('recordUnmatchedQuery: NO persiste una línea de reading_list que es un teléfono largo (8 dígitos, formato UY fijo)', async () => {
+    const db = createD1();
+    await ensureDemandRadarSchema(db);
+    await recordUnmatchedQuery(db, { rawQuery: '2900-1234', source: 'reading_list' });
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 0);
+});
+
+test('recordUnmatchedQuery: SÍ persiste un ISBN-13 de reading_list (shape de 13 dígitos preservado a propósito, no es un teléfono)', async () => {
+    const db = createD1();
+    await ensureDemandRadarSchema(db);
+    await recordUnmatchedQuery(db, { rawQuery: '9789871387861', source: 'reading_list' });
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 1);
+});
+
+test('recordUnmatchedQuery: SÍ persiste un ISBN-10 de reading_list', async () => {
+    const db = createD1();
+    await ensureDemandRadarSchema(db);
+    await recordUnmatchedQuery(db, { rawQuery: '0143039431', source: 'reading_list' });
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 1);
+});
+
+test('recordUnmatchedQuery: SÍ persiste un título normal con números cortos (ej. "1984")', async () => {
+    const db = createD1();
+    await ensureDemandRadarSchema(db);
+    await recordUnmatchedQuery(db, { rawQuery: '1984 George Orwell', source: 'reading_list' });
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 1);
+});
+
+test('recordUnmatchedQuery: la higiene de PII no aplica a catalogo_search (la caja de búsqueda no es texto libre pegado)', async () => {
+    const db = createD1();
+    await ensureDemandRadarSchema(db);
+    // Un número de 9 dígitos buscado explícitamente en /catalogo?q= (por
+    // ejemplo, alguien probando un ISBN mal copiado) sí se registra —
+    // sólo 'reading_list' aplica el filtro de teléfonos, porque ahí el
+    // texto es pegado libremente y con más riesgo de traer datos ajenos.
+    await recordUnmatchedQuery(db, { rawQuery: '099123456', source: 'catalogo_search' });
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 1);
 });

--- a/functions/__tests__/demand-radar.test.js
+++ b/functions/__tests__/demand-radar.test.js
@@ -1,0 +1,166 @@
+// GW1 (Radar de Demanda No Satisfecha) + GW2 (Kit de Lista de Lectura) —
+// lógica pura de matching y persistencia del registro agregado.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+import {
+    ensureDemandRadarSchema,
+    matchCatalogLine,
+    normalizeQuery,
+    recordUnmatchedQuery,
+} from '../_shared/demand-radar.js';
+
+function createD1() {
+    const sqlite = new DatabaseSync(':memory:');
+    return {
+        sqlite,
+        prepare(sql) {
+            const statement = sqlite.prepare(sql);
+            return {
+                bind(...args) {
+                    return {
+                        async first() { return statement.get(...args) || null; },
+                        async all() { return { results: statement.all(...args) }; },
+                        async run() {
+                            const result = statement.run(...args);
+                            return { success: true, meta: { changes: Number(result.changes) } };
+                        },
+                    };
+                },
+            };
+        },
+    };
+}
+
+function activeItem(overrides = {}) {
+    return { id: 'MLU1', title: 'Cien Años De Soledad', author: 'Gabriel García Márquez', isbn: null, price: 1200, available_quantity: 3, ...overrides };
+}
+
+function pausedItem(overrides = {}) {
+    return { id: 'MLU2', title: 'El Amor En Los Tiempos Del Cólera', author: 'Gabriel García Márquez', isbn: null, ...overrides };
+}
+
+// ── normalizeQuery ────────────────────────────────────────────────────────
+
+test('normalizeQuery: minúsculas, sin acentos, espacios colapsados', () => {
+    assert.equal(normalizeQuery('  Cién   Años  '), 'cien anos');
+    assert.equal(normalizeQuery(''), '');
+    assert.equal(normalizeQuery(null), '');
+});
+
+// ── matchCatalogLine: activos ────────────────────────────────────────────
+
+test('matchCatalogLine: título con cobertura fuerte de tokens matchea activo con precio y stock', () => {
+    const result = matchCatalogLine('cien años de soledad', { activeItems: [activeItem()], pausedItems: [] });
+    assert.equal(result.status, 'matched_active');
+    assert.equal(result.match.id, 'MLU1');
+    assert.equal(result.match.price, 1200);
+    assert.equal(result.match.stock, 3);
+});
+
+test('matchCatalogLine: activo tiene prioridad sobre por-encargo cuando ambos matchean', () => {
+    const result = matchCatalogLine('cien años de soledad', {
+        activeItems: [activeItem()],
+        pausedItems: [pausedItem({ title: 'Cien Años De Soledad' })],
+    });
+    assert.equal(result.status, 'matched_active');
+});
+
+// ── matchCatalogLine: por encargo ────────────────────────────────────────
+
+test('matchCatalogLine: sin match activo, matchea por-encargo sin precio ni stock (nunca se inventan)', () => {
+    const result = matchCatalogLine('el amor en los tiempos del colera', { activeItems: [], pausedItems: [pausedItem()] });
+    assert.equal(result.status, 'matched_by_encargo');
+    assert.equal(result.match.id, 'MLU2');
+    assert.equal(result.match.price, null);
+    assert.equal(result.match.stock, null);
+});
+
+// ── matchCatalogLine: ISBN ────────────────────────────────────────────────
+
+test('matchCatalogLine: ISBN exacto (>=10 dígitos) matchea aunque el título no coincida en texto', () => {
+    const result = matchCatalogLine('978-987-138-786-1', {
+        activeItems: [activeItem({ id: 'MLU9', title: 'Título Distinto', isbn: '9789871387861' })],
+        pausedItems: [],
+    });
+    assert.equal(result.status, 'matched_active');
+    assert.equal(result.match.id, 'MLU9');
+});
+
+// ── matchCatalogLine: no_match — nunca inventa una coincidencia dudosa ──
+
+test('matchCatalogLine: sin ningún candidato real, no_match', () => {
+    const result = matchCatalogLine('un libro que no existe en absoluto', { activeItems: [activeItem()], pausedItems: [] });
+    assert.equal(result.status, 'no_match');
+    assert.equal(result.match, null);
+});
+
+test('matchCatalogLine: coincidencia de una sola palabra común NO alcanza (evita falsos positivos)', () => {
+    // "el libro" comparte sólo "libro" con un título que también dice
+    // "libro" en otro contexto — no debe considerarse una coincidencia real.
+    const result = matchCatalogLine('el libro', {
+        activeItems: [activeItem({ title: 'Un Libro Cualquiera Sobre Otra Cosa Completamente Distinta' })],
+        pausedItems: [],
+    });
+    assert.equal(result.status, 'no_match');
+});
+
+test('matchCatalogLine: cobertura parcial insuficiente (menos del 80% de los tokens) queda no_match', () => {
+    const result = matchCatalogLine('cien años de soledad y algo mas que no esta', {
+        activeItems: [activeItem()],
+        pausedItems: [],
+    });
+    assert.equal(result.status, 'no_match');
+});
+
+test('matchCatalogLine: línea vacía devuelve null (no genera una fila de resultado)', () => {
+    assert.equal(matchCatalogLine('   ', { activeItems: [], pausedItems: [] }), null);
+    assert.equal(matchCatalogLine('', { activeItems: [], pausedItems: [] }), null);
+});
+
+// ── recordUnmatchedQuery / ensureDemandRadarSchema (D1 real vía sqlite) ──
+
+test('recordUnmatchedQuery: primera vez inserta con occurrence_count=1', async () => {
+    const db = createD1();
+    await ensureDemandRadarSchema(db);
+    await recordUnmatchedQuery(db, { rawQuery: 'Rayuela Cortázar', source: 'catalogo_search', appEnv: 'production' });
+    const row = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries WHERE normalized_query = ?').get('rayuela cortazar');
+    assert.ok(row);
+    assert.equal(row.occurrence_count, 1);
+    assert.equal(row.raw_query, 'Rayuela Cortázar');
+    assert.equal(row.source, 'catalogo_search');
+});
+
+test('recordUnmatchedQuery: repetir la misma búsqueda (normalizada) incrementa el contador, no duplica fila', async () => {
+    const db = createD1();
+    await ensureDemandRadarSchema(db);
+    await recordUnmatchedQuery(db, { rawQuery: 'rayuela', source: 'catalogo_search' });
+    await recordUnmatchedQuery(db, { rawQuery: 'Rayuela', source: 'autocomplete' });
+    await recordUnmatchedQuery(db, { rawQuery: '  RAYUELA  ', source: 'reading_list' });
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].occurrence_count, 3);
+    assert.equal(rows[0].source, 'reading_list', 'la fuente se actualiza a la del último evento');
+});
+
+test('recordUnmatchedQuery: sin db (undefined), no lanza (llamador siempre puede invocarlo sin binding)', async () => {
+    await assert.doesNotReject(recordUnmatchedQuery(undefined, { rawQuery: 'x', source: 'catalogo_search' }));
+});
+
+test('recordUnmatchedQuery: query demasiado corta o source inválido se ignora silenciosamente', async () => {
+    const db = createD1();
+    await ensureDemandRadarSchema(db);
+    await recordUnmatchedQuery(db, { rawQuery: 'a', source: 'catalogo_search' });
+    await recordUnmatchedQuery(db, { rawQuery: 'consulta valida', source: 'fuente_no_reconocida' });
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 0);
+});
+
+test('recordUnmatchedQuery: recorta a MAX_QUERY_LENGTH sin lanzar con input extremadamente largo', async () => {
+    const db = createD1();
+    await ensureDemandRadarSchema(db);
+    await recordUnmatchedQuery(db, { rawQuery: 'x'.repeat(5000), source: 'catalogo_search' });
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 1);
+    assert.ok(rows[0].raw_query.length <= 200);
+});

--- a/functions/_shared/demand-radar.js
+++ b/functions/_shared/demand-radar.js
@@ -12,14 +12,21 @@
  * consultable de qué se busca y no se encuentra, para decidir qué conseguir
  * a continuación. No toca la promesa de privacidad de /pedir-libro (ese
  * formulario sigue sin loguear nada) — sólo persiste el TEXTO de búsqueda
- * público de /catalogo?q= y del autocompletado (ya visible en la URL/en
- * Search Console), nunca datos personales.
+ * público de /catalogo?q= (búsqueda explícita) y de la lista de GW2, nunca
+ * datos personales del formulario.
+ *
+ * Fuentes registradas: sólo 'catalogo_search' y 'reading_list' — el
+ * autocompletado NO alimenta este ledger (capturaría fragmentos mientras la
+ * persona todavía está tipeando, antes de decidir qué buscar de verdad;
+ * sería ruido, no demanda real).
  *
  * GW2 reutiliza el mismo catálogo activo+pausado ya cargado en cada
  * request (fetchActiveIndex/fetchPausedIndex, sin fetch adicional) para
  * responder, línea por línea de una lista de títulos, si Amado lo tiene
  * ahora, si lo puede conseguir por encargo, o si no lo identifica — nunca
- * inventa una coincidencia dudosa.
+ * inventa una coincidencia dudosa, y si dos obras distintas quedan
+ * indistinguibles, devuelve 'needs_confirmation' en vez de una afirmación
+ * falsa.
  */
 
 function normalizeQuery(value) {
@@ -35,15 +42,21 @@ function normalizeQuery(value) {
 // Persistencia — GW1
 // ---------------------------------------------------------------------------
 
+// La clave es (normalized_query, source): la MISMA palabra buscada en
+// /catalogo?q= y pegada en una lista son señales de calidad distinta y no
+// deben pisarse — mezclarlas en una sola fila destruiría la atribución de
+// origen que el negocio necesita para decidir qué canal está generando la
+// demanda.
 const UNMATCHED_QUERIES_TABLE_SQL = `
 CREATE TABLE IF NOT EXISTS demand_radar_unmatched_queries (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  normalized_query TEXT NOT NULL UNIQUE,
+  normalized_query TEXT NOT NULL,
   raw_query TEXT NOT NULL,
-  source TEXT NOT NULL CHECK (source IN ('catalogo_search','autocomplete','reading_list')),
+  source TEXT NOT NULL CHECK (source IN ('catalogo_search','reading_list')),
   occurrence_count INTEGER NOT NULL DEFAULT 1,
   first_seen_at TEXT NOT NULL,
-  last_seen_at TEXT NOT NULL
+  last_seen_at TEXT NOT NULL,
+  UNIQUE (normalized_query, source)
 )`;
 
 const previewSchemaPromises = new WeakMap();
@@ -72,20 +85,46 @@ export async function ensureDemandRadarSchema(db) {
 
 const MAX_QUERY_LENGTH = 200;
 const MIN_QUERY_LENGTH = 2;
+const VALID_SOURCES = ['catalogo_search', 'reading_list'];
+
+const EMAIL_RE = /[^\s@]+@[^\s@]+\.[^\s@]+/;
+const URL_RE = /https?:\/\/|www\./i;
+
+/**
+ * GW2: 'reading_list' es texto libre que la persona pega tal cual — a
+ * diferencia de /catalogo?q=, puede traer un mail, un teléfono o una URL
+ * sin que lo piense como "una búsqueda". Esto sólo afecta si la línea se
+ * persiste en el ledger agregado; la respuesta que ve la persona
+ * (matchCatalogLine) nunca depende de esto. Un ISBN real (10 o 13 dígitos,
+ * el mismo shape que ya usa matchCatalogLine) se preserva a propósito: es
+ * una señal de demanda válida, no un teléfono.
+ */
+function looksLikePersonalData(raw) {
+    if (EMAIL_RE.test(raw)) return true;
+    if (URL_RE.test(raw)) return true;
+    const digitsOnly = raw.replace(/[^\d]/g, '');
+    const nonSpaceLength = raw.replace(/\s/g, '').length;
+    const mostlyDigits = digitsOnly.length >= 7 && nonSpaceLength > 0 &&
+        (digitsOnly.length / nonSpaceLength) > 0.7;
+    if (!mostlyDigits) return false;
+    const isIsbnShaped = digitsOnly.length === 10 || digitsOnly.length === 13;
+    return !isIsbnShaped;
+}
 
 /**
  * Registra (o incrementa) una búsqueda sin resultado. Deliberadamente
  * "best effort": un fallo acá NUNCA debe romper la respuesta al usuario —
  * quien llama a esta función es responsable de invocarla de forma que no
  * bloquee ni pueda tirar abajo el request (ver uso con ctx.waitUntil en
- * catalogo.js / search-suggestions.js / list-lookup.js).
+ * catalogo.js / list-lookup.js).
  */
 export async function recordUnmatchedQuery(db, { rawQuery, source, appEnv } = {}) {
     if (!db) return;
     const raw = String(rawQuery || '').trim().slice(0, MAX_QUERY_LENGTH);
     const normalized = normalizeQuery(raw);
     if (normalized.length < MIN_QUERY_LENGTH) return;
-    if (!['catalogo_search', 'autocomplete', 'reading_list'].includes(source)) return;
+    if (!VALID_SOURCES.includes(source)) return;
+    if (source === 'reading_list' && looksLikePersonalData(raw)) return;
 
     if (appEnv === 'preview') await ensureDemandRadarSchema(db);
 
@@ -94,10 +133,9 @@ export async function recordUnmatchedQuery(db, { rawQuery, source, appEnv } = {}
     INSERT INTO demand_radar_unmatched_queries
       (normalized_query, raw_query, source, occurrence_count, first_seen_at, last_seen_at)
     VALUES (?, ?, ?, 1, ?, ?)
-    ON CONFLICT(normalized_query) DO UPDATE SET
+    ON CONFLICT(normalized_query, source) DO UPDATE SET
       occurrence_count = occurrence_count + 1,
       raw_query = excluded.raw_query,
-      source = excluded.source,
       last_seen_at = excluded.last_seen_at
   `).bind(normalized, raw, source, now, now).run();
 }
@@ -113,56 +151,79 @@ function tokenize(value) {
 }
 
 /**
- * Sólo cuenta como match cuando hay evidencia real: ISBN exacto (sin
- * guiones/espacios), o superposición fuerte de tokens del título (y,
- * cuando el candidato trae autor, evidencia también en el autor). Un
- * resultado ambiguo se descarta — 'no_match' siempre es preferible a una
- * coincidencia inventada ("tenemos X" siendo en realidad otro libro).
+ * Pre-tokeniza el catálogo (activo + pausado) UNA vez por request, no una
+ * vez por línea. Con hasta 40 líneas por lista, tokenizar cada título de
+ * cada candidato en cada línea multiplica trabajo innecesario — acá se
+ * arma la estructura una sola vez y matchCatalogLine la reutiliza para
+ * todas las líneas de la misma solicitud.
  */
-function scoreCandidate(item, queryTokens, queryDigits) {
-    const isbnDigits = String(item.isbn || '').replace(/\D/g, '');
-    if (queryDigits && isbnDigits && queryDigits.length >= 10 && queryDigits === isbnDigits) {
-        return { score: 100, reason: 'isbn' };
-    }
-    const titleTokens = tokenize(item.title);
-    if (queryTokens.length === 0 || titleTokens.length === 0) return { score: 0, reason: null };
-    const titleTokenSet = new Set(titleTokens);
-    const overlap = queryTokens.filter(t => titleTokenSet.has(t)).length;
-    const coverage = overlap / queryTokens.length;
-    // Exige que prácticamente todos los tokens de la consulta aparezcan en
-    // el título real — evita matchear "el amor en los tiempos" contra
-    // cualquier libro que sólo comparta una palabra común.
-    if (coverage < 0.8 || overlap < Math.min(2, queryTokens.length)) return { score: 0, reason: null };
-    return { score: 10 + overlap, reason: 'title' };
+export function prepareCatalogCandidates({ activeItems = [], pausedItems = [] } = {}) {
+    const prepareOne = (item, status) => {
+        const titleTokens = tokenize(item.title);
+        const authorTokens = tokenize(item.author);
+        return {
+            item,
+            status,
+            titleTokens,
+            titleTokenSet: new Set(titleTokens),
+            authorTokens,
+            authorTokenSet: new Set(authorTokens),
+            isbnDigits: String(item.isbn || '').replace(/\D/g, ''),
+        };
+    };
+    return [
+        ...activeItems.map(item => prepareOne(item, 'matched_active')),
+        ...pausedItems.map(item => prepareOne(item, 'matched_by_encargo')),
+    ];
 }
 
 /**
- * Intenta matchear una línea de texto libre contra el catálogo real.
- * activeItems: items de fetchActiveIndex (con price/available_quantity).
- * pausedItems: items de fetchPausedIndex (sin price/stock: por encargo).
- * Nunca inventa una coincidencia: sin evidencia suficiente, 'no_match'.
+ * Sólo cuenta como match cuando hay evidencia real: ISBN exacto, o
+ * superposición fuerte de tokens del título. El autor, cuando está en la
+ * consulta, REFUERZA una coincidencia de título real (agregar "Gabriel
+ * García Márquez" a "Cien años de soledad" nunca debe empeorar la
+ * cobertura) pero nunca la SUSTITUYE — una consulta que sólo trae el autor
+ * correcto pero ningún token real del título sigue sin matchear, porque
+ * un autor prolífico tiene muchos libros y "sólo el autor" es ambiguo por
+ * definición. Un resultado ambiguo se descarta acá y se resuelve más
+ * arriba (matchCatalogLine): 'no_match'/'needs_confirmation' siempre es
+ * preferible a una coincidencia inventada.
  */
-export function matchCatalogLine(rawLine, { activeItems = [], pausedItems = [] } = {}) {
-    const raw = String(rawLine || '').trim();
-    if (!raw) return null;
-    const queryTokens = tokenize(raw);
-    const queryDigits = ISBN_LIKE_RE.test(raw) ? raw.replace(/\D/g, '') : '';
+function scoreCandidate(candidate, queryTokens, queryDigits) {
+    if (queryDigits && candidate.isbnDigits && queryDigits.length >= 10 && queryDigits === candidate.isbnDigits) {
+        return { score: 100, reason: 'isbn' };
+    }
+    if (queryTokens.length === 0 || candidate.titleTokens.length === 0) return { score: 0, reason: null };
 
-    let best = null;
-    for (const item of activeItems) {
-        const { score, reason } = scoreCandidate(item, queryTokens, queryDigits);
-        if (score > 0 && (!best || score > best.score)) best = { item, score, reason, status: 'matched_active' };
-    }
-    if (!best) {
-        for (const item of pausedItems) {
-            const { score, reason } = scoreCandidate(item, queryTokens, queryDigits);
-            if (score > 0 && (!best || score > best.score)) best = { item, score, reason, status: 'matched_by_encargo' };
-        }
-    }
+    const titleOverlap = queryTokens.filter(t => candidate.titleTokenSet.has(t)).length;
+    // Tokens que sólo el autor explica (ya contados por el título no se
+    // recuentan) — es lo que permite que agregar el autor correcto sume en
+    // vez de diluir la cobertura.
+    const authorOnlyOverlap = queryTokens.filter(t =>
+        !candidate.titleTokenSet.has(t) && candidate.authorTokenSet.has(t)).length;
+    const coveredCount = titleOverlap + authorOnlyOverlap;
+    const coverage = coveredCount / queryTokens.length;
 
-    if (!best) {
-        return { query: raw, status: 'no_match', match: null };
+    // Exige que el TÍTULO por sí solo aporte una base real — el autor sólo
+    // completa cobertura, nunca la reemplaza.
+    if (coverage < 0.8 || titleOverlap < Math.min(2, candidate.titleTokens.length)) {
+        return { score: 0, reason: null };
     }
+    // La precisión combina dos cosas: cuánto de la CONSULTA explica este
+    // candidato (coverage) y cuánto del TÍTULO del candidato usa la
+    // consulta (titlePrecision). Sin lo segundo, "Eva Luna" y "Eva Luna
+    // Historias De Mujeres" puntuarían igual para la búsqueda "eva luna" —
+    // el primero es un match mucho más exacto y debe ganar el ranking, no
+    // sólo empatar por casualidad de orden. El autor, cuando refuerza, suma
+    // un empujón menor — nunca decide por sí solo (ver el gate de arriba).
+    const titlePrecision = titleOverlap / candidate.titleTokens.length;
+    return {
+        score: coverage + titlePrecision + (authorOnlyOverlap > 0 ? 0.01 : 0),
+        reason: authorOnlyOverlap > 0 ? 'title+author' : 'title',
+    };
+}
+
+function toResult(raw, best) {
     const item = best.item;
     return {
         query: raw,
@@ -174,6 +235,61 @@ export function matchCatalogLine(rawLine, { activeItems = [], pausedItems = [] }
             price: best.status === 'matched_active' ? Number(item.price) || 0 : null,
             stock: best.status === 'matched_active' ? Number(item.available_quantity) || 0 : null,
         },
+    };
+}
+
+/**
+ * Intenta matchear una línea de texto libre contra el catálogo ya
+ * preparado por prepareCatalogCandidates(). Activo y pausado se rankean
+ * JUNTOS por precisión — el estado comercial sólo desempata cuando la
+ * precisión es idéntica, nunca antes: un activo mediocre no debe tapar un
+ * por-encargo mucho más exacto. Si tras desempatar por estado comercial
+ * siguen empatadas dos OBRAS DISTINTAS, es ambigüedad real: se devuelve
+ * 'needs_confirmation' en vez de afirmar "tenemos X" siendo en realidad
+ * otro libro.
+ */
+export function matchCatalogLine(rawLine, preparedCandidates = []) {
+    const raw = String(rawLine || '').trim();
+    if (!raw) return null;
+    const queryTokens = tokenize(raw);
+    const queryDigits = ISBN_LIKE_RE.test(raw) ? raw.replace(/\D/g, '') : '';
+
+    const scored = [];
+    for (const candidate of preparedCandidates) {
+        const { score, reason } = scoreCandidate(candidate, queryTokens, queryDigits);
+        if (score > 0) scored.push({ ...candidate, score, reason });
+    }
+
+    if (scored.length === 0) {
+        return { query: raw, status: 'no_match', match: null };
+    }
+
+    const maxScore = Math.max(...scored.map(c => c.score));
+    const top = scored.filter(c => c.score === maxScore);
+    if (top.length === 1) return toResult(raw, top[0]);
+
+    const topActive = top.filter(c => c.status === 'matched_active');
+    if (topActive.length === 1) return toResult(raw, topActive[0]);
+
+    const winners = topActive.length > 1 ? topActive : top;
+    const uniqueById = [];
+    const seenIds = new Set();
+    for (const c of winners) {
+        if (seenIds.has(c.item.id)) continue;
+        seenIds.add(c.item.id);
+        uniqueById.push(c);
+    }
+    if (uniqueById.length === 1) return toResult(raw, uniqueById[0]);
+
+    return {
+        query: raw,
+        status: 'needs_confirmation',
+        match: null,
+        candidates: uniqueById.map(c => ({
+            id: c.item.id,
+            title: c.item.title,
+            author: c.item.author || null,
+        })),
     };
 }
 

--- a/functions/_shared/demand-radar.js
+++ b/functions/_shared/demand-radar.js
@@ -1,0 +1,180 @@
+/**
+ * functions/_shared/demand-radar.js
+ *
+ * GW1 (Radar de Demanda No Satisfecha) + GW2 (Kit de Lista de Lectura).
+ *
+ * GW1 llena un vacío real, no una funcionalidad nueva de cara al cliente:
+ * la recuperación de búsquedas sin resultado YA EXISTE (el CTA de WhatsApp
+ * en functions/catalogo.js y la página /pedir-libro), pero esa página dice
+ * explícitamente "Este formulario no guarda datos en la web" — hoy, cada
+ * búsqueda sin resultado se pierde apenas el visitante cierra la pestaña.
+ * Este módulo agrega la única pieza que faltaba: un registro agregado y
+ * consultable de qué se busca y no se encuentra, para decidir qué conseguir
+ * a continuación. No toca la promesa de privacidad de /pedir-libro (ese
+ * formulario sigue sin loguear nada) — sólo persiste el TEXTO de búsqueda
+ * público de /catalogo?q= y del autocompletado (ya visible en la URL/en
+ * Search Console), nunca datos personales.
+ *
+ * GW2 reutiliza el mismo catálogo activo+pausado ya cargado en cada
+ * request (fetchActiveIndex/fetchPausedIndex, sin fetch adicional) para
+ * responder, línea por línea de una lista de títulos, si Amado lo tiene
+ * ahora, si lo puede conseguir por encargo, o si no lo identifica — nunca
+ * inventa una coincidencia dudosa.
+ */
+
+function normalizeQuery(value) {
+    return String(value || '')
+        .normalize('NFD')
+        .replace(/[̀-ͯ]/g, '')
+        .toLowerCase()
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Persistencia — GW1
+// ---------------------------------------------------------------------------
+
+const UNMATCHED_QUERIES_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS demand_radar_unmatched_queries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  normalized_query TEXT NOT NULL UNIQUE,
+  raw_query TEXT NOT NULL,
+  source TEXT NOT NULL CHECK (source IN ('catalogo_search','autocomplete','reading_list')),
+  occurrence_count INTEGER NOT NULL DEFAULT 1,
+  first_seen_at TEXT NOT NULL,
+  last_seen_at TEXT NOT NULL
+)`;
+
+const previewSchemaPromises = new WeakMap();
+
+/**
+ * Crea la tabla si no existe — sólo necesario en Preview (producción la
+ * recibe vía migrations/, aplicada por deploy.yml). Memoizado por
+ * instancia de DB para no repetir el CREATE TABLE en cada request.
+ */
+export async function ensureDemandRadarSchema(db) {
+    if (!db) return;
+    let pending = previewSchemaPromises.get(db);
+    if (!pending) {
+        pending = db.prepare(UNMATCHED_QUERIES_TABLE_SQL).bind().run();
+        previewSchemaPromises.set(db, pending);
+        try {
+            await pending;
+        } catch (error) {
+            previewSchemaPromises.delete(db);
+            throw error;
+        }
+    } else {
+        await pending;
+    }
+}
+
+const MAX_QUERY_LENGTH = 200;
+const MIN_QUERY_LENGTH = 2;
+
+/**
+ * Registra (o incrementa) una búsqueda sin resultado. Deliberadamente
+ * "best effort": un fallo acá NUNCA debe romper la respuesta al usuario —
+ * quien llama a esta función es responsable de invocarla de forma que no
+ * bloquee ni pueda tirar abajo el request (ver uso con ctx.waitUntil en
+ * catalogo.js / search-suggestions.js / list-lookup.js).
+ */
+export async function recordUnmatchedQuery(db, { rawQuery, source, appEnv } = {}) {
+    if (!db) return;
+    const raw = String(rawQuery || '').trim().slice(0, MAX_QUERY_LENGTH);
+    const normalized = normalizeQuery(raw);
+    if (normalized.length < MIN_QUERY_LENGTH) return;
+    if (!['catalogo_search', 'autocomplete', 'reading_list'].includes(source)) return;
+
+    if (appEnv === 'preview') await ensureDemandRadarSchema(db);
+
+    const now = new Date().toISOString();
+    await db.prepare(`
+    INSERT INTO demand_radar_unmatched_queries
+      (normalized_query, raw_query, source, occurrence_count, first_seen_at, last_seen_at)
+    VALUES (?, ?, ?, 1, ?, ?)
+    ON CONFLICT(normalized_query) DO UPDATE SET
+      occurrence_count = occurrence_count + 1,
+      raw_query = excluded.raw_query,
+      source = excluded.source,
+      last_seen_at = excluded.last_seen_at
+  `).bind(normalized, raw, source, now, now).run();
+}
+
+// ---------------------------------------------------------------------------
+// Matching de lista — GW2
+// ---------------------------------------------------------------------------
+
+const ISBN_LIKE_RE = /^[\d\s-]{8,}$/;
+
+function tokenize(value) {
+    return normalizeQuery(value).split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+/**
+ * Sólo cuenta como match cuando hay evidencia real: ISBN exacto (sin
+ * guiones/espacios), o superposición fuerte de tokens del título (y,
+ * cuando el candidato trae autor, evidencia también en el autor). Un
+ * resultado ambiguo se descarta — 'no_match' siempre es preferible a una
+ * coincidencia inventada ("tenemos X" siendo en realidad otro libro).
+ */
+function scoreCandidate(item, queryTokens, queryDigits) {
+    const isbnDigits = String(item.isbn || '').replace(/\D/g, '');
+    if (queryDigits && isbnDigits && queryDigits.length >= 10 && queryDigits === isbnDigits) {
+        return { score: 100, reason: 'isbn' };
+    }
+    const titleTokens = tokenize(item.title);
+    if (queryTokens.length === 0 || titleTokens.length === 0) return { score: 0, reason: null };
+    const titleTokenSet = new Set(titleTokens);
+    const overlap = queryTokens.filter(t => titleTokenSet.has(t)).length;
+    const coverage = overlap / queryTokens.length;
+    // Exige que prácticamente todos los tokens de la consulta aparezcan en
+    // el título real — evita matchear "el amor en los tiempos" contra
+    // cualquier libro que sólo comparta una palabra común.
+    if (coverage < 0.8 || overlap < Math.min(2, queryTokens.length)) return { score: 0, reason: null };
+    return { score: 10 + overlap, reason: 'title' };
+}
+
+/**
+ * Intenta matchear una línea de texto libre contra el catálogo real.
+ * activeItems: items de fetchActiveIndex (con price/available_quantity).
+ * pausedItems: items de fetchPausedIndex (sin price/stock: por encargo).
+ * Nunca inventa una coincidencia: sin evidencia suficiente, 'no_match'.
+ */
+export function matchCatalogLine(rawLine, { activeItems = [], pausedItems = [] } = {}) {
+    const raw = String(rawLine || '').trim();
+    if (!raw) return null;
+    const queryTokens = tokenize(raw);
+    const queryDigits = ISBN_LIKE_RE.test(raw) ? raw.replace(/\D/g, '') : '';
+
+    let best = null;
+    for (const item of activeItems) {
+        const { score, reason } = scoreCandidate(item, queryTokens, queryDigits);
+        if (score > 0 && (!best || score > best.score)) best = { item, score, reason, status: 'matched_active' };
+    }
+    if (!best) {
+        for (const item of pausedItems) {
+            const { score, reason } = scoreCandidate(item, queryTokens, queryDigits);
+            if (score > 0 && (!best || score > best.score)) best = { item, score, reason, status: 'matched_by_encargo' };
+        }
+    }
+
+    if (!best) {
+        return { query: raw, status: 'no_match', match: null };
+    }
+    const item = best.item;
+    return {
+        query: raw,
+        status: best.status,
+        match: {
+            id: item.id,
+            title: item.title,
+            author: item.author || null,
+            price: best.status === 'matched_active' ? Number(item.price) || 0 : null,
+            stock: best.status === 'matched_active' ? Number(item.available_quantity) || 0 : null,
+        },
+    };
+}
+
+export { normalizeQuery };

--- a/functions/api/__tests__/list-lookup.test.js
+++ b/functions/api/__tests__/list-lookup.test.js
@@ -198,6 +198,98 @@ test('línea sin match dispara recordUnmatchedQuery vía waitUntil (source: read
     assert.equal(rows[0].raw_query, 'Un libro que definitivamente no tenemos');
 });
 
+test('la misma línea repetida dos veces en una lista sólo registra una vez en el radar (dedup)', async () => {
+    const db = createD1();
+    await db.prepare(`
+    CREATE TABLE IF NOT EXISTS demand_radar_unmatched_queries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      normalized_query TEXT NOT NULL UNIQUE,
+      raw_query TEXT NOT NULL,
+      source TEXT NOT NULL CHECK (source IN ('catalogo_search','autocomplete','reading_list')),
+      occurrence_count INTEGER NOT NULL DEFAULT 1,
+      first_seen_at TEXT NOT NULL,
+      last_seen_at TEXT NOT NULL
+    )`).bind().run();
+
+    const waitUntilCalls = [];
+    const response = await listLookup(context(
+        request({ lines: ['Un libro que no tenemos', '  UN LIBRO QUE NO TENEMOS  '] }),
+        { db, waitUntilCalls },
+    ));
+    const data = await response.json();
+    assert.equal(data.results.length, 2, 'ambas líneas aparecen en la respuesta al usuario');
+    await Promise.all(waitUntilCalls);
+
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 1, 'pero sólo generan una fila en el ledger');
+    assert.equal(rows[0].occurrence_count, 1, 'occurrence_count no se infla por el duplicado dentro del mismo POST');
+});
+
+// ── rate limit por IP (protege el ledger de contaminación barata) ────────
+
+function fakeKv(initial = {}) {
+    const store = new Map(Object.entries(initial));
+    return {
+        store,
+        async get(key) { return store.has(key) ? store.get(key) : null; },
+        async put(key, value) { store.set(key, value); },
+    };
+}
+
+test('bajo el límite: permite la consulta y NO escala el 429', async () => {
+    const kv = fakeKv();
+    const req = request({ lines: ['Cien Años De Soledad'] });
+    req.headers.set('CF-Connecting-IP', '203.0.113.5');
+    const ctx = context(req);
+    ctx.env.AMADO_KV = kv;
+    const response = await listLookup(ctx);
+    assert.equal(response.status, 200);
+    assert.equal(kv.store.get('list-lookup-rl:203.0.113.5'), '1');
+});
+
+test('al superar RATE_LIMIT_MAX_REQUESTS para la misma IP, responde 429', async () => {
+    const kv = fakeKv({ 'list-lookup-rl:203.0.113.9': '15' });
+    const req = request({ lines: ['Cien Años De Soledad'] });
+    req.headers.set('CF-Connecting-IP', '203.0.113.9');
+    const ctx = context(req);
+    ctx.env.AMADO_KV = kv;
+    const response = await listLookup(ctx);
+    assert.equal(response.status, 429);
+});
+
+test('IPs distintas tienen contadores independientes', async () => {
+    const kv = fakeKv({ 'list-lookup-rl:203.0.113.9': '15' });
+    const req = request({ lines: ['Cien Años De Soledad'] });
+    req.headers.set('CF-Connecting-IP', '203.0.113.10');
+    const ctx = context(req);
+    ctx.env.AMADO_KV = kv;
+    const response = await listLookup(ctx);
+    assert.equal(response.status, 200);
+});
+
+test('si AMADO_KV no está disponible (o falla), nunca bloquea al usuario real (fail open)', async () => {
+    const req = request({ lines: ['Cien Años De Soledad'] });
+    req.headers.set('CF-Connecting-IP', '203.0.113.20');
+    const ctx = context(req); // sin AMADO_KV en env
+    const response = await listLookup(ctx);
+    assert.equal(response.status, 200);
+
+    const brokenKv = { async get() { throw new Error('KV down'); }, async put() { throw new Error('KV down'); } };
+    const ctx2 = context(request({ lines: ['Cien Años De Soledad'] }), {});
+    ctx2.request.headers.set('CF-Connecting-IP', '203.0.113.21');
+    ctx2.env.AMADO_KV = brokenKv;
+    const response2 = await listLookup(ctx2);
+    assert.equal(response2.status, 200);
+});
+
+test('sin header CF-Connecting-IP (ej. en tests locales), no aplica rate limit', async () => {
+    const kv = fakeKv({ 'list-lookup-rl:': '999' });
+    const ctx = context(request({ lines: ['Cien Años De Soledad'] }));
+    ctx.env.AMADO_KV = kv;
+    const response = await listLookup(ctx);
+    assert.equal(response.status, 200);
+});
+
 test('línea con match NO dispara ninguna escritura en el radar de demanda', async () => {
     const db = createD1();
     await db.prepare(`

--- a/functions/api/__tests__/list-lookup.test.js
+++ b/functions/api/__tests__/list-lookup.test.js
@@ -1,0 +1,220 @@
+// GW2 (Kit de Lista de Lectura) — validación del endpoint POST /api/list-lookup
+// y su integración con el catálogo real (índice compacto activo + pausado)
+// y con el Radar de Demanda No Satisfecha (GW1) para las líneas sin match.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+import { onRequest as listLookup } from '../list-lookup.js';
+import { PAUSED_MANIFEST_URL, R2_BASE } from '../../_shared/catalog.js';
+
+const MANIFEST_CURRENT = {
+    version: 'v1',
+    index_key: 'stock1-preview/index.json',
+    active_index_key: 'stock1-preview/active-index.json',
+    block_prefix: 'stock1-preview/blocks',
+    block_count: 1,
+};
+
+const ACTIVE_INDEX = {
+    schema_version: 1,
+    fields: ['id', 'title', 'author', 'isbn', 'image', 'price', 'available_quantity'],
+    derived_fields: { slug: 'slugify-v1', status: 'active' },
+    items: [
+        ['MLU0001', 'Cien Años De Soledad', 'Gabriel García Márquez', '9789871387861', '', 1200, 3],
+    ],
+};
+
+const PAUSED_INDEX = {
+    schema_version: 1,
+    fields: ['id', 'title', 'author', 'isbn', 'image'],
+    derived_fields: { slug: 'slugify-v1', status: 'paused', block: 'numeric-id-mod-block-count' },
+    block_count: 1,
+    items: [
+        ['MLU0002', 'El Amor En Los Tiempos Del Cólera', 'Gabriel García Márquez', '', ''],
+    ],
+};
+
+function installCacheHits(hits) {
+    globalThis.caches = {
+        default: {
+            async match(request) {
+                const entry = hits[request.url];
+                return entry === undefined ? null : Response.json(entry);
+            },
+            async put() {},
+        },
+    };
+}
+
+function createD1() {
+    const sqlite = new DatabaseSync(':memory:');
+    return {
+        sqlite,
+        prepare(sql) {
+            const statement = sqlite.prepare(sql);
+            return {
+                bind(...args) {
+                    return {
+                        async first() { return statement.get(...args) || null; },
+                        async all() { return { results: statement.all(...args) }; },
+                        async run() {
+                            const result = statement.run(...args);
+                            return { success: true, meta: { changes: Number(result.changes) } };
+                        },
+                    };
+                },
+            };
+        },
+    };
+}
+
+function request(body, { method = 'POST', contentType = 'application/json' } = {}) {
+    const text = typeof body === 'string' ? body : JSON.stringify(body);
+    const headers = {};
+    if (contentType) headers['Content-Type'] = contentType;
+    return new Request('https://www.amadolibros.com/api/list-lookup', {
+        method,
+        headers,
+        body: method === 'GET' ? undefined : text,
+    });
+}
+
+function context(req, { db, waitUntilCalls } = {}) {
+    return {
+        request: req,
+        params: {},
+        env: { APP_ENV: 'preview', ORDERS_DB: db },
+        data: {},
+        waitUntil(promise) {
+            if (waitUntilCalls) waitUntilCalls.push(promise);
+        },
+    };
+}
+
+test.beforeEach(() => {
+    installCacheHits({
+        [PAUSED_MANIFEST_URL]: { schema_version: 1, current: MANIFEST_CURRENT, previous: null },
+        [`${R2_BASE}/${MANIFEST_CURRENT.active_index_key}`]: ACTIVE_INDEX,
+        [`${R2_BASE}/${MANIFEST_CURRENT.index_key}`]: PAUSED_INDEX,
+    });
+    globalThis.fetch = async () => new Response('not found', { status: 404 });
+});
+
+test.afterEach(() => {
+    delete globalThis.fetch;
+    delete globalThis.caches;
+});
+
+// ── validación de método / content-type / body ───────────────────────────
+
+test('rechaza método distinto de POST', async () => {
+    const response = await listLookup(context(request(null, { method: 'GET' })));
+    assert.equal(response.status, 405);
+});
+
+test('rechaza Content-Type distinto de application/json', async () => {
+    const response = await listLookup(context(request('lines=x', { contentType: 'text/plain' })));
+    assert.equal(response.status, 415);
+});
+
+test('rechaza JSON inválido', async () => {
+    const response = await listLookup(context(request('{esto no es json', {})));
+    assert.equal(response.status, 400);
+});
+
+test('rechaza body sin { lines: string[] }', async () => {
+    const response = await listLookup(context(request({ foo: 'bar' })));
+    assert.equal(response.status, 400);
+});
+
+test('lines vacío o sólo espacios devuelve results: []', async () => {
+    const response = await listLookup(context(request({ lines: ['   ', ''] })));
+    const data = await response.json();
+    assert.deepEqual(data.results, []);
+});
+
+// ── matching contra el catálogo real (índice compacto activo + pausado) ──
+
+test('responde matched_active con precio y stock para un título disponible', async () => {
+    const response = await listLookup(context(request({ lines: ['Cien Años De Soledad'] })));
+    assert.equal(response.status, 200);
+    const data = await response.json();
+    assert.equal(data.results.length, 1);
+    assert.equal(data.results[0].status, 'matched_active');
+    assert.equal(data.results[0].match.price, 1200);
+    assert.equal(data.results[0].match.stock, 3);
+});
+
+test('responde matched_by_encargo sin precio ni stock para un título pausado', async () => {
+    const response = await listLookup(context(request({ lines: ['El Amor En Los Tiempos Del Cólera'] })));
+    const data = await response.json();
+    assert.equal(data.results[0].status, 'matched_by_encargo');
+    assert.equal(data.results[0].match.price, null);
+    assert.equal(data.results[0].match.stock, null);
+});
+
+test('varias líneas en una sola consulta: cada una se resuelve de forma independiente', async () => {
+    const response = await listLookup(context(request({
+        lines: ['Cien Años De Soledad', 'El Amor En Los Tiempos Del Cólera', 'Un libro que no existe en absoluto'],
+    })));
+    const data = await response.json();
+    assert.equal(data.results.length, 3);
+    assert.deepEqual(data.results.map(r => r.status), ['matched_active', 'matched_by_encargo', 'no_match']);
+});
+
+test('trunca a MAX_LINES=40 y descarta líneas de más de MAX_LINE_LENGTH', async () => {
+    const manyLines = Array.from({ length: 50 }, (_, i) => `línea de consulta número ${i}`);
+    const response = await listLookup(context(request({ lines: manyLines })));
+    const data = await response.json();
+    assert.equal(data.results.length, 40);
+});
+
+// ── integración con el Radar de Demanda No Satisfecha (GW1) ──────────────
+
+test('línea sin match dispara recordUnmatchedQuery vía waitUntil (source: reading_list)', async () => {
+    const db = createD1();
+    await db.prepare(`
+    CREATE TABLE IF NOT EXISTS demand_radar_unmatched_queries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      normalized_query TEXT NOT NULL UNIQUE,
+      raw_query TEXT NOT NULL,
+      source TEXT NOT NULL CHECK (source IN ('catalogo_search','autocomplete','reading_list')),
+      occurrence_count INTEGER NOT NULL DEFAULT 1,
+      first_seen_at TEXT NOT NULL,
+      last_seen_at TEXT NOT NULL
+    )`).bind().run();
+
+    const waitUntilCalls = [];
+    const response = await listLookup(context(
+        request({ lines: ['Un libro que definitivamente no tenemos'] }),
+        { db, waitUntilCalls },
+    ));
+    assert.equal(response.status, 200);
+    await Promise.all(waitUntilCalls);
+
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].source, 'reading_list');
+    assert.equal(rows[0].raw_query, 'Un libro que definitivamente no tenemos');
+});
+
+test('línea con match NO dispara ninguna escritura en el radar de demanda', async () => {
+    const db = createD1();
+    await db.prepare(`
+    CREATE TABLE IF NOT EXISTS demand_radar_unmatched_queries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      normalized_query TEXT NOT NULL UNIQUE,
+      raw_query TEXT NOT NULL,
+      source TEXT NOT NULL CHECK (source IN ('catalogo_search','autocomplete','reading_list')),
+      occurrence_count INTEGER NOT NULL DEFAULT 1,
+      first_seen_at TEXT NOT NULL,
+      last_seen_at TEXT NOT NULL
+    )`).bind().run();
+
+    const waitUntilCalls = [];
+    await listLookup(context(request({ lines: ['Cien Años De Soledad'] }), { db, waitUntilCalls }));
+    await Promise.all(waitUntilCalls);
+
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 0);
+});

--- a/functions/api/__tests__/list-lookup.test.js
+++ b/functions/api/__tests__/list-lookup.test.js
@@ -68,6 +68,21 @@ function createD1() {
     };
 }
 
+async function withDemandRadarSchema(db) {
+    await db.prepare(`
+    CREATE TABLE IF NOT EXISTS demand_radar_unmatched_queries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      normalized_query TEXT NOT NULL,
+      raw_query TEXT NOT NULL,
+      source TEXT NOT NULL CHECK (source IN ('catalogo_search','reading_list')),
+      occurrence_count INTEGER NOT NULL DEFAULT 1,
+      first_seen_at TEXT NOT NULL,
+      last_seen_at TEXT NOT NULL,
+      UNIQUE (normalized_query, source)
+    )`).bind().run();
+    return db;
+}
+
 function request(body, { method = 'POST', contentType = 'application/json' } = {}) {
     const text = typeof body === 'string' ? body : JSON.stringify(body);
     const headers = {};
@@ -172,18 +187,7 @@ test('trunca a MAX_LINES=40 y descarta líneas de más de MAX_LINE_LENGTH', asyn
 // ── integración con el Radar de Demanda No Satisfecha (GW1) ──────────────
 
 test('línea sin match dispara recordUnmatchedQuery vía waitUntil (source: reading_list)', async () => {
-    const db = createD1();
-    await db.prepare(`
-    CREATE TABLE IF NOT EXISTS demand_radar_unmatched_queries (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      normalized_query TEXT NOT NULL UNIQUE,
-      raw_query TEXT NOT NULL,
-      source TEXT NOT NULL CHECK (source IN ('catalogo_search','autocomplete','reading_list')),
-      occurrence_count INTEGER NOT NULL DEFAULT 1,
-      first_seen_at TEXT NOT NULL,
-      last_seen_at TEXT NOT NULL
-    )`).bind().run();
-
+    const db = await withDemandRadarSchema(createD1());
     const waitUntilCalls = [];
     const response = await listLookup(context(
         request({ lines: ['Un libro que definitivamente no tenemos'] }),
@@ -199,18 +203,7 @@ test('línea sin match dispara recordUnmatchedQuery vía waitUntil (source: read
 });
 
 test('la misma línea repetida dos veces en una lista sólo registra una vez en el radar (dedup)', async () => {
-    const db = createD1();
-    await db.prepare(`
-    CREATE TABLE IF NOT EXISTS demand_radar_unmatched_queries (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      normalized_query TEXT NOT NULL UNIQUE,
-      raw_query TEXT NOT NULL,
-      source TEXT NOT NULL CHECK (source IN ('catalogo_search','autocomplete','reading_list')),
-      occurrence_count INTEGER NOT NULL DEFAULT 1,
-      first_seen_at TEXT NOT NULL,
-      last_seen_at TEXT NOT NULL
-    )`).bind().run();
-
+    const db = await withDemandRadarSchema(createD1());
     const waitUntilCalls = [];
     const response = await listLookup(context(
         request({ lines: ['Un libro que no tenemos', '  UN LIBRO QUE NO TENEMOS  '] }),
@@ -236,19 +229,19 @@ function fakeKv(initial = {}) {
     };
 }
 
-test('bajo el límite: permite la consulta y NO escala el 429', async () => {
+test('bajo el límite: permite la consulta y NO escala el 429 (clave incluye el namespace de entorno)', async () => {
     const kv = fakeKv();
     const req = request({ lines: ['Cien Años De Soledad'] });
     req.headers.set('CF-Connecting-IP', '203.0.113.5');
-    const ctx = context(req);
+    const ctx = context(req); // context() usa APP_ENV: 'preview'
     ctx.env.AMADO_KV = kv;
     const response = await listLookup(ctx);
     assert.equal(response.status, 200);
-    assert.equal(kv.store.get('list-lookup-rl:203.0.113.5'), '1');
+    assert.equal(kv.store.get('list-lookup-rl:preview:203.0.113.5'), '1');
 });
 
-test('al superar RATE_LIMIT_MAX_REQUESTS para la misma IP, responde 429', async () => {
-    const kv = fakeKv({ 'list-lookup-rl:203.0.113.9': '15' });
+test('al superar RATE_LIMIT_MAX_REQUESTS para la misma IP y el mismo entorno, responde 429', async () => {
+    const kv = fakeKv({ 'list-lookup-rl:preview:203.0.113.9': '15' });
     const req = request({ lines: ['Cien Años De Soledad'] });
     req.headers.set('CF-Connecting-IP', '203.0.113.9');
     const ctx = context(req);
@@ -258,13 +251,49 @@ test('al superar RATE_LIMIT_MAX_REQUESTS para la misma IP, responde 429', async 
 });
 
 test('IPs distintas tienen contadores independientes', async () => {
-    const kv = fakeKv({ 'list-lookup-rl:203.0.113.9': '15' });
+    const kv = fakeKv({ 'list-lookup-rl:preview:203.0.113.9': '15' });
     const req = request({ lines: ['Cien Años De Soledad'] });
     req.headers.set('CF-Connecting-IP', '203.0.113.10');
     const ctx = context(req);
     ctx.env.AMADO_KV = kv;
     const response = await listLookup(ctx);
     assert.equal(response.status, 200);
+});
+
+test('la misma IP en Preview y en producción NO comparte cupo — AMADO_KV es el mismo namespace, la clave lo separa', async () => {
+    // Preview ya consumió su cupo entero para esta IP...
+    const kv = fakeKv({ 'list-lookup-rl:preview:203.0.113.30': '15' });
+    const previewReq = request({ lines: ['Cien Años De Soledad'] });
+    previewReq.headers.set('CF-Connecting-IP', '203.0.113.30');
+    const previewCtx = context(previewReq);
+    previewCtx.env.AMADO_KV = kv;
+    const previewResponse = await listLookup(previewCtx);
+    assert.equal(previewResponse.status, 429, 'preview ya sin cupo');
+
+    // ...pero producción, misma IP, mismo AMADO_KV compartido, sigue con cupo.
+    const prodReq = request({ lines: ['Cien Años De Soledad'] });
+    prodReq.headers.set('CF-Connecting-IP', '203.0.113.30');
+    const prodCtx = context(prodReq);
+    prodCtx.env.APP_ENV = 'production';
+    prodCtx.env.AMADO_KV = kv;
+    const prodResponse = await listLookup(prodCtx);
+    assert.equal(prodResponse.status, 200, 'producción no paga el consumo de preview');
+});
+
+test('sin APP_ENV, usa el hostname de la request como namespace de fallback (nunca junta todo bajo una sola clave)', async () => {
+    const kv = fakeKv();
+    const req = new Request('https://pr-999.amadolibros-web.pages.dev/api/list-lookup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lines: ['Cien Años De Soledad'] }),
+    });
+    req.headers.set('CF-Connecting-IP', '203.0.113.40');
+    const ctx = context(req);
+    delete ctx.env.APP_ENV;
+    ctx.env.AMADO_KV = kv;
+    const response = await listLookup(ctx);
+    assert.equal(response.status, 200);
+    assert.equal(kv.store.get('list-lookup-rl:pr-999.amadolibros-web.pages.dev:203.0.113.40'), '1');
 });
 
 test('si AMADO_KV no está disponible (o falla), nunca bloquea al usuario real (fail open)', async () => {
@@ -291,22 +320,72 @@ test('sin header CF-Connecting-IP (ej. en tests locales), no aplica rate limit',
 });
 
 test('línea con match NO dispara ninguna escritura en el radar de demanda', async () => {
-    const db = createD1();
-    await db.prepare(`
-    CREATE TABLE IF NOT EXISTS demand_radar_unmatched_queries (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      normalized_query TEXT NOT NULL UNIQUE,
-      raw_query TEXT NOT NULL,
-      source TEXT NOT NULL CHECK (source IN ('catalogo_search','autocomplete','reading_list')),
-      occurrence_count INTEGER NOT NULL DEFAULT 1,
-      first_seen_at TEXT NOT NULL,
-      last_seen_at TEXT NOT NULL
-    )`).bind().run();
-
+    const db = await withDemandRadarSchema(createD1());
     const waitUntilCalls = [];
     await listLookup(context(request({ lines: ['Cien Años De Soledad'] }), { db, waitUntilCalls }));
     await Promise.all(waitUntilCalls);
 
     const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
     assert.equal(rows.length, 0);
+});
+
+// ── needs_confirmation: ambigüedad real, nunca una afirmación arbitraria ─
+
+test('dos obras activas distintas empatadas en precisión responden needs_confirmation, no un match arbitrario', async () => {
+    installCacheHits({
+        [PAUSED_MANIFEST_URL]: { schema_version: 1, current: MANIFEST_CURRENT, previous: null },
+        [`${R2_BASE}/${MANIFEST_CURRENT.active_index_key}`]: {
+            schema_version: 1,
+            fields: ['id', 'title', 'author', 'isbn', 'image', 'price', 'available_quantity'],
+            derived_fields: { slug: 'slugify-v1', status: 'active' },
+            items: [
+                ['MLU0010', 'Poemas', 'Autor Uno', '', '', 500, 1],
+                ['MLU0011', 'Poemas', 'Autor Dos', '', '', 600, 2],
+            ],
+        },
+        [`${R2_BASE}/${MANIFEST_CURRENT.index_key}`]: { ...PAUSED_INDEX, items: [] },
+    });
+    const response = await listLookup(context(request({ lines: ['Poemas'] })));
+    const data = await response.json();
+    assert.equal(data.results[0].status, 'needs_confirmation');
+    assert.equal(data.results[0].match, null);
+    assert.equal(data.results[0].candidates.length, 2);
+});
+
+test('una línea needs_confirmation NO dispara escritura en el radar de demanda (encontró algo, sólo es ambiguo)', async () => {
+    installCacheHits({
+        [PAUSED_MANIFEST_URL]: { schema_version: 1, current: MANIFEST_CURRENT, previous: null },
+        [`${R2_BASE}/${MANIFEST_CURRENT.active_index_key}`]: {
+            schema_version: 1,
+            fields: ['id', 'title', 'author', 'isbn', 'image', 'price', 'available_quantity'],
+            derived_fields: { slug: 'slugify-v1', status: 'active' },
+            items: [
+                ['MLU0010', 'Poemas', 'Autor Uno', '', '', 500, 1],
+                ['MLU0011', 'Poemas', 'Autor Dos', '', '', 600, 2],
+            ],
+        },
+        [`${R2_BASE}/${MANIFEST_CURRENT.index_key}`]: { ...PAUSED_INDEX, items: [] },
+    });
+    const db = await withDemandRadarSchema(createD1());
+    const waitUntilCalls = [];
+    await listLookup(context(request({ lines: ['Poemas'] }), { db, waitUntilCalls }));
+    await Promise.all(waitUntilCalls);
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 0);
+});
+
+// ── higiene de PII en 'reading_list' (extremo a extremo vía el endpoint) ─
+
+test('una línea sin match que contiene un email no se persiste en el radar (extremo a extremo)', async () => {
+    const db = await withDemandRadarSchema(createD1());
+    const waitUntilCalls = [];
+    const response = await listLookup(context(
+        request({ lines: ['contactame a juan@example.com'] }),
+        { db, waitUntilCalls },
+    ));
+    const data = await response.json();
+    assert.equal(data.results[0].status, 'no_match', 'la respuesta al usuario no cambia');
+    await Promise.all(waitUntilCalls);
+    const rows = db.sqlite.prepare('SELECT * FROM demand_radar_unmatched_queries').all();
+    assert.equal(rows.length, 0, 'pero no se persiste el email');
 });

--- a/functions/api/list-lookup.js
+++ b/functions/api/list-lookup.js
@@ -1,0 +1,90 @@
+/**
+ * functions/api/list-lookup.js
+ *
+ * GW2 (Kit de Lista de Lectura): recibe una lista de líneas de texto libre
+ * (título, autor, ISBN — lo que la persona tenga) y responde, línea por
+ * línea, contra el catálogo real: disponible ahora (con precio), lo
+ * conseguimos por encargo, o no lo identificamos (nunca inventa una
+ * coincidencia). Cada línea sin match alimenta el mismo Radar de Demanda
+ * No Satisfecha que ya usan catalogo.js y search-suggestions.js
+ * (functions/_shared/demand-radar.js) — "o en el mundo" también queda
+ * registrado, no sólo lo que hay en stock.
+ */
+
+import { fetchActiveIndex, fetchPausedIndex } from '../_shared/catalog.js';
+import { matchCatalogLine, recordUnmatchedQuery } from '../_shared/demand-radar.js';
+
+const MAX_BODY_BYTES = 8 * 1024;
+const MAX_LINES = 40;
+const MAX_LINE_LENGTH = 200;
+
+function json(data, status = 200, extraHeaders = {}) {
+    return new Response(JSON.stringify(data), {
+        status,
+        headers: {
+            'Content-Type': 'application/json;charset=UTF-8',
+            'Cache-Control': 'no-store',
+            ...extraHeaders,
+        },
+    });
+}
+
+export async function onRequest(context) {
+    const { request, env, waitUntil } = context;
+
+    if (request.method !== 'POST') {
+        return json({ error: 'Método no permitido.' }, 405, { Allow: 'POST' });
+    }
+    const contentType = request.headers.get('Content-Type') || '';
+    if (!contentType.toLowerCase().includes('application/json')) {
+        return json({ error: 'Content-Type debe ser application/json.' }, 415);
+    }
+    const contentLength = Number.parseInt(request.headers.get('Content-Length') || '0', 10);
+    if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+        return json({ error: 'Solicitud demasiado grande.' }, 413);
+    }
+
+    let body;
+    try {
+        const text = await request.text();
+        if (new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) {
+            return json({ error: 'Solicitud demasiado grande.' }, 413);
+        }
+        body = JSON.parse(text);
+    } catch {
+        return json({ error: 'JSON inválido.' }, 400);
+    }
+
+    if (!body || typeof body !== 'object' || !Array.isArray(body.lines)) {
+        return json({ error: 'Se espera { lines: string[] }.' }, 400);
+    }
+
+    const lines = body.lines
+        .filter(line => typeof line === 'string')
+        .map(line => line.slice(0, MAX_LINE_LENGTH).trim())
+        .filter(Boolean)
+        .slice(0, MAX_LINES);
+
+    if (lines.length === 0) {
+        return json({ results: [] });
+    }
+
+    const [active, paused] = await Promise.all([fetchActiveIndex(context), fetchPausedIndex(context)]);
+    const activeItems = Array.isArray(active?.items) ? active.items : [];
+    const pausedItems = Array.isArray(paused?.items) ? paused.items : [];
+
+    const results = lines.map(line => matchCatalogLine(line, { activeItems, pausedItems })).filter(Boolean);
+
+    const unmatched = results.filter(r => r.status === 'no_match');
+    if (unmatched.length > 0 && typeof waitUntil === 'function') {
+        waitUntil(Promise.all(unmatched.map(r =>
+            recordUnmatchedQuery(env?.ORDERS_DB, {
+                rawQuery: r.query,
+                source: 'reading_list',
+                appEnv: env?.APP_ENV,
+            }).catch(() => {}),
+        )));
+    }
+
+    return json({ results });
+}

--- a/functions/api/list-lookup.js
+++ b/functions/api/list-lookup.js
@@ -12,11 +12,36 @@
  */
 
 import { fetchActiveIndex, fetchPausedIndex } from '../_shared/catalog.js';
-import { matchCatalogLine, recordUnmatchedQuery } from '../_shared/demand-radar.js';
+import { matchCatalogLine, normalizeQuery, recordUnmatchedQuery } from '../_shared/demand-radar.js';
 
 const MAX_BODY_BYTES = 8 * 1024;
 const MAX_LINES = 40;
 const MAX_LINE_LENGTH = 200;
+
+// Cada POST puede escribir hasta MAX_LINES términos en el Radar de Demanda
+// (functions/_shared/demand-radar.js) — una sola línea de /catalogo?q=
+// equivale a hasta 40 acá. Ese ledger existe para que el negocio decida qué
+// comprar con datos reales; sin un tope por IP, sería trivial contaminarlo.
+// "Fail open": si AMADO_KV no está disponible o falla, no bloqueamos al
+// usuario real — el rate limit es una mitigación best-effort, no un gate.
+const RATE_LIMIT_MAX_REQUESTS = 15;
+const RATE_LIMIT_WINDOW_SECONDS = 600;
+
+async function checkRateLimit(env, ip) {
+    if (!ip || !env?.AMADO_KV || typeof env.AMADO_KV.get !== 'function') return true;
+    try {
+        const key = `list-lookup-rl:${ip}`;
+        const raw = await env.AMADO_KV.get(key);
+        const count = Number.parseInt(raw || '0', 10) || 0;
+        if (count >= RATE_LIMIT_MAX_REQUESTS) return false;
+        if (typeof env.AMADO_KV.put === 'function') {
+            await env.AMADO_KV.put(key, String(count + 1), { expirationTtl: RATE_LIMIT_WINDOW_SECONDS });
+        }
+        return true;
+    } catch {
+        return true;
+    }
+}
 
 function json(data, status = 200, extraHeaders = {}) {
     return new Response(JSON.stringify(data), {
@@ -38,6 +63,10 @@ export async function onRequest(context) {
     const contentType = request.headers.get('Content-Type') || '';
     if (!contentType.toLowerCase().includes('application/json')) {
         return json({ error: 'Content-Type debe ser application/json.' }, 415);
+    }
+    const ip = request.headers.get('CF-Connecting-IP') || '';
+    if (!(await checkRateLimit(env, ip))) {
+        return json({ error: 'Demasiadas consultas. Probá de nuevo en unos minutos.' }, 429);
     }
     const contentLength = Number.parseInt(request.headers.get('Content-Length') || '0', 10);
     if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
@@ -75,7 +104,16 @@ export async function onRequest(context) {
 
     const results = lines.map(line => matchCatalogLine(line, { activeItems, pausedItems })).filter(Boolean);
 
-    const unmatched = results.filter(r => r.status === 'no_match');
+    // Dedup por normalizeQuery: pegar la misma línea dos veces en una lista
+    // es una sola señal de demanda, no dos — no infla occurrence_count.
+    const seenNormalized = new Set();
+    const unmatched = results.filter(r => {
+        if (r.status !== 'no_match') return false;
+        const key = normalizeQuery(r.query);
+        if (seenNormalized.has(key)) return false;
+        seenNormalized.add(key);
+        return true;
+    });
     if (unmatched.length > 0 && typeof waitUntil === 'function') {
         waitUntil(Promise.all(unmatched.map(r =>
             recordUnmatchedQuery(env?.ORDERS_DB, {

--- a/functions/api/list-lookup.js
+++ b/functions/api/list-lookup.js
@@ -12,7 +12,12 @@
  */
 
 import { fetchActiveIndex, fetchPausedIndex } from '../_shared/catalog.js';
-import { matchCatalogLine, normalizeQuery, recordUnmatchedQuery } from '../_shared/demand-radar.js';
+import {
+    matchCatalogLine,
+    normalizeQuery,
+    prepareCatalogCandidates,
+    recordUnmatchedQuery,
+} from '../_shared/demand-radar.js';
 
 const MAX_BODY_BYTES = 8 * 1024;
 const MAX_LINES = 40;
@@ -27,10 +32,14 @@ const MAX_LINE_LENGTH = 200;
 const RATE_LIMIT_MAX_REQUESTS = 15;
 const RATE_LIMIT_WINDOW_SECONDS = 600;
 
-async function checkRateLimit(env, ip) {
+// AMADO_KV es el MISMO namespace en Preview y en producción (ver
+// wrangler.toml: mismo id en las tres secciones) — sin este prefijo, tráfico
+// de pruebas en Preview consumiría el cupo real de un visitante de
+// producción que comparte esa IP (NAT, red corporativa, VPN).
+async function checkRateLimit(env, envNamespace, ip) {
     if (!ip || !env?.AMADO_KV || typeof env.AMADO_KV.get !== 'function') return true;
     try {
-        const key = `list-lookup-rl:${ip}`;
+        const key = `list-lookup-rl:${envNamespace}:${ip}`;
         const raw = await env.AMADO_KV.get(key);
         const count = Number.parseInt(raw || '0', 10) || 0;
         if (count >= RATE_LIMIT_MAX_REQUESTS) return false;
@@ -65,7 +74,8 @@ export async function onRequest(context) {
         return json({ error: 'Content-Type debe ser application/json.' }, 415);
     }
     const ip = request.headers.get('CF-Connecting-IP') || '';
-    if (!(await checkRateLimit(env, ip))) {
+    const envNamespace = env?.APP_ENV || new URL(request.url).hostname || 'unknown';
+    if (!(await checkRateLimit(env, envNamespace, ip))) {
         return json({ error: 'Demasiadas consultas. Probá de nuevo en unos minutos.' }, 429);
     }
     const contentLength = Number.parseInt(request.headers.get('Content-Length') || '0', 10);
@@ -101,8 +111,12 @@ export async function onRequest(context) {
     const [active, paused] = await Promise.all([fetchActiveIndex(context), fetchPausedIndex(context)]);
     const activeItems = Array.isArray(active?.items) ? active.items : [];
     const pausedItems = Array.isArray(paused?.items) ? paused.items : [];
+    // Se prepara (tokeniza) el catálogo UNA vez por request, no una vez por
+    // línea — con hasta 40 líneas, retokenizar cada candidato en cada línea
+    // multiplicaría trabajo innecesario.
+    const preparedCandidates = prepareCatalogCandidates({ activeItems, pausedItems });
 
-    const results = lines.map(line => matchCatalogLine(line, { activeItems, pausedItems })).filter(Boolean);
+    const results = lines.map(line => matchCatalogLine(line, preparedCandidates)).filter(Boolean);
 
     // Dedup por normalizeQuery: pegar la misma línea dos veces en una lista
     // es una sola señal de demanda, no dos — no infla occurrence_count.

--- a/functions/api/search-suggestions.js
+++ b/functions/api/search-suggestions.js
@@ -1,4 +1,8 @@
 import { fetchActiveIndex, fetchPausedIndex } from '../_shared/catalog.js';
+// GW1 (Radar de Demanda No Satisfecha): mismo registro que catalogo.js,
+// acá capturado mientras la persona todavía está tipeando (antes incluso
+// de que presione buscar) — señal más temprana, mismo destino agregado.
+import { recordUnmatchedQuery } from '../_shared/demand-radar.js';
 
 function normalize(value = '') {
   return String(value).normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().trim();
@@ -45,7 +49,17 @@ export async function onRequest(ctx) {
     ...(Array.isArray(active?.items) ? active.items : []),
     ...(Array.isArray(paused?.items) ? paused.items : []),
   ];
-  return Response.json({ suggestions: buildSuggestions(items, query) }, {
+  const suggestions = buildSuggestions(items, query);
+  if (suggestions.length === 0 && typeof ctx.waitUntil === 'function') {
+    ctx.waitUntil(
+      recordUnmatchedQuery(ctx.env?.ORDERS_DB, {
+        rawQuery: query,
+        source: 'autocomplete',
+        appEnv: ctx.env?.APP_ENV,
+      }).catch(() => {}),
+    );
+  }
+  return Response.json({ suggestions }, {
     headers: { 'cache-control': 'public,max-age=300', 'x-robots-tag': 'noindex' },
   });
 }

--- a/functions/api/search-suggestions.js
+++ b/functions/api/search-suggestions.js
@@ -1,8 +1,4 @@
 import { fetchActiveIndex, fetchPausedIndex } from '../_shared/catalog.js';
-// GW1 (Radar de Demanda No Satisfecha): mismo registro que catalogo.js,
-// acá capturado mientras la persona todavía está tipeando (antes incluso
-// de que presione buscar) — señal más temprana, mismo destino agregado.
-import { recordUnmatchedQuery } from '../_shared/demand-radar.js';
 
 function normalize(value = '') {
   return String(value).normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().trim();
@@ -49,17 +45,7 @@ export async function onRequest(ctx) {
     ...(Array.isArray(active?.items) ? active.items : []),
     ...(Array.isArray(paused?.items) ? paused.items : []),
   ];
-  const suggestions = buildSuggestions(items, query);
-  if (suggestions.length === 0 && typeof ctx.waitUntil === 'function') {
-    ctx.waitUntil(
-      recordUnmatchedQuery(ctx.env?.ORDERS_DB, {
-        rawQuery: query,
-        source: 'autocomplete',
-        appEnv: ctx.env?.APP_ENV,
-      }).catch(() => {}),
-    );
-  }
-  return Response.json({ suggestions }, {
+  return Response.json({ suggestions: buildSuggestions(items, query) }, {
     headers: { 'cache-control': 'public,max-age=300', 'x-robots-tag': 'noindex' },
   });
 }

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -680,6 +680,13 @@ export async function onRequest(ctx) {
         const fuzzy = eligibleItems.filter(b => fuzzyMatches(b, queryTokens));
         if (fuzzy.length > 0) { strictMatches = fuzzy; usedFuzzy = true; }
     }
+    // GW1: si la búsqueda encuentra algo en TODO el catálogo elegible (antes
+    // de categoría/subcategoría/disponibilidad), no es demanda insatisfecha
+    // — es un libro real que el usuario dejó afuera con un filtro. Medir
+    // esto después de filtrar registraría como "no lo tenemos" un libro que
+    // sí está, sólo porque quedó fuera de la categoría o disponibilidad
+    // elegidas.
+    const globalQueryHasMatch = strictMatches.length > 0;
     const scopedMatches = strictMatches
         .filter(b => (categoria ? (categoryItems[b.id] || [])[0] === categoria : true))
         .filter(b => (subcategoria ? (categoryItems[b.id] || [])[1] === subcategoria : true));
@@ -716,11 +723,12 @@ export async function onRequest(ctx) {
     recordPerf(ctx, 'search', searchStartedAt);
 
     const totalResults = filtered.length;
-    // GW1: registra el término sólo cuando hubo una búsqueda real (rawQ) y
-    // dio 0 resultados — la señal de demanda más calificada que existe. Vía
-    // waitUntil y con try/catch: un fallo acá nunca debe demorar ni romper
-    // la respuesta de /catalogo.
-    if (rawQ && totalResults === 0 && typeof ctx.waitUntil === 'function') {
+    // GW1: registra el término sólo cuando hubo una búsqueda real (rawQ),
+    // dio 0 resultados EN LA VISTA ACTUAL, y tampoco existe en absoluto en
+    // el catálogo elegible completo (!globalQueryHasMatch) — la señal de
+    // demanda más calificada que existe. Vía waitUntil y con try/catch: un
+    // fallo acá nunca debe demorar ni romper la respuesta de /catalogo.
+    if (rawQ && totalResults === 0 && !globalQueryHasMatch && typeof ctx.waitUntil === 'function') {
         ctx.waitUntil(
             recordUnmatchedQuery(ctx.env?.ORDERS_DB, {
                 rawQuery: rawQ,

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -58,6 +58,10 @@ import {
     serverTimingValue,
 } from './_shared/perf.js';
 import { previewCoverUrl } from './_shared/preview-cover.js';
+// GW1 (Radar de Demanda No Satisfecha): sólo cuando rawQ + 0 resultados.
+// No reemplaza ni toca el CTA de recuperación que ya existe más abajo —
+// agrega el registro que faltaba.
+import { recordUnmatchedQuery } from './_shared/demand-radar.js';
 import {
     bookCoverUrl,
     CARD_IMAGE_SIZES,
@@ -712,6 +716,19 @@ export async function onRequest(ctx) {
     recordPerf(ctx, 'search', searchStartedAt);
 
     const totalResults = filtered.length;
+    // GW1: registra el término sólo cuando hubo una búsqueda real (rawQ) y
+    // dio 0 resultados — la señal de demanda más calificada que existe. Vía
+    // waitUntil y con try/catch: un fallo acá nunca debe demorar ni romper
+    // la respuesta de /catalogo.
+    if (rawQ && totalResults === 0 && typeof ctx.waitUntil === 'function') {
+        ctx.waitUntil(
+            recordUnmatchedQuery(ctx.env?.ORDERS_DB, {
+                rawQuery: rawQ,
+                source: 'catalogo_search',
+                appEnv: ctx.env?.APP_ENV,
+            }).catch(() => {}),
+        );
+    }
     const totalPages   = Math.max(1, Math.ceil(totalResults / MAX_RESULTS));
     // Página inexistente: 404 real. No redirigimos a la última página porque
     // el tamaño del catálogo cambia y esa normalización convertiría una URL

--- a/migrations/0010_demand_radar_unmatched_queries.sql
+++ b/migrations/0010_demand_radar_unmatched_queries.sql
@@ -5,15 +5,22 @@
 -- formulario de /pedir-libro (ese formulario sigue sin persistir nada,
 -- promesa de privacidad intacta). Sirve para decidir qué conseguir a
 -- continuación, no para identificar personas.
+--
+-- Clave (normalized_query, source), no normalized_query sola: la misma
+-- palabra buscada en /catalogo?q= y pegada en una lista de GW2 son señales
+-- de calidad distinta — mezclarlas en una sola fila destruiría la
+-- atribución de origen. 'autocomplete' no es una fuente válida: capturaría
+-- fragmentos mientras la persona todavía está tipeando, no demanda real.
 
 CREATE TABLE IF NOT EXISTS demand_radar_unmatched_queries (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  normalized_query TEXT NOT NULL UNIQUE,
+  normalized_query TEXT NOT NULL,
   raw_query TEXT NOT NULL,
-  source TEXT NOT NULL CHECK (source IN ('catalogo_search','autocomplete','reading_list')),
+  source TEXT NOT NULL CHECK (source IN ('catalogo_search','reading_list')),
   occurrence_count INTEGER NOT NULL DEFAULT 1,
   first_seen_at TEXT NOT NULL,
-  last_seen_at TEXT NOT NULL
+  last_seen_at TEXT NOT NULL,
+  UNIQUE (normalized_query, source)
 );
 
 CREATE INDEX IF NOT EXISTS idx_demand_radar_unmatched_queries_last_seen

--- a/migrations/0010_demand_radar_unmatched_queries.sql
+++ b/migrations/0010_demand_radar_unmatched_queries.sql
@@ -1,0 +1,20 @@
+-- GW1: Radar de Demanda No Satisfecha.
+-- Registra el TEXTO de búsqueda (público, ya visible en la URL de
+-- /catalogo?q= y en Search Console) cuando no matchea ningún libro real —
+-- ni activo ni por encargo. No guarda IP, user-agent, ni ningún dato del
+-- formulario de /pedir-libro (ese formulario sigue sin persistir nada,
+-- promesa de privacidad intacta). Sirve para decidir qué conseguir a
+-- continuación, no para identificar personas.
+
+CREATE TABLE IF NOT EXISTS demand_radar_unmatched_queries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  normalized_query TEXT NOT NULL UNIQUE,
+  raw_query TEXT NOT NULL,
+  source TEXT NOT NULL CHECK (source IN ('catalogo_search','autocomplete','reading_list')),
+  occurrence_count INTEGER NOT NULL DEFAULT 1,
+  first_seen_at TEXT NOT NULL,
+  last_seen_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_demand_radar_unmatched_queries_last_seen
+  ON demand_radar_unmatched_queries (last_seen_at);


### PR DESCRIPTION
## Qué hace

**GW1 — Radar de Demanda No Satisfecha**
- Registra (agregado, sin datos personales) las búsquedas de `/catalogo?q=` que no encuentran nada **en todo el catálogo elegible** — no sólo en la vista filtrada por categoría/subcategoría/disponibilidad. Un libro real que el usuario dejó afuera con un filtro nunca se registra como demanda insatisfecha.
- El autocompletado (`/api/search-suggestions`) **no** alimenta este ledger — capturaría fragmentos mientras la persona todavía está tipeando, no demanda real. Ese archivo no tiene cambios propios en este PR.
- Vía `ctx.waitUntil` (best-effort, nunca bloquea ni rompe la respuesta).
- No reemplaza el CTA de recuperación que ya existe en `catalogo.js` (WhatsApp + `/pedir-libro?tipo=sin-resultados`) — sólo agrega el registro consultable que faltaba.
- No toca la promesa de privacidad de `/pedir-libro` ("Este formulario no guarda datos en la web"): sólo persiste el texto de búsqueda público (ya visible en la URL / Search Console), nunca datos personales del formulario.

**GW2 — Kit de Lista de Lectura**
- Nueva página `/lista-de-libros` (indexable, enlazada desde `/pedir-libro`) + endpoint `POST /api/list-lookup`.
- Pegás varios títulos (uno por línea, hasta 40 líneas / 200 caracteres c/u) y responde línea por línea: disponible ahora (con precio y stock), lo podemos buscar por encargo (sin precio/stock inventados), no lo identificamos, o **necesita confirmación** cuando dos obras distintas quedan indistinguibles en precisión — nunca una afirmación falsa por orden arbitrario del catálogo.
- Matching: título y autor son señales separadas — un autor correcto refuerza la cobertura (nunca la sustituye ni la perjudica), y activo/pausado se rankean juntos por precisión real (el estado comercial sólo desempata cuando la precisión es idéntica).
- El catálogo se pre-tokeniza una sola vez por request (`prepareCatalogCandidates`), no una vez por línea.
- Las líneas sin match alimentan el mismo radar de GW1 (`source: 'reading_list'`), con higiene de PII: nunca persiste una línea que parece email, URL o teléfono largo (un ISBN de 10/13 dígitos se preserva a propósito).
- Throttle por IP vía `AMADO_KV` (15 req/10 min), namespaceado por entorno — `AMADO_KV` es el mismo namespace en Preview y producción, así que la clave incluye `APP_ENV` (con fallback a hostname) para que tráfico de Preview nunca consuma el cupo real de producción. Fail-open si KV falla.
- Sin fallback de número de WhatsApp hardcodeado: si `window.AmadoWhatsApp` no cargó, el CTA se oculta.

**Migración**
- `migrations/0010_demand_radar_unmatched_queries.sql`: clave compuesta `(normalized_query, source)` — la misma búsqueda en `/catalogo?q=` y pegada en una lista son señales de origen distinto y no deben pisarse. `autocomplete` fuera del CHECK. Se aplica sola al mergear (paso existente de `deploy.yml`); Preview la crea con `CREATE TABLE IF NOT EXISTS`.

## Tests

- `functions/__tests__/demand-radar.test.js` (35): matching por título/autor/ISBN, refuerzo de autor sin sustituirlo, ambigüedad → `needs_confirmation`, activo-vs-pausado por precisión (no por orden), guard estructural de escala (no benchmark frágil), clave compuesta del ledger, higiene de PII.
- `functions/api/__tests__/list-lookup.test.js` (22): validación de endpoint, matching contra índice real, `needs_confirmation` no logueado, rate-limit namespaceado por entorno (incluye el caso Preview-no-consume-cupo-de-producción), fail-open de KV, PII extremo a extremo.
- `functions/__tests__/catalogo-demand-radar.test.js` (4, nuevo): existe globalmente + filtro de categoría → NO registra; existe por encargo + filtro disponibles → NO registra; inexistente globalmente → SÍ registra; sin filtros → tampoco registra.
- Regresión completa: `functions/__tests__/*` + `functions/api/__tests__/*` → **1107/1109** pass (los 2 fails son preexistentes y no relacionados: `deploy-branch-guards.test.js` compara regex ancladas a `\n` contra `.github/workflows/*.yml` que Git en este checkout Windows trae con `\r\n` — no se tocaron esos workflows).
- `worker-sync/__tests__/*` → 117/117. `astro-front/src/lib/__tests__/*` → 29/29.
- Build checkout OFF y checkout ON (`scripts/validate-ci.sh`, guards manuales de 404/carrito/Turnstile/copy/teléfono/link cruzado) → ambos OK.

## Historial de revisión

1. Autorevisión inicial (seguridad): throttle por IP + dedup de líneas repetidas en el Radar — ver comentarios del PR.
2. Segunda revisión (lógica de negocio, 12 puntos): medición de "sin resultados" post-filtro en `/catalogo`, autocomplete alimentando el ledger, clave del ledger pisando `source`, matching sólo por título, empates arbitrarios, orden activo-antes-que-pausado, falta de pre-tokenización, copy que promete de más, teléfono hardcodeado, sin descubrimiento de `/lista-de-libros`, rate-limit compartido entre entornos, higiene de PII — los 12 corregidos en este head.

## Scope / no incluido

- No incluye GW3 (Brújula de Adquisición por Demanda de Google) — quedó fuera de este approval.
- No hay UI de administración para leer `demand_radar_unmatched_queries` todavía (consulta directa a D1 por ahora).
- **MANTENER DRAFT. NO MERGEAR. NO PRODUCCIÓN** — pendiente de aprobación explícita.