### PR TITLE
HOME-DISCOVERY-1: buscador primero + categorías visuales

### DIFF
--- a/astro-front/src/components/BestsellerSection.astro
+++ b/astro-front/src/components/BestsellerSection.astro
@@ -43,9 +43,9 @@ try {
 {missing
   ? <Fragment set:html="<!-- novedades: home.json no encontrado en build — sección omitida -->" />
   : (books.length > 0 && (
-      <section class="bs-section">
+      <section id="incorporaciones-recientes" class="bs-section" aria-labelledby="incorporaciones-recientes-title">
         <div class="bs-inner">
-          <h2 class="bs-heading">Incorporaciones recientes</h2>
+          <h2 id="incorporaciones-recientes-title" class="bs-heading">Incorporaciones recientes</h2>
           <div class="bs-grid">
             {books.map(book => <BookCard book={book} />)}
           </div>
@@ -59,6 +59,7 @@ try {
   .bs-section {
     background: var(--bg);
     border-top: 1px solid var(--border);
+    scroll-margin-top: 6rem;
   }
 
   .bs-inner {

--- a/astro-front/src/components/CategoryAccess.astro
+++ b/astro-front/src/components/CategoryAccess.astro
@@ -1,40 +1,25 @@
 ---
-// HOME — ACCESO A CATEGORÍAS
-// Acceso visual compacto a las categorías principales, conectado con el
-// filtro ?categoria= de /catalogo. Mismo patrón de BestsellerSection: lee
-// un JSON estático en build time (fs), sin JS cliente, sin llamada nueva
-// en runtime. No toca checkout, Mercado Pago ni fichas individuales.
-//
-// Fuente: astro-front/public/data/active-categories.json — el mismo
-// artefacto que consume functions/catalogo.js (scripts/categorize/
-// export-active-categories.js). No se regenera en cada deploy: se
-// actualiza cuando se vuelve a correr el pipeline de clasificación y se
-// commitea, igual que en el catálogo.
+// HOME-DISCOVERY-1 — acceso visual a categorías.
+// Usa el artefacto real de categorías para mostrar cantidades, pero las
+// tarjetas y destinos son una selección editorial cerrada. No agrega JS de
+// cliente ni nuevas llamadas en runtime.
 import fs from 'node:fs';
 import path from 'node:path';
 
 const CATEGORIES_JSON = path.resolve(process.cwd(), 'public/data/active-categories.json');
 
-interface Category {
+interface Subcategory {
   id: string;
   name: string;
   count: number;
 }
 
-// Allowlist SEO: solo estas categorías tienen una landing limpia e
-// indexable. Mantener cerrada evita enlazar automáticamente categorías
-// débiles o catch-all a páginas que Google no debería indexar.
-const SEO_CATEGORY_IDS = [
-  'infantil-juvenil',
-  'esoterismo-tarot',
-  'medicina-salud',
-  'literatura-ficcion',
-  'idiomas-aprendizaje',
-  'psicologia',
-  'desarrollo-personal',
-  'religion-espiritualidad',
-];
-const seoOrder = new Map(SEO_CATEGORY_IDS.map((id, index) => [id, index]));
+interface Category {
+  id: string;
+  name: string;
+  count: number;
+  subcategories?: Subcategory[];
+}
 
 let categories: Category[] = [];
 let missing = false;
@@ -42,173 +27,364 @@ let missing = false;
 try {
   const raw = fs.readFileSync(CATEGORIES_JSON, 'utf-8');
   const data = JSON.parse(raw) as { categories: Category[] };
-  categories = (data.categories || [])
-    .filter(c => seoOrder.has(c.id))
-    .sort((a, b) => seoOrder.get(a.id)! - seoOrder.get(b.id)!);
+  categories = data.categories || [];
 } catch (e: unknown) {
   missing = true;
   const msg = e instanceof Error ? e.message : String(e);
   console.warn('[CategoryAccess] active-categories.json no disponible en build:', msg);
 }
+
+function countFor(categoryId?: string, subcategoryId?: string) {
+  if (!categoryId) return null;
+  const category = categories.find(item => item.id === categoryId);
+  if (!category) return null;
+  if (!subcategoryId) return category.count;
+  return category.subcategories?.find(item => item.id === subcategoryId)?.count ?? null;
+}
+
+const cards = [
+  {
+    label: 'Tarot y oráculos',
+    description: 'Mazos, oráculos y libros para aprender',
+    href: '/catalogo?categoria=esoterismo-tarot&subcategoria=tarot-oraculos',
+    categoryId: 'esoterismo-tarot',
+    subcategoryId: 'tarot-oraculos',
+    theme: 'tarot',
+    visual: 'TAROT',
+  },
+  {
+    label: 'Psicología',
+    description: 'Clínica, psicoanálisis, vínculos y mente',
+    href: '/libros/psicologia',
+    categoryId: 'psicologia',
+    theme: 'psychology',
+    visual: 'MENTE',
+  },
+  {
+    label: 'Nuevos',
+    description: 'Los últimos libros incorporados al catálogo',
+    href: '#incorporaciones-recientes',
+    theme: 'new',
+    visual: 'NUEVOS',
+  },
+  {
+    label: 'Infantil',
+    description: 'Cuentos, primeras lecturas y actividades',
+    href: '/libros/infantil-juvenil',
+    categoryId: 'infantil-juvenil',
+    theme: 'kids',
+    visual: 'LEER',
+  },
+  {
+    label: 'Educación',
+    description: 'Pedagogía, formación docente y aprendizaje',
+    href: '/catalogo?categoria=educacion',
+    categoryId: 'educacion',
+    theme: 'education',
+    visual: 'APRENDER',
+  },
+  {
+    label: 'Literatura y ficción',
+    description: 'Novela, cuento, policial, fantasía y más',
+    href: '/libros/literatura-ficcion',
+    categoryId: 'literatura-ficcion',
+    theme: 'fiction',
+    visual: 'HISTORIAS',
+  },
+  {
+    label: 'Desarrollo personal',
+    description: 'Hábitos, bienestar, vínculos y crecimiento',
+    href: '/libros/desarrollo-personal',
+    categoryId: 'desarrollo-personal',
+    theme: 'growth',
+    visual: 'CRECER',
+  },
+  {
+    label: 'Espiritualidad',
+    description: 'Religión, Biblias y búsquedas espirituales',
+    href: '/libros/religion-espiritualidad',
+    categoryId: 'religion-espiritualidad',
+    theme: 'spirituality',
+    visual: 'CALMA',
+  },
+].map(card => ({ ...card, count: countFor(card.categoryId, card.subcategoryId) }));
 ---
 
-{missing
-  ? <Fragment set:html="<!-- acceso a categorías: active-categories.json no encontrado en build — sección omitida -->" />
-  : (categories.length > 0 && (
-      <section class="ca-section" aria-label="Categorías del catálogo">
-        <div class="ca-inner">
-          <h2 class="ca-heading">Explorá por categoría</h2>
-          <div class="ca-row" role="list">
-            {categories.map(cat => (
-              <a
-                class="ca-chip"
-                href={`/libros/${encodeURIComponent(cat.id)}`}
-                role="listitem"
-              >
-                <span class="ca-chip-name">{cat.name}</span>
-                <span class="ca-chip-count">{cat.count} títulos</span>
-                <span class="ca-chip-scope">Disponibles y por encargo</span>
-              </a>
-            ))}
-            <a class="ca-chip ca-chip-all" href="/catalogo">
-              Ver todo el catálogo →
-            </a>
-          </div>
-        </div>
-      </section>
-    ))
-}
+<section class="ca-section" aria-labelledby="category-access-title">
+  <div class="ca-inner">
+    <div class="ca-heading-wrap">
+      <p class="ca-kicker">Explorá el catálogo</p>
+      <h2 id="category-access-title" class="ca-heading">Descubrí libros por categoría.</h2>
+      <p class="ca-intro">Entrá directo a lo que te interesa. Cada tarjeta abre una colección real del catálogo.</p>
+    </div>
+
+    <div class="ca-grid" role="list">
+      {cards.map(card => (
+        <a class="ca-card" href={card.href} data-theme={card.theme} role="listitem">
+          <span class="ca-visual" aria-hidden="true">
+            {card.theme === 'tarot' ? (
+              <span class="tarot-fan">
+                <i>☼</i><i>✦</i><i>☾</i>
+              </span>
+            ) : (
+              <span class="book-scene">
+                <i class="book-back"></i>
+                <i class="book-main"><b>{card.visual}</b></i>
+                <i class="book-side"></i>
+              </span>
+            )}
+          </span>
+
+          <span class="ca-copy">
+            <strong>{card.label}</strong>
+            <small>{card.description}</small>
+            <span class="ca-meta">
+              {card.count ? `${card.count.toLocaleString('es-UY')} títulos` : 'Ver selección'}
+              <b aria-hidden="true">→</b>
+            </span>
+          </span>
+        </a>
+      ))}
+    </div>
+
+    <a class="ca-all" href="/catalogo">Ver todas las categorías y libros <span aria-hidden="true">→</span></a>
+    {missing && <span class="sr-only">Las cantidades por categoría no están disponibles en este build.</span>}
+  </div>
+</section>
 
 <style>
   .ca-section {
-    background: var(--surface);
-    border-top: 1px solid var(--border);
+    background: var(--ink);
+    color: #fff;
   }
 
   .ca-inner {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 1.75rem 1.5rem;
+    padding: clamp(2.7rem, 7vw, 4.75rem) 1.25rem;
   }
 
-  @media (min-width: 768px) {
-    .ca-inner { padding: 2.25rem 2rem; }
+  .ca-heading-wrap { max-width: 720px; }
+
+  .ca-kicker {
+    margin: 0;
+    color: var(--salmon);
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
   }
 
   .ca-heading {
+    max-width: 16ch;
+    margin: 0.45rem 0 0;
+    color: #fff;
     font-family: var(--font-display);
+    font-size: clamp(2rem, 6vw, 3.35rem);
     font-weight: 700;
-    font-size: clamp(1.125rem, 2.4vw, 1.375rem);
-    color: var(--ink);
-    letter-spacing: -0.01em;
-    margin-bottom: 1rem;
+    letter-spacing: -0.035em;
+    line-height: 1.04;
   }
 
-  /* Mobile (HOME-UX-MOBILE-1 punto 2): grilla compacta de 2 columnas
-     iguales, sin scroll horizontal — antes era una fila con scroll que
-     escondía categorías sin que fuera evidente que había que arrastrar.
-     Nombre arriba (puede ocupar 2 líneas), cantidad debajo y
-     visualmente secundaria. */
-  .ca-row {
+  .ca-intro {
+    max-width: 58ch;
+    margin: 0.8rem 0 0;
+    color: rgba(255,255,255,0.72);
+    font-size: 0.94rem;
+    line-height: 1.55;
+  }
+
+  .ca-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.6rem;
+    gap: 0.75rem;
+    margin-top: 1.8rem;
   }
 
-  .ca-chip {
+  .ca-card {
     display: flex;
+    min-width: 0;
     flex-direction: column;
-    align-items: flex-start;
-    gap: 0.2rem;
-    min-height: 3.25rem;
-    padding: 0.75rem 0.9rem;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: var(--r);
-    color: var(--ink);
-    font-family: var(--font-ui);
-    font-size: 0.85rem;
-    font-weight: 600;
-    text-decoration: none;
-    white-space: normal;
-    overflow-wrap: break-word;
-    transition: background 0.15s, border-color 0.15s, transform 0.15s;
-  }
-
-  .ca-chip:hover {
-    background: rgba(228, 153, 130, 0.12);
-    border-color: var(--salmon);
-    transform: translateY(-1px);
-  }
-
-  .ca-chip-name {
-    line-height: 1.3;
-  }
-
-  .ca-chip-count {
-    color: var(--ink-2);
-    font-weight: 500;
-    font-size: 0.75rem;
-  }
-
-  .ca-chip-scope {
-    color: var(--ink-2);
-    font-weight: 500;
-    font-size: 0.68rem;
-    line-height: 1.2;
-  }
-
-  .ca-chip-all {
-    grid-column: 1 / -1;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    background: var(--ink);
-    border-color: var(--ink);
+    overflow: hidden;
+    border: 1px solid rgba(255,255,255,0.14);
+    border-radius: 0.95rem;
+    background: rgba(255,255,255,0.055);
     color: #fff;
+    text-decoration: none;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.08);
+    transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
   }
 
-  .ca-chip-all:hover {
-    background: var(--salmon-hover);
-    border-color: var(--salmon-hover);
+  .ca-card:hover,
+  .ca-card:focus-visible {
+    transform: translateY(-3px);
+    border-color: var(--salmon);
+    box-shadow: 0 14px 34px rgba(0,0,0,0.2), 0 0 0 1px rgba(228,153,130,0.32);
+    outline: none;
   }
 
-  /* Desktop (>=700px): presentación anterior — pill de una línea, nombre
-     y cantidad lado a lado, grid de 3 columnas. Queda igual que antes de
-     este lote. */
+  .ca-visual {
+    position: relative;
+    display: grid;
+    min-height: 118px;
+    place-items: center;
+    overflow: hidden;
+    background: linear-gradient(145deg, #40352f, #201a17);
+  }
+
+  .ca-card[data-theme='tarot'] .ca-visual { background: radial-gradient(circle at 72% 20%, #5b4665, transparent 28%), linear-gradient(145deg, #2b2137, #17131d); }
+  .ca-card[data-theme='psychology'] .ca-visual { background: linear-gradient(145deg, #49645c, #263a34); }
+  .ca-card[data-theme='new'] .ca-visual { background: linear-gradient(145deg, #eadfc9, #bfa985); }
+  .ca-card[data-theme='kids'] .ca-visual { background: linear-gradient(145deg, #a9d3cf, #e0b88c); }
+  .ca-card[data-theme='education'] .ca-visual { background: linear-gradient(145deg, #53665a, #2d3d36); }
+  .ca-card[data-theme='fiction'] .ca-visual { background: linear-gradient(145deg, #80624d, #3f3028); }
+  .ca-card[data-theme='growth'] .ca-visual { background: linear-gradient(145deg, #b9836d, #6a514a); }
+  .ca-card[data-theme='spirituality'] .ca-visual { background: linear-gradient(145deg, #66546f, #332b3b); }
+
+  .book-scene {
+    position: relative;
+    width: 94px;
+    height: 86px;
+  }
+
+  .book-scene i {
+    position: absolute;
+    display: grid;
+    place-items: center;
+    border-radius: 3px 6px 6px 3px;
+    box-shadow: 0 8px 20px rgba(0,0,0,0.2);
+    font-style: normal;
+  }
+
+  .book-back {
+    left: 2px;
+    bottom: 4px;
+    width: 48px;
+    height: 64px;
+    transform: rotate(-8deg);
+    background: rgba(255,255,255,0.4);
+  }
+
+  .book-main {
+    z-index: 2;
+    left: 27px;
+    top: 2px;
+    width: 58px;
+    height: 78px;
+    padding: 6px;
+    background: #f6efe4;
+    color: #58463c;
+    text-align: center;
+  }
+
+  .book-main b {
+    font-family: var(--font-display);
+    font-size: 0.62rem;
+    letter-spacing: 0.06em;
+    line-height: 1.05;
+    overflow-wrap: anywhere;
+  }
+
+  .book-side {
+    right: 0;
+    bottom: 5px;
+    width: 32px;
+    height: 55px;
+    transform: rotate(7deg);
+    background: rgba(24,18,14,0.5);
+  }
+
+  .ca-card[data-theme='new'] .book-main,
+  .ca-card[data-theme='kids'] .book-main { background: #fff8eb; }
+  .ca-card[data-theme='psychology'] .book-main,
+  .ca-card[data-theme='education'] .book-main { background: #dfe9df; color: #31443c; }
+  .ca-card[data-theme='growth'] .book-main { background: #f0d3c3; color: #70483c; }
+  .ca-card[data-theme='spirituality'] .book-main { background: #d6c6da; color: #4b3654; }
+
+  .tarot-fan {
+    position: relative;
+    width: 104px;
+    height: 88px;
+  }
+
+  .tarot-fan i {
+    position: absolute;
+    top: 5px;
+    display: grid;
+    width: 49px;
+    height: 72px;
+    place-items: center;
+    border: 2px solid #d4ae58;
+    border-radius: 5px;
+    background: #203759;
+    color: #e9c96e;
+    font-size: 1.65rem;
+    font-style: normal;
+    box-shadow: 0 8px 20px rgba(0,0,0,0.3);
+  }
+
+  .tarot-fan i:nth-child(1) { left: 2px; transform: rotate(-13deg); }
+  .tarot-fan i:nth-child(2) { left: 28px; z-index: 2; }
+  .tarot-fan i:nth-child(3) { right: 2px; transform: rotate(13deg); }
+
+  .ca-copy {
+    display: flex;
+    min-height: 120px;
+    flex: 1;
+    flex-direction: column;
+    padding: 0.85rem;
+  }
+
+  .ca-copy strong {
+    color: #fff;
+    font-size: 0.88rem;
+    line-height: 1.25;
+  }
+
+  .ca-copy small {
+    margin-top: 0.3rem;
+    color: rgba(255,255,255,0.65);
+    font-size: 0.7rem;
+    line-height: 1.35;
+  }
+
+  .ca-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.4rem;
+    margin-top: auto;
+    padding-top: 0.7rem;
+    color: var(--salmon);
+    font-size: 0.68rem;
+    font-weight: 800;
+  }
+
+  .ca-meta b { font-size: 1rem; }
+
+  .ca-all {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin-top: 1.35rem;
+    color: var(--salmon);
+    font-size: 0.82rem;
+    font-weight: 800;
+    text-underline-offset: 0.2em;
+  }
+
+  .ca-all:hover { color: #fff; }
+
   @media (min-width: 700px) {
-    .ca-row {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-    }
+    .ca-inner { padding-right: 2rem; padding-left: 2rem; }
+    .ca-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 0.9rem; }
+    .ca-visual { min-height: 165px; }
+    .ca-copy { min-height: 132px; padding: 1rem; }
+    .ca-copy strong { font-size: 0.96rem; }
+    .ca-copy small { font-size: 0.74rem; }
+  }
 
-    .ca-chip {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) auto;
-      align-items: center;
-      gap: 0.4rem;
-      min-height: 0;
-      padding: 0.6rem 1rem;
-      border-radius: 999px;
-    }
-
-    .ca-chip-name {
-      grid-row: 1 / 3;
-    }
-
-    .ca-chip-count,
-    .ca-chip-scope {
-      text-align: right;
-      white-space: nowrap;
-    }
-
-    .ca-chip-scope {
-      font-size: 0.62rem;
-    }
-
-    .ca-chip-all {
-      display: flex;
-      max-width: 260px;
-      margin: 0 auto;
-    }
+  @media (min-width: 1200px) {
+    .ca-inner { padding-right: 0; padding-left: 0; }
   }
 </style>

--- a/astro-front/src/components/Hero.astro
+++ b/astro-front/src/components/Hero.astro
@@ -1,21 +1,22 @@
 ---
 ---
 
-<section class="hero-shell">
+<section class="hero-shell" aria-labelledby="hero-title">
   <div class="hero">
     <div class="hero-content">
-      <span class="hero-badge">Librería uruguaya</span>
+      <span class="hero-badge">Librería uruguaya · búsqueda especializada</span>
 
-      <h1 class="hero-h1">Especialistas en libros difíciles de conseguir.</h1>
+      <h1 id="hero-title" class="hero-h1">Encontrá el libro que estás buscando.</h1>
 
       <p class="hero-lead">
-        Buscá entre nuestros libros disponibles o pedinos ediciones agotadas e importadas de Europa y otros mercados.
+        Buscá por título, autor o ISBN. Si no aparece, también conseguimos libros agotados,
+        importados y ediciones difíciles de ubicar.
       </p>
 
       <form class="hero-search" action="/catalogo" method="get" role="search">
         <label class="sr-only" for="hero-search-input">Buscar por título, autor o ISBN</label>
         <span class="hero-search-icon" aria-hidden="true">
-          <svg width="23" height="23" viewBox="0 0 24 24" fill="none">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
             <circle cx="10.5" cy="10.5" r="6.5" stroke="currentColor" stroke-width="1.8"/>
             <path d="m15.5 15.5 5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
           </svg>
@@ -30,95 +31,20 @@
         >
         <button type="submit">Buscar</button>
       </form>
+
+      <div class="hero-secondary">
+        <span>¿No aparece?</span>
+        <a href="/pedir-libro?tipo=exacto">Contanos qué libro buscás <span aria-hidden="true">→</span></a>
+      </div>
     </div>
-
-    <aside class="hero-commercial" aria-label="Ventajas de comprar en Amado Libros">
-      <div class="commercial-heading">
-        <span>Comprar en Amado Libros</span>
-        <h2>Claro, rápido y con atención personal.</h2>
-      </div>
-
-      <ul class="benefit-grid" role="list">
-        <li>
-          <span class="benefit-icon" aria-hidden="true">
-            <svg viewBox="0 0 32 32" fill="none">
-              <path d="M3 19h17V9H3v10Zm17-7h5l4 5v2h-9v-7Z" stroke="currentColor" stroke-width="1.8"/>
-              <circle cx="8" cy="22" r="2.5" stroke="currentColor" stroke-width="1.8"/>
-              <circle cx="24" cy="22" r="2.5" stroke="currentColor" stroke-width="1.8"/>
-            </svg>
-          </span>
-          <span>
-            <strong>Entrega en 2 horas*</strong>
-            <small>En Montevideo</small>
-          </span>
-        </li>
-
-        <li>
-          <span class="benefit-icon" aria-hidden="true">
-            <svg viewBox="0 0 32 32" fill="none">
-              <rect x="3.5" y="7" width="25" height="18" rx="3" stroke="currentColor" stroke-width="1.8"/>
-              <path d="M4 12h24M8 20h7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
-            </svg>
-          </span>
-          <span>
-            <strong>Hasta 12 cuotas</strong>
-            <small>Con Mercado Pago</small>
-          </span>
-        </li>
-
-        <li>
-          <span class="benefit-icon" aria-hidden="true">
-            <svg viewBox="0 0 32 32" fill="none">
-              <path d="M6 10.5A4.5 4.5 0 1 0 15 10.5a4.5 4.5 0 0 0-9 0ZM17 21.5a4.5 4.5 0 1 0 9 0 4.5 4.5 0 0 0-9 0Z" stroke="currentColor" stroke-width="1.8"/>
-              <path d="m8 26 16-20" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-          </span>
-          <span>
-            <strong>12% menos</strong>
-            <small>Pagando por transferencia</small>
-          </span>
-        </li>
-
-        <li>
-          <span class="benefit-icon" aria-hidden="true">
-            <svg viewBox="0 0 32 32" fill="none">
-              <circle cx="14.5" cy="15.5" r="9.5" stroke="currentColor" stroke-width="1.8"/>
-              <path d="M5 15.5h19M14.5 6c3.4 3.3 4.5 6.5 4.5 9.5S17.9 21.7 14.5 25M14.5 6C11.1 9.3 10 12.5 10 15.5s1.1 6.2 4.5 9.5" stroke="currentColor" stroke-width="1.6"/>
-              <path d="m22 22 6 6M23.5 18.5v7M20 22h7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
-            </svg>
-          </span>
-          <span>
-            <strong>Libros por encargo</strong>
-            <small>Europa y otros mercados</small>
-          </span>
-        </li>
-      </ul>
-
-      <p class="delivery-disclaimer">*El plazo depende de la zona y del horario del pedido. Coordinamos la entrega con vos.</p>
-
-      <div class="request-box">
-        <div>
-          <strong>¿No encontrás el libro?</strong>
-          <span>Buscamos agotados, importados y ediciones difíciles.</span>
-          <a class="request-guide" href="/libros-agotados-importados-uruguay">
-            Cómo funciona nuestro servicio de encargos →
-          </a>
-        </div>
-        <a
-          href="/pedir-libro?tipo=exacto"
-          aria-label="Contar qué libro buscás"
-        >
-          Contanos qué libro buscás
-        </a>
-      </div>
-    </aside>
   </div>
 </section>
 
 <style>
   .hero-shell {
     background:
-      radial-gradient(circle at 18% 30%, rgba(228, 153, 130, 0.1), transparent 34%),
+      radial-gradient(circle at 18% 24%, rgba(228, 153, 130, 0.16), transparent 34%),
+      radial-gradient(circle at 84% 10%, rgba(228, 153, 130, 0.08), transparent 28%),
       var(--bg);
     border-bottom: 1px solid var(--border);
   }
@@ -126,63 +52,63 @@
   .hero {
     max-width: 1200px;
     margin: 0 auto;
-    display: grid;
   }
 
   .hero-content {
     display: flex;
+    min-height: 390px;
     flex-direction: column;
     justify-content: center;
-    padding: 2rem 1.25rem;
+    padding: clamp(3rem, 9vw, 6.5rem) 1.25rem;
   }
 
   .hero-badge {
     align-self: flex-start;
-    margin-bottom: 0.8rem;
+    margin-bottom: 0.85rem;
     color: var(--salmon-hover);
-    font-size: 0.6875rem;
+    font-size: 0.7rem;
     font-weight: 800;
     letter-spacing: 0.09em;
     text-transform: uppercase;
   }
 
   .hero-h1 {
-    max-width: 12.5ch;
+    max-width: 16ch;
     color: var(--ink);
     font-family: var(--font-display);
-    font-size: clamp(2.05rem, 7vw, 3.8rem);
+    font-size: clamp(2.35rem, 8vw, 4.7rem);
     font-weight: 700;
-    letter-spacing: -0.035em;
-    line-height: 1.04;
+    letter-spacing: -0.045em;
+    line-height: 0.98;
   }
 
   .hero-lead {
-    max-width: 48ch;
-    margin-top: 1rem;
+    max-width: 62ch;
+    margin-top: 1.15rem;
     color: var(--ink-2);
-    font-size: clamp(0.96rem, 2vw, 1.08rem);
-    line-height: 1.55;
+    font-size: clamp(1rem, 2vw, 1.12rem);
+    line-height: 1.6;
   }
 
   .hero-search {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: center;
-    gap: 0.65rem;
+    gap: 0.7rem;
     width: 100%;
-    max-width: 650px;
-    margin-top: 1.35rem;
-    padding: 0.4rem;
+    max-width: 760px;
+    margin-top: 1.55rem;
+    padding: 0.45rem;
     padding-left: 1rem;
     background: var(--surface);
     border: 1.5px solid #d8cfc4;
-    border-radius: 0.875rem;
-    box-shadow: 0 8px 28px rgba(24, 18, 14, 0.06);
+    border-radius: 1rem;
+    box-shadow: 0 14px 38px rgba(24, 18, 14, 0.08);
   }
 
   .hero-search:focus-within {
     border-color: var(--salmon);
-    box-shadow: 0 0 0 4px rgba(228, 153, 130, 0.14);
+    box-shadow: 0 0 0 4px rgba(228, 153, 130, 0.14), 0 14px 38px rgba(24, 18, 14, 0.08);
   }
 
   .hero-search-icon {
@@ -193,7 +119,7 @@
   .hero-search input {
     min-width: 0;
     width: 100%;
-    padding: 0.68rem 0;
+    padding: 0.82rem 0;
     border: 0;
     outline: 0;
     background: transparent;
@@ -207,13 +133,13 @@
   }
 
   .hero-search button {
-    min-height: 44px;
-    padding: 0.7rem 1.35rem;
+    min-height: 48px;
+    padding: 0.8rem 1.55rem;
     border: 0;
-    border-radius: 0.65rem;
+    border-radius: 0.72rem;
     background: var(--salmon);
     color: #fff;
-    font: 700 0.95rem/1 var(--font-ui);
+    font: 800 0.95rem/1 var(--font-ui);
     cursor: pointer;
     transition: background 0.15s, transform 0.15s;
   }
@@ -221,212 +147,47 @@
   .hero-search button:hover { background: var(--salmon-hover); }
   .hero-search button:active { transform: translateY(1px); }
 
-  .hero-commercial {
-    padding: 1.4rem 1.25rem 1.6rem;
-    border-top: 1px solid var(--border);
-    background: var(--ink);
-    color: #fff;
-  }
-
-  .commercial-heading > span {
-    color: var(--salmon);
-    font-size: 0.68rem;
-    font-weight: 800;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  .commercial-heading h2 {
-    max-width: 22ch;
-    margin-top: 0.35rem;
-    color: #fff;
-    font-family: var(--font-display);
-    font-size: clamp(1.4rem, 4.5vw, 1.8rem);
-    line-height: 1.12;
-  }
-
-  .benefit-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.65rem;
-    margin-top: 1.1rem;
-    padding: 0;
-    list-style: none;
-  }
-
-  .benefit-grid li {
+  .hero-secondary {
     display: flex;
-    align-items: center;
-    gap: 0.65rem;
-    min-width: 0;
-    padding: 0.7rem;
-    border: 1px solid rgba(255, 255, 255, 0.14);
-    border-radius: 0.75rem;
-    background: rgba(255, 255, 255, 0.06);
+    flex-wrap: wrap;
+    gap: 0.35rem 0.55rem;
+    margin-top: 0.9rem;
+    color: var(--ink-2);
+    font-size: 0.82rem;
   }
 
-  .benefit-icon {
-    display: flex;
-    flex: 0 0 auto;
-    width: 28px;
-    height: 28px;
-    color: var(--salmon);
-  }
-
-  .benefit-icon svg {
-    width: 100%;
-    height: 100%;
-  }
-
-  .benefit-grid strong,
-  .benefit-grid small {
-    display: block;
-  }
-
-  .benefit-grid strong {
-    color: #fff;
-    font-size: 0.8rem;
-    line-height: 1.2;
-  }
-
-  .benefit-grid small {
-    margin-top: 0.2rem;
-    color: rgba(255, 255, 255, 0.72);
-    font-size: 0.68rem;
-    line-height: 1.25;
-  }
-
-  .delivery-disclaimer {
-    margin-top: 0.6rem;
-    color: rgba(255, 255, 255, 0.5);
-    font-size: 0.68rem;
-    line-height: 1.4;
-  }
-
-  .request-box {
-    display: grid;
-    gap: 0.85rem;
-    margin-top: 1rem;
-    padding-top: 1rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.16);
-  }
-
-  .request-box strong,
-  .request-box span {
-    display: block;
-  }
-
-  .request-box .request-guide {
-    display: inline-block;
-    min-height: 0;
-    margin-top: 0.45rem;
-    padding: 0;
-    border-radius: 0;
-    background: transparent;
-    color: #fff;
-    font-size: 0.76rem;
-    font-weight: 700;
-    line-height: 1.35;
-    text-align: left;
-    text-decoration: underline;
-    text-decoration-color: rgba(255, 255, 255, 0.45);
-    text-underline-offset: 0.18em;
-  }
-
-  .request-box .request-guide:hover {
-    background: transparent;
-    text-decoration-color: #fff;
-  }
-
-  .request-box strong {
-    color: #fff;
-    font-size: 0.95rem;
-  }
-
-  .request-box span {
-    margin-top: 0.2rem;
-    color: rgba(255, 255, 255, 0.72);
-    font-size: 0.78rem;
-  }
-
-  .request-box a {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 46px;
-    padding: 0.75rem 1rem;
-    border-radius: 0.65rem;
-    background: var(--salmon);
-    color: #fff;
-    font-size: 0.84rem;
+  .hero-secondary a {
+    color: var(--ink);
     font-weight: 800;
-    line-height: 1.15;
-    text-align: center;
-    text-decoration: none;
-    transition: background 0.15s, transform 0.15s;
+    text-decoration-color: rgba(24, 18, 14, 0.28);
+    text-underline-offset: 0.2em;
   }
 
-  .request-box a:hover { background: var(--salmon-hover); }
-  .request-box a:active { transform: translateY(1px); }
+  .hero-secondary a:hover { color: var(--salmon-hover); }
 
   @media (min-width: 700px) {
-    .hero-content { padding: 3rem 2rem; }
-
-    .hero-commercial {
-      padding: 2rem;
-    }
-
-    .request-box {
-      grid-template-columns: minmax(0, 1fr) auto;
-      align-items: center;
-    }
-  }
-
-  @media (min-width: 900px) {
-    .hero {
-      grid-template-columns: minmax(0, 1.08fr) minmax(420px, 0.92fr);
-      min-height: 510px;
-      align-items: stretch;
-    }
-
     .hero-content {
-      padding: 3.5rem 3rem 3.5rem 2rem;
+      min-height: 470px;
+      padding-right: 2rem;
+      padding-left: 2rem;
     }
-
-    .hero-commercial {
-      align-self: center;
-      margin: 2.25rem 2rem 2.25rem 0;
-      padding: 1.75rem;
-      border: 0;
-      border-radius: 1rem;
-      box-shadow: 0 18px 48px rgba(24, 18, 14, 0.18);
-    }
-
-    .benefit-grid li { padding: 0.8rem; }
-    .benefit-grid strong { font-size: 0.84rem; }
-    .benefit-grid small { font-size: 0.72rem; }
   }
 
   @media (min-width: 1200px) {
     .hero-content { padding-left: 0; }
-    .hero-commercial { margin-right: 0; }
   }
 
-  @media (max-width: 430px) {
+  @media (max-width: 520px) {
+    .hero-content { min-height: 0; }
+
     .hero-search {
       grid-template-columns: auto minmax(0, 1fr);
-      padding: 0.55rem 0.75rem;
+      padding: 0.55rem 0.7rem 0.7rem 0.9rem;
     }
 
     .hero-search button {
       grid-column: 1 / -1;
       width: 100%;
     }
-
-    .commercial-heading h2 { max-width: none; }
-  }
-
-  @media (max-width: 350px) {
-    .benefit-grid { grid-template-columns: 1fr; }
   }
 </style>

--- a/astro-front/src/pages/index.astro
+++ b/astro-front/src/pages/index.astro
@@ -72,11 +72,11 @@ const jsonLd = {
   <Header showSearch={false} showMobileDeliveryBanner={true} />
   <main>
     <Hero />
-    <DeliveryCoordination />
     <CategoryAccess />
-    <OrderHubAccess />
     <BestsellerSection />
+    <OrderHubAccess />
     <BookDiscovery />
+    <DeliveryCoordination />
     <GuideAccess />
     <HowToBuy />
     <ShippingPayments />

--- a/functions/__tests__/home-discovery-architecture.test.js
+++ b/functions/__tests__/home-discovery-architecture.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+function read(relativePath) {
+  return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+test('hero queda enfocado en búsqueda y no repite el panel comercial grande', () => {
+  const hero = read('astro-front/src/components/Hero.astro');
+  assert.match(hero, /Encontrá el libro que estás buscando/);
+  assert.match(hero, /action="\/catalogo"/);
+  assert.match(hero, /Contanos qué libro buscás/);
+  assert.doesNotMatch(hero, /Claro, rápido y con atención personal/);
+  assert.doesNotMatch(hero, /Entrega en 2 horas/);
+  assert.doesNotMatch(hero, /Hasta 12 cuotas/);
+  assert.doesNotMatch(hero, /12% menos/);
+});
+
+test('home ofrece categorías visuales con destinos reales y sin inventar más vendidos', () => {
+  const categories = read('astro-front/src/components/CategoryAccess.astro');
+  for (const label of [
+    'Tarot y oráculos',
+    'Psicología',
+    'Nuevos',
+    'Infantil',
+    'Educación',
+    'Literatura y ficción',
+    'Desarrollo personal',
+    'Espiritualidad',
+  ]) {
+    assert.match(categories, new RegExp(label));
+  }
+  assert.match(categories, /categoria=esoterismo-tarot&subcategoria=tarot-oraculos/);
+  assert.match(categories, /\/libros\/psicologia/);
+  assert.match(categories, /#incorporaciones-recientes/);
+  assert.match(categories, /categoria=educacion/);
+  assert.doesNotMatch(categories, /Más vendidos/);
+});
+
+test('jerarquía de la home prioriza búsqueda, categorías y novedades antes de beneficios', () => {
+  const home = read('astro-front/src/pages/index.astro');
+  const hero = home.indexOf('<Hero />');
+  const categories = home.indexOf('<CategoryAccess />');
+  const recent = home.indexOf('<BestsellerSection />');
+  const orderHub = home.indexOf('<OrderHubAccess />');
+  const delivery = home.indexOf('<DeliveryCoordination />');
+  const payments = home.indexOf('<ShippingPayments />');
+
+  assert.ok(hero >= 0);
+  assert.ok(hero < categories);
+  assert.ok(categories < recent);
+  assert.ok(recent < orderHub);
+  assert.ok(orderHub < delivery);
+  assert.ok(delivery < payments);
+});
+
+test('Nuevos apunta a un ancla estable de incorporaciones recientes', () => {
+  const recent = read('astro-front/src/components/BestsellerSection.astro');
+  assert.match(recent, /id="incorporaciones-recientes"/);
+  assert.match(recent, /Incorporaciones recientes/);
+});


### PR DESCRIPTION
## Objetivo

Reordenar la home para priorizar intención de compra y descubrimiento:

**buscador → categorías visuales → incorporaciones recientes → encargos → beneficios**.

## Qué cambia

- el Hero deja de ocupar media primera pantalla con el panel grande de entrega/cuotas/transferencia;
- el buscador pasa a ser el foco principal, con CTA secundario para pedir un libro que no aparece;
- `CategoryAccess` deja de ser una grilla de chips y pasa a 8 tarjetas visuales, mobile-first, sin imágenes externas ni JS cliente;
- destinos reales:
  - Tarot y oráculos → filtro real `esoterismo-tarot / tarot-oraculos`;
  - Psicología → landing SEO existente;
  - Nuevos → ancla real de Incorporaciones recientes;
  - Infantil → landing SEO existente;
  - Educación → filtro real del catálogo;
  - Literatura y ficción → landing SEO existente;
  - Desarrollo personal → landing SEO existente;
  - Espiritualidad → landing SEO existente;
- las cantidades salen del artefacto real `active-categories.json`;
- `DeliveryCoordination` y pagos siguen en la home, pero bajan después de descubrimiento/encargos;
- se agrega ancla estable `#incorporaciones-recientes`;
- se agregan tests de arquitectura para impedir que vuelva el panel comercial grande arriba o que se invente `Más vendidos` sin una fuente de ventas.

## Decisión deliberada: Más vendidos

No se agrega todavía. El componente llamado internamente `BestsellerSection` hoy contiene **incorporaciones recientes**, no ranking de ventas. No se etiqueta como “Más vendidos” hasta tener una métrica real y reproducible.

## Riesgo

Bajo y acotado a la home Astro. No toca checkout, fichas, catálogo SSR, canonical, sitemap, robots, R2, D1, KV ni Workers de producto.

## Gate

Mantener Draft hasta:

1. CI PASS;
2. Preview PASS;
3. revisión visual desktop;
4. revisión visual celular por el usuario.

**NO MERGEAR TODAVÍA. NO PRODUCCIÓN.**