### PR TITLE
COPY-DELIVERY-1: aclarar coordinación de entregas

### DIFF
--- a/astro-front/src/components/DeliveryCoordination.astro
+++ b/astro-front/src/components/DeliveryCoordination.astro
@@ -13,7 +13,7 @@
       <h2 id="delivery-coordination-title">El cadete no llega de sorpresa.</h2>
       <p>
         Antes de enviar tu pedido, coordinamos contigo la hora o franja en la que podés recibirlo.
-        Si el cadete llega y no estás, no te preocupes: te contactamos para resolver cómo completar la entrega.
+        Si necesitás cambiarla, avisános antes de que salga el cadete.
       </p>
     </div>
 

--- a/astro-front/src/components/ShippingPayments.astro
+++ b/astro-front/src/components/ShippingPayments.astro
@@ -19,7 +19,7 @@
           <li>Envíos a todo Uruguay.</li>
           <li>Envío gratis desde $1.500.</li>
         </ul>
-        <p class="sp-disclaimer">*El plazo depende de la zona y del horario del pedido. Si el cadete llega y no estás, te contactamos para resolver cómo completar la entrega.</p>
+        <p class="sp-disclaimer">*El plazo depende de la zona y del horario del pedido. Coordinamos la entrega por WhatsApp antes de que salga el cadete.</p>
       </div>
 
       <div class="sp-col">

--- a/astro-front/src/pages/envios.astro
+++ b/astro-front/src/pages/envios.astro
@@ -70,7 +70,7 @@ const shippingPolicy = {
 
   <h2>Montevideo</h2>
   <aside class="delivery-reassurance">
-    <strong>El cadete no llega de sorpresa.</strong> Antes de enviar tu pedido, coordinamos contigo la hora o franja en la que podés recibirlo. Si al llegar no estás, no te preocupes: te contactamos para resolver cómo completar la entrega.
+    <strong>El cadete no llega de sorpresa.</strong> Antes de enviar tu pedido, coordinamos contigo la hora o franja en la que podés recibirlo. Si necesitás cambiarla, avisános antes de que salga el cadete.
   </aside>
   <p>Los productos disponibles pueden entregarse en el día mediante cadetería. La entrega en aproximadamente 2 horas está sujeta a disponibilidad, zona, horario y confirmación por WhatsApp. La fecha y la franja elegidas en el checkout quedan sujetas a confirmación.</p>
 

--- a/functions/__tests__/delivery-coordination.test.js
+++ b/functions/__tests__/delivery-coordination.test.js
@@ -12,17 +12,20 @@ test('la home destaca la coordinación de la entrega inmediatamente después del
   assert.ok(page.indexOf('<DeliveryCoordination />') > page.indexOf('<Hero />'));
   assert.match(component, /El cadete no llega de sorpresa/);
   assert.match(component, /coordinamos contigo la hora o franja/);
-  assert.match(component, /Si el cadete llega y no estás, no te preocupes/);
+  assert.match(component, /Si necesitás cambiarla, avisános antes de que salga el cadete/);
+  assert.doesNotMatch(component, /Si el cadete llega y no estás, no te preocupes/i);
   assert.match(component, /href="\/envios"/);
 });
 
-test('envíos y el bloque comercial repiten la tranquilidad sin prometer reentrega gratuita', () => {
+test('envíos y el bloque comercial priorizan coordinación previa sin prometer resolución o reentrega', () => {
   const policy = read('astro-front/src/pages/envios.astro');
   const shipping = read('astro-front/src/components/ShippingPayments.astro');
   const combined = `${policy}\n${shipping}`;
 
   assert.match(policy, /class="delivery-reassurance"/);
-  assert.match(policy, /Si al llegar no estás, no te preocupes/);
+  assert.match(policy, /Si necesitás cambiarla, avisános antes de que salga el cadete/);
   assert.match(shipping, /Coordinamos la hora o franja antes de que salga el cadete/);
+  assert.match(shipping, /Coordinamos la entrega por WhatsApp antes de que salga el cadete/);
+  assert.doesNotMatch(combined, /no te preocupes: te contactamos para resolver cómo completar la entrega/i);
   assert.doesNotMatch(combined, /reentrega gratuita|segunda entrega gratis/i);
 });


### PR DESCRIPTION
## Objetivo

Eliminar el copy ambiguo que podía interpretarse como que un segundo intento de entrega quedaba resuelto sin costo si el cliente no estaba.

## Qué cambia

- Home / bloque de coordinación: mantiene la promesa fuerte de coordinación previa y reemplaza el mensaje posterior por `Si necesitás cambiarla, avisános antes de que salga el cadete.`
- Bloque `Envíos y pagos`: el disclaimer pasa a enfatizar coordinación previa por WhatsApp.
- `/envios`: mismo criterio; desaparece `no te preocupes: te contactamos para resolver cómo completar la entrega`.
- Test actualizado para exigir que el copy ambiguo no vuelva a aparecer.

## Alcance

Sólo copy/logística + test. No toca checkout, precios, shipping rates, Mercado Pago, SEO técnico ni lógica de entrega.

## Riesgo

Muy bajo. El cambio reduce ambigüedad comercial y reclamos potenciales.

## Gate

Draft. Ejecutar CI + Preview antes de pedir merge. No producción sin aprobación explícita.