### PR TITLE
FICHAS-VIDRIERA-2: SOURCE-COVERAGE-2 con Library of Congress

### DIFF
--- a/.github/workflows/book-intelligence-source-coverage-2.yml
+++ b/.github/workflows/book-intelligence-source-coverage-2.yml
@@ -9,6 +9,7 @@ on:
       - 'scripts/seo/book-intelligence-library-of-congress.mjs'
       - 'scripts/seo/book-intelligence-source-coverage-2.mjs'
       - 'functions/__tests__/book-intelligence-library-of-congress.test.js'
+      - 'functions/__tests__/book-intelligence-source-coverage-2.test.js'
       - 'functions/_shared/book-intelligence-evidence.js'
   pull_request:
     paths:
@@ -16,6 +17,7 @@ on:
       - 'scripts/seo/book-intelligence-library-of-congress.mjs'
       - 'scripts/seo/book-intelligence-source-coverage-2.mjs'
       - 'functions/__tests__/book-intelligence-library-of-congress.test.js'
+      - 'functions/__tests__/book-intelligence-source-coverage-2.test.js'
       - 'functions/_shared/book-intelligence-evidence.js'
   workflow_dispatch:
     inputs:
@@ -52,7 +54,7 @@ jobs:
         run: |
           node --check scripts/seo/book-intelligence-library-of-congress.mjs
           node --check scripts/seo/book-intelligence-source-coverage-2.mjs
-          node --test functions/__tests__/book-intelligence-library-of-congress.test.js functions/__tests__/book-intelligence-evidence.test.js
+          node --test functions/__tests__/book-intelligence-library-of-congress.test.js functions/__tests__/book-intelligence-source-coverage-2.test.js functions/__tests__/book-intelligence-evidence.test.js
 
       - name: Authenticate Google Books through existing Workload Identity
         id: google_auth

--- a/.github/workflows/book-intelligence-source-coverage-2.yml
+++ b/.github/workflows/book-intelligence-source-coverage-2.yml
@@ -1,0 +1,122 @@
+name: FICHAS-VIDRIERA-2 source coverage 2
+
+on:
+  push:
+    branches:
+      - agent/fichas-vidriera-v2-source-coverage-2
+    paths:
+      - '.github/workflows/book-intelligence-source-coverage-2.yml'
+      - 'scripts/seo/book-intelligence-library-of-congress.mjs'
+      - 'scripts/seo/book-intelligence-source-coverage-2.mjs'
+      - 'functions/__tests__/book-intelligence-library-of-congress.test.js'
+      - 'functions/_shared/book-intelligence-evidence.js'
+  pull_request:
+    paths:
+      - '.github/workflows/book-intelligence-source-coverage-2.yml'
+      - 'scripts/seo/book-intelligence-library-of-congress.mjs'
+      - 'scripts/seo/book-intelligence-source-coverage-2.mjs'
+      - 'functions/__tests__/book-intelligence-library-of-congress.test.js'
+      - 'functions/_shared/book-intelligence-evidence.js'
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: Cantidad de ISBN con demanda GSC a medir
+        required: true
+        default: '12'
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: book-intelligence-source-coverage-2-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: Google Books + Library of Congress coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Validate source adapter without network
+        run: |
+          node --check scripts/seo/book-intelligence-library-of-congress.mjs
+          node --check scripts/seo/book-intelligence-source-coverage-2.mjs
+          node --test functions/__tests__/book-intelligence-library-of-congress.test.js functions/__tests__/book-intelligence-evidence.test.js
+
+      - name: Authenticate Google Books through existing Workload Identity
+        id: google_auth
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: amado-libros-analytics
+          workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
+          service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/books
+          create_credentials_file: false
+
+      - name: Execute source coverage run
+        id: coverage_run
+        continue-on-error: true
+        env:
+          GOOGLE_BOOKS_ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
+          BOOK_INTELLIGENCE_LIMIT: ${{ inputs.limit || '12' }}
+          BOOK_INTELLIGENCE_OUTPUT_DIR: artifacts/book-intelligence/source-coverage-2
+          LIBRARY_OF_CONGRESS_DELAY_MS: '150'
+        run: node scripts/seo/book-intelligence-source-coverage-2.mjs --limit "$BOOK_INTELLIGENCE_LIMIT"
+
+      - name: Validate generated report
+        if: steps.coverage_run.outcome == 'success'
+        env:
+          BOOK_INTELLIGENCE_LIMIT: ${{ inputs.limit || '12' }}
+        run: |
+          test -s artifacts/book-intelligence/source-coverage-2/source-coverage-2-report.json
+          test -s artifacts/book-intelligence/source-coverage-2/report-summary.md
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const report = JSON.parse(fs.readFileSync('artifacts/book-intelligence/source-coverage-2/source-coverage-2-report.json', 'utf8'));
+          if (report.schema_version !== 1) process.exit(1);
+          if (report.run !== 'FICHAS-VIDRIERA-2/SOURCE-COVERAGE-2') process.exit(1);
+          if (report.cohort.selected !== Number(process.env.BOOK_INTELLIGENCE_LIMIT || 12)) process.exit(1);
+          if (report.sources.library_of_congress.http_successes < 1) process.exit(1);
+          NODE
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: book-intelligence-source-coverage-2-${{ github.run_id }}
+          path: artifacts/book-intelligence/source-coverage-2/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Write coverage summary
+        if: always()
+        run: |
+          if [ -f artifacts/book-intelligence/source-coverage-2/report-summary.md ]; then
+            cat artifacts/book-intelligence/source-coverage-2/report-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## SOURCE-COVERAGE-2 incompleto' >> "$GITHUB_STEP_SUMMARY"
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo 'No se generó reporte. Revisar tests o conectividad SRU.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Library of Congress: SRU oficial, sin secreto' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Modo: sólo lectura' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Deploy: no se ejecuta' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if coverage run did not complete
+        if: steps.coverage_run.outcome != 'success'
+        run: |
+          echo 'SOURCE-COVERAGE-2 no completó la corrida real.'
+          exit 1

--- a/functions/__tests__/book-intelligence-library-of-congress.test.js
+++ b/functions/__tests__/book-intelligence-library-of-congress.test.js
@@ -1,0 +1,116 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildLibraryOfCongressUrl,
+  fetchLibraryOfCongressEvidence,
+  parseLibraryOfCongressEvidence,
+} from '../../scripts/seo/book-intelligence-library-of-congress.mjs';
+
+const ISBN = '9788496836693';
+const OTHER_ISBN = '9780194527552';
+
+function marcRecord({ isbn = ISBN, title = 'Padres fuertes, hijas felices', author = 'Meeker, Meg' } = {}) {
+  return `
+    <record xmlns="http://www.loc.gov/MARC21/slim">
+      <leader>00000nam a2200000 i 4500</leader>
+      <controlfield tag="001">12345678</controlfield>
+      <datafield tag="020" ind1=" " ind2=" "><subfield code="a">${isbn} (paperback)</subfield></datafield>
+      <datafield tag="100" ind1="1" ind2=" "><subfield code="a">${author},</subfield></datafield>
+      <datafield tag="245" ind1="1" ind2="0">
+        <subfield code="a">${title} :</subfield>
+        <subfield code="b">cómo fortalecer el vínculo familiar /</subfield>
+      </datafield>
+      <datafield tag="264" ind1=" " ind2="1">
+        <subfield code="b">Ciudadela Libros,</subfield>
+        <subfield code="c">2008.</subfield>
+      </datafield>
+      <datafield tag="300" ind1=" " ind2=" "><subfield code="a">304 pages ;</subfield></datafield>
+      <datafield tag="041" ind1="0" ind2=" "><subfield code="a">spa</subfield></datafield>
+      <datafield tag="520" ind1=" " ind2=" ">
+        <subfield code="a">Una síntesis bibliográfica suficientemente extensa sobre la obra, su enfoque práctico y el vínculo entre padres e hijas.</subfield>
+      </datafield>
+      <datafield tag="650" ind1=" " ind2="0"><subfield code="a">Parent and child.</subfield></datafield>
+      <datafield tag="650" ind1=" " ind2="0"><subfield code="a">Father-daughter relationship.</subfield></datafield>
+      <datafield tag="650" ind1=" " ind2="0"><subfield code="a">Family relationships.</subfield></datafield>
+    </record>`;
+}
+
+function sruResponse(records) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+    <zs:searchRetrieveResponse xmlns:zs="http://www.loc.gov/zing/srw/">
+      <zs:version>1.1</zs:version>
+      <zs:numberOfRecords>${records.length}</zs:numberOfRecords>
+      <zs:records>
+        ${records.map(record => `<zs:record><zs:recordSchema>info:srw/schema/1/marcxml-v1.1</zs:recordSchema><zs:recordData>${record}</zs:recordData></zs:record>`).join('')}
+      </zs:records>
+    </zs:searchRetrieveResponse>`;
+}
+
+test('URL SRU usa bath.isbn exacto, MARCXML y HTTPS oficial', () => {
+  const url = new URL(buildLibraryOfCongressUrl(ISBN));
+  assert.equal(url.origin, 'https://lx2.loc.gov');
+  assert.equal(url.pathname, '/sru/lcdb');
+  assert.equal(url.searchParams.get('operation'), 'searchRetrieve');
+  assert.equal(url.searchParams.get('query'), `bath.isbn=${ISBN}`);
+  assert.equal(url.searchParams.get('recordSchema'), 'marcxml');
+});
+
+test('parser MARCXML revalida 020$a y extrae evidencia bibliográfica fuerte', () => {
+  const xml = sruResponse([
+    marcRecord(),
+    marcRecord({ isbn: OTHER_ISBN, title: 'Otra obra', author: 'Otra, Persona' }),
+  ]);
+  const records = parseLibraryOfCongressEvidence(xml, ISBN);
+  assert.equal(records.length, 1);
+  const record = records[0];
+  assert.equal(record.source, 'library_catalog');
+  assert.equal(record.source_provider, 'library_of_congress');
+  assert.equal(record.source_id, '12345678');
+  assert.equal(record.isbn, ISBN);
+  assert.match(record.title, /Padres fuertes, hijas felices/);
+  assert.match(record.title, /cómo fortalecer el vínculo familiar/);
+  assert.equal(record.author, 'Meeker, Meg');
+  assert.equal(record.publisher, 'Ciudadela Libros');
+  assert.equal(record.pages, 304);
+  assert.equal(record.language, 'spa');
+  assert.equal(record.publication_year, '2008');
+  assert.equal(record.topics.length, 3);
+  assert.equal(record.raw_quality.exact_isbn, true);
+});
+
+test('ISBN sólo en otro registro no se convierte en evidencia del solicitado', () => {
+  const records = parseLibraryOfCongressEvidence(
+    sruResponse([marcRecord({ isbn: OTHER_ISBN })]),
+    ISBN,
+  );
+  assert.deepEqual(records, []);
+});
+
+test('fetch real es inyectable, pide XML y no requiere secreto', async () => {
+  let requestedUrl = null;
+  let requestedOptions = null;
+  const records = await fetchLibraryOfCongressEvidence(ISBN, {
+    fetchImpl: async (url, options) => {
+      requestedUrl = String(url);
+      requestedOptions = options;
+      return {
+        ok: true,
+        status: 200,
+        async text() { return sruResponse([marcRecord()]); },
+      };
+    },
+  });
+  assert.equal(new URL(requestedUrl).searchParams.get('query'), `bath.isbn=${ISBN}`);
+  assert.match(requestedOptions.headers.accept, /xml/);
+  assert.equal(records.length, 1);
+});
+
+test('error HTTP se propaga y no se convierte en no-match', async () => {
+  await assert.rejects(
+    () => fetchLibraryOfCongressEvidence(ISBN, {
+      fetchImpl: async () => ({ ok: false, status: 503, async text() { return ''; } }),
+    }),
+    /HTTP 503/,
+  );
+});

--- a/functions/__tests__/book-intelligence-source-coverage-2.test.js
+++ b/functions/__tests__/book-intelligence-source-coverage-2.test.js
@@ -1,0 +1,84 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildCoverageResult,
+  coverageMarkdown,
+} from '../../scripts/seo/book-intelligence-source-coverage-2.mjs';
+
+const ISBN = '9789878675701';
+
+function item() {
+  return {
+    id: 'MLU1',
+    isbn: ISBN,
+    title: 'El legado',
+    author: 'Beder, German',
+    research: { gsc_impressions: 7, gsc_clicks: 0 },
+  };
+}
+
+function classification() {
+  return {
+    tier: 'green',
+    reason: 'multi_source_exact_identity',
+    exact_isbn_source_count: 2,
+    independent_work_source_count: 2,
+    strong_work_source_count: 2,
+    identity_conflicts: [],
+    generation_policy: {
+      can_generate_work_content: true,
+      can_auto_publish_work_content: true,
+      can_generate_five_topics: true,
+      can_generate_audience: false,
+      can_generate_author_context: false,
+    },
+  };
+}
+
+test('resultado de coverage publica conteos, no texto externo', () => {
+  const result = buildCoverageResult(
+    item(),
+    classification(),
+    [{ source: 'google_books', description: 'Descripción externa que no debe salir.' }],
+    [{
+      source: 'library_catalog',
+      description: 'Resumen bibliográfico externo que tampoco debe salir.',
+      topics: ['Tema 1', 'Tema 2', 'Tema 3'],
+    }],
+  );
+  assert.equal(result.google_books_records, 1);
+  assert.equal(result.library_of_congress_records, 1);
+  assert.equal(result.library_of_congress_substantive_records, 1);
+  const serialized = JSON.stringify(result);
+  assert.equal(serialized.includes('Descripción externa'), false);
+  assert.equal(serialized.includes('Resumen bibliográfico externo'), false);
+});
+
+test('markdown declara fuentes, tiers y contrato sin Producción', () => {
+  const report = {
+    generated_at: '2026-08-22T12:00:00.000Z',
+    cohort: { selected: 1 },
+    sources: {
+      google_books: { matched: 1, errors: 0 },
+      library_of_congress: { matched: 1, substantive_matches: 1, errors: 0 },
+    },
+    classification: { green: 1, yellow: 0, red: 0, auto_publish_work_content: 1 },
+    results: [{
+      id: 'MLU1',
+      isbn: ISBN,
+      gsc_impressions: 7,
+      google_books_records: 1,
+      library_of_congress_records: 1,
+      library_of_congress_substantive_records: 1,
+      tier: 'green',
+      reason: 'multi_source_exact_identity',
+    }],
+  };
+  const markdown = coverageMarkdown(report);
+  assert.match(markdown, /SOURCE-COVERAGE-2/);
+  assert.match(markdown, /Library of Congress/);
+  assert.match(markdown, /GREEN 1, YELLOW 0, RED 0/);
+  assert.match(markdown, /No se modifica ninguna ficha/);
+  assert.match(markdown, /Producción/);
+});

--- a/scripts/seo/book-intelligence-library-of-congress.mjs
+++ b/scripts/seo/book-intelligence-library-of-congress.mjs
@@ -44,6 +44,17 @@ function blocks(xml, tagName) {
   }));
 }
 
+function unprefixedBlocks(xml, tagName) {
+  const pattern = new RegExp(
+    `<${tagName}\\b([^>]*)>([\\s\\S]*?)<\\/${tagName}>`,
+    'gi',
+  );
+  return [...String(xml ?? '').matchAll(pattern)].map(match => ({
+    attributes: match[1] || '',
+    body: match[2] || '',
+  }));
+}
+
 function parseMarcRecord(xml) {
   const controlfields = [];
   for (const block of blocks(xml, 'controlfield')) {
@@ -199,9 +210,10 @@ export function parseLibraryOfCongressEvidence(xml, isbn) {
   const target = normalizeValidIsbn(isbn);
   if (!target) return [];
   const output = [];
-  for (const recordBlock of blocks(xml, 'record')) {
-    // El wrapper SRU es <zs:record>; `blocks(..., 'record')` sólo captura el
-    // MARCXML <record> sin prefijo, pero mantenemos la revalidación por 020$a.
+  // El response SRU envuelve cada MARCXML en <zs:record>. Sólo tomamos
+  // <record> sin prefijo para no confundir el wrapper protocolar con el
+  // registro bibliográfico real.
+  for (const recordBlock of unprefixedBlocks(xml, 'record')) {
     const record = parseMarcRecord(recordBlock.body);
     const identifiers = recordIsbns(record);
     if (!identifiers.includes(target)) continue;

--- a/scripts/seo/book-intelligence-library-of-congress.mjs
+++ b/scripts/seo/book-intelligence-library-of-congress.mjs
@@ -1,0 +1,259 @@
+// FICHAS-VIDRIERA-2 / SOURCE-COVERAGE-2
+// Adaptador oficial de Library of Congress vía SRU 1.1 + MARCXML.
+//
+// Contrato:
+// - consulta por bath.isbn exacto;
+// - revalida el ISBN dentro de MARC 020$a;
+// - no requiere API key ni usuario/contraseña;
+// - devuelve evidencia `library_catalog`, nunca copy final;
+// - sólo se usa offline/batch, nunca en una request de cliente.
+
+import { normalizeValidIsbn } from '../../functions/_shared/showcase-ranking.js';
+
+export const LIBRARY_OF_CONGRESS_SRU_BASE = 'https://lx2.loc.gov/sru/lcdb';
+export const LIBRARY_OF_CONGRESS_MAX_RECORDS = 5;
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function decodeXml(value) {
+  return clean(String(value ?? '')
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#([0-9]+);/g, (_, decimal) => String.fromCodePoint(Number.parseInt(decimal, 10)))
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;/gi, "'"));
+}
+
+function attrValue(attributes, name) {
+  const match = String(attributes ?? '').match(new RegExp(`${name}\\s*=\\s*["']([^"']*)["']`, 'i'));
+  return match ? decodeXml(match[1]) : '';
+}
+
+function blocks(xml, tagName) {
+  const pattern = new RegExp(
+    `<(?:[\\w.-]+:)?${tagName}\\b([^>]*)>([\\s\\S]*?)<\\/(?:[\\w.-]+:)?${tagName}>`,
+    'gi',
+  );
+  return [...String(xml ?? '').matchAll(pattern)].map(match => ({
+    attributes: match[1] || '',
+    body: match[2] || '',
+  }));
+}
+
+function parseMarcRecord(xml) {
+  const controlfields = [];
+  for (const block of blocks(xml, 'controlfield')) {
+    controlfields.push({
+      tag: attrValue(block.attributes, 'tag'),
+      value: decodeXml(block.body.replace(/<[^>]+>/g, ' ')),
+    });
+  }
+
+  const datafields = [];
+  for (const field of blocks(xml, 'datafield')) {
+    const subfields = blocks(field.body, 'subfield').map(subfield => ({
+      code: attrValue(subfield.attributes, 'code'),
+      value: decodeXml(subfield.body.replace(/<[^>]+>/g, ' ')),
+    }));
+    datafields.push({
+      tag: attrValue(field.attributes, 'tag'),
+      ind1: attrValue(field.attributes, 'ind1'),
+      ind2: attrValue(field.attributes, 'ind2'),
+      subfields,
+    });
+  }
+
+  return { controlfields, datafields };
+}
+
+function fields(record, tags) {
+  const wanted = new Set(Array.isArray(tags) ? tags : [tags]);
+  return record.datafields.filter(field => wanted.has(field.tag));
+}
+
+function subfieldValues(record, tags, codes) {
+  const wantedCodes = new Set(Array.isArray(codes) ? codes : [codes]);
+  return fields(record, tags).flatMap(field =>
+    field.subfields
+      .filter(subfield => wantedCodes.has(subfield.code))
+      .map(subfield => clean(subfield.value))
+      .filter(Boolean),
+  );
+}
+
+function firstSubfield(record, tags, codes) {
+  return subfieldValues(record, tags, codes)[0] || '';
+}
+
+function controlfield(record, tag) {
+  return record.controlfields.find(field => field.tag === tag)?.value || '';
+}
+
+function normalizeIsbnText(value) {
+  const direct = normalizeValidIsbn(clean(value));
+  if (direct) return direct;
+  const candidates = String(value ?? '').match(/(?:97[89][0-9\s-]{10,20}|[0-9][0-9Xx\s-]{8,18})/g) || [];
+  for (const candidate of candidates) {
+    const normalized = normalizeValidIsbn(candidate);
+    if (normalized) return normalized;
+  }
+  return null;
+}
+
+function recordIsbns(record) {
+  return [...new Set(
+    subfieldValues(record, '020', 'a')
+      .map(normalizeIsbnText)
+      .filter(Boolean),
+  )];
+}
+
+function stripTerminalPunctuation(value) {
+  return clean(value).replace(/[\s\/:;,=]+$/g, '').trim();
+}
+
+function titleValue(record) {
+  return stripTerminalPunctuation(
+    subfieldValues(record, '245', ['a', 'b', 'n', 'p'])
+      .map(stripTerminalPunctuation)
+      .filter(Boolean)
+      .join(' : '),
+  );
+}
+
+function authorValue(record) {
+  const main = firstSubfield(record, ['100', '110', '111'], 'a');
+  if (main) return stripTerminalPunctuation(main);
+  return stripTerminalPunctuation(firstSubfield(record, '700', 'a'));
+}
+
+function publisherValue(record) {
+  return stripTerminalPunctuation(
+    firstSubfield(record, '264', 'b') || firstSubfield(record, '260', 'b'),
+  ) || null;
+}
+
+function yearFromDate(value) {
+  const match = clean(value).match(/\b(1[5-9]\d{2}|20\d{2}|21\d{2})\b/);
+  return match ? match[1] : null;
+}
+
+function publicationYear(record) {
+  return yearFromDate(firstSubfield(record, '264', 'c') || firstSubfield(record, '260', 'c'));
+}
+
+function pageCount(record) {
+  const physical = firstSubfield(record, '300', 'a');
+  const match = physical.match(/\b(\d{1,5})\s*(?:p\.?|pages?|p[aá]ginas?)\b/i);
+  if (!match) return null;
+  const pages = Number(match[1]);
+  return Number.isInteger(pages) && pages > 0 ? pages : null;
+}
+
+function languageValue(record) {
+  const values = [...new Set(subfieldValues(record, '041', ['a', 'd', 'h']))];
+  return values.length ? values.join(', ') : null;
+}
+
+function summaryValue(record) {
+  return subfieldValues(record, '520', ['a', 'b'])
+    .map(stripTerminalPunctuation)
+    .filter(Boolean)
+    .join(' ');
+}
+
+function topicValues(record) {
+  const subjectTags = new Set(['600', '610', '611', '630', '648', '650', '651', '655']);
+  const topics = [];
+  for (const field of record.datafields) {
+    if (!subjectTags.has(field.tag)) continue;
+    const parts = field.subfields
+      .filter(subfield => ['a', 'x', 'y', 'z', 'v'].includes(subfield.code))
+      .map(subfield => stripTerminalPunctuation(subfield.value))
+      .filter(Boolean);
+    if (parts.length) topics.push(parts.join(' — '));
+  }
+  return [...new Set(topics)].slice(0, 12);
+}
+
+export function buildLibraryOfCongressUrl(isbn, { maximumRecords = LIBRARY_OF_CONGRESS_MAX_RECORDS } = {}) {
+  const normalized = normalizeValidIsbn(isbn);
+  if (!normalized) throw new Error('ISBN inválido para Library of Congress.');
+  const limit = Number.isInteger(Number(maximumRecords))
+    ? Math.min(Math.max(Number(maximumRecords), 1), 50)
+    : LIBRARY_OF_CONGRESS_MAX_RECORDS;
+  const url = new URL(LIBRARY_OF_CONGRESS_SRU_BASE);
+  url.searchParams.set('version', '1.1');
+  url.searchParams.set('operation', 'searchRetrieve');
+  url.searchParams.set('query', `bath.isbn=${normalized}`);
+  url.searchParams.set('recordSchema', 'marcxml');
+  url.searchParams.set('maximumRecords', String(limit));
+  return url.toString();
+}
+
+export function parseLibraryOfCongressEvidence(xml, isbn) {
+  const target = normalizeValidIsbn(isbn);
+  if (!target) return [];
+  const output = [];
+  for (const recordBlock of blocks(xml, 'record')) {
+    // El wrapper SRU es <zs:record>; `blocks(..., 'record')` sólo captura el
+    // MARCXML <record> sin prefijo, pero mantenemos la revalidación por 020$a.
+    const record = parseMarcRecord(recordBlock.body);
+    const identifiers = recordIsbns(record);
+    if (!identifiers.includes(target)) continue;
+    output.push({
+      source: 'library_catalog',
+      source_provider: 'library_of_congress',
+      source_id: clean(controlfield(record, '001')) || null,
+      source_url: buildLibraryOfCongressUrl(target),
+      isbn: target,
+      title: titleValue(record),
+      author: authorValue(record),
+      description: summaryValue(record),
+      publisher: publisherValue(record),
+      pages: pageCount(record),
+      language: languageValue(record),
+      publication_year: publicationYear(record),
+      format: null,
+      topics: topicValues(record),
+      raw_quality: {
+        exact_isbn: true,
+        identifiers,
+        catalog: 'LCDB',
+      },
+    });
+  }
+  return output;
+}
+
+async function fetchText(url, {
+  fetchImpl = globalThis.fetch,
+  timeoutMs = 12_000,
+} = {}) {
+  if (typeof fetchImpl !== 'function') throw new Error('fetch no disponible.');
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      headers: {
+        accept: 'application/xml,text/xml;q=0.9,*/*;q=0.1',
+        'user-agent': 'AmadoLibros-BookIntelligence/1.0',
+      },
+      signal: controller.signal,
+    });
+    if (!response?.ok) throw new Error(`HTTP ${response?.status || 0}`);
+    return await response.text();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function fetchLibraryOfCongressEvidence(isbn, { fetchImpl, timeoutMs } = {}) {
+  const url = buildLibraryOfCongressUrl(isbn);
+  const xml = await fetchText(url, { fetchImpl, timeoutMs });
+  return parseLibraryOfCongressEvidence(xml, isbn);
+}

--- a/scripts/seo/book-intelligence-source-coverage-2.mjs
+++ b/scripts/seo/book-intelligence-source-coverage-2.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { fetchAndConsolidate } from '../categorize/fetch-catalog.js';
+import { PAUSED_SEO_COHORT } from '../../functions/_shared/paused-seo-cohort.js';
+import {
+  classifyBookIntelligenceEvidence,
+  summarizeBookIntelligenceEvidence,
+} from '../../functions/_shared/book-intelligence-evidence.js';
+import { fetchGoogleBooksEvidence } from './book-intelligence-sources.mjs';
+import { fetchLibraryOfCongressEvidence } from './book-intelligence-library-of-congress.mjs';
+import { selectResearchCohort } from './book-intelligence-research-run.mjs';
+
+const DEFAULT_LIMIT = 12;
+const DEFAULT_OUTPUT_DIR = 'artifacts/book-intelligence/source-coverage-2';
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function sourceSummary(attempts) {
+  return {
+    requested: attempts.length,
+    http_successes: attempts.filter(attempt => attempt.ok).length,
+    matched: attempts.filter(attempt => attempt.ok && attempt.record_count > 0).length,
+    no_match: attempts.filter(attempt => attempt.ok && attempt.record_count === 0).length,
+    errors: attempts.filter(attempt => !attempt.ok).length,
+  };
+}
+
+export function buildCoverageResult(item, classification, googleRecords, libraryRecords) {
+  return {
+    id: String(item?.id || '').toUpperCase(),
+    isbn: clean(item?.isbn),
+    title: clean(item?.title),
+    author: clean(item?.author),
+    gsc_impressions: Number(item?.research?.gsc_impressions) || 0,
+    gsc_clicks: Number(item?.research?.gsc_clicks) || 0,
+    google_books_records: Array.isArray(googleRecords) ? googleRecords.length : 0,
+    library_of_congress_records: Array.isArray(libraryRecords) ? libraryRecords.length : 0,
+    library_of_congress_substantive_records: (Array.isArray(libraryRecords) ? libraryRecords : []).filter(record =>
+      clean(record.description).length >= 80 || (Array.isArray(record.topics) && record.topics.length >= 3),
+    ).length,
+    tier: classification.tier,
+    reason: classification.reason,
+    exact_isbn_source_count: classification.exact_isbn_source_count,
+    independent_work_source_count: classification.independent_work_source_count,
+    strong_work_source_count: classification.strong_work_source_count,
+    identity_conflicts: classification.identity_conflicts,
+    generation_policy: classification.generation_policy,
+  };
+}
+
+export function coverageMarkdown(report) {
+  const lines = [
+    '# FICHAS-VIDRIERA-2 — SOURCE-COVERAGE-2',
+    '',
+    `- Generado: ${report.generated_at}`,
+    `- Cohorte: ${report.cohort.selected} ISBN con demanda GSC.`,
+    `- Google Books: ${report.sources.google_books.matched}/${report.cohort.selected} matches exactos; ${report.sources.google_books.errors} errores.`,
+    `- Library of Congress: ${report.sources.library_of_congress.matched}/${report.cohort.selected} matches exactos; ${report.sources.library_of_congress.errors} errores.`,
+    `- Library of Congress con evidencia semántica suficiente: ${report.sources.library_of_congress.substantive_matches}/${report.cohort.selected}.`,
+    `- Tiers combinados Google + LoC: GREEN ${report.classification.green}, YELLOW ${report.classification.yellow}, RED ${report.classification.red}.`,
+    `- Auto-publicables: ${report.classification.auto_publish_work_content}.`,
+    '',
+    '## Resultado por ISBN',
+    '',
+    '| MLU | ISBN | GSC imp. | Google | LoC | LoC sust. | Tier | Razón |',
+    '| --- | --- | ---: | ---: | ---: | ---: | --- | --- |',
+    ...report.results.map(result =>
+      `| ${result.id} | ${result.isbn} | ${result.gsc_impressions} | ${result.google_books_records} | ${result.library_of_congress_records} | ${result.library_of_congress_substantive_records} | ${result.tier.toUpperCase()} | ${result.reason} |`,
+    ),
+    '',
+    '## Contrato',
+    '',
+    '- Sólo lectura contra R2, Google Books y Library of Congress SRU.',
+    '- No se modifica ninguna ficha, sitemap, canonical, Worker, R2, D1, KV ni Producción.',
+    '- No se guarda el token OAuth y Library of Congress no requiere secreto.',
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+export async function runSourceCoverage({
+  limit = DEFAULT_LIMIT,
+  outputDir = DEFAULT_OUTPUT_DIR,
+  googleBooksAccessToken = process.env.GOOGLE_BOOKS_ACCESS_TOKEN,
+  googleBooksApiKey = process.env.GOOGLE_BOOKS_API_KEY,
+  locDelayMs = Number(process.env.LIBRARY_OF_CONGRESS_DELAY_MS ?? 150),
+} = {}) {
+  if (!clean(googleBooksAccessToken) && !clean(googleBooksApiKey)) {
+    throw new Error('SOURCE-COVERAGE-2 requiere GOOGLE_BOOKS_ACCESS_TOKEN o GOOGLE_BOOKS_API_KEY.');
+  }
+
+  const catalog = await fetchAndConsolidate();
+  const { selected, missing_catalog_ids: missingCatalogIds } = selectResearchCohort({
+    cohort: PAUSED_SEO_COHORT,
+    catalogItems: catalog.items,
+    limit,
+  });
+
+  const googleByIsbn = new Map();
+  const libraryByIsbn = new Map();
+  const googleAttempts = [];
+  const libraryAttempts = [];
+
+  for (const item of selected) {
+    try {
+      const records = await fetchGoogleBooksEvidence(item.isbn, {
+        accessToken: googleBooksAccessToken,
+        apiKey: googleBooksApiKey,
+      });
+      googleByIsbn.set(item.isbn, records);
+      googleAttempts.push({ isbn: item.isbn, ok: true, record_count: records.length });
+    } catch (error) {
+      googleByIsbn.set(item.isbn, []);
+      googleAttempts.push({ isbn: item.isbn, ok: false, record_count: 0, error: error?.message || String(error) });
+    }
+
+    try {
+      const records = await fetchLibraryOfCongressEvidence(item.isbn);
+      libraryByIsbn.set(item.isbn, records);
+      libraryAttempts.push({ isbn: item.isbn, ok: true, record_count: records.length });
+    } catch (error) {
+      libraryByIsbn.set(item.isbn, []);
+      libraryAttempts.push({ isbn: item.isbn, ok: false, record_count: 0, error: error?.message || String(error) });
+    }
+
+    if (Number.isFinite(locDelayMs) && locDelayMs > 0) await sleep(Math.min(locDelayMs, 2_000));
+  }
+
+  const classifications = selected.map(item => classifyBookIntelligenceEvidence(item, [
+    ...(googleByIsbn.get(item.isbn) || []),
+    ...(libraryByIsbn.get(item.isbn) || []),
+  ]));
+  const results = selected.map((item, index) => buildCoverageResult(
+    item,
+    classifications[index],
+    googleByIsbn.get(item.isbn) || [],
+    libraryByIsbn.get(item.isbn) || [],
+  ));
+  const librarySummary = sourceSummary(libraryAttempts);
+  librarySummary.substantive_matches = results.filter(result => result.library_of_congress_substantive_records > 0).length;
+
+  const report = {
+    schema_version: 1,
+    run: 'FICHAS-VIDRIERA-2/SOURCE-COVERAGE-2',
+    generated_at: new Date().toISOString(),
+    cohort: {
+      requested: positiveInteger(limit, DEFAULT_LIMIT),
+      selected: selected.length,
+      demand_only: true,
+      missing_catalog_ids: missingCatalogIds,
+      total_impressions: selected.reduce((sum, item) => sum + (Number(item.research?.gsc_impressions) || 0), 0),
+      total_clicks: selected.reduce((sum, item) => sum + (Number(item.research?.gsc_clicks) || 0), 0),
+    },
+    catalog: {
+      fetched_at: catalog.fetched_at,
+      total_items: catalog.items.length,
+      active_total_raw: catalog.sources?.active_total_raw ?? null,
+      paused_total_raw: catalog.sources?.paused_total_raw ?? null,
+      paused_manifest_version: catalog.sources?.paused_manifest_version ?? null,
+    },
+    sources: {
+      google_books: sourceSummary(googleAttempts),
+      library_of_congress: librarySummary,
+    },
+    classification: summarizeBookIntelligenceEvidence(classifications),
+    results,
+  };
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(path.join(outputDir, 'source-coverage-2-report.json'), JSON.stringify(report, null, 2));
+  await writeFile(path.join(outputDir, 'report-summary.md'), coverageMarkdown(report));
+
+  if (googleAttempts.length && !googleAttempts.some(attempt => attempt.ok)) {
+    throw new Error('Google Books no completó ninguna consulta HTTP.');
+  }
+  if (libraryAttempts.length && !libraryAttempts.some(attempt => attempt.ok)) {
+    throw new Error('Library of Congress SRU no completó ninguna consulta HTTP.');
+  }
+
+  return report;
+}
+
+function cliOptions(argv) {
+  const options = {
+    limit: positiveInteger(process.env.BOOK_INTELLIGENCE_LIMIT, DEFAULT_LIMIT),
+    outputDir: process.env.BOOK_INTELLIGENCE_OUTPUT_DIR || DEFAULT_OUTPUT_DIR,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (flag === '--limit') options.limit = positiveInteger(argv[++index], DEFAULT_LIMIT);
+    else if (flag === '--output-dir') options.outputDir = argv[++index];
+    else throw new Error(`Argumento desconocido: ${flag}`);
+  }
+  return options;
+}
+
+async function main() {
+  const report = await runSourceCoverage(cliOptions(process.argv.slice(2)));
+  console.log(JSON.stringify({
+    run: report.run,
+    cohort: report.cohort,
+    sources: report.sources,
+    classification: report.classification,
+  }, null, 2));
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  main().catch(error => {
+    console.error(`[source-coverage-2] ERROR: ${error?.message || error}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Objetivo

Medir una segunda fuente bibliográfica fuerte para FICHAS-VIDRIERA-2 después de que RESEARCH-RUN-1 demostrara que Google Books + Open Library no alcanza.

Este PR está **apilado sobre #219** y sigue siendo sólo investigación/read-only.

## Fuente nueva

Library of Congress LCDB vía SRU 1.1 + MARCXML:

- endpoint oficial HTTPS;
- búsqueda exacta `bath.isbn`;
- sin API key, usuario ni contraseña;
- revalidación obligatoria del ISBN dentro de MARC `020$a`;
- extracción de título, autor, editorial, año, páginas, idioma, resumen 520 y materias 6XX;
- la evidencia entra como `library_catalog`, familia fuerte independiente.

## Corrida

Misma cohorte técnica de 12 ISBN `gsc-demand` usada en RESEARCH-RUN-1.

Se comparan Google Books + Library of Congress y se recalculan GREEN/YELLOW/RED. Open Library no se vuelve a gastar en esta prueba porque ya dio 0/12 en el lote anterior.

## Gate

1. tests sintéticos MARCXML;
2. conectividad SRU real;
3. 12/12 intentos controlados o errores explícitos;
4. reporte de cobertura exacta y cobertura semántica;
5. medir cambio real de tiers antes de integrar la fuente al caché permanente.

## Seguridad

Sólo lectura. No cambia HTML público, renderer, sitemap, canonical, R2, D1, KV, Worker, checkout ni Producción. No agrega secretos.

**MANTENER DRAFT. NO MERGEAR. NO PRODUCCIÓN.**