### PR TITLE
FICHAS-VIDRIERA-2: motor de evidencia para enriquecimiento masivo

### DIFF
--- a/docs/seo/fichas-vidriera-v2-architecture-2026-08-22.md
+++ b/docs/seo/fichas-vidriera-v2-architecture-2026-08-22.md
@@ -1,0 +1,217 @@
+# FICHAS-VIDRIERA-2 — arquitectura de enriquecimiento semántico masivo
+
+Fecha: 2026-08-22
+
+## Objetivo
+
+Convertir miles de fichas de Amado Libros —tanto disponibles como por encargo— en páginas editoriales útiles para personas y buscadores, sin convertir la generación con IA en texto genérico o no verificable.
+
+Este documento define la capa de evidencia previa. **No cambia HTML, canonical, robots, sitemap, checkout ni Producción.**
+
+## Estado real del sistema que ya existe
+
+### Fichas activas
+
+`functions/_shared/showcase-ranking.js` tiene un límite configurado de hasta 3.000 fichas vidriera y `isShowcaseEligible()` exige hoy:
+
+- ID MLU válido;
+- título;
+- `status === active`;
+- stock > 0;
+- precio > 0;
+- moneda UYU;
+- señales de libro.
+
+Por diseño, una ficha pausada nunca entra en esa cohorte aunque tenga excelente contenido y demanda orgánica.
+
+### Fichas por encargo
+
+La cohorte SEO pausada versionada registra:
+
+- límite: 3.000;
+- 10.083 publicaciones pausadas en el snapshot que la generó;
+- 5.060 ISBN únicos elegibles antes del corte;
+- 130 fichas seleccionadas con demanda histórica de Search Console;
+- 2.870 seleccionadas por calidad de catálogo;
+- 0 fichas de fallback débil;
+- 754 impresiones y 52 clics históricos dentro de la cohorte seleccionada.
+
+Estas URLs ya tienen una base estructural suficientemente fuerte para dejar de tratarlas como simples páginas logísticas.
+
+## Problema arquitectónico
+
+Hoy `availability` y `editorial_quality` están acoplados de forma accidental:
+
+- activo puede acceder al renderer de ficha vidriera;
+- pausado puede ser indexable y tener demanda, pero no recibe el mismo enriquecimiento editorial automático.
+
+FICHAS-VIDRIERA-2 separa ambos ejes:
+
+```text
+availability: active | by_request
+editorial_tier: green | yellow | red
+```
+
+Una ficha `by_request + green` debe poder ser editorialmente más rica que una ficha `active + red`.
+
+## Fuentes previstas
+
+La investigación se ejecutará offline/batch, nunca durante una request de cliente.
+
+Fuentes admisibles:
+
+1. Mercado Libre / descripción real de la publicación;
+2. editorial o sello editorial;
+3. web oficial del autor cuando corresponda;
+4. Google Books;
+5. Open Library;
+6. catálogos de bibliotecas confiables;
+7. distribuidores;
+8. referencias web secundarias como apoyo, nunca como única base automática.
+
+Cada evidencia se conserva con su fuente. La IA redacta a partir del paquete de evidencia; no reemplaza la evidencia.
+
+## Dos identidades distintas
+
+### Identidad de edición
+
+Datos como editorial, páginas, idioma, formato, año y edición sólo se aceptan automáticamente cuando la evidencia coincide con el ISBN exacto.
+
+Una fuente sobre otra edición de la misma obra puede ayudar a explicar el contenido del libro, pero no puede cambiar los datos de la edición vendida.
+
+### Identidad de obra
+
+Para resumen, temas, público y contexto del autor se admite:
+
+- ISBN exacto; o
+- título + autor compatibles cuando se trata claramente de la misma obra.
+
+Esto permite aprovechar conocimiento de la obra sin mezclar datos físicos de ediciones distintas.
+
+## Tiers
+
+### GREEN
+
+Requisitos mínimos:
+
+- ISBN válido de la ficha;
+- dos familias de fuentes independientes con contenido sustantivo;
+- al menos una fuente fuerte;
+- sin contradicción de identidad.
+
+Permite:
+
+- generación automática de resumen;
+- `Para quién es`;
+- cinco temas principales cuando la evidencia los sostiene;
+- contexto del autor;
+- publicación automática del contenido generado después de validaciones estructurales.
+
+### YELLOW
+
+Una sola fuente fuerte o evidencia suficiente a nivel de obra.
+
+Permite generación automática limitada, pero no auto-publicación semántica completa. Puede publicar datos concretos de edición sólo campo por campo cuando el ISBN exacto y la fuente fuerte los respaldan.
+
+### RED
+
+- evidencia insuficiente; o
+- conflicto de identidad.
+
+No genera contenido semántico automático.
+
+La regla no es “si no sabemos, abandonamos”. La regla es **buscar más evidencia automáticamente** hasta mover la ficha a amarillo o verde cuando sea posible.
+
+## Qué debe producir el generador
+
+Artefacto versionado por ficha:
+
+```json
+{
+  "product_id": "MLU...",
+  "isbn": "978...",
+  "availability": "active|by_request",
+  "tier": "green|yellow|red",
+  "sources": [],
+  "summary": "...",
+  "audience": "...",
+  "topics": ["..."],
+  "author_context": "...",
+  "edition_facts": {},
+  "generated_at": "...",
+  "generator_version": "..."
+}
+```
+
+El renderer sólo consume un artefacto ya validado. No llama a Google Books, Open Library, buscadores ni modelos de IA durante la carga de una ficha.
+
+## Orden de despliegue propuesto
+
+### FASE A — evidencia y generación offline
+
+1. motor de confianza (este lote);
+2. conectores de investigación por ISBN/obra;
+3. caché/versionado de evidencia;
+4. generador de contenido estructurado;
+5. auditor que rechaza contradicciones, duplicación y texto demasiado genérico.
+
+### FASE B — primera cohorte masiva
+
+Prioridad:
+
+1. las 130 fichas por encargo con demanda GSC;
+2. activas con demanda GSC y ficha vidriera existente;
+3. resto de la cohorte activa elegible;
+4. 2.870 pausadas seleccionadas por calidad.
+
+No es un piloto manual de un solo libro. La arquitectura se diseña para miles; las cohortes sólo limitan el radio de despliegue y permiten medir causalidad.
+
+### FASE C — expansión
+
+Ampliar según tasa real de `green` y resultados de Google:
+
+- 3.000 activas + 3.000 por encargo como primera superficie estructural;
+- después 10.000+ si la evidencia y la indexación lo justifican.
+
+## Render deseado
+
+Orden editorial recomendado en ficha:
+
+1. título / autor / portada;
+2. `De qué trata`;
+3. `Para quién es`;
+4. `5 temas principales`;
+5. `Sobre el autor`;
+6. `Ficha de esta edición`;
+7. bloque comercial.
+
+En fichas por encargo, el bloque comercial debe ser compacto y no tapar el contenido editorial.
+
+## Medición SEO obligatoria
+
+Cada cohorte debe registrar antes/después:
+
+- indexación;
+- impresiones;
+- consultas nuevas;
+- posición media;
+- CTR;
+- clics;
+- sesiones orgánicas;
+- WhatsApp / aviso / carrito cuando aplique.
+
+Ventanas: 14, 28 y 56 días.
+
+No se debe atribuir automáticamente un cambio de ranking a la generación; se compara por cohortes y se conserva baseline.
+
+## Fuera de alcance de este lote
+
+- llamadas reales a fuentes externas;
+- uso de una API de IA;
+- cambios visibles en ficha;
+- cambio de copy de encargo;
+- eliminación de placas promocionales de galerías;
+- canonical/redirect/sitemap;
+- Producción.
+
+Esos cambios deben ir en lotes separados para mantener atribución y rollback claros.

--- a/functions/__tests__/book-intelligence-evidence.test.js
+++ b/functions/__tests__/book-intelligence-evidence.test.js
@@ -79,6 +79,25 @@ test('otro ISBN de la misma obra puede aportar contenido de obra pero no datos d
   assert.equal(result.edition_facts.publisher.value, null);
 });
 
+test('otra edición nunca se acepta sólo por título si falta el autor de la ficha', () => {
+  const result = classifyBookIntelligenceEvidence(
+    item({ isbn: null, author: '' }),
+    [evidence('publisher', { isbn: null, title: 'Padres fuertes, hijas felices', author: 'Otra persona' })],
+  );
+  assert.equal(result.tier, 'red');
+  assert.equal(result.work_source_count, 0);
+  assert.equal(result.generation_policy.can_generate_work_content, false);
+});
+
+test('otra edición con mismo título pero autor distinto no aporta contenido de obra', () => {
+  const result = classifyBookIntelligenceEvidence(
+    item({ isbn: null }),
+    [evidence('publisher', { isbn: null, author: 'Otra persona' })],
+  );
+  assert.equal(result.tier, 'red');
+  assert.equal(result.work_source_count, 0);
+});
+
 test('datos de edición sólo se vuelven auto-publicables con ISBN exacto y fuente fuerte', () => {
   const result = classifyBookIntelligenceEvidence(item(), [
     evidence('google_books', {
@@ -114,7 +133,7 @@ test('cinco temas explícitos en una fuente fuerte yellow habilitan generación 
   assert.equal(result.generation_policy.can_generate_five_topics, true);
 });
 
-test('sin ISBN puede clasificarse yellow a nivel obra, pero nunca publica datos de edición', () => {
+test('sin ISBN puede clasificarse yellow a nivel obra con título+autor, pero nunca publica datos de edición', () => {
   const result = classifyBookIntelligenceEvidence(item({ isbn: null }), [
     evidence('publisher', { isbn: null }),
   ]);

--- a/functions/__tests__/book-intelligence-evidence.test.js
+++ b/functions/__tests__/book-intelligence-evidence.test.js
@@ -1,0 +1,152 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  classifyBookIntelligenceEvidence,
+  normalizeEvidenceText,
+  summarizeBookIntelligenceEvidence,
+} from '../_shared/book-intelligence-evidence.js';
+
+const ISBN = '9788496836693';
+
+function item(overrides = {}) {
+  return {
+    id: 'MLU1',
+    title: 'Padres fuertes, hijas felices',
+    author: 'Meg Meeker',
+    isbn: ISBN,
+    status: 'active',
+    available_quantity: 2,
+    ...overrides,
+  };
+}
+
+function evidence(source, overrides = {}) {
+  return {
+    source,
+    isbn: ISBN,
+    title: 'Padres fuertes, hijas felices',
+    author: 'Meg Meeker',
+    description: 'Una descripción suficientemente extensa y específica de la obra, su enfoque, los temas que desarrolla y el tipo de lector al que puede resultar útil. Incluye evidencia editorial concreta para permitir una síntesis posterior sin inventar contenido.',
+    ...overrides,
+  };
+}
+
+test('normaliza texto de identidad de forma determinista', () => {
+  assert.equal(normalizeEvidenceText('  Psicología, Clínica  '), 'psicologia clinica');
+});
+
+test('dos fuentes independientes, una fuerte, habilitan tier green', () => {
+  const result = classifyBookIntelligenceEvidence(item(), [
+    evidence('google_books'),
+    evidence('open_library', { summary: 'Resumen independiente suficientemente detallado sobre la misma obra y edición.' }),
+  ]);
+  assert.equal(result.tier, 'green');
+  assert.equal(result.generation_policy.can_generate_work_content, true);
+  assert.equal(result.generation_policy.can_auto_publish_work_content, true);
+  assert.equal(result.independent_work_source_count, 2);
+});
+
+test('una sola fuente fuerte queda yellow: puede generar, no auto-publicar', () => {
+  const result = classifyBookIntelligenceEvidence(item(), [evidence('publisher')]);
+  assert.equal(result.tier, 'yellow');
+  assert.equal(result.generation_policy.can_generate_work_content, true);
+  assert.equal(result.generation_policy.can_auto_publish_work_content, false);
+});
+
+test('una referencia web débil sola no habilita generación', () => {
+  const result = classifyBookIntelligenceEvidence(item(), [evidence('web_reference')]);
+  assert.equal(result.tier, 'red');
+  assert.equal(result.generation_policy.can_generate_work_content, false);
+});
+
+test('mismo ISBN con título incompatible bloquea por conflicto de identidad', () => {
+  const result = classifyBookIntelligenceEvidence(item(), [
+    evidence('google_books', { title: 'Un libro completamente distinto' }),
+    evidence('open_library'),
+  ]);
+  assert.equal(result.tier, 'red');
+  assert.equal(result.reason, 'identity_conflict');
+  assert.equal(result.identity_conflicts.some(conflict => conflict.field === 'title'), true);
+});
+
+test('otro ISBN de la misma obra puede aportar contenido de obra pero no datos de edición', () => {
+  const result = classifyBookIntelligenceEvidence(item(), [
+    evidence('google_books', { isbn: '9788499988771' }),
+  ]);
+  assert.equal(result.tier, 'yellow');
+  assert.equal(result.exact_isbn_source_count, 0);
+  assert.equal(result.edition_facts.publisher.value, null);
+});
+
+test('datos de edición sólo se vuelven auto-publicables con ISBN exacto y fuente fuerte', () => {
+  const result = classifyBookIntelligenceEvidence(item(), [
+    evidence('google_books', {
+      publisher: 'Ciudadela Libros',
+      pages: 304,
+      language: 'Español',
+      publication_year: '2008',
+    }),
+  ]);
+  assert.equal(result.edition_fields_auto_publishable.publisher, true);
+  assert.equal(result.edition_fields_auto_publishable.pages, true);
+  assert.equal(result.edition_fields_auto_publishable.language, true);
+});
+
+test('conflicto de páginas se expone y ese campo deja de ser auto-publicable', () => {
+  const result = classifyBookIntelligenceEvidence(item(), [
+    evidence('google_books', { pages: 304 }),
+    evidence('open_library', { pages: 320 }),
+  ]);
+  assert.equal(result.edition_fact_conflicts.includes('pages'), true);
+  assert.equal(result.edition_fields_auto_publishable.pages, false);
+  assert.equal(result.tier, 'green');
+});
+
+test('cinco temas explícitos en una fuente fuerte yellow habilitan generación de temas', () => {
+  const result = classifyBookIntelligenceEvidence(item(), [
+    evidence('publisher', {
+      topics: ['Liderazgo', 'Familia', 'Comunicación', 'Confianza', 'Educación'],
+      description: '',
+    }),
+  ]);
+  assert.equal(result.tier, 'yellow');
+  assert.equal(result.generation_policy.can_generate_five_topics, true);
+});
+
+test('sin ISBN puede clasificarse yellow a nivel obra, pero nunca publica datos de edición', () => {
+  const result = classifyBookIntelligenceEvidence(item({ isbn: null }), [
+    evidence('publisher', { isbn: null }),
+  ]);
+  assert.equal(result.tier, 'yellow');
+  assert.equal(result.isbn, null);
+  assert.equal(Object.values(result.edition_fields_auto_publishable).some(Boolean), false);
+});
+
+test('estado pausado se separa de la calidad editorial', () => {
+  const result = classifyBookIntelligenceEvidence(
+    item({ status: 'paused', available_quantity: 0 }),
+    [evidence('google_books'), evidence('open_library')],
+  );
+  assert.equal(result.availability, 'by_request');
+  assert.equal(result.tier, 'green');
+});
+
+test('resumen agrega tiers, disponibilidad y conflictos', () => {
+  const green = classifyBookIntelligenceEvidence(item(), [evidence('google_books'), evidence('open_library')]);
+  const yellow = classifyBookIntelligenceEvidence(item({ id: 'MLU2', status: 'paused', available_quantity: 0 }), [evidence('publisher')]);
+  const red = classifyBookIntelligenceEvidence(item({ id: 'MLU3' }), []);
+  const summary = summarizeBookIntelligenceEvidence([green, yellow, red]);
+  assert.deepEqual(summary, {
+    total: 3,
+    green: 1,
+    yellow: 1,
+    red: 1,
+    active: 2,
+    by_request: 1,
+    auto_publish_work_content: 1,
+    generate_five_topics: 1,
+    identity_conflicts: 0,
+    edition_fact_conflicts: 0,
+  });
+});

--- a/functions/_shared/book-intelligence-evidence.js
+++ b/functions/_shared/book-intelligence-evidence.js
@@ -1,0 +1,272 @@
+// FICHAS-VIDRIERA-2 — motor de evidencia para enriquecimiento semántico masivo.
+//
+// Esta capa NO genera texto y NO toca el renderer. Su trabajo es decidir qué
+// evidencia puede alimentar una generación editorial automática y con qué
+// nivel de confianza. Separa explícitamente dos conceptos que antes estaban
+// mezclados: disponibilidad comercial (active/paused) y calidad editorial.
+
+import { normalizeValidIsbn } from './showcase-ranking.js';
+
+export const BOOK_EVIDENCE_SOURCE_POLICY = Object.freeze({
+  publisher: Object.freeze({ trust: 5, independentFamily: 'publisher', official: true }),
+  author_site: Object.freeze({ trust: 5, independentFamily: 'author', official: true }),
+  national_library: Object.freeze({ trust: 5, independentFamily: 'library', official: true }),
+  google_books: Object.freeze({ trust: 4, independentFamily: 'google_books', official: false }),
+  open_library: Object.freeze({ trust: 4, independentFamily: 'open_library', official: false }),
+  library_catalog: Object.freeze({ trust: 4, independentFamily: 'library_catalog', official: false }),
+  meli: Object.freeze({ trust: 3, independentFamily: 'meli', official: false }),
+  distributor: Object.freeze({ trust: 3, independentFamily: 'distributor', official: false }),
+  web_reference: Object.freeze({ trust: 2, independentFamily: 'web_reference', official: false }),
+});
+
+const EDITION_FIELDS = Object.freeze([
+  'publisher',
+  'pages',
+  'language',
+  'format',
+  'edition',
+  'publication_year',
+]);
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+export function normalizeEvidenceText(value) {
+  return clean(value)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLocaleLowerCase('es')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function sourcePolicy(source) {
+  return BOOK_EVIDENCE_SOURCE_POLICY[source] || null;
+}
+
+function compatibleIdentityText(left, right) {
+  const a = normalizeEvidenceText(left);
+  const b = normalizeEvidenceText(right);
+  if (!a || !b) return true;
+  if (a === b) return true;
+  if (a.length >= 8 && b.includes(a)) return true;
+  if (b.length >= 8 && a.includes(b)) return true;
+  return false;
+}
+
+function normalizedComparable(value) {
+  if (value === null || value === undefined || value === '') return null;
+  if (typeof value === 'number') return String(value);
+  return normalizeEvidenceText(value);
+}
+
+function contentLength(record) {
+  return Math.max(
+    clean(record.description).length,
+    clean(record.summary).length,
+    clean(record.author_context).length,
+  );
+}
+
+function hasSubstantiveWorkContent(record) {
+  const topics = Array.isArray(record.topics)
+    ? record.topics.map(clean).filter(Boolean)
+    : [];
+  const audience = clean(record.audience);
+  return clean(record.description).length >= 120 ||
+    clean(record.summary).length >= 80 ||
+    clean(record.author_context).length >= 80 ||
+    topics.length >= 3 ||
+    audience.length >= 40;
+}
+
+function normalizeRecord(record, index) {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) return null;
+  const policy = sourcePolicy(record.source);
+  if (!policy) return null;
+
+  return {
+    ...record,
+    _index: index,
+    _policy: policy,
+    isbn: normalizeValidIsbn(record.isbn),
+    title: clean(record.title),
+    author: clean(record.author),
+    description: clean(record.description),
+    summary: clean(record.summary),
+    audience: clean(record.audience),
+    author_context: clean(record.author_context),
+    topics: Array.isArray(record.topics)
+      ? record.topics.map(clean).filter(Boolean).slice(0, 12)
+      : [],
+  };
+}
+
+function consensusForField(records, field) {
+  const candidates = records
+    .map(record => record[field])
+    .filter(value => value !== null && value !== undefined && clean(value));
+  if (candidates.length === 0) {
+    return { value: null, sourceCount: 0, conflict: false };
+  }
+
+  const groups = new Map();
+  for (const value of candidates) {
+    const key = normalizedComparable(value);
+    if (!key) continue;
+    const current = groups.get(key) || { value, count: 0 };
+    current.count++;
+    groups.set(key, current);
+  }
+  const ranked = [...groups.values()].sort((a, b) => b.count - a.count);
+  if (ranked.length === 0) return { value: null, sourceCount: 0, conflict: false };
+
+  return {
+    value: ranked[0].value,
+    sourceCount: candidates.length,
+    conflict: ranked.length > 1,
+  };
+}
+
+/**
+ * Clasifica evidencia externa para una edición concreta.
+ *
+ * Reglas principales:
+ * - los datos de EDICIÓN requieren ISBN exacto;
+ * - el contenido de OBRA puede usar ISBN exacto o título+autor compatibles;
+ * - dos familias de fuentes independientes permiten publicación automática;
+ * - una sola fuente suficiente permite generar, pero no auto-publicar;
+ * - una contradicción de identidad sobre el mismo ISBN bloquea el lote.
+ */
+export function classifyBookIntelligenceEvidence(item, evidenceRecords = []) {
+  const itemIsbn = normalizeValidIsbn(item?.isbn);
+  const itemTitle = clean(item?.title);
+  const itemAuthor = clean(item?.author);
+  const records = evidenceRecords
+    .map(normalizeRecord)
+    .filter(Boolean);
+
+  const exactIsbnRecords = itemIsbn
+    ? records.filter(record => record.isbn === itemIsbn)
+    : [];
+
+  const identityConflicts = [];
+  for (const record of exactIsbnRecords) {
+    if (record.title && !compatibleIdentityText(itemTitle, record.title)) {
+      identityConflicts.push({ source: record.source, field: 'title', value: record.title });
+    }
+    if (itemAuthor && record.author && !compatibleIdentityText(itemAuthor, record.author)) {
+      identityConflicts.push({ source: record.source, field: 'author', value: record.author });
+    }
+  }
+
+  const workRecords = records.filter(record => {
+    if (!hasSubstantiveWorkContent(record)) return false;
+    if (itemIsbn && record.isbn === itemIsbn) return true;
+    return compatibleIdentityText(itemTitle, record.title) &&
+      compatibleIdentityText(itemAuthor, record.author) &&
+      Boolean(normalizeEvidenceText(record.title));
+  });
+
+  const independentWorkFamilies = new Set(
+    workRecords.map(record => record._policy.independentFamily),
+  );
+  const strongWorkFamilies = new Set(
+    workRecords
+      .filter(record => record._policy.trust >= 4)
+      .map(record => record._policy.independentFamily),
+  );
+
+  const editionFacts = {};
+  const editionFactConflicts = [];
+  for (const field of EDITION_FIELDS) {
+    const consensus = consensusForField(exactIsbnRecords, field);
+    editionFacts[field] = consensus;
+    if (consensus.conflict) editionFactConflicts.push(field);
+  }
+
+  let tier = 'red';
+  let reason = 'insufficient_evidence';
+  if (identityConflicts.length > 0) {
+    tier = 'red';
+    reason = 'identity_conflict';
+  } else if (itemIsbn && independentWorkFamilies.size >= 2 && strongWorkFamilies.size >= 1) {
+    tier = 'green';
+    reason = 'multi_source_exact_identity';
+  } else if (workRecords.length >= 1 && strongWorkFamilies.size >= 1) {
+    tier = 'yellow';
+    reason = itemIsbn ? 'single_strong_source' : 'work_identity_only';
+  }
+
+  const trustedExactEditionSources = exactIsbnRecords.filter(record => record._policy.trust >= 4);
+  const editionFieldsAutoPublishable = Object.fromEntries(
+    EDITION_FIELDS.map(field => {
+      const fact = editionFacts[field];
+      return [field, Boolean(
+        fact.value &&
+        !fact.conflict &&
+        trustedExactEditionSources.some(record => normalizedComparable(record[field]) === normalizedComparable(fact.value))
+      )];
+    }),
+  );
+
+  return {
+    schema_version: 1,
+    product_id: clean(item?.id).toUpperCase() || null,
+    isbn: itemIsbn,
+    availability: item?.status === 'active' && Number(item?.available_quantity) > 0
+      ? 'active'
+      : 'by_request',
+    tier,
+    reason,
+    work_source_count: workRecords.length,
+    independent_work_source_count: independentWorkFamilies.size,
+    strong_work_source_count: strongWorkFamilies.size,
+    exact_isbn_source_count: exactIsbnRecords.length,
+    identity_conflicts: identityConflicts,
+    edition_fact_conflicts: editionFactConflicts,
+    edition_facts: editionFacts,
+    edition_fields_auto_publishable: editionFieldsAutoPublishable,
+    generation_policy: {
+      can_generate_work_content: tier === 'green' || tier === 'yellow',
+      can_auto_publish_work_content: tier === 'green',
+      can_generate_five_topics: tier === 'green' || (
+        tier === 'yellow' && workRecords.some(record => record.topics.length >= 5)
+      ),
+      can_generate_audience: tier === 'green' || workRecords.some(record => clean(record.audience).length >= 40),
+      can_generate_author_context: tier === 'green' || workRecords.some(record => clean(record.author_context).length >= 80),
+    },
+    diagnostics: {
+      max_content_chars: workRecords.reduce((max, record) => Math.max(max, contentLength(record)), 0),
+      work_sources: workRecords.map(record => record.source),
+      exact_isbn_sources: exactIsbnRecords.map(record => record.source),
+    },
+  };
+}
+
+export function summarizeBookIntelligenceEvidence(results = []) {
+  const summary = {
+    total: results.length,
+    green: 0,
+    yellow: 0,
+    red: 0,
+    active: 0,
+    by_request: 0,
+    auto_publish_work_content: 0,
+    generate_five_topics: 0,
+    identity_conflicts: 0,
+    edition_fact_conflicts: 0,
+  };
+
+  for (const result of results) {
+    if (result?.tier in summary) summary[result.tier]++;
+    if (result?.availability in summary) summary[result.availability]++;
+    if (result?.generation_policy?.can_auto_publish_work_content) summary.auto_publish_work_content++;
+    if (result?.generation_policy?.can_generate_five_topics) summary.generate_five_topics++;
+    summary.identity_conflicts += Array.isArray(result?.identity_conflicts) ? result.identity_conflicts.length : 0;
+    summary.edition_fact_conflicts += Array.isArray(result?.edition_fact_conflicts) ? result.edition_fact_conflicts.length : 0;
+  }
+
+  return summary;
+}

--- a/functions/_shared/book-intelligence-evidence.js
+++ b/functions/_shared/book-intelligence-evidence.js
@@ -55,6 +55,22 @@ function compatibleIdentityText(left, right) {
   return false;
 }
 
+/**
+ * Evidencia que NO coincide por ISBN exacto sólo puede representar la misma
+ * obra si tenemos ambas piezas de identidad: título y autor. Aceptar sólo el
+ * título cuando falta autor permitiría mezclar homónimos y contaminar el
+ * contenido semántico a escala.
+ */
+function sameWorkIdentityMatches(itemTitle, itemAuthor, recordTitle, recordAuthor) {
+  const titleA = normalizeEvidenceText(itemTitle);
+  const titleB = normalizeEvidenceText(recordTitle);
+  const authorA = normalizeEvidenceText(itemAuthor);
+  const authorB = normalizeEvidenceText(recordAuthor);
+  if (!titleA || !titleB || !authorA || !authorB) return false;
+  return compatibleIdentityText(itemTitle, recordTitle) &&
+    compatibleIdentityText(itemAuthor, recordAuthor);
+}
+
 function normalizedComparable(value) {
   if (value === null || value === undefined || value === '') return null;
   if (typeof value === 'number') return String(value);
@@ -164,9 +180,7 @@ export function classifyBookIntelligenceEvidence(item, evidenceRecords = []) {
   const workRecords = records.filter(record => {
     if (!hasSubstantiveWorkContent(record)) return false;
     if (itemIsbn && record.isbn === itemIsbn) return true;
-    return compatibleIdentityText(itemTitle, record.title) &&
-      compatibleIdentityText(itemAuthor, record.author) &&
-      Boolean(normalizeEvidenceText(record.title));
+    return sameWorkIdentityMatches(itemTitle, itemAuthor, record.title, record.author);
   });
 
   const independentWorkFamilies = new Set(
@@ -260,8 +274,8 @@ export function summarizeBookIntelligenceEvidence(results = []) {
   };
 
   for (const result of results) {
-    if (result?.tier in summary) summary[result.tier]++;
-    if (result?.availability in summary) summary[result.availability]++;
+    if (result?.tier && Object.prototype.hasOwnProperty.call(summary, result.tier)) summary[result.tier]++;
+    if (result?.availability && Object.prototype.hasOwnProperty.call(summary, result.availability)) summary[result.availability]++;
     if (result?.generation_policy?.can_auto_publish_work_content) summary.auto_publish_work_content++;
     if (result?.generation_policy?.can_generate_five_topics) summary.generate_five_topics++;
     summary.identity_conflicts += Array.isArray(result?.identity_conflicts) ? result.identity_conflicts.length : 0;


### PR DESCRIPTION
## Objetivo

Crear la capa de evidencia/confianza que permita enriquecer miles de fichas con web + IA sin mezclar ediciones ni auto-publicar texto débil.

## Diagnóstico que congela este PR

El sistema actual separa de forma accidental disponibilidad y riqueza editorial:

- `showcase-ranking.js` permite hasta 3.000 fichas vidriera, pero `isShowcaseEligible()` exige `status=active`, stock, precio UYU y señales de libro;
- la cohorte SEO pausada ya contiene 3.000 fichas por encargo: 130 con demanda GSC + 2.870 por calidad, 0 fallback débil;
- por lo tanto una ficha pausada puede ser indexable y tener demanda pero quedar fuera del enriquecimiento editorial automático.

## Qué agrega

### `functions/_shared/book-intelligence-evidence.js`

Motor puro y determinista que:

- separa `availability: active|by_request` de `tier: green|yellow|red`;
- exige ISBN exacto para datos de edición;
- permite evidencia de otra edición sólo cuando **título + autor** coinciden con la obra; título solo nunca alcanza;
- distingue familias de fuentes independientes;
- bloquea contradicciones de identidad;
- detecta conflictos campo a campo en editorial/páginas/idioma/formato/edición/año;
- decide qué puede generar IA y qué puede auto-publicarse;
- permite `5 temas principales` sólo cuando la evidencia alcanza el gate;
- no genera ningún texto todavía.

### Tests

14 casos focalizados:

- 2 fuentes independientes → green;
- 1 fuente fuerte → yellow;
- referencia web débil sola → red;
- conflicto de identidad → red;
- otra edición puede alimentar contenido de obra pero no datos físicos;
- sin autor no se acepta otra edición sólo por título;
- mismo título con autor distinto no se considera la misma obra;
- exact ISBN + fuente fuerte habilita datos concretos;
- conflicto de páginas bloquea ese campo;
- 5 temas explícitos habilitan generación controlada;
- sin ISBN puede existir evidencia de obra sólo con título+autor;
- pausado puede ser green;
- resumen de métricas.

### Arquitectura

Documento `docs/seo/fichas-vidriera-v2-architecture-2026-08-22.md` con pipeline previsto:

1. investigación offline/batch por ISBN/obra;
2. fuentes: ML, editorial/autor, Google Books, Open Library, bibliotecas, distribuidores y web secundaria;
3. artefacto versionado de evidencia;
4. generación con IA desde evidencia;
5. renderer consume sólo artefacto validado;
6. primera prioridad masiva: 130 pausadas con demanda GSC + activas con demanda + resto de cohortes;
7. medición SEO a 14/28/56 días.

## Hardening posterior

Después de la primera corrida de CI se cerró un riesgo de escala: una evidencia de otra edición ya no puede entrar por coincidencia de título cuando falta autor. El match cross-edition exige las dos piezas de identidad, `title + author`.

## Validación final del head actual

Head: `82fe86060a1e4226e672f344ce117c18ce51a428`.

- CI completo: **PASS**;
- Preview protegido + auditoría: **PASS**;
- SEO baseline público: **PASS**;
- primer Preview del head anterior había fallado por deriva transitoria del snapshot/sitemap (15 URLs 404), ajena a estos 3 archivos de tooling; el head actual pasó el mismo audit;
- Producción: intacta.

## Riesgo

Muy bajo. Este PR agrega sólo un módulo puro, tests y documentación. **No toca HTML, ficha visible, canonical, robots, sitemap, checkout, R2, Worker, IA externa ni Producción.**

## Gate

Mantener Draft. El siguiente PR debe implementar investigación batch/caché de fuentes reales. No mezclar todavía copy de encargo, galerías ni renderer.

**NO MERGEAR. NO PRODUCCIÓN.**