### PR TITLE
SEO audit: medir duplicados por identidad de Catálogo ML

### DIFF
--- a/docs/seo/ml-duplicate-origin-audit-2026-08-22.md
+++ b/docs/seo/ml-duplicate-origin-audit-2026-08-22.md
@@ -1,0 +1,137 @@
+# ML-DUPLICATE-ORIGIN-AUDIT-1 — evidencia 2026-08-22
+
+Objetivo: medir cuánto de la aparente duplicación del catálogo web proviene del patrón de Mercado Libre **publicación común + publicación de Catálogo**. Este documento es sólo evidencia. No autoriza `rel=canonical`, redirects, exclusiones de sitemap ni cambios en Mercado Libre.
+
+## Snapshot auditado
+
+Artifact `seo-baseline-public-2026-08-08` regenerado por el workflow `SEO baseline public audit` sobre el head de PR #213.
+
+- generado: `2026-08-22T01:07:05.667Z`;
+- `catalog.json`: 7.086 listings activos con stock;
+- active-index: 7.103;
+- paused-index: 10.096;
+- grupos con ISBN repetido: 3.136;
+- listings dentro de esos grupos: 6.283;
+- `same_book` histórico: 209;
+- `isbn_inconsistent` histórico: 2.927.
+
+## Hallazgo principal
+
+Sobre los **3.136 grupos con ISBN repetido**:
+
+- 3.118 (`99,43%`) son `ml_common_plus_catalog`: todos los miembros comparten un único `catalog_product_id` y el grupo contiene al menos una publicación común (`catalog_listing=false`) y una de Catálogo (`catalog_listing=true`);
+- 1 grupo (`0,03%`) comparte un único `catalog_product_id` pero no presenta la mezcla common/catalog;
+- 8 grupos son `bibliographic_only` (sin identidad de Catálogo ML observable);
+- 5 tienen `catalog_product_id` sólo en parte de los miembros;
+- 4 tienen más de un `catalog_product_id` y se marcan como conflicto.
+
+En total, el `catalog_product_id` explica estructuralmente 3.119/3.136 grupos (`99,46%`), pero **esto no significa que todos sean seguros para canonical**. La identidad de Catálogo ML es una señal fuerte de origen, no una autorización SEO automática.
+
+## Subconjunto estricto `same_book`
+
+Los 209 grupos que el baseline histórico ya clasificaba `same_book` son, sin excepción:
+
+- `ml_common_plus_catalog`: **209/209 (100%)**;
+- un solo `catalog_product_id` por grupo;
+- mezcla `catalog_listing=false` + `catalog_listing=true`.
+
+Al aplicar además los gates del detector #208 sobre los campos completos disponibles (condición + autor + edición/idioma/formato):
+
+- **177 grupos** quedan sin motivos de revisión/rechazo y son candidatos de alta confianza estructural;
+- **26 grupos** requieren revisión humana;
+- **6 grupos** se rechazan por conflicto de idioma.
+
+Motivos de revisión dentro de los 26:
+
+- 19 por autor genérico;
+- 4 por idioma presente sólo en parte del grupo;
+- 3 por autor faltante (2 de ellos además con formato parcial);
+- 1 por formato parcial adicional.
+
+Los 177 candidatos de alta confianza siguen siendo sólo candidatos de auditoría. La selección del representante y la salud SEO del destino deben verificarse antes de aplicar cualquier canonical.
+
+## Tres pares ya priorizados por GSC
+
+### Headway Elementary 5th Edition Audio CD
+
+- ISBN `9780194527552`;
+- MLU `MLU715787398` / `MLU648794507`;
+- ambos `active`, stock 2, condición `new`;
+- mismo `catalog_product_id`: `MLU22050086`;
+- uno `catalog_listing=true`, otro `false`;
+- mismo título y autor (`Soars, John`);
+- idioma en ambos: `Inglés Internacional`;
+- sin conflicto de edición/formato observable.
+
+Estado estructural: **alta confianza**.
+
+### Obesidad — Virginia Busnelli
+
+- ISBN `9789500217262`;
+- MLU `MLU1067876690` / `MLU677997343`;
+- ambos `active`, stock 3, condición `new`;
+- mismo `catalog_product_id`: `MLU67241264`;
+- uno `catalog_listing=true`, otro `false`;
+- mismo título y autor (`Virginia Busnelli`);
+- idioma en ambos: `Español`;
+- sin conflicto de edición/formato observable.
+
+Estado estructural: **alta confianza**.
+
+### Memento Mori — Recuerda Tu Muerte
+
+- ISBN `9798294067946`;
+- MLU `MLU834746174` / `MLU1420573720`;
+- ambos `active`, stock 1, condición `new`;
+- mismo `catalog_product_id`: `MLU71971140`;
+- uno `catalog_listing=true`, otro `false`;
+- mismo título;
+- autor en ambos: `Varios autores`;
+- idioma en ambos: `Español`.
+
+Estado estructural: **manual_review** por `author_generic`, manteniendo el gate conservador de #208.
+
+## Por qué no conviene convertir `catalog_product_id` en una llave absoluta
+
+Hay al menos un contraejemplo relevante: el grupo ISBN `9781234567897` contiene tres libros usados claramente distintos pero todos asociados a `catalog_product_id=MLU21109168`. Esto demuestra que `catalog_product_id` puede estar sucio o reutilizado incorrectamente en publicaciones comunes.
+
+Por eso la regla segura sigue siendo combinar señales:
+
+1. ISBN válido idéntico;
+2. condición compatible;
+3. identidad ML consistente;
+4. título/autor y campos bibliográficos sin contradicciones críticas;
+5. destino SEO saludable antes de canonical.
+
+## Qué explica el volumen de `isbn_inconsistent`
+
+Dentro de los 3.118 grupos `ml_common_plus_catalog`, 2.909 fueron históricamente `isbn_inconsistent` porque el título y/o autor normalizado no coinciden de forma exacta.
+
+Desglose de esos 2.909:
+
+- 2.166: título distinto, autor igual;
+- 20: título igual, autor distinto;
+- 723: título y autor distintos.
+
+Además:
+
+- sólo 1 grupo presenta conflicto de condición;
+- 92 presentan diferencias de idioma declarado;
+- 0 presentan conflicto de formato observable;
+- 0 presentan conflicto de edición observable.
+
+La mayoría son pares simples: 3.114/3.118 grupos `ml_common_plus_catalog` contienen exactamente dos listings, típicamente una publicación común y una publicación de Catálogo.
+
+Esto confirma la hipótesis de origen — Mercado Libre está generando gran parte de la duplicación aparente — pero no justifica consolidar automáticamente los 2.909 grupos textualmente inconsistentes. Esos grupos deben estudiarse con reglas separadas antes de cualquier canonical.
+
+## Conclusión operativa
+
+La hipótesis queda **confirmada con evidencia fuerte**: casi todos los ISBN repetidos observados provienen del patrón de identidad de Catálogo ML, y el 100% del subconjunto histórico `same_book` es common+catalog.
+
+Siguiente paso seguro:
+
+- mantener #213 como audit-only;
+- usar los 177 grupos de alta confianza como universo de estudio;
+- mantener #208 conservador;
+- preparar, en un lote separado y sujeto a aprobación, un piloto reversible muy pequeño (por ejemplo Headway + Obesidad) donde el destino se elige también por salud SEO/indexable, no sólo por stock/precio;
+- 301 sigue fuera de alcance.

--- a/functions/__tests__/duplication-report-ml-origin.test.js
+++ b/functions/__tests__/duplication-report-ml-origin.test.js
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  classifyMlCatalogOrigin,
+  summarizeMlOrigins,
+} from '../../scripts/seo/duplication-report.mjs';
+
+function item(overrides = {}) {
+  return {
+    id: 'MLU1',
+    catalog_listing: null,
+    catalog_product_id: null,
+    ...overrides,
+  };
+}
+
+test('clasifica publicación común + catálogo cuando comparten catalog_product_id', () => {
+  const result = classifyMlCatalogOrigin([
+    item({ id: 'MLU1', catalog_listing: false, catalog_product_id: 'MLU-PROD-1' }),
+    item({ id: 'MLU2', catalog_listing: true, catalog_product_id: 'mlu-prod-1' }),
+  ]);
+  assert.equal(result.origin, 'ml_common_plus_catalog');
+  assert.deepEqual(result.catalogProductIds, ['MLU-PROD-1']);
+  assert.deepEqual(result.catalogListingValues, [false, true]);
+});
+
+test('mismo catalog_product_id sin mezcla común/catálogo queda separado', () => {
+  const result = classifyMlCatalogOrigin([
+    item({ id: 'MLU1', catalog_listing: true, catalog_product_id: 'MLU-PROD-1' }),
+    item({ id: 'MLU2', catalog_listing: true, catalog_product_id: 'MLU-PROD-1' }),
+  ]);
+  assert.equal(result.origin, 'same_ml_catalog_product');
+});
+
+test('catalog_product_id distintos se marcan como conflicto', () => {
+  const result = classifyMlCatalogOrigin([
+    item({ id: 'MLU1', catalog_listing: false, catalog_product_id: 'MLU-PROD-1' }),
+    item({ id: 'MLU2', catalog_listing: true, catalog_product_id: 'MLU-PROD-2' }),
+  ]);
+  assert.equal(result.origin, 'catalog_product_conflict');
+});
+
+test('catalog_product_id presente sólo en parte del grupo se marca parcial', () => {
+  const result = classifyMlCatalogOrigin([
+    item({ id: 'MLU1', catalog_listing: false, catalog_product_id: 'MLU-PROD-1' }),
+    item({ id: 'MLU2', catalog_listing: null, catalog_product_id: null }),
+  ]);
+  assert.equal(result.origin, 'catalog_product_partial');
+});
+
+test('catalog_listing true sin product id no se interpreta como identidad suficiente', () => {
+  const result = classifyMlCatalogOrigin([
+    item({ id: 'MLU1', catalog_listing: true }),
+    item({ id: 'MLU2', catalog_listing: false }),
+  ]);
+  assert.equal(result.origin, 'catalog_listing_without_product_id');
+});
+
+test('summarizeMlOrigins calcula porcentajes sobre el universo auditado', () => {
+  const groups = [
+    { mlCatalogIdentity: { origin: 'ml_common_plus_catalog' } },
+    { mlCatalogIdentity: { origin: 'same_ml_catalog_product' } },
+    { mlCatalogIdentity: { origin: 'bibliographic_only' } },
+    { mlCatalogIdentity: { origin: 'catalog_product_conflict' } },
+  ];
+  const summary = summarizeMlOrigins(groups);
+  assert.equal(summary.totalGroups, 4);
+  assert.equal(summary.mlIdentityExplainedGroups, 2);
+  assert.equal(summary.mlIdentityExplainedPct, 50);
+  assert.equal(summary.mlCommonPlusCatalogPct, 25);
+});

--- a/scripts/seo/duplication-report.mjs
+++ b/scripts/seo/duplication-report.mjs
@@ -1,5 +1,6 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { gunzipSync } from 'node:zlib';
 
 const R2_BASE = process.env.SEO_R2_BASE || 'https://pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev';
@@ -23,10 +24,81 @@ function normalizeIsbn(value) {
   return normalized.length === 10 || normalized.length === 13 ? normalized : '';
 }
 
+function normalizeCatalogProductId(value) {
+  return String(value || '').trim().toUpperCase();
+}
+
 function titleAuthorKey(item) {
   const title = normalizeText(item.title);
   const author = normalizeText(item.author);
   return title ? `${title}||${author}` : '';
+}
+
+export function classifyMlCatalogOrigin(group) {
+  const items = Array.isArray(group) ? group : [];
+  const rawIds = items.map((item) => normalizeCatalogProductId(item?.catalog_product_id));
+  const ids = [...new Set(rawIds.filter(Boolean))].sort();
+  const presentCount = rawIds.filter(Boolean).length;
+  const listingValues = [...new Set(
+    items
+      .map((item) => typeof item?.catalog_listing === 'boolean' ? item.catalog_listing : null)
+      .filter((value) => value !== null),
+  )].sort();
+
+  let origin = 'bibliographic_only';
+  if (ids.length > 1) {
+    origin = 'catalog_product_conflict';
+  } else if (ids.length === 1) {
+    if (presentCount !== items.length) {
+      origin = 'catalog_product_partial';
+    } else if (listingValues.includes(true) && listingValues.includes(false)) {
+      origin = 'ml_common_plus_catalog';
+    } else {
+      origin = 'same_ml_catalog_product';
+    }
+  } else if (items.some((item) => item?.catalog_listing === true)) {
+    origin = 'catalog_listing_without_product_id';
+  }
+
+  return {
+    origin,
+    catalogProductIds: ids,
+    catalogListingValues: listingValues,
+  };
+}
+
+export function summarizeMlOrigins(groups) {
+  const summary = {
+    totalGroups: 0,
+    mlCommonPlusCatalogGroups: 0,
+    sameMlCatalogProductGroups: 0,
+    bibliographicOnlyGroups: 0,
+    catalogProductPartialGroups: 0,
+    catalogProductConflictGroups: 0,
+    catalogListingWithoutProductIdGroups: 0,
+  };
+
+  for (const group of Array.isArray(groups) ? groups : []) {
+    summary.totalGroups += 1;
+    const origin = group?.mlCatalogIdentity?.origin;
+    if (origin === 'ml_common_plus_catalog') summary.mlCommonPlusCatalogGroups += 1;
+    else if (origin === 'same_ml_catalog_product') summary.sameMlCatalogProductGroups += 1;
+    else if (origin === 'catalog_product_partial') summary.catalogProductPartialGroups += 1;
+    else if (origin === 'catalog_product_conflict') summary.catalogProductConflictGroups += 1;
+    else if (origin === 'catalog_listing_without_product_id') summary.catalogListingWithoutProductIdGroups += 1;
+    else summary.bibliographicOnlyGroups += 1;
+  }
+
+  summary.mlIdentityExplainedGroups =
+    summary.mlCommonPlusCatalogGroups + summary.sameMlCatalogProductGroups;
+  summary.mlIdentityExplainedPct = summary.totalGroups > 0
+    ? Math.round((summary.mlIdentityExplainedGroups / summary.totalGroups) * 10000) / 100
+    : 0;
+  summary.mlCommonPlusCatalogPct = summary.totalGroups > 0
+    ? Math.round((summary.mlCommonPlusCatalogGroups / summary.totalGroups) * 10000) / 100
+    : 0;
+
+  return summary;
 }
 
 async function fetchJson(url) {
@@ -55,7 +127,7 @@ function expandIndex(payload) {
   }).filter(Boolean);
 }
 
-function buildGroups(items, keyFn, kind) {
+export function buildGroups(items, keyFn, kind) {
   const buckets = new Map();
   for (const item of items) {
     const key = keyFn(item);
@@ -72,6 +144,7 @@ function buildGroups(items, keyFn, kind) {
       let classification;
       if (kind === 'title_author') classification = isbns.length > 1 ? 'isbn_inconsistent' : 'same_book';
       else classification = titleAuthors.length > 1 ? 'isbn_inconsistent' : 'same_book';
+      const mlCatalogIdentity = classifyMlCatalogOrigin(group);
 
       return {
         key,
@@ -80,6 +153,7 @@ function buildGroups(items, keyFn, kind) {
         count: group.length,
         isbns,
         titleAuthorKeys: titleAuthors,
+        mlCatalogIdentity,
         items: group.map((item) => ({
           id: item.id,
           title: item.title || null,
@@ -87,6 +161,14 @@ function buildGroups(items, keyFn, kind) {
           isbn: item.isbn || null,
           status: item.status || null,
           available_quantity: Number(item.available_quantity || 0),
+          condition: item.condition || null,
+          catalog_listing: typeof item.catalog_listing === 'boolean' ? item.catalog_listing : null,
+          catalog_product_id: item.catalog_product_id || null,
+          bibliographic: item.bibliographic ? {
+            edition: item.bibliographic.edition || null,
+            language: item.bibliographic.language || null,
+            format: item.bibliographic.format || null,
+          } : null,
         })),
       };
     })
@@ -101,10 +183,12 @@ function summarizeGroups(groups) {
     duplicateListings: groups.reduce((sum, group) => sum + group.count, 0),
     sameBookGroups: sameBook.length,
     isbnInconsistentGroups: inconsistent.length,
+    mlCatalogOrigins: summarizeMlOrigins(groups),
+    sameBookMlCatalogOrigins: summarizeMlOrigins(sameBook),
   };
 }
 
-async function main() {
+export async function main() {
   const generatedAt = new Date().toISOString();
   const [catalog, manifest] = await Promise.all([fetchJson(CATALOG_URL), fetchJson(MANIFEST_URL)]);
   const current = manifest?.current || {};
@@ -128,7 +212,7 @@ async function main() {
   const onlyIndex = [...activeIndexIds].filter((id) => !activeCatalogIds.has(id)).sort();
 
   const report = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     generatedAt,
     sources: {
       catalogUrl: CATALOG_URL,
@@ -152,6 +236,7 @@ async function main() {
     methodology: {
       isbn: 'ISBN normalizado a 10/13 caracteres; grupos con 2+ listings. Mismo ISBN con más de un título+autor normalizado se marca isbn_inconsistent.',
       titleAuthor: 'Título y autor sin tildes, minúsculas, puntuación colapsada; grupos con 2+ listings. Más de un ISBN válido dentro del grupo se marca isbn_inconsistent.',
+      mlCatalogIdentity: 'Clasifica el origen observable con catalog_listing + catalog_product_id: común+catálogo, mismo producto de catálogo, conflicto, parcial o sólo evidencia bibliográfica. No autoriza canonical por sí solo.',
       scope: 'Solo listings activos con available_quantity > 0 para la clasificación de duplicados; el índice R2 se usa como control de paridad y contexto de inventario.',
     },
     summaries: {
@@ -171,7 +256,10 @@ async function main() {
   console.log(`Escrito: ${outputPath}`);
 }
 
-main().catch((error) => {
-  console.error(error.stack || error.message);
-  process.exitCode = 1;
-});
+const isDirectRun = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isDirectRun) {
+  main().catch((error) => {
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Objetivo

Medir, sin tocar comportamiento productivo, qué parte de los grupos duplicados observados se explica por señales nativas de Mercado Libre (`catalog_listing` + `catalog_product_id`).

## Qué cambia

- `scripts/seo/duplication-report.mjs` sube a schema v2 y agrega clasificación de origen observable:
  - `ml_common_plus_catalog`;
  - `same_ml_catalog_product`;
  - `bibliographic_only`;
  - `catalog_product_partial`;
  - `catalog_product_conflict`;
  - `catalog_listing_without_product_id`.
- conserva en el artifact `condition`, `catalog_listing`, `catalog_product_id` y edición/idioma/formato disponibles;
- agrega resumen porcentual sobre todos los grupos por ISBN y sobre el subconjunto histórico `same_book`;
- tests focalizados para la clasificación y porcentajes;
- evidencia reproducida en `docs/seo/ml-duplicate-origin-audit-2026-08-22.md`.

## Resultado fresco del artifact

Snapshot generado `2026-08-22T01:07:05.667Z`:

- 7.086 listings activos con stock;
- 3.136 grupos con ISBN repetido;
- 6.283 listings dentro de esos grupos;
- 209 `same_book` históricos;
- 2.927 `isbn_inconsistent` históricos.

Origen ML de los 3.136 grupos:

- **3.118 (`99,43%`) `ml_common_plus_catalog`**;
- 1 `same_ml_catalog_product`;
- 8 `bibliographic_only`;
- 5 `catalog_product_partial`;
- 4 `catalog_product_conflict`.

El subconjunto histórico `same_book` es **209/209 (`100%`) common+catalog**.

Aplicando además los gates estructurales del detector #208 sobre los campos completos disponibles:

- 177 alta confianza estructural;
- 26 manual review;
- 6 reject por conflicto de idioma.

Headway (`9780194527552`) y Obesidad (`9789500217262`) pasan el gate estructural completo: mismo ISBN, condición `new`, mismo título/autor, mismo `catalog_product_id`, common+catalog y mismo idioma. Memento Mori mantiene `manual_review` por autor genérico `Varios autores`.

## Riesgo

Muy bajo. Sólo tooling de auditoría + tests + documentación. No modifica rutas, catálogo, fichas, canonical, redirects, sitemap, checkout ni Mercado Libre.

## Conclusión

La hipótesis de origen queda confirmada: casi toda la duplicación por ISBN observada nace del patrón publicación común + Catálogo ML. Eso **no autoriza canonical automático** para los grupos textualmente inconsistentes: `catalog_product_id` también tiene contraejemplos sucios y debe combinarse con ISBN/condición/bibliografía.

## Gate

Mantener Draft. Esperar checks del head actual. Después usar este resultado para endurecer/afinar el universo de estudio de #208 y proponer por separado un piloto reversible mínimo. No canonicalizar ni redirigir desde este PR.