### PR TITLE
FICHAS-VIDRIERA-2: fuentes reales y caché por ISBN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ astro-front/.astro/
 # masiva (~17k registros): datos derivados, reproducibles desde R2 público,
 # no pertenecen al repositorio. Reglas, esquema y tests sí se versionan.
 scripts/categorize/data/
+
+# FICHAS-VIDRIERA-2 — caché local de investigación bibliográfica.
+# Puede regenerarse; nunca debe versionar API keys ni respuestas de trabajo.
+scripts/seo/data/book-intelligence/

--- a/docs/seo/fichas-vidriera-v2-sources-2026-08-22.md
+++ b/docs/seo/fichas-vidriera-v2-sources-2026-08-22.md
@@ -20,7 +20,12 @@ Documentación oficial usada para este contrato:
 
 `https://developers.google.com/books/docs/v1/using`
 
-La documentación oficial exige identificar las requests públicas con API key u OAuth. El cliente de este lote exige `GOOGLE_BOOKS_API_KEY` en modo de red real y nunca guarda esa key en la caché.
+La documentación oficial permite identificar requests públicas con API key u OAuth 2.0 access token. El cliente admite ambos caminos:
+
+- `GOOGLE_BOOKS_API_KEY`; o
+- `accessToken`, enviado únicamente como `Authorization: Bearer ...` y nunca dentro de la URL.
+
+Amado Libros ya usa Workload Identity Federation para otros workflows Google. Antes de crear otro secreto, RESEARCH-RUN-1 debe intentar reutilizar ese mecanismo con un token OAuth adecuado para Books. Ninguna credencial se guarda en la caché.
 
 Campos útiles cuando el volume contiene exactamente el ISBN pedido:
 
@@ -66,7 +71,7 @@ La caché se guarda fuera del repositorio en:
 
 `scripts/seo/data/book-intelligence/`
 
-`.gitignore` impide versionarla. El artefacto de evidencia final sí podrá versionarse más adelante, pero nunca la API key ni secretos.
+`.gitignore` impide versionarla. El artefacto de evidencia final sí podrá versionarse más adelante, pero nunca API keys, access tokens ni otros secretos.
 
 ## Priorización
 
@@ -117,11 +122,12 @@ Esos records se pasan al clasificador de evidencia de #217 para obtener `green/y
 `FICHAS-VIDRIERA-2 / RESEARCH-RUN-1`:
 
 1. seleccionar una cohorte real desde GSC + catálogo;
-2. ejecutar Google Books con key segura y caché;
-3. usar Open Library sólo dentro del presupuesto permitido;
-4. medir cuántas fichas quedan green/yellow/red;
-5. decidir qué tercera fuente aumenta más la cobertura (editorial, distribuidor, bibliotecas o dump de Open Library);
-6. todavía sin publicar texto en la web.
+2. autenticar Google Books reutilizando WIF/OAuth si el proyecto lo admite; fallback a API key sólo si hace falta;
+3. ejecutar Google Books con caché;
+4. usar Open Library sólo dentro del presupuesto permitido;
+5. medir cuántas fichas quedan green/yellow/red;
+6. decidir qué tercera fuente aumenta más la cobertura (editorial, distribuidor, bibliotecas o dump de Open Library);
+7. todavía sin publicar texto en la web.
 
 ## Fuera de alcance
 

--- a/docs/seo/fichas-vidriera-v2-sources-2026-08-22.md
+++ b/docs/seo/fichas-vidriera-v2-sources-2026-08-22.md
@@ -16,6 +16,10 @@ Endpoint oficial de búsqueda de volumes:
 
 `https://www.googleapis.com/books/v1/volumes?q=isbn:...`
 
+Documentación oficial usada para este contrato:
+
+`https://developers.google.com/books/docs/v1/using`
+
 La documentación oficial exige identificar las requests públicas con API key u OAuth. El cliente de este lote exige `GOOGLE_BOOKS_API_KEY` en modo de red real y nunca guarda esa key en la caché.
 
 Campos útiles cuando el volume contiene exactamente el ISBN pedido:
@@ -35,6 +39,10 @@ Una respuesta de búsqueda que no contiene el ISBN exacto en `industryIdentifier
 ### Open Library
 
 Uso previsto: segunda verificación de bajo volumen sobre la cohorte prioritaria, no backend masivo.
+
+Política/API consultada:
+
+`https://openlibrary.org/developers/api`
 
 Open Library declara expresamente que su Web API es para usos de bajo volumen y que para bulk deben usarse dumps. También pide caché y un `User-Agent` identificable con contacto cuando se realizan requests frecuentes.
 

--- a/docs/seo/fichas-vidriera-v2-sources-2026-08-22.md
+++ b/docs/seo/fichas-vidriera-v2-sources-2026-08-22.md
@@ -1,0 +1,126 @@
+# FICHAS-VIDRIERA-2 — FUENTES-1
+
+Fecha: 2026-08-22
+
+## Objetivo
+
+Preparar investigación bibliográfica real, reproducible y cacheada para alimentar el motor de evidencia de FICHAS-VIDRIERA-2. Este lote no genera contenido con IA, no modifica fichas y no toca Producción.
+
+## Fuentes de este lote
+
+### Google Books
+
+Uso previsto: cobertura amplia por ISBN exacto.
+
+Endpoint oficial de búsqueda de volumes:
+
+`https://www.googleapis.com/books/v1/volumes?q=isbn:...`
+
+La documentación oficial exige identificar las requests públicas con API key u OAuth. El cliente de este lote exige `GOOGLE_BOOKS_API_KEY` en modo de red real y nunca guarda esa key en la caché.
+
+Campos útiles cuando el volume contiene exactamente el ISBN pedido:
+
+- título;
+- autores;
+- descripción;
+- editorial;
+- páginas;
+- idioma;
+- fecha/año de publicación;
+- categorías/temas;
+- identificadores.
+
+Una respuesta de búsqueda que no contiene el ISBN exacto en `industryIdentifiers` se descarta, aunque el título parezca coincidir.
+
+### Open Library
+
+Uso previsto: segunda verificación de bajo volumen sobre la cohorte prioritaria, no backend masivo.
+
+Open Library declara expresamente que su Web API es para usos de bajo volumen y que para bulk deben usarse dumps. También pide caché y un `User-Agent` identificable con contacto cuando se realizan requests frecuentes.
+
+Por eso este lote:
+
+- usa requests multi-ISBN del Partner/Read API para reducir llamadas;
+- limita cada request a 20 ISBN;
+- fija un presupuesto por defecto de sólo 25 ISBN por corrida;
+- exige `User-Agent` + contacto;
+- cachea Open Library durante 180 días;
+- deja la ingestión de dumps para un lote posterior si necesitamos enriquecer miles con esta fuente.
+
+## Caché
+
+TTL inicial:
+
+- Google Books: 90 días;
+- Open Library: 180 días.
+
+La caché se guarda fuera del repositorio en:
+
+`scripts/seo/data/book-intelligence/`
+
+`.gitignore` impide versionarla. El artefacto de evidencia final sí podrá versionarse más adelante, pero nunca la API key ni secretos.
+
+## Priorización
+
+El planner ordena primero por:
+
+1. `priority_score`;
+2. impresiones GSC;
+3. clics GSC;
+4. ID estable como desempate.
+
+Deduplica por ISBN antes de consumir presupuesto. Si dos publicaciones comparten ISBN, sólo se investiga una vez y el resultado de evidencia puede reutilizarse para la edición compatible.
+
+## Seguridad de identidad
+
+Google Books:
+
+- la búsqueda se hace por `isbn:`;
+- el parser vuelve a exigir que `industryIdentifiers` incluya exactamente el ISBN normalizado.
+
+Open Library:
+
+- sólo se conservan records cuyo listado de ISBN contiene exactamente uno de los ISBN solicitados;
+- los datos devueltos siguen siendo evidencia, no verdad absoluta;
+- el motor de #217 aplica después los gates de conflicto de identidad y edición.
+
+## Política de errores
+
+Una caída de una fuente no genera contenido vacío ni falso.
+
+El caller debe registrar el error en caché junto con `fetched_at` y decidir cuándo reintentar. La ausencia de match es un dato de investigación, no motivo para inventar información.
+
+## Qué permite este lote
+
+Una vez conectado a una fuente de catálogo real, podremos producir paquetes como:
+
+```json
+{
+  "isbn": "978...",
+  "google_books": [{ "source": "google_books", "...": "..." }],
+  "open_library": [{ "source": "open_library", "...": "..." }]
+}
+```
+
+Esos records se pasan al clasificador de evidencia de #217 para obtener `green/yellow/red`.
+
+## Siguiente lote
+
+`FICHAS-VIDRIERA-2 / RESEARCH-RUN-1`:
+
+1. seleccionar una cohorte real desde GSC + catálogo;
+2. ejecutar Google Books con key segura y caché;
+3. usar Open Library sólo dentro del presupuesto permitido;
+4. medir cuántas fichas quedan green/yellow/red;
+5. decidir qué tercera fuente aumenta más la cobertura (editorial, distribuidor, bibliotecas o dump de Open Library);
+6. todavía sin publicar texto en la web.
+
+## Fuera de alcance
+
+- llamadas de red desde CI;
+- API de IA;
+- renderer visible;
+- copy de fichas por encargo;
+- galerías/promocionales;
+- canonical, sitemap o robots;
+- Production.

--- a/functions/__tests__/book-intelligence-sources.test.js
+++ b/functions/__tests__/book-intelligence-sources.test.js
@@ -29,14 +29,19 @@ function fakeResponse(payload, { status = 200 } = {}) {
   };
 }
 
-test('Google Books URL exige API key y usa búsqueda exacta por ISBN', () => {
-  assert.throws(() => buildGoogleBooksUrl(ISBN), /GOOGLE_BOOKS_API_KEY/);
-  const url = new URL(buildGoogleBooksUrl(ISBN, { apiKey: 'test-key' }));
-  assert.equal(url.origin, 'https://www.googleapis.com');
-  assert.equal(url.pathname, '/books/v1/volumes');
-  assert.equal(url.searchParams.get('q'), `isbn:${ISBN}`);
-  assert.equal(url.searchParams.get('printType'), 'books');
-  assert.equal(url.searchParams.get('key'), 'test-key');
+test('Google Books exige API key u OAuth token y usa búsqueda exacta por ISBN', () => {
+  assert.throws(() => buildGoogleBooksUrl(ISBN), /API key u OAuth/);
+  const keyUrl = new URL(buildGoogleBooksUrl(ISBN, { apiKey: 'test-key' }));
+  assert.equal(keyUrl.origin, 'https://www.googleapis.com');
+  assert.equal(keyUrl.pathname, '/books/v1/volumes');
+  assert.equal(keyUrl.searchParams.get('q'), `isbn:${ISBN}`);
+  assert.equal(keyUrl.searchParams.get('printType'), 'books');
+  assert.equal(keyUrl.searchParams.get('key'), 'test-key');
+
+  const oauthUrl = new URL(buildGoogleBooksUrl(ISBN, { accessToken: 'token-from-wif' }));
+  assert.equal(oauthUrl.searchParams.get('q'), `isbn:${ISBN}`);
+  assert.equal(oauthUrl.searchParams.has('key'), false);
+  assert.equal(oauthUrl.toString().includes('token-from-wif'), false);
 });
 
 test('parseGoogleBooksEvidence sólo acepta volumes que contienen el ISBN exacto', () => {
@@ -166,7 +171,6 @@ test('Open Library budget es bajo por defecto y se divide en requests de máximo
     isbn: base[index % base.length],
   }));
   const plan = planBookSourceResearch(items, {}, { openLibraryBudget: 25 });
-  // Sólo hay dos ISBN únicos en el fixture.
   assert.equal(plan.open_library.length, 2);
   const synthetic = {
     open_library: Array.from({ length: 25 }, (_, i) => ({ id: `X${i}`, isbn: ISBN })),
@@ -175,7 +179,7 @@ test('Open Library budget es bajo por defecto y se divide en requests de máximo
   assert.deepEqual(chunks.map(chunk => chunk.length), [20, 5]);
 });
 
-test('fetchGoogleBooksEvidence usa fetch inyectable y parsea respuesta', async () => {
+test('fetchGoogleBooksEvidence con API key usa fetch inyectable y parsea respuesta', async () => {
   let requestedUrl = null;
   const records = await fetchGoogleBooksEvidence(ISBN, {
     apiKey: 'abc123',
@@ -196,6 +200,32 @@ test('fetchGoogleBooksEvidence usa fetch inyectable y parsea respuesta', async (
   assert.equal(new URL(requestedUrl).searchParams.get('key'), 'abc123');
   assert.equal(records.length, 1);
   assert.equal(records[0].source_id, 'G1');
+});
+
+test('fetchGoogleBooksEvidence con OAuth manda Bearer y nunca filtra token en URL', async () => {
+  let requestedUrl = null;
+  let requestedOptions = null;
+  const records = await fetchGoogleBooksEvidence(ISBN, {
+    accessToken: 'wif-access-token',
+    fetchImpl: async (url, options) => {
+      requestedUrl = String(url);
+      requestedOptions = options;
+      return fakeResponse({
+        items: [{
+          id: 'G2',
+          volumeInfo: {
+            title: 'Padres fuertes, hijas felices',
+            authors: ['Meg Meeker'],
+            industryIdentifiers: [{ type: 'ISBN_13', identifier: ISBN }],
+          },
+        }],
+      });
+    },
+  });
+  assert.equal(new URL(requestedUrl).searchParams.has('key'), false);
+  assert.equal(requestedUrl.includes('wif-access-token'), false);
+  assert.equal(requestedOptions.headers.authorization, 'Bearer wif-access-token');
+  assert.equal(records[0].source_id, 'G2');
 });
 
 test('fetchOpenLibraryBatchEvidence exige contacto identificable', async () => {

--- a/functions/__tests__/book-intelligence-sources.test.js
+++ b/functions/__tests__/book-intelligence-sources.test.js
@@ -1,0 +1,249 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  GOOGLE_BOOKS_CACHE_TTL_MS,
+  OPEN_LIBRARY_CACHE_TTL_MS,
+  OPEN_LIBRARY_MAX_ISBNS_PER_REQUEST,
+  buildGoogleBooksUrl,
+  buildOpenLibraryBatchUrl,
+  chunkOpenLibraryPlan,
+  emptySourceCache,
+  fetchGoogleBooksEvidence,
+  fetchOpenLibraryBatchEvidence,
+  isSourceCacheFresh,
+  mergeSourceCache,
+  parseGoogleBooksEvidence,
+  parseOpenLibraryEvidence,
+  planBookSourceResearch,
+} from '../../scripts/seo/book-intelligence-sources.mjs';
+
+const ISBN = '9788496836693';
+const ISBN_2 = '9780194527552';
+
+function fakeResponse(payload, { status = 200 } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() { return payload; },
+  };
+}
+
+test('Google Books URL exige API key y usa búsqueda exacta por ISBN', () => {
+  assert.throws(() => buildGoogleBooksUrl(ISBN), /GOOGLE_BOOKS_API_KEY/);
+  const url = new URL(buildGoogleBooksUrl(ISBN, { apiKey: 'test-key' }));
+  assert.equal(url.origin, 'https://www.googleapis.com');
+  assert.equal(url.pathname, '/books/v1/volumes');
+  assert.equal(url.searchParams.get('q'), `isbn:${ISBN}`);
+  assert.equal(url.searchParams.get('printType'), 'books');
+  assert.equal(url.searchParams.get('key'), 'test-key');
+});
+
+test('parseGoogleBooksEvidence sólo acepta volumes que contienen el ISBN exacto', () => {
+  const payload = {
+    items: [
+      {
+        id: 'good',
+        volumeInfo: {
+          title: 'Padres fuertes, hijas felices',
+          authors: ['Meg Meeker'],
+          publisher: 'Ciudadela',
+          publishedDate: '2008-05-01',
+          pageCount: 304,
+          language: 'es',
+          printType: 'BOOK',
+          description: '<p>Una descripción editorial real &amp; útil sobre el libro.</p>',
+          categories: ['Familia', 'Educación'],
+          industryIdentifiers: [{ type: 'ISBN_13', identifier: ISBN }],
+          infoLink: 'https://books.google.test/good',
+        },
+      },
+      {
+        id: 'wrong',
+        volumeInfo: {
+          title: 'Otra obra',
+          industryIdentifiers: [{ type: 'ISBN_13', identifier: ISBN_2 }],
+        },
+      },
+    ],
+  };
+  const records = parseGoogleBooksEvidence(payload, ISBN);
+  assert.equal(records.length, 1);
+  assert.equal(records[0].source, 'google_books');
+  assert.equal(records[0].source_id, 'good');
+  assert.equal(records[0].isbn, ISBN);
+  assert.equal(records[0].author, 'Meg Meeker');
+  assert.equal(records[0].publisher, 'Ciudadela');
+  assert.equal(records[0].pages, 304);
+  assert.equal(records[0].publication_year, '2008');
+  assert.equal(records[0].description.includes('<p>'), false);
+  assert.deepEqual(records[0].topics, ['Familia', 'Educación']);
+});
+
+test('Open Library batch URL agrupa ISBN y limita el tamaño por request', () => {
+  const url = buildOpenLibraryBatchUrl([ISBN, ISBN_2]);
+  assert.equal(url.includes(`isbn:${ISBN}|isbn:${ISBN_2}`), true);
+  const tooMany = Array.from({ length: OPEN_LIBRARY_MAX_ISBNS_PER_REQUEST + 1 }, () => ISBN);
+  assert.throws(() => buildOpenLibraryBatchUrl(tooMany), /como máximo/);
+});
+
+test('parseOpenLibraryEvidence conserva sólo matches exactos solicitados', () => {
+  const payload = {
+    records: {
+      '/books/OL1M': {
+        isbns: [ISBN],
+        olids: ['OL1M'],
+        recordURL: 'https://openlibrary.org/books/OL1M',
+        publishDates: ['2008'],
+        data: {
+          key: '/books/OL1M',
+          title: 'Padres fuertes, hijas felices',
+          authors: [{ name: 'Meg Meeker' }],
+          publishers: [{ name: 'Ciudadela' }],
+          number_of_pages: 304,
+          languages: [{ key: '/languages/spa' }],
+          description: { value: 'Descripción bibliográfica de la edición.' },
+          subjects: [{ name: 'Familia' }, { name: 'Educación' }],
+          identifiers: { isbn_13: [ISBN] },
+        },
+      },
+      '/books/OL2M': {
+        isbns: [ISBN_2],
+        data: { title: 'Headway Elementary' },
+      },
+    },
+  };
+  const records = parseOpenLibraryEvidence(payload, [ISBN]);
+  assert.equal(records.length, 1);
+  assert.equal(records[0].source, 'open_library');
+  assert.equal(records[0].isbn, ISBN);
+  assert.equal(records[0].title, 'Padres fuertes, hijas felices');
+  assert.equal(records[0].author, 'Meg Meeker');
+  assert.equal(records[0].publisher, 'Ciudadela');
+  assert.equal(records[0].pages, 304);
+  assert.equal(records[0].publication_year, '2008');
+  assert.deepEqual(records[0].topics, ['Familia', 'Educación']);
+});
+
+test('planner deduplica por ISBN y prioriza score/GSC antes de aplicar budgets', () => {
+  const plan = planBookSourceResearch([
+    { id: 'LOW', isbn: ISBN, priority_score: 1, gsc_impressions: 1 },
+    { id: 'DUP-HIGH', isbn: ISBN, priority_score: 10, gsc_impressions: 5 },
+    { id: 'SECOND', isbn: ISBN_2, priority_score: 8, gsc_impressions: 100 },
+  ], {}, { googleBooksBudget: 1, openLibraryBudget: 1, now: Date.parse('2026-08-22T00:00:00Z') });
+
+  assert.equal(plan.eligible_unique_isbns, 2);
+  assert.deepEqual(plan.google_books, [{ id: 'DUP-HIGH', isbn: ISBN }]);
+  assert.deepEqual(plan.open_library, [{ id: 'DUP-HIGH', isbn: ISBN }]);
+});
+
+test('caché fresca evita requests y caché vencida vuelve al plan', () => {
+  const now = Date.parse('2026-08-22T00:00:00Z');
+  let cache = emptySourceCache();
+  cache = mergeSourceCache(cache, ISBN, 'google_books', [], {
+    fetchedAt: new Date(now - GOOGLE_BOOKS_CACHE_TTL_MS + 1000).toISOString(),
+  });
+  cache = mergeSourceCache(cache, ISBN, 'open_library', [], {
+    fetchedAt: new Date(now - OPEN_LIBRARY_CACHE_TTL_MS + 1000).toISOString(),
+  });
+
+  assert.equal(isSourceCacheFresh(cache, ISBN, 'google_books', { now }), true);
+  assert.equal(isSourceCacheFresh(cache, ISBN, 'open_library', { now }), true);
+  let plan = planBookSourceResearch([{ id: 'A', isbn: ISBN }], cache, { now });
+  assert.equal(plan.google_books.length, 0);
+  assert.equal(plan.open_library.length, 0);
+
+  const later = now + OPEN_LIBRARY_CACHE_TTL_MS + GOOGLE_BOOKS_CACHE_TTL_MS;
+  plan = planBookSourceResearch([{ id: 'A', isbn: ISBN }], cache, { now: later });
+  assert.equal(plan.google_books.length, 1);
+  assert.equal(plan.open_library.length, 1);
+});
+
+test('Open Library budget es bajo por defecto y se divide en requests de máximo 20', () => {
+  const base = [ISBN, ISBN_2];
+  const items = Array.from({ length: 40 }, (_, index) => ({
+    id: `MLU${index}`,
+    isbn: base[index % base.length],
+  }));
+  const plan = planBookSourceResearch(items, {}, { openLibraryBudget: 25 });
+  // Sólo hay dos ISBN únicos en el fixture.
+  assert.equal(plan.open_library.length, 2);
+  const synthetic = {
+    open_library: Array.from({ length: 25 }, (_, i) => ({ id: `X${i}`, isbn: ISBN })),
+  };
+  const chunks = chunkOpenLibraryPlan(synthetic);
+  assert.deepEqual(chunks.map(chunk => chunk.length), [20, 5]);
+});
+
+test('fetchGoogleBooksEvidence usa fetch inyectable y parsea respuesta', async () => {
+  let requestedUrl = null;
+  const records = await fetchGoogleBooksEvidence(ISBN, {
+    apiKey: 'abc123',
+    fetchImpl: async (url) => {
+      requestedUrl = String(url);
+      return fakeResponse({
+        items: [{
+          id: 'G1',
+          volumeInfo: {
+            title: 'Padres fuertes, hijas felices',
+            authors: ['Meg Meeker'],
+            industryIdentifiers: [{ type: 'ISBN_13', identifier: ISBN }],
+          },
+        }],
+      });
+    },
+  });
+  assert.equal(new URL(requestedUrl).searchParams.get('key'), 'abc123');
+  assert.equal(records.length, 1);
+  assert.equal(records[0].source_id, 'G1');
+});
+
+test('fetchOpenLibraryBatchEvidence exige contacto identificable', async () => {
+  await assert.rejects(
+    () => fetchOpenLibraryBatchEvidence([ISBN], { fetchImpl: async () => fakeResponse({}) }),
+    /contacto identificable/,
+  );
+});
+
+test('fetchOpenLibraryBatchEvidence identifica User-Agent y usa una llamada multi-ISBN', async () => {
+  let requestedUrl = null;
+  let requestedOptions = null;
+  const records = await fetchOpenLibraryBatchEvidence([ISBN, ISBN_2], {
+    contact: 'seo@example.test',
+    userAgent: 'AmadoTest/1.0',
+    fetchImpl: async (url, options) => {
+      requestedUrl = String(url);
+      requestedOptions = options;
+      return fakeResponse({
+        records: {
+          OL1: { isbns: [ISBN], data: { title: 'Libro uno', authors: [{ name: 'Autora' }] } },
+          OL2: { isbns: [ISBN_2], data: { title: 'Libro dos', authors: [{ name: 'Autor' }] } },
+        },
+      });
+    },
+  });
+  assert.equal(requestedUrl.includes('|'), true);
+  assert.equal(requestedOptions.headers['user-agent'], 'AmadoTest/1.0 (seo@example.test)');
+  assert.equal(records.length, 2);
+});
+
+test('errores HTTP no se convierten en evidencia silenciosa', async () => {
+  await assert.rejects(
+    () => fetchGoogleBooksEvidence(ISBN, {
+      apiKey: 'abc',
+      fetchImpl: async () => fakeResponse({}, { status: 503 }),
+    }),
+    /HTTP 503/,
+  );
+});
+
+test('mergeSourceCache versiona records/error por ISBN y fuente sin pisar la otra fuente', () => {
+  const fetchedAt = '2026-08-22T10:00:00.000Z';
+  let cache = emptySourceCache();
+  cache = mergeSourceCache(cache, ISBN, 'google_books', [{ source: 'google_books', isbn: ISBN }], { fetchedAt });
+  cache = mergeSourceCache(cache, ISBN, 'open_library', [], { fetchedAt, error: 'sin match' });
+  assert.equal(cache.schema_version, 1);
+  assert.equal(cache.entries[ISBN].google_books.records.length, 1);
+  assert.equal(cache.entries[ISBN].open_library.error, 'sin match');
+  assert.equal(cache.generated_at, fetchedAt);
+});

--- a/scripts/seo/book-intelligence-sources.mjs
+++ b/scripts/seo/book-intelligence-sources.mjs
@@ -3,7 +3,7 @@
 //
 // Reglas:
 // - nunca se ejecutan en el camino de una request de cliente;
-// - Google Books se consulta por ISBN exacto y requiere API key en modo real;
+// - Google Books se consulta por ISBN exacto y requiere API key u OAuth token;
 // - Open Library usa el Partner/Read API multi-request para reducir llamadas;
 // - todo resultado conserva `source` y se vuelve evidencia, no contenido final;
 // - la caché evita volver a pedir datos estables en cada corrida.
@@ -61,16 +61,18 @@ function googleBooksExactItems(payload, isbn) {
     .filter(item => normalizedIdentifiers(item?.volumeInfo).includes(target));
 }
 
-export function buildGoogleBooksUrl(isbn, { apiKey } = {}) {
+export function buildGoogleBooksUrl(isbn, { apiKey, accessToken } = {}) {
   const normalized = normalizeValidIsbn(isbn);
   if (!normalized) throw new Error('ISBN inválido para Google Books.');
-  if (!clean(apiKey)) throw new Error('GOOGLE_BOOKS_API_KEY es obligatorio para consultas reales.');
+  if (!clean(apiKey) && !clean(accessToken)) {
+    throw new Error('Google Books requiere API key u OAuth access token para consultas reales.');
+  }
   const url = new URL(GOOGLE_BOOKS_BASE);
   url.searchParams.set('q', `isbn:${normalized}`);
   url.searchParams.set('printType', 'books');
   url.searchParams.set('projection', 'full');
   url.searchParams.set('maxResults', '10');
-  url.searchParams.set('key', clean(apiKey));
+  if (clean(apiKey)) url.searchParams.set('key', clean(apiKey));
   return url.toString();
 }
 
@@ -288,11 +290,15 @@ async function fetchJson(url, {
 
 export async function fetchGoogleBooksEvidence(isbn, {
   apiKey,
+  accessToken,
   fetchImpl,
   timeoutMs,
 } = {}) {
-  const url = buildGoogleBooksUrl(isbn, { apiKey });
-  const payload = await fetchJson(url, { fetchImpl, timeoutMs });
+  const url = buildGoogleBooksUrl(isbn, { apiKey, accessToken });
+  const headers = clean(accessToken)
+    ? { authorization: `Bearer ${clean(accessToken)}` }
+    : {};
+  const payload = await fetchJson(url, { fetchImpl, timeoutMs, headers });
   return parseGoogleBooksEvidence(payload, isbn);
 }
 

--- a/scripts/seo/book-intelligence-sources.mjs
+++ b/scripts/seo/book-intelligence-sources.mjs
@@ -1,0 +1,351 @@
+// FICHAS-VIDRIERA-2 / FUENTES-1
+// Adaptadores de investigación bibliográfica offline/batch.
+//
+// Reglas:
+// - nunca se ejecutan en el camino de una request de cliente;
+// - Google Books se consulta por ISBN exacto y requiere API key en modo real;
+// - Open Library usa el Partner/Read API multi-request para reducir llamadas;
+// - todo resultado conserva `source` y se vuelve evidencia, no contenido final;
+// - la caché evita volver a pedir datos estables en cada corrida.
+
+import { normalizeValidIsbn } from '../../functions/_shared/showcase-ranking.js';
+
+export const SOURCE_CACHE_SCHEMA_VERSION = 1;
+export const GOOGLE_BOOKS_CACHE_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+export const OPEN_LIBRARY_CACHE_TTL_MS = 180 * 24 * 60 * 60 * 1000;
+export const OPEN_LIBRARY_MAX_ISBNS_PER_REQUEST = 20;
+export const DEFAULT_OPEN_LIBRARY_BATCH_BUDGET = 25;
+
+const GOOGLE_BOOKS_BASE = 'https://www.googleapis.com/books/v1/volumes';
+const OPEN_LIBRARY_READ_BASE = 'https://openlibrary.org/api/volumes/brief/json';
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function plainText(value) {
+  return clean(String(value ?? '')
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'"));
+}
+
+function firstArrayValue(value) {
+  return Array.isArray(value) && value.length ? value[0] : null;
+}
+
+function yearFromDate(value) {
+  const match = clean(value).match(/\b(1[5-9]\d{2}|20\d{2}|21\d{2})\b/);
+  return match ? match[1] : null;
+}
+
+function normalizedIdentifiers(volumeInfo = {}) {
+  const ids = [];
+  for (const identifier of Array.isArray(volumeInfo.industryIdentifiers) ? volumeInfo.industryIdentifiers : []) {
+    const normalized = normalizeValidIsbn(identifier?.identifier);
+    if (normalized) ids.push(normalized);
+  }
+  return [...new Set(ids)];
+}
+
+function googleBooksExactItems(payload, isbn) {
+  const target = normalizeValidIsbn(isbn);
+  if (!target) return [];
+  return (Array.isArray(payload?.items) ? payload.items : [])
+    .filter(item => normalizedIdentifiers(item?.volumeInfo).includes(target));
+}
+
+export function buildGoogleBooksUrl(isbn, { apiKey } = {}) {
+  const normalized = normalizeValidIsbn(isbn);
+  if (!normalized) throw new Error('ISBN inválido para Google Books.');
+  if (!clean(apiKey)) throw new Error('GOOGLE_BOOKS_API_KEY es obligatorio para consultas reales.');
+  const url = new URL(GOOGLE_BOOKS_BASE);
+  url.searchParams.set('q', `isbn:${normalized}`);
+  url.searchParams.set('printType', 'books');
+  url.searchParams.set('projection', 'full');
+  url.searchParams.set('maxResults', '10');
+  url.searchParams.set('key', clean(apiKey));
+  return url.toString();
+}
+
+export function parseGoogleBooksEvidence(payload, isbn) {
+  const target = normalizeValidIsbn(isbn);
+  if (!target) return [];
+
+  return googleBooksExactItems(payload, target).map(item => {
+    const info = item?.volumeInfo || {};
+    const authors = Array.isArray(info.authors) ? info.authors.map(clean).filter(Boolean) : [];
+    const topics = Array.isArray(info.categories) ? info.categories.map(clean).filter(Boolean).slice(0, 12) : [];
+    return {
+      source: 'google_books',
+      source_id: clean(item?.id) || null,
+      source_url: clean(info.infoLink) || clean(item?.selfLink) || null,
+      isbn: target,
+      title: clean(info.title),
+      author: authors.join(', '),
+      description: plainText(info.description),
+      publisher: clean(info.publisher) || null,
+      pages: Number.isInteger(Number(info.pageCount)) && Number(info.pageCount) > 0 ? Number(info.pageCount) : null,
+      language: clean(info.language) || null,
+      publication_year: yearFromDate(info.publishedDate),
+      format: clean(info.printType) || null,
+      topics,
+      raw_quality: {
+        exact_isbn: true,
+        identifiers: normalizedIdentifiers(info),
+      },
+    };
+  });
+}
+
+export function buildOpenLibraryBatchUrl(isbns) {
+  if (!Array.isArray(isbns) || isbns.length === 0) throw new Error('Se necesita al menos un ISBN.');
+  if (isbns.length > OPEN_LIBRARY_MAX_ISBNS_PER_REQUEST) {
+    throw new Error(`Open Library admite como máximo ${OPEN_LIBRARY_MAX_ISBNS_PER_REQUEST} ISBN por request en este cliente.`);
+  }
+  const normalized = [...new Set(isbns.map(normalizeValidIsbn).filter(Boolean))];
+  if (normalized.length === 0) throw new Error('No hay ISBN válidos para Open Library.');
+  const requests = normalized.map(isbn => `isbn:${isbn}`).join('|');
+  return `${OPEN_LIBRARY_READ_BASE}/${requests}`;
+}
+
+function recordIsbns(record) {
+  const raw = [
+    ...(Array.isArray(record?.isbns) ? record.isbns : []),
+    ...(Array.isArray(record?.data?.identifiers?.isbn_13) ? record.data.identifiers.isbn_13 : []),
+    ...(Array.isArray(record?.data?.identifiers?.isbn_10) ? record.data.identifiers.isbn_10 : []),
+  ];
+  return [...new Set(raw.map(normalizeValidIsbn).filter(Boolean))];
+}
+
+function authorNames(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map(author => typeof author === 'string' ? clean(author) : clean(author?.name))
+    .filter(Boolean);
+}
+
+function publisherName(value) {
+  const first = firstArrayValue(value);
+  if (typeof first === 'string') return clean(first);
+  return clean(first?.name) || null;
+}
+
+function descriptionValue(value) {
+  if (typeof value === 'string') return plainText(value);
+  return plainText(value?.value);
+}
+
+function openLibraryRecords(payload) {
+  if (Array.isArray(payload?.records)) return payload.records;
+  if (payload?.records && typeof payload.records === 'object') return Object.values(payload.records);
+  if (Array.isArray(payload)) return payload;
+  return [];
+}
+
+export function parseOpenLibraryEvidence(payload, requestedIsbns) {
+  const wanted = new Set((Array.isArray(requestedIsbns) ? requestedIsbns : [requestedIsbns])
+    .map(normalizeValidIsbn)
+    .filter(Boolean));
+  if (!wanted.size) return [];
+
+  const output = [];
+  for (const record of openLibraryRecords(payload)) {
+    const exactMatches = recordIsbns(record).filter(isbn => wanted.has(isbn));
+    if (!exactMatches.length) continue;
+    const data = record?.data || {};
+    const authors = authorNames(data.authors);
+    const topics = [
+      ...(Array.isArray(data.subjects) ? data.subjects : []),
+      ...(Array.isArray(record?.subjects) ? record.subjects : []),
+    ].map(value => typeof value === 'string' ? clean(value) : clean(value?.name)).filter(Boolean).slice(0, 12);
+    const pages = Number(data.number_of_pages ?? record?.number_of_pages);
+    const publishDate = clean(data.publish_date) || clean(firstArrayValue(record?.publishDates));
+    const languages = Array.isArray(data.languages)
+      ? data.languages.map(lang => clean(lang?.key || lang)).filter(Boolean)
+      : [];
+
+    for (const isbn of exactMatches) {
+      output.push({
+        source: 'open_library',
+        source_id: clean(data.key || record?.key || firstArrayValue(record?.olids)) || null,
+        source_url: clean(record?.recordURL) || null,
+        isbn,
+        title: clean(data.title || record?.title),
+        author: authors.join(', '),
+        description: descriptionValue(data.description || record?.description),
+        publisher: publisherName(data.publishers || record?.publishers),
+        pages: Number.isInteger(pages) && pages > 0 ? pages : null,
+        language: languages.length ? languages.join(', ') : null,
+        publication_year: yearFromDate(publishDate),
+        format: clean(data.physical_format || record?.physical_format) || null,
+        topics,
+        raw_quality: {
+          exact_isbn: true,
+          identifiers: recordIsbns(record),
+        },
+      });
+    }
+  }
+  return output;
+}
+
+function cacheEntry(cache, isbn, source) {
+  return cache?.entries?.[isbn]?.[source] || null;
+}
+
+export function isSourceCacheFresh(cache, isbn, source, { now = Date.now() } = {}) {
+  const entry = cacheEntry(cache, isbn, source);
+  if (!entry?.fetched_at) return false;
+  const fetchedAt = Date.parse(entry.fetched_at);
+  if (!Number.isFinite(fetchedAt)) return false;
+  const ttl = source === 'open_library' ? OPEN_LIBRARY_CACHE_TTL_MS : GOOGLE_BOOKS_CACHE_TTL_MS;
+  return now - fetchedAt >= 0 && now - fetchedAt < ttl;
+}
+
+function priorityTuple(item) {
+  return [
+    Number(item?.priority_score) || 0,
+    Number(item?.gsc_impressions) || 0,
+    Number(item?.gsc_clicks) || 0,
+  ];
+}
+
+function comparePriority(a, b) {
+  const left = priorityTuple(a);
+  const right = priorityTuple(b);
+  for (let i = 0; i < left.length; i++) {
+    if (right[i] !== left[i]) return right[i] - left[i];
+  }
+  return String(a?.id || '').localeCompare(String(b?.id || ''));
+}
+
+/**
+ * Produce un plan reproducible sin ejecutar red. Open Library queda
+ * deliberadamente presupuestado a bajo volumen; para miles de registros se
+ * debe ingerir su dump/bulk en un lote posterior, no abusar del API público.
+ */
+export function planBookSourceResearch(items, cache = {}, {
+  googleBooksBudget = 300,
+  openLibraryBudget = DEFAULT_OPEN_LIBRARY_BATCH_BUDGET,
+  now = Date.now(),
+} = {}) {
+  const eligible = (Array.isArray(items) ? items : [])
+    .map(item => ({ ...item, isbn: normalizeValidIsbn(item?.isbn) }))
+    .filter(item => item.isbn)
+    .sort(comparePriority);
+
+  const uniqueByIsbn = [];
+  const seen = new Set();
+  for (const item of eligible) {
+    if (seen.has(item.isbn)) continue;
+    seen.add(item.isbn);
+    uniqueByIsbn.push(item);
+  }
+
+  const googleBooks = uniqueByIsbn
+    .filter(item => !isSourceCacheFresh(cache, item.isbn, 'google_books', { now }))
+    .slice(0, Math.max(0, googleBooksBudget));
+  const openLibrary = uniqueByIsbn
+    .filter(item => !isSourceCacheFresh(cache, item.isbn, 'open_library', { now }))
+    .slice(0, Math.max(0, openLibraryBudget));
+
+  return {
+    schema_version: 1,
+    eligible_unique_isbns: uniqueByIsbn.length,
+    google_books: googleBooks.map(item => ({ id: item.id || null, isbn: item.isbn })),
+    open_library: openLibrary.map(item => ({ id: item.id || null, isbn: item.isbn })),
+    cached_google_books: uniqueByIsbn.length - uniqueByIsbn.filter(item => !isSourceCacheFresh(cache, item.isbn, 'google_books', { now })).length,
+    cached_open_library: uniqueByIsbn.length - uniqueByIsbn.filter(item => !isSourceCacheFresh(cache, item.isbn, 'open_library', { now })).length,
+  };
+}
+
+async function fetchJson(url, {
+  fetchImpl = globalThis.fetch,
+  headers = {},
+  timeoutMs = 10_000,
+} = {}) {
+  if (typeof fetchImpl !== 'function') throw new Error('fetch no disponible.');
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      headers: { accept: 'application/json', ...headers },
+      signal: controller.signal,
+    });
+    if (!response?.ok) throw new Error(`HTTP ${response?.status || 0}`);
+    return await response.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function fetchGoogleBooksEvidence(isbn, {
+  apiKey,
+  fetchImpl,
+  timeoutMs,
+} = {}) {
+  const url = buildGoogleBooksUrl(isbn, { apiKey });
+  const payload = await fetchJson(url, { fetchImpl, timeoutMs });
+  return parseGoogleBooksEvidence(payload, isbn);
+}
+
+export async function fetchOpenLibraryBatchEvidence(isbns, {
+  fetchImpl,
+  timeoutMs,
+  userAgent = 'AmadoLibros-BookIntelligence/1.0',
+  contact,
+} = {}) {
+  if (!clean(contact)) throw new Error('Open Library requiere un contacto identificable para este cliente.');
+  const url = buildOpenLibraryBatchUrl(isbns);
+  const payload = await fetchJson(url, {
+    fetchImpl,
+    timeoutMs,
+    headers: {
+      'user-agent': `${clean(userAgent)} (${clean(contact)})`,
+    },
+  });
+  return parseOpenLibraryEvidence(payload, isbns);
+}
+
+export function emptySourceCache() {
+  return {
+    schema_version: SOURCE_CACHE_SCHEMA_VERSION,
+    generated_at: null,
+    entries: {},
+  };
+}
+
+export function mergeSourceCache(cache, isbn, source, records, {
+  fetchedAt = new Date().toISOString(),
+  error = null,
+} = {}) {
+  const normalized = normalizeValidIsbn(isbn);
+  if (!normalized) throw new Error('ISBN inválido para caché.');
+  if (!['google_books', 'open_library'].includes(source)) throw new Error('Fuente no cacheable.');
+  const next = JSON.parse(JSON.stringify(cache?.entries ? cache : emptySourceCache()));
+  next.schema_version = SOURCE_CACHE_SCHEMA_VERSION;
+  next.generated_at = fetchedAt;
+  next.entries[normalized] ||= {};
+  next.entries[normalized][source] = {
+    fetched_at: fetchedAt,
+    error: error ? clean(error) : null,
+    records: Array.isArray(records) ? records : [],
+  };
+  return next;
+}
+
+export function chunkOpenLibraryPlan(plan) {
+  const entries = Array.isArray(plan?.open_library) ? plan.open_library : [];
+  const chunks = [];
+  for (let i = 0; i < entries.length; i += OPEN_LIBRARY_MAX_ISBNS_PER_REQUEST) {
+    chunks.push(entries.slice(i, i + OPEN_LIBRARY_MAX_ISBNS_PER_REQUEST));
+  }
+  return chunks;
+}


### PR DESCRIPTION
## Objetivo

Agregar adaptadores y política de caché para investigar libros por ISBN con fuentes reales, sin ejecutar red en CI ni modificar la web visible.

Este PR está **apilado sobre #217** para mantener el diff propio limpio. Para validar el head se retargeteó temporalmente a `main`; una vez terminados CI/Preview vuelve a base #217. Después de fusionar #217, se retargetea definitivamente a `main` antes de cualquier merge.

## Qué agrega

### Google Books

- búsqueda oficial por `q=isbn:...`;
- admite API key **o OAuth access token**;
- el camino OAuth manda `Authorization: Bearer` y nunca pone el token en la URL;
- esto permite intentar reutilizar el Workload Identity Federation ya existente en el repo antes de crear otro secreto;
- el parser vuelve a exigir ISBN exacto dentro de `industryIdentifiers`;
- extrae sólo evidencia: título, autor, descripción, editorial, páginas, idioma, año, formato y categorías;
- TTL de caché: 90 días.

### Open Library

- usa Partner/Read API multi-request para agrupar ISBN;
- máximo 20 ISBN por request;
- presupuesto por defecto: 25 ISBN por corrida;
- exige `User-Agent` + contacto identificable;
- conserva sólo records cuyo ISBN coincide exactamente;
- TTL de caché: 180 días;
- no pretende usar la Web API como backend masivo: para miles, la siguiente fase debe evaluar dumps/bulk.

### Planner reproducible

- deduplica por ISBN antes de consumir cuota;
- ordena por `priority_score`, impresiones GSC, clics GSC e ID;
- salta fuentes con caché fresca;
- divide Open Library en chunks de hasta 20;
- nunca guarda API keys ni access tokens.

### Tests

13 pruebas focalizadas sobre:

- Google Books API key/OAuth/ISBN exacto;
- Bearer OAuth sin filtración del token en URL;
- parseo Google Books;
- Open Library multi-ISBN y límite;
- parseo exacto Open Library;
- priorización/dedupe;
- TTL de caché;
- presupuesto y chunking;
- fetch inyectable sin red en CI;
- identificación obligatoria para Open Library;
- propagación de errores HTTP;
- merge de caché sin pisar otra fuente.

## Datos locales

`scripts/seo/data/book-intelligence/` queda ignorado por Git. La caché de investigación es reproducible y no se versiona.

## Validación del head actual

Head `90980691ad55146aff8e84f789c32628cc00128c`:

- CI completo: **PASS**;
- Preview protegido + auditoría: **PASS**;
- SEO baseline público: en ejecución al actualizar este cuerpo;
- ninguna llamada real a Google Books/Open Library en CI;
- Producción: intacta.

## Riesgo

Muy bajo. Sólo tooling/tests/docs. No renderer, no catálogo visible, no Worker productivo, no canonical, no sitemap, no checkout, no IA, no Production.

## Gate

- mantener Draft;
- no realizar todavía una corrida masiva;
- siguiente lote: seleccionar cohorte real + autenticar Books con WIF/OAuth si funciona + ejecutar research cacheado + medir green/yellow/red.

**NO MERGEAR. NO PRODUCCIÓN.**