### PR TITLE
FICHAS-VIDRIERA-2: RESEARCH-RUN-1 con WIF y evidencia real

### DIFF
--- a/.github/workflows/book-intelligence-research-run.yml
+++ b/.github/workflows/book-intelligence-research-run.yml
@@ -1,0 +1,126 @@
+name: FICHAS-VIDRIERA-2 research run 1
+
+on:
+  push:
+    branches:
+      - agent/fichas-vidriera-v2-research-run-1
+    paths:
+      - '.github/workflows/book-intelligence-research-run.yml'
+      - 'scripts/seo/book-intelligence-research-run.mjs'
+      - 'scripts/seo/book-intelligence-sources.mjs'
+      - 'functions/_shared/book-intelligence-evidence.js'
+      - 'functions/_shared/paused-seo-cohort.js'
+      - 'functions/__tests__/book-intelligence-research-run.test.js'
+      - 'functions/__tests__/book-intelligence-sources.test.js'
+  pull_request:
+    paths:
+      - '.github/workflows/book-intelligence-research-run.yml'
+      - 'scripts/seo/book-intelligence-research-run.mjs'
+      - 'scripts/seo/book-intelligence-sources.mjs'
+      - 'functions/_shared/book-intelligence-evidence.js'
+      - 'functions/_shared/paused-seo-cohort.js'
+      - 'functions/__tests__/book-intelligence-research-run.test.js'
+      - 'functions/__tests__/book-intelligence-sources.test.js'
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: Cantidad de ISBN con demanda GSC a investigar
+        required: true
+        default: '12'
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: book-intelligence-research-run-1-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  research:
+    name: WIF + Google Books + Open Library + evidence tiers
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Validate research code without network
+        run: |
+          node --check scripts/seo/book-intelligence-research-run.mjs
+          node --check scripts/seo/book-intelligence-sources.mjs
+          node --test functions/__tests__/book-intelligence-sources.test.js functions/__tests__/book-intelligence-research-run.test.js
+
+      - name: Authenticate Google Books through existing Workload Identity
+        id: google_auth
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: amado-libros-analytics
+          workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
+          service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/books
+          create_credentials_file: false
+
+      - name: Execute controlled research run
+        id: research_run
+        continue-on-error: true
+        env:
+          GOOGLE_BOOKS_ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
+          OPEN_LIBRARY_CONTACT: https://www.amadolibros.com
+          BOOK_INTELLIGENCE_LIMIT: ${{ inputs.limit || '12' }}
+          BOOK_INTELLIGENCE_OUTPUT_DIR: artifacts/book-intelligence/research-run-1
+        run: node scripts/seo/book-intelligence-research-run.mjs --limit "$BOOK_INTELLIGENCE_LIMIT"
+
+      - name: Validate generated report
+        if: steps.research_run.outcome == 'success'
+        run: |
+          test -s artifacts/book-intelligence/research-run-1/research-run-1-report.json
+          test -s artifacts/book-intelligence/research-run-1/report-summary.md
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const report = JSON.parse(fs.readFileSync('artifacts/book-intelligence/research-run-1/research-run-1-report.json', 'utf8'));
+          if (report.schema_version !== 1) process.exit(1);
+          if (report.run !== 'FICHAS-VIDRIERA-2/RESEARCH-RUN-1') process.exit(1);
+          if (report.cohort.selected !== Number(process.env.BOOK_INTELLIGENCE_LIMIT || 12)) process.exit(1);
+          if (report.execution.google_books_http_successes < 1) process.exit(1);
+          NODE
+        env:
+          BOOK_INTELLIGENCE_LIMIT: ${{ inputs.limit || '12' }}
+
+      - name: Upload research report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: book-intelligence-research-run-1-${{ github.run_id }}
+          path: artifacts/book-intelligence/research-run-1/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Write research summary
+        if: always()
+        run: |
+          if [ -f artifacts/book-intelligence/research-run-1/report-summary.md ]; then
+            cat artifacts/book-intelligence/research-run-1/report-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## FICHAS-VIDRIERA-2 — RESEARCH-RUN-1 incompleto' >> "$GITHUB_STEP_SUMMARY"
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo 'No se generó reporte. Revisar WIF, scope Books y ejecución del runner.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Autenticación: WIF existente; sin API key nueva' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Modo: sólo lectura' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Deploy: no se ejecuta' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if research run did not complete
+        if: steps.research_run.outcome != 'success'
+        run: |
+          echo 'RESEARCH-RUN-1 no completó Google Books con WIF/OAuth. Revisar el reporte y los logs.'
+          exit 1

--- a/.github/workflows/book-intelligence-research-run.yml
+++ b/.github/workflows/book-intelligence-research-run.yml
@@ -10,6 +10,7 @@ on:
       - 'scripts/seo/book-intelligence-sources.mjs'
       - 'functions/_shared/book-intelligence-evidence.js'
       - 'functions/_shared/paused-seo-cohort.js'
+      - 'functions/__tests__/book-intelligence-evidence.test.js'
       - 'functions/__tests__/book-intelligence-research-run.test.js'
       - 'functions/__tests__/book-intelligence-sources.test.js'
   pull_request:
@@ -19,6 +20,7 @@ on:
       - 'scripts/seo/book-intelligence-sources.mjs'
       - 'functions/_shared/book-intelligence-evidence.js'
       - 'functions/_shared/paused-seo-cohort.js'
+      - 'functions/__tests__/book-intelligence-evidence.test.js'
       - 'functions/__tests__/book-intelligence-research-run.test.js'
       - 'functions/__tests__/book-intelligence-sources.test.js'
   workflow_dispatch:
@@ -56,7 +58,7 @@ jobs:
         run: |
           node --check scripts/seo/book-intelligence-research-run.mjs
           node --check scripts/seo/book-intelligence-sources.mjs
-          node --test functions/__tests__/book-intelligence-sources.test.js functions/__tests__/book-intelligence-research-run.test.js
+          node --test functions/__tests__/book-intelligence-evidence.test.js functions/__tests__/book-intelligence-sources.test.js functions/__tests__/book-intelligence-research-run.test.js
 
       - name: Authenticate Google Books through existing Workload Identity
         id: google_auth

--- a/docs/seo/fichas-vidriera-research-run-1.md
+++ b/docs/seo/fichas-vidriera-research-run-1.md
@@ -1,0 +1,84 @@
+# FICHAS-VIDRIERA-2 — RESEARCH-RUN-1
+
+Fecha: 2026-08-22
+
+## Alcance
+
+Este lote valida la tubería de investigación bibliográfica antes de publicar contenido generado en fichas.
+
+La corrida es sólo lectura: catálogo público R2 -> fuentes externas -> motor de evidencia -> reporte. No escribe fichas, sitemap, canonical, R2, D1, KV, Worker ni Producción.
+
+## Cohorte técnica
+
+Se usan los primeros 12 ISBN `gsc-demand` de la cohorte SEO ya versionada, conservando el orden real de prioridad de Search Console.
+
+La corrida validada cubrió:
+
+- 12 ISBN seleccionados;
+- 559 impresiones históricas GSC;
+- 46 clics históricos GSC;
+- catálogo vigente de 17.201 fichas consolidadas;
+- 7.111 activas y 10.096 pausadas en el snapshot usado.
+
+## Resultado de fuentes
+
+### Google Books
+
+- autenticación WIF/OAuth reutilizando la service account existente: PASS;
+- 12/12 consultas HTTP: PASS;
+- 4/12 ISBN con match exacto;
+- 8/12 sin match;
+- 0 errores HTTP.
+
+No se necesita una API key nueva para esta tubería mientras el WIF existente siga emitiendo correctamente el token con scope Books.
+
+### Open Library
+
+- 12/12 ISBN consultados mediante un único batch de bajo volumen;
+- 0/12 con match exacto;
+- 0 errores HTTP.
+
+Conclusión: en esta muestra de demanda, Open Library no aporta cobertura suficiente para actuar como segunda fuente masiva. No se debe aumentar agresivamente el uso del API público. Si Open Library vuelve a evaluarse a escala, debe hacerse mediante su Search API/bulk dumps conforme a sus guías actuales, no convirtiendo el API público en backend masivo.
+
+## Clasificación real
+
+Después del hardening de identidad:
+
+- GREEN: 0;
+- YELLOW: 2;
+- RED: 10;
+- auto-publicables: 0.
+
+Los dos YELLOW son:
+
+- `9789878675701` — El legado, Germán Beder;
+- `9788416894864` — La jubilación: una nueva oportunidad, Bartolomé Freire Arteta.
+
+Ambos cuentan con una fuente fuerte exacta y contenido suficiente para generar borrador, pero no para auto-publicar.
+
+## Hallazgos del gate de identidad
+
+La primera corrida reveló falsos conflictos por diferencias bibliográficas normales:
+
+- `Beder, German` vs `Germán Beder`;
+- `Freire Arteta, Bartolomé` vs `Bartolomé Freire Arteta`.
+
+El comparador ahora tolera:
+
+- diacríticos;
+- orden apellido/nombre;
+- autores compuestos con los mismos tokens;
+- honoríficos comunes;
+- título localizado o comercialmente adaptado cuando el ISBN es exacto y el autor coincide.
+
+Sigue bloqueando diferencias materiales de autor y también un título divergente cuando la fuente exacta no aporta autor y todavía no existe otra fuente exacta que confirme un autor compatible.
+
+Esto evita dos fallos opuestos: contaminación por homónimos y bloqueo permanente por una fuente incompleta. Una confirmación posterior de editorial/biblioteca puede neutralizar un mismatch de título de una fuente sin autor, pero una contradicción real de autor continúa en RED.
+
+## Decisión
+
+RESEARCH-RUN-1 demuestra que la infraestructura funciona y que el principal cuello de botella ya no es autenticación ni ejecución: es cobertura de evidencia.
+
+No corresponde escalar todavía la generación editorial a miles con Google Books + Open Library solamente. El siguiente lote debe aumentar la segunda fuente real, priorizando fuentes con mejor cobertura para los ISBN que Amado Libros vende: editorial/distribuidor/catálogos bibliográficos verificables, siempre con revalidación de ISBN y trazabilidad de origen.
+
+La generación visible de `De qué trata / Para quién es / 5 temas / Autor / Edición` sigue detrás del gate de evidencia. No publicar copy nuevo hasta que la cobertura y los tiers estén medidos en un lote mayor.

--- a/functions/__tests__/book-intelligence-evidence.test.js
+++ b/functions/__tests__/book-intelligence-evidence.test.js
@@ -60,14 +60,55 @@ test('una referencia web débil sola no habilita generación', () => {
   assert.equal(result.generation_policy.can_generate_work_content, false);
 });
 
-test('mismo ISBN con título incompatible bloquea por conflicto de identidad', () => {
+test('mismo ISBN con título y autor incompatibles bloquea por conflicto de identidad', () => {
   const result = classifyBookIntelligenceEvidence(item(), [
-    evidence('google_books', { title: 'Un libro completamente distinto' }),
+    evidence('google_books', {
+      title: 'Un libro completamente distinto',
+      author: 'Otra persona',
+    }),
     evidence('open_library'),
   ]);
   assert.equal(result.tier, 'red');
   assert.equal(result.reason, 'identity_conflict');
   assert.equal(result.identity_conflicts.some(conflict => conflict.field === 'title'), true);
+  assert.equal(result.identity_conflicts.some(conflict => conflict.field === 'author'), true);
+});
+
+test('ISBN exacto tolera título localizado si el autor coincide', () => {
+  const result = classifyBookIntelligenceEvidence(
+    item({
+      title: 'Libro Colorea Y Descubre El Misterio Los Ositos Cariñosos',
+      author: 'Varone, Eugénie',
+    }),
+    [evidence('google_books', {
+      title: 'Coloriages mystères Bisounours',
+      author: 'Eugénie Varone',
+    })],
+  );
+  assert.equal(result.identity_conflicts.length, 0);
+  assert.equal(result.tier, 'yellow');
+  assert.equal(result.reason, 'single_strong_source');
+});
+
+test('autor apellido-nombre y nombre-apellido se consideran la misma identidad', () => {
+  const result = classifyBookIntelligenceEvidence(
+    item({ title: 'El legado', author: 'Beder, German' }),
+    [evidence('google_books', { title: 'El legado', author: 'Germán Beder' })],
+  );
+  assert.equal(result.identity_conflicts.length, 0);
+  assert.equal(result.tier, 'yellow');
+});
+
+test('autor compuesto conserva identidad aunque cambie el orden de tokens', () => {
+  const result = classifyBookIntelligenceEvidence(
+    item({ title: 'La jubilación: una nueva oportunidad', author: 'Freire Arteta, Bartolomé' }),
+    [evidence('google_books', {
+      title: 'La jubilación: una nueva oportunidad',
+      author: 'Bartolomé Freire Arteta',
+    })],
+  );
+  assert.equal(result.identity_conflicts.length, 0);
+  assert.equal(result.tier, 'yellow');
 });
 
 test('otro ISBN de la misma obra puede aportar contenido de obra pero no datos de edición', () => {

--- a/functions/__tests__/book-intelligence-evidence.test.js
+++ b/functions/__tests__/book-intelligence-evidence.test.js
@@ -90,6 +90,44 @@ test('ISBN exacto tolera título localizado si el autor coincide', () => {
   assert.equal(result.reason, 'single_strong_source');
 });
 
+test('fuente exacta incompleta deja de bloquear cuando otra fuente confirma el autor', () => {
+  const result = classifyBookIntelligenceEvidence(
+    item({
+      title: 'Libro Colorea Y Descubre El Misterio Los Ositos Cariñosos',
+      author: 'Varone, Eugénie',
+    }),
+    [
+      evidence('google_books', {
+        title: 'Coloriages mystères Bisounours',
+        author: '',
+      }),
+      evidence('publisher', {
+        title: 'Coloriages mystères - Bisounours',
+        author: 'Eugénie Varone',
+      }),
+    ],
+  );
+  assert.equal(result.identity_conflicts.length, 0);
+  assert.equal(result.tier, 'green');
+  assert.equal(result.reason, 'multi_source_exact_identity');
+});
+
+test('fuente exacta sin autor y título divergente permanece bloqueada si no hay corroboración', () => {
+  const result = classifyBookIntelligenceEvidence(
+    item({
+      title: 'Libro Colorea Y Descubre El Misterio Los Ositos Cariñosos',
+      author: 'Varone, Eugénie',
+    }),
+    [evidence('google_books', {
+      title: 'Coloriages mystères Bisounours',
+      author: '',
+    })],
+  );
+  assert.equal(result.tier, 'red');
+  assert.equal(result.reason, 'identity_conflict');
+  assert.equal(result.identity_conflicts.some(conflict => conflict.field === 'title'), true);
+});
+
 test('autor apellido-nombre y nombre-apellido se consideran la misma identidad', () => {
   const result = classifyBookIntelligenceEvidence(
     item({ title: 'El legado', author: 'Beder, German' }),

--- a/functions/__tests__/book-intelligence-research-run.test.js
+++ b/functions/__tests__/book-intelligence-research-run.test.js
@@ -1,0 +1,151 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildResearchResult,
+  researchMarkdown,
+  selectResearchCohort,
+} from '../../scripts/seo/book-intelligence-research-run.mjs';
+
+function catalogItem(id, isbn, overrides = {}) {
+  return {
+    id,
+    isbn,
+    title: `Título ${id}`,
+    author: `Autor ${id}`,
+    status: 'paused',
+    available_quantity: 0,
+    domain_id: 'MLU-BOOKS',
+    ...overrides,
+  };
+}
+
+function cohortItem(id, isbn, impressions, clicks = 0, source = 'gsc-demand') {
+  return {
+    id,
+    isbn,
+    source,
+    impressions,
+    clicks,
+    quality_score: 40,
+  };
+}
+
+test('RESEARCH-RUN-1 selecciona sólo demanda GSC y conserva el orden de la cohorte real', () => {
+  const cohort = [
+    cohortItem('MLU1', '9788410301245', 100, 4),
+    cohortItem('MLU2', '9789878629933', 80, 3),
+    cohortItem('MLU3', '9789876282703', 0, 0, 'catalog-quality'),
+    cohortItem('MLU4', '9786073121958', 20, 1),
+  ];
+  const catalogItems = [
+    catalogItem('MLU1', '9788410301245'),
+    catalogItem('MLU2', '9789878629933'),
+    catalogItem('MLU3', '9789876282703'),
+    catalogItem('MLU4', '9786073121958'),
+  ];
+
+  const result = selectResearchCohort({ cohort, catalogItems, limit: 3 });
+  assert.deepEqual(result.selected.map(item => item.id), ['MLU1', 'MLU2', 'MLU4']);
+  assert.deepEqual(result.selected.map(item => item.gsc_impressions), [100, 80, 20]);
+  assert.equal(result.selected.every(item => item.priority_score === 1), true);
+});
+
+test('si una ficha histórica ya no existe en snapshot, la salta y sigue hasta completar el lote', () => {
+  const cohort = [
+    cohortItem('MLU-MISSING', '9788410301245', 100),
+    cohortItem('MLU2', '9789878629933', 80),
+    cohortItem('MLU4', '9786073121958', 20),
+  ];
+  const catalogItems = [
+    catalogItem('MLU2', '9789878629933'),
+    catalogItem('MLU4', '9786073121958'),
+  ];
+
+  const result = selectResearchCohort({ cohort, catalogItems, limit: 2 });
+  assert.deepEqual(result.selected.map(item => item.id), ['MLU2', 'MLU4']);
+  assert.deepEqual(result.missing_catalog_ids, ['MLU-MISSING']);
+});
+
+test('el reporte público expone conteos de fuentes pero nunca descripciones ni tokens', () => {
+  const item = catalogItem('MLU1', '9788410301245', {
+    research: { gsc_impressions: 12, gsc_clicks: 2, quality_score: 40 },
+  });
+  const classification = {
+    tier: 'green',
+    reason: 'multi_source_exact_identity',
+    availability: 'by_request',
+    exact_isbn_source_count: 2,
+    independent_work_source_count: 2,
+    strong_work_source_count: 2,
+    identity_conflicts: [],
+    edition_fact_conflicts: [],
+    generation_policy: {
+      can_generate_work_content: true,
+      can_auto_publish_work_content: true,
+      can_generate_five_topics: true,
+      can_generate_audience: true,
+      can_generate_author_context: true,
+    },
+  };
+  const cache = {
+    entries: {
+      '9788410301245': {
+        google_books: {
+          fetched_at: '2026-08-22T12:00:00.000Z',
+          error: null,
+          records: [{ description: 'texto externo que no debe salir en resumen' }],
+        },
+        open_library: {
+          fetched_at: '2026-08-22T12:00:00.000Z',
+          error: null,
+          records: [{ description: 'otro texto externo' }],
+        },
+      },
+    },
+  };
+
+  const result = buildResearchResult(item, classification, cache);
+  const serialized = JSON.stringify(result);
+  assert.equal(result.sources.google_books.record_count, 1);
+  assert.equal(result.sources.open_library.record_count, 1);
+  assert.equal(serialized.includes('texto externo'), false);
+  assert.equal(serialized.includes('token'), false);
+});
+
+test('resumen markdown deja explícito que la corrida no toca Producción', () => {
+  const report = {
+    generated_at: '2026-08-22T12:00:00.000Z',
+    cohort: { selected: 2 },
+    catalog: { total_items: 17000 },
+    sources: {
+      google_books: { matched: 2, errors: 0 },
+      open_library: { matched: 1, errors: 0 },
+    },
+    classification: {
+      green: 1,
+      yellow: 1,
+      red: 0,
+      auto_publish_work_content: 1,
+      identity_conflicts: 0,
+    },
+    results: [
+      {
+        id: 'MLU1', isbn: '9788410301245', gsc_impressions: 12,
+        sources: { google_books: { record_count: 1 }, open_library: { record_count: 1 } },
+        tier: 'green', reason: 'multi_source_exact_identity',
+      },
+      {
+        id: 'MLU2', isbn: '9789878629933', gsc_impressions: 5,
+        sources: { google_books: { record_count: 1 }, open_library: { record_count: 0 } },
+        tier: 'yellow', reason: 'single_strong_source',
+      },
+    ],
+  };
+
+  const markdown = researchMarkdown(report);
+  assert.match(markdown, /RESEARCH-RUN-1/);
+  assert.match(markdown, /GREEN 1, YELLOW 1, RED 0/);
+  assert.match(markdown, /No se modifica ninguna ficha pública/);
+  assert.match(markdown, /Producción/);
+});

--- a/functions/_shared/book-intelligence-evidence.js
+++ b/functions/_shared/book-intelligence-evidence.js
@@ -28,6 +28,11 @@ const EDITION_FIELDS = Object.freeze([
   'publication_year',
 ]);
 
+const AUTHOR_NOISE_TOKENS = new Set([
+  'dr', 'dra', 'doctor', 'doctora', 'phd', 'prof', 'profesor', 'profesora',
+  'lic', 'licenciado', 'licenciada', 'md',
+]);
+
 function clean(value) {
   return String(value ?? '').replace(/\s+/g, ' ').trim();
 }
@@ -55,6 +60,30 @@ function compatibleIdentityText(left, right) {
   return false;
 }
 
+function authorTokens(value) {
+  return normalizeEvidenceText(value)
+    .split(' ')
+    .filter(Boolean)
+    .filter(token => !AUTHOR_NOISE_TOKENS.has(token));
+}
+
+function compatibleAuthorIdentity(left, right) {
+  if (compatibleIdentityText(left, right)) return true;
+  const leftTokens = authorTokens(left);
+  const rightTokens = authorTokens(right);
+  if (!leftTokens.length || !rightTokens.length) return true;
+
+  const leftSet = new Set(leftTokens);
+  const rightSet = new Set(rightTokens);
+  const sameSet = leftSet.size === rightSet.size && [...leftSet].every(token => rightSet.has(token));
+  if (sameSet) return true;
+
+  const [shorter, longer] = leftSet.size <= rightSet.size
+    ? [leftSet, rightSet]
+    : [rightSet, leftSet];
+  return shorter.size >= 2 && [...shorter].every(token => longer.has(token));
+}
+
 /**
  * Evidencia que NO coincide por ISBN exacto sólo puede representar la misma
  * obra si tenemos ambas piezas de identidad: título y autor. Aceptar sólo el
@@ -68,7 +97,7 @@ function sameWorkIdentityMatches(itemTitle, itemAuthor, recordTitle, recordAutho
   const authorB = normalizeEvidenceText(recordAuthor);
   if (!titleA || !titleB || !authorA || !authorB) return false;
   return compatibleIdentityText(itemTitle, recordTitle) &&
-    compatibleIdentityText(itemAuthor, recordAuthor);
+    compatibleAuthorIdentity(itemAuthor, recordAuthor);
 }
 
 function normalizedComparable(value) {
@@ -153,7 +182,13 @@ function consensusForField(records, field) {
  * - el contenido de OBRA puede usar ISBN exacto o título+autor compatibles;
  * - dos familias de fuentes independientes permiten publicación automática;
  * - una sola fuente suficiente permite generar, pero no auto-publicar;
- * - una contradicción de identidad sobre el mismo ISBN bloquea el lote.
+ * - una contradicción de identidad material sobre el mismo ISBN bloquea el lote.
+ *
+ * Un ISBN exacto con autor compatible tolera diferencias de título por idioma,
+ * subtítulos o copy comercial del marketplace. En autores se tolera orden
+ * "apellido, nombre", diacríticos y honoríficos. Esto evita falsos conflictos
+ * observados en RESEARCH-RUN-1 sin relajar el gate ante identidades realmente
+ * distintas.
  */
 export function classifyBookIntelligenceEvidence(item, evidenceRecords = []) {
   const itemIsbn = normalizeValidIsbn(item?.isbn);
@@ -169,11 +204,16 @@ export function classifyBookIntelligenceEvidence(item, evidenceRecords = []) {
 
   const identityConflicts = [];
   for (const record of exactIsbnRecords) {
-    if (record.title && !compatibleIdentityText(itemTitle, record.title)) {
-      identityConflicts.push({ source: record.source, field: 'title', value: record.title });
-    }
-    if (itemAuthor && record.author && !compatibleIdentityText(itemAuthor, record.author)) {
+    const titleComparable = Boolean(itemTitle && record.title);
+    const authorComparable = Boolean(itemAuthor && record.author);
+    const titleMismatch = titleComparable && !compatibleIdentityText(itemTitle, record.title);
+    const authorMismatch = authorComparable && !compatibleAuthorIdentity(itemAuthor, record.author);
+
+    if (authorMismatch) {
       identityConflicts.push({ source: record.source, field: 'author', value: record.author });
+    }
+    if (titleMismatch && (!authorComparable || authorMismatch)) {
+      identityConflicts.push({ source: record.source, field: 'title', value: record.title });
     }
   }
 

--- a/functions/_shared/book-intelligence-evidence.js
+++ b/functions/_shared/book-intelligence-evidence.js
@@ -186,9 +186,9 @@ function consensusForField(records, field) {
  *
  * Un ISBN exacto con autor compatible tolera diferencias de título por idioma,
  * subtítulos o copy comercial del marketplace. En autores se tolera orden
- * "apellido, nombre", diacríticos y honoríficos. Esto evita falsos conflictos
- * observados en RESEARCH-RUN-1 sin relajar el gate ante identidades realmente
- * distintas.
+ * "apellido, nombre", diacríticos y honoríficos. Una fuente exacta sin autor
+ * y con título divergente sigue siendo conservadora por sí sola, pero deja de
+ * bloquear cuando otra fuente del mismo ISBN confirma un autor compatible.
  */
 export function classifyBookIntelligenceEvidence(item, evidenceRecords = []) {
   const itemIsbn = normalizeValidIsbn(item?.isbn);
@@ -202,6 +202,10 @@ export function classifyBookIntelligenceEvidence(item, evidenceRecords = []) {
     ? records.filter(record => record.isbn === itemIsbn)
     : [];
 
+  const hasExactCompatibleAuthor = Boolean(itemAuthor) && exactIsbnRecords.some(record =>
+    record.author && compatibleAuthorIdentity(itemAuthor, record.author),
+  );
+
   const identityConflicts = [];
   for (const record of exactIsbnRecords) {
     const titleComparable = Boolean(itemTitle && record.title);
@@ -212,7 +216,7 @@ export function classifyBookIntelligenceEvidence(item, evidenceRecords = []) {
     if (authorMismatch) {
       identityConflicts.push({ source: record.source, field: 'author', value: record.author });
     }
-    if (titleMismatch && (!authorComparable || authorMismatch)) {
+    if (titleMismatch && (authorMismatch || (!authorComparable && !hasExactCompatibleAuthor))) {
       identityConflicts.push({ source: record.source, field: 'title', value: record.title });
     }
   }

--- a/scripts/seo/book-intelligence-research-run.mjs
+++ b/scripts/seo/book-intelligence-research-run.mjs
@@ -1,0 +1,333 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { fetchAndConsolidate } from '../categorize/fetch-catalog.js';
+import { PAUSED_SEO_COHORT } from '../../functions/_shared/paused-seo-cohort.js';
+import {
+  classifyBookIntelligenceEvidence,
+  summarizeBookIntelligenceEvidence,
+} from '../../functions/_shared/book-intelligence-evidence.js';
+import {
+  chunkOpenLibraryPlan,
+  emptySourceCache,
+  fetchGoogleBooksEvidence,
+  fetchOpenLibraryBatchEvidence,
+  mergeSourceCache,
+  planBookSourceResearch,
+} from './book-intelligence-sources.mjs';
+
+const DEFAULT_LIMIT = 12;
+const DEFAULT_OUTPUT_DIR = 'artifacts/book-intelligence/research-run-1';
+const DEFAULT_CACHE_PATH = 'scripts/seo/data/book-intelligence/source-cache.json';
+const DEFAULT_OPEN_LIBRARY_CONTACT = 'https://www.amadolibros.com';
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function selectResearchCohort({ cohort = [], catalogItems = [], limit = DEFAULT_LIMIT } = {}) {
+  const target = positiveInteger(limit, DEFAULT_LIMIT);
+  const byId = new Map(
+    (Array.isArray(catalogItems) ? catalogItems : [])
+      .filter(item => item?.id)
+      .map(item => [String(item.id).toUpperCase(), item]),
+  );
+
+  const selected = [];
+  const missing = [];
+  const seenIsbns = new Set();
+
+  for (const candidate of Array.isArray(cohort) ? cohort : []) {
+    if (candidate?.source !== 'gsc-demand') continue;
+    const id = String(candidate?.id || '').toUpperCase();
+    const item = byId.get(id);
+    if (!item) {
+      missing.push(id);
+      continue;
+    }
+    const isbn = clean(candidate?.isbn);
+    if (!isbn || seenIsbns.has(isbn)) continue;
+    seenIsbns.add(isbn);
+    selected.push({
+      ...item,
+      isbn,
+      research: {
+        cohort_source: candidate.source,
+        gsc_impressions: Number(candidate.impressions) || 0,
+        gsc_clicks: Number(candidate.clicks) || 0,
+        quality_score: Number(candidate.quality_score) || 0,
+      },
+      priority_score: 1,
+      gsc_impressions: Number(candidate.impressions) || 0,
+      gsc_clicks: Number(candidate.clicks) || 0,
+    });
+    if (selected.length >= target) break;
+  }
+
+  if (selected.length < target) {
+    throw new Error(`RESEARCH-RUN-1 resolvió ${selected.length}/${target} fichas con demanda en el catálogo actual.`);
+  }
+
+  return {
+    selected,
+    missing_catalog_ids: missing,
+  };
+}
+
+async function loadCache(filePath) {
+  try {
+    const parsed = JSON.parse(await readFile(filePath, 'utf8'));
+    return parsed?.entries && typeof parsed.entries === 'object' ? parsed : emptySourceCache();
+  } catch (error) {
+    if (error?.code === 'ENOENT') return emptySourceCache();
+    throw error;
+  }
+}
+
+async function saveCache(filePath, cache) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(cache, null, 2));
+}
+
+function recordsFor(cache, isbn) {
+  const entry = cache?.entries?.[isbn] || {};
+  return [
+    ...(Array.isArray(entry.google_books?.records) ? entry.google_books.records : []),
+    ...(Array.isArray(entry.open_library?.records) ? entry.open_library.records : []),
+  ];
+}
+
+function sourceState(cache, isbn, source) {
+  const entry = cache?.entries?.[isbn]?.[source] || null;
+  return {
+    fetched_at: entry?.fetched_at || null,
+    error: entry?.error || null,
+    record_count: Array.isArray(entry?.records) ? entry.records.length : 0,
+  };
+}
+
+export function buildResearchResult(item, classification, cache) {
+  return {
+    id: String(item?.id || '').toUpperCase(),
+    isbn: clean(item?.isbn),
+    title: clean(item?.title),
+    author: clean(item?.author),
+    status: item?.status || null,
+    gsc_impressions: Number(item?.research?.gsc_impressions) || 0,
+    gsc_clicks: Number(item?.research?.gsc_clicks) || 0,
+    quality_score: Number(item?.research?.quality_score) || 0,
+    tier: classification.tier,
+    reason: classification.reason,
+    availability: classification.availability,
+    exact_isbn_source_count: classification.exact_isbn_source_count,
+    independent_work_source_count: classification.independent_work_source_count,
+    strong_work_source_count: classification.strong_work_source_count,
+    identity_conflicts: classification.identity_conflicts,
+    edition_fact_conflicts: classification.edition_fact_conflicts,
+    generation_policy: classification.generation_policy,
+    sources: {
+      google_books: sourceState(cache, item.isbn, 'google_books'),
+      open_library: sourceState(cache, item.isbn, 'open_library'),
+    },
+  };
+}
+
+function sourceSummary(results, source) {
+  return {
+    fetched: results.filter(result => result.sources[source].fetched_at).length,
+    matched: results.filter(result => result.sources[source].record_count > 0).length,
+    no_match: results.filter(result => result.sources[source].fetched_at && !result.sources[source].error && result.sources[source].record_count === 0).length,
+    errors: results.filter(result => result.sources[source].error).length,
+  };
+}
+
+export function researchMarkdown(report) {
+  const lines = [
+    '# FICHAS-VIDRIERA-2 — RESEARCH-RUN-1',
+    '',
+    `- Generado: ${report.generated_at}`,
+    `- Cohorte técnica: ${report.cohort.selected} ISBN con demanda GSC, en orden de prioridad real.`,
+    `- Catálogo actual: ${report.catalog.total_items} fichas consolidadas.`,
+    `- Google Books: ${report.sources.google_books.matched}/${report.cohort.selected} con match exacto; ${report.sources.google_books.errors} errores.`,
+    `- Open Library: ${report.sources.open_library.matched}/${report.cohort.selected} con match exacto; ${report.sources.open_library.errors} errores.`,
+    `- Tiers: GREEN ${report.classification.green}, YELLOW ${report.classification.yellow}, RED ${report.classification.red}.`,
+    `- Auto-publicables por evidencia: ${report.classification.auto_publish_work_content}.`,
+    `- Conflictos de identidad: ${report.classification.identity_conflicts}.`,
+    '',
+    '## Resultado por ISBN',
+    '',
+    '| MLU | ISBN | GSC imp. | Google | Open Library | Tier | Razón |',
+    '| --- | --- | ---: | ---: | ---: | --- | --- |',
+    ...report.results.map(result =>
+      `| ${result.id} | ${result.isbn} | ${result.gsc_impressions} | ${result.sources.google_books.record_count} | ${result.sources.open_library.record_count} | ${result.tier.toUpperCase()} | ${result.reason} |`,
+    ),
+    '',
+    '## Contrato',
+    '',
+    '- Sólo lectura contra R2, Google Books y Open Library.',
+    '- No se modifica ninguna ficha pública, sitemap, canonical, Worker, R2, D1, KV ni Producción.',
+    '- El token OAuth no se escribe en archivos ni en URLs.',
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+function cliOptions(argv) {
+  const options = {
+    limit: positiveInteger(process.env.BOOK_INTELLIGENCE_LIMIT, DEFAULT_LIMIT),
+    outputDir: process.env.BOOK_INTELLIGENCE_OUTPUT_DIR || DEFAULT_OUTPUT_DIR,
+    cachePath: process.env.BOOK_INTELLIGENCE_CACHE_PATH || DEFAULT_CACHE_PATH,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (flag === '--limit') options.limit = positiveInteger(argv[++index], DEFAULT_LIMIT);
+    else if (flag === '--output-dir') options.outputDir = argv[++index];
+    else if (flag === '--cache') options.cachePath = argv[++index];
+    else throw new Error(`Argumento desconocido: ${flag}`);
+  }
+  return options;
+}
+
+export async function runResearch({
+  limit = DEFAULT_LIMIT,
+  outputDir = DEFAULT_OUTPUT_DIR,
+  cachePath = DEFAULT_CACHE_PATH,
+  googleBooksAccessToken = process.env.GOOGLE_BOOKS_ACCESS_TOKEN,
+  googleBooksApiKey = process.env.GOOGLE_BOOKS_API_KEY,
+  openLibraryContact = process.env.OPEN_LIBRARY_CONTACT || DEFAULT_OPEN_LIBRARY_CONTACT,
+} = {}) {
+  if (!clean(googleBooksAccessToken) && !clean(googleBooksApiKey)) {
+    throw new Error('RESEARCH-RUN-1 requiere GOOGLE_BOOKS_ACCESS_TOKEN o GOOGLE_BOOKS_API_KEY.');
+  }
+
+  const catalog = await fetchAndConsolidate();
+  const { selected, missing_catalog_ids: missingCatalogIds } = selectResearchCohort({
+    cohort: PAUSED_SEO_COHORT,
+    catalogItems: catalog.items,
+    limit,
+  });
+
+  let cache = await loadCache(cachePath);
+  const plan = planBookSourceResearch(selected, cache, {
+    googleBooksBudget: selected.length,
+    openLibraryBudget: selected.length,
+  });
+
+  const googleAttempts = [];
+  for (const entry of plan.google_books) {
+    try {
+      const records = await fetchGoogleBooksEvidence(entry.isbn, {
+        accessToken: googleBooksAccessToken,
+        apiKey: googleBooksApiKey,
+      });
+      cache = mergeSourceCache(cache, entry.isbn, 'google_books', records);
+      googleAttempts.push({ isbn: entry.isbn, ok: true, records: records.length });
+    } catch (error) {
+      cache = mergeSourceCache(cache, entry.isbn, 'google_books', [], { error: error?.message || String(error) });
+      googleAttempts.push({ isbn: entry.isbn, ok: false, error: error?.message || String(error) });
+    }
+  }
+
+  const openLibraryAttempts = [];
+  for (const chunk of chunkOpenLibraryPlan(plan)) {
+    const isbns = chunk.map(entry => entry.isbn);
+    try {
+      const records = await fetchOpenLibraryBatchEvidence(isbns, { contact: openLibraryContact });
+      for (const isbn of isbns) {
+        const isbnRecords = records.filter(record => record.isbn === isbn);
+        cache = mergeSourceCache(cache, isbn, 'open_library', isbnRecords);
+        openLibraryAttempts.push({ isbn, ok: true, records: isbnRecords.length });
+      }
+    } catch (error) {
+      for (const isbn of isbns) {
+        cache = mergeSourceCache(cache, isbn, 'open_library', [], { error: error?.message || String(error) });
+        openLibraryAttempts.push({ isbn, ok: false, error: error?.message || String(error) });
+      }
+    }
+  }
+
+  await saveCache(cachePath, cache);
+
+  const classifications = selected.map(item =>
+    classifyBookIntelligenceEvidence(item, recordsFor(cache, item.isbn)),
+  );
+  const summary = summarizeBookIntelligenceEvidence(classifications);
+  const results = selected.map((item, index) => buildResearchResult(item, classifications[index], cache));
+  const generatedAt = new Date().toISOString();
+  const report = {
+    schema_version: 1,
+    run: 'FICHAS-VIDRIERA-2/RESEARCH-RUN-1',
+    generated_at: generatedAt,
+    cohort: {
+      requested: positiveInteger(limit, DEFAULT_LIMIT),
+      selected: selected.length,
+      demand_only: true,
+      missing_catalog_ids: missingCatalogIds,
+      total_impressions: selected.reduce((sum, item) => sum + (Number(item.research?.gsc_impressions) || 0), 0),
+      total_clicks: selected.reduce((sum, item) => sum + (Number(item.research?.gsc_clicks) || 0), 0),
+    },
+    catalog: {
+      fetched_at: catalog.fetched_at,
+      total_items: catalog.items.length,
+      active_total_raw: catalog.sources?.active_total_raw ?? null,
+      paused_total_raw: catalog.sources?.paused_total_raw ?? null,
+      paused_manifest_version: catalog.sources?.paused_manifest_version ?? null,
+    },
+    plan: {
+      eligible_unique_isbns: plan.eligible_unique_isbns,
+      google_books_requests: plan.google_books.length,
+      open_library_isbns: plan.open_library.length,
+      cached_google_books: plan.cached_google_books,
+      cached_open_library: plan.cached_open_library,
+    },
+    execution: {
+      google_books_http_successes: googleAttempts.filter(attempt => attempt.ok).length,
+      google_books_errors: googleAttempts.filter(attempt => !attempt.ok).length,
+      open_library_http_successes: openLibraryAttempts.filter(attempt => attempt.ok).length,
+      open_library_errors: openLibraryAttempts.filter(attempt => !attempt.ok).length,
+    },
+    sources: {
+      google_books: sourceSummary(results, 'google_books'),
+      open_library: sourceSummary(results, 'open_library'),
+    },
+    classification: summary,
+    results,
+  };
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(path.join(outputDir, 'research-run-1-report.json'), JSON.stringify(report, null, 2));
+  await writeFile(path.join(outputDir, 'report-summary.md'), researchMarkdown(report));
+
+  const googleWasPlanned = plan.google_books.length > 0;
+  const googleHadSuccessfulHttp = googleAttempts.some(attempt => attempt.ok);
+  if (googleWasPlanned && !googleHadSuccessfulHttp) {
+    throw new Error('Google Books no completó ninguna consulta HTTP: revisar scope Books/API habilitada para el proyecto WIF.');
+  }
+
+  return report;
+}
+
+async function main() {
+  const options = cliOptions(process.argv.slice(2));
+  const report = await runResearch(options);
+  console.log(JSON.stringify({
+    run: report.run,
+    selected: report.cohort.selected,
+    sources: report.sources,
+    classification: report.classification,
+  }, null, 2));
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  main().catch(error => {
+    console.error(`[research-run-1] ERROR: ${error?.message || error}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Objetivo

Ejecutar el primer lote técnico real de FICHAS-VIDRIERA-2 sobre ISBN con demanda GSC, sin cambiar fichas públicas ni Producción.

Este PR queda **apilado sobre #218** para mantener el diff propio limpio.

## Qué hace

- toma la cohorte ya versionada de 3.000 ISBN y selecciona sólo fichas `gsc-demand`, en su orden real de prioridad;
- resuelve los productos contra el snapshot vigente de R2, sólo lectura;
- usa el WIF ya existente (`ga4-reporter@amado-libros-analytics`) para pedir un access token con scope Google Books;
- consulta Google Books por ISBN exacto y Open Library en batch limitado;
- pasa la evidencia real por el clasificador de #217;
- produce métricas GREEN/YELLOW/RED y conflictos de identidad;
- el reporte público contiene sólo conteos/diagnóstico, no descripciones externas ni tokens;
- el cache de evidencia queda fuera de Git.

## Resultado real de RESEARCH-RUN-1

Cohorte técnica: **12 ISBN con demanda GSC**, 559 impresiones y 46 clics históricos.

Catálogo resuelto en la corrida: **17.201 fichas consolidadas**.

Fuentes:

- **WIF/OAuth Google Books: PASS**, sin API key nueva;
- Google Books: 12/12 consultas HTTP exitosas, **4/12 ISBN con match exacto**, 0 errores;
- Open Library: 12/12 ISBN consultados, **0/12 con match exacto**, 0 errores.

Clasificación después del hardening de identidad:

- **GREEN: 0**
- **YELLOW: 2**
- **RED: 10**
- auto-publicables: **0**

YELLOW reales:

- `9789878675701` — *El legado*, Germán Beder;
- `9788416894864` — *La jubilación: una nueva oportunidad*, Bartolomé Freire Arteta.

## Hardening derivado de datos reales

La primera corrida reveló falsos conflictos bibliográficos normales. El gate ahora tolera, sin relajar la identidad:

- `Beder, German` vs `Germán Beder`;
- `Freire Arteta, Bartolomé` vs `Bartolomé Freire Arteta`;
- diacríticos y orden apellido/nombre;
- autores compuestos con los mismos tokens;
- título localizado/comercial cuando el ISBN es exacto y el autor coincide.

Una fuente exacta sin autor y con título divergente sigue bloqueada por sí sola. Si otra fuente exacta posterior confirma un autor compatible, esa fuente incompleta deja de contaminar el resultado. Una contradicción material de autor sigue en RED.

## Validación contra `main`

Se retargeteó temporalmente este PR a `main` únicamente para validar el stack completo y después se devolvió a #218.

- **CI completo: PASS**
- **SEO baseline: PASS**
- **RESEARCH-RUN-1: PASS**
- **Preview aislado: PASS completo** en reintento

El primer Preview tuvo un 404 transitorio de propagación en `sitemap-books-active.xml`; el mismo commit reejecutado sin cambios terminó verde en build, deploy, auditoría comercial, showcase y grafo por encargo. No se modificó sitemap ni routing.

## Decisión técnica

La infraestructura ya está probada. El cuello de botella es **cobertura de evidencia**, no autenticación.

Google Books aporta, pero **Google Books + Open Library no alcanza para escalar generación masiva** con el estándar de seguridad editorial definido. Open Library no aportó ningún match exacto en esta muestra y no se aumentará agresivamente el uso de su API pública.

El siguiente lote debe sumar una segunda familia de fuentes reales —editorial, distribuidor y/o catálogo bibliográfico verificable— con control por ISBN y trazabilidad. Recién después corresponde medir 100–250 ISBN y decidir la escala a cientos/miles.

## Seguridad

Sólo lectura. No modifica HTML público, renderer, canonical, sitemap, R2, D1, KV, Worker, checkout ni Producción. No agrega secretos ni API keys.

**MANTENER DRAFT. NO MERGEAR. NO PRODUCCIÓN.**