### PR TITLE
STOCK-AVISO-2: confirmación al cliente al registrar aviso de stock

### DIFF
--- a/functions/api/__tests__/stock_waitlist.test.js
+++ b/functions/api/__tests__/stock_waitlist.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   buildStockWaitlistEmail,
+  buildRegistrationConfirmationEmail,
   createStockWaitlistHandler,
 } from '../_stock_waitlist_handler.js';
 
@@ -34,9 +35,11 @@ function env(db, patch = {}) {
 function memoryDb({ duplicate = false } = {}) {
   const rows = new Map();
   const updates = [];
+  const confirmationUpdates = [];
   return {
     rows,
     updates,
+    confirmationUpdates,
     prepare(sql) {
       return {
         bind(...args) {
@@ -64,6 +67,10 @@ function memoryDb({ duplicate = false } = {}) {
               }
               if (sql.startsWith('UPDATE stock_waitlist SET internal_notification_status=')) {
                 updates.push(args);
+                return { meta: { changes: 1 } };
+              }
+              if (sql.startsWith('UPDATE stock_waitlist SET registration_confirmation_status=')) {
+                confirmationUpdates.push(args);
                 return { meta: { changes: 1 } };
               }
               throw new Error(`SQL inesperado: ${sql}`);
@@ -98,9 +105,11 @@ function makeHandler({
     fetchFn: async (...args) => {
       hooks.emailCalls = (hooks.emailCalls || 0) + 1;
       hooks.emailArgs = args;
+      hooks.emailCallArgs = (hooks.emailCallArgs || []).concat([args]);
       return fetchFn(...args);
     },
     getNow: () => NOW,
+    sleep: async () => {},
   });
 }
 
@@ -318,4 +327,174 @@ test('stock-1: el correo escapa HTML y no confía en un título del navegador', 
   assert.match(email.subject, /Libro <agotado>/);
   assert.match(email.html, /Libro &lt;agotado&gt;/);
   assert.doesNotMatch(email.html, /Libro <agotado>/);
+});
+
+// ── STOCK-AVISO-2: confirmación al cliente ──────────────────────────────────
+
+function prodEnvPatch(patch = {}) {
+  return {
+    APP_ENV: 'production',
+    ALLOWED_HOSTS: 'www.amadolibros.com',
+    CANONICAL_ORIGIN: 'https://www.amadolibros.com',
+    ...patch,
+  };
+}
+const PROD_REQUEST = { url: 'https://www.amadolibros.com/api/stock-waitlist' };
+
+test('STOCK-AVISO-2: un registro nuevo en producción envía la confirmación al cliente exactamente una vez', async () => {
+  const db = memoryDb();
+  const hooks = {};
+  const { response, data } = await call(
+    makeHandler({ hooks }),
+    db,
+    validBody(),
+    prodEnvPatch(),
+    PROD_REQUEST
+  );
+
+  assert.equal(response.status, 201);
+  assert.equal(data.already_registered, false);
+  assert.equal(hooks.emailCalls, 2, 'aviso interno + confirmación al cliente');
+  const confirmationCall = hooks.emailCallArgs.find(
+    args => args[1].headers['Idempotency-Key'].startsWith('stock-waitlist-confirm/')
+  );
+  assert.ok(confirmationCall, 'debe haber una llamada con el idempotency key de confirmación');
+  const confirmationBody = JSON.parse(confirmationCall[1].body);
+  assert.deepEqual(confirmationBody.to, ['cliente@example.com']);
+  assert.match(confirmationBody.subject, /Te avisaremos cuando vuelva/);
+  assert.match(confirmationBody.html, />Ver libro</);
+  assert.equal(db.confirmationUpdates.length, 1);
+  assert.equal(db.confirmationUpdates[0][0], 'sent');
+});
+
+test('STOCK-AVISO-2: en Preview no se envía confirmación real al cliente (CANONICAL_ORIGIN no productivo)', async () => {
+  const db = memoryDb();
+  const hooks = {};
+  const { response } = await call(handlerDefault(hooks), db, validBody());
+
+  assert.equal(response.status, 201);
+  // Solo el aviso interno debe llamar a Resend; la confirmación se salta.
+  assert.equal(hooks.emailCalls, 1);
+  assert.equal(db.confirmationUpdates.length, 1);
+  assert.equal(db.confirmationUpdates[0][0], 'skipped');
+});
+
+function handlerDefault(hooks) {
+  return makeHandler({ hooks });
+}
+
+test('STOCK-AVISO-2: el duplicado no repite la confirmación al cliente', async () => {
+  const db = memoryDb({ duplicate: true });
+  const hooks = {};
+  const { response, data } = await call(
+    makeHandler({ hooks }),
+    db,
+    validBody(),
+    prodEnvPatch(),
+    PROD_REQUEST
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(data.already_registered, true);
+  assert.equal(hooks.emailCalls || 0, 0);
+  assert.equal(db.confirmationUpdates.length, 0);
+});
+
+test('STOCK-AVISO-2: honeypot no dispara ninguna confirmación', async () => {
+  const db = memoryDb();
+  const hooks = {};
+  const { response } = await call(
+    makeHandler({ hooks }),
+    db,
+    validBody({ company: 'robot inc.' }),
+    prodEnvPatch(),
+    PROD_REQUEST
+  );
+
+  assert.equal(response.status, 201);
+  assert.equal(hooks.emailCalls || 0, 0);
+  assert.equal(db.confirmationUpdates.length, 0);
+});
+
+test('STOCK-AVISO-2: Turnstile inválido no dispara ninguna confirmación', async () => {
+  const db = memoryDb();
+  const hooks = {};
+  const handler = makeHandler({ hooks, verify: async () => ({ ok: false, code: 'TOKEN_INVALID' }) });
+  const { response } = await call(handler, db, validBody(), prodEnvPatch(), PROD_REQUEST);
+
+  assert.equal(response.status, 403);
+  assert.equal(hooks.emailCalls || 0, 0);
+  assert.equal(db.confirmationUpdates.length, 0);
+});
+
+test('STOCK-AVISO-2: libro ya disponible no registra ni confirma', async () => {
+  const db = memoryDb();
+  const hooks = {};
+  const { response } = await call(
+    makeHandler({ hooks }),
+    db,
+    validBody({ product_id: 'MLU100' }),
+    prodEnvPatch(),
+    PROD_REQUEST
+  );
+
+  assert.equal(response.status, 409);
+  assert.equal(db.rows.size, 0);
+  assert.equal(hooks.emailCalls || 0, 0);
+  assert.equal(db.confirmationUpdates.length, 0);
+});
+
+test('STOCK-AVISO-2: una falla persistente de Resend en la confirmación no pierde el registro y reintenta', async () => {
+  const db = memoryDb();
+  const hooks = {};
+  let confirmationCalls = 0;
+  const handler = makeHandler({
+    hooks,
+    fetchFn: async (_url, init) => {
+      const isConfirmation = init.headers['Idempotency-Key'].startsWith('stock-waitlist-confirm/');
+      if (isConfirmation) {
+        confirmationCalls++;
+        return new Response('{}', { status: 503 });
+      }
+      return Response.json({ id: 'email-internal' });
+    },
+  });
+  const { response, data } = await call(handler, db, validBody(), prodEnvPatch(), PROD_REQUEST);
+
+  assert.equal(response.status, 201);
+  assert.equal(data.registered, true);
+  assert.equal(db.rows.size, 1, 'el registro en D1 se conserva pese a la falla de email');
+  assert.equal(confirmationCalls, 3, 'una falla 503 se reintenta hasta el máximo configurado');
+  assert.equal(db.confirmationUpdates[0][0], 'failed');
+  assert.equal(db.confirmationUpdates[0][2], 'RESEND_HTTP_503');
+});
+
+test('STOCK-AVISO-2: una URL fuera de amadolibros.com nunca se usa para confirmar', async () => {
+  const db = memoryDb();
+  const hooks = {};
+  const handler = makeHandler({ hooks });
+  const { response } = await call(
+    handler,
+    db,
+    validBody(),
+    prodEnvPatch(),
+    { url: 'https://evil.example.com/api/stock-waitlist' }
+  );
+
+  assert.equal(response.status, 201);
+  assert.equal(db.confirmationUpdates.length, 1);
+  assert.equal(db.confirmationUpdates[0][0], 'skipped');
+  // Solo el aviso interno debió llamar a Resend.
+  assert.equal(hooks.emailCalls, 1);
+});
+
+test('STOCK-AVISO-2: la confirmación escapa HTML y no confía en un título del navegador', () => {
+  const email = buildRegistrationConfirmationEmail({
+    product: PAUSED,
+    url: 'https://www.amadolibros.com/libro/MLU200',
+  });
+  assert.match(email.subject, /Te avisaremos cuando vuelva «Libro <agotado>»/);
+  assert.match(email.html, /Libro &lt;agotado&gt;/);
+  assert.doesNotMatch(email.html, /Libro <agotado>/);
+  assert.match(email.html, /No es una reserva ni garantiza disponibilidad/);
 });

--- a/functions/api/_stock_waitlist_handler.js
+++ b/functions/api/_stock_waitlist_handler.js
@@ -3,6 +3,7 @@ import { verifyTurnstile } from './_turnstile.js';
 const MAX_BODY_BYTES = 8 * 1024;
 const RESEND_ENDPOINT = 'https://api.resend.com/emails';
 const EMAIL_TIMEOUT_MS = 7000;
+const CONFIRMATION_MAX_SEND_ATTEMPTS = 3;
 const PAGES_PREVIEW_HOSTNAME_RE = /^[^.]+\.amadolibros-web\.pages\.dev$/;
 const previewSchemaPromises = new WeakMap();
 
@@ -19,6 +20,10 @@ CREATE TABLE IF NOT EXISTS stock_waitlist (
     CHECK (internal_notification_status IN ('pending','sent','failed','skipped')),
   internal_notification_id TEXT,
   internal_notification_error TEXT,
+  registration_confirmation_status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (registration_confirmation_status IN ('pending','sent','failed','skipped')),
+  registration_confirmation_id TEXT,
+  registration_confirmation_error TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
   restocked_at TEXT,
@@ -109,6 +114,29 @@ function resolveEmailConfig(env) {
   return { apiKey, from, to };
 }
 
+// La confirmación va al correo del cliente (no a la lista interna), así que
+// se exige el mismo gate exacto que usa worker-sync/stock-waitlist-notifier.js
+// para el aviso de reposición: CANONICAL_ORIGIN igual al dominio productivo.
+// Esto evita que un Preview con secretos compartidos (RESEND_API_KEY no tiene
+// forma de scoping por-ambiente verificable desde este repo) le mande un
+// correo real a un cliente real durante una prueba.
+function resolveConfirmationConfig(env) {
+  const apiKey = cleanString(env?.RESEND_API_KEY);
+  const from = cleanString(env?.SALES_NOTIFICATION_FROM);
+  const canonicalOrigin = cleanString(env?.CANONICAL_ORIGIN).replace(/\/$/, '');
+  if (!apiKey || !from || canonicalOrigin !== 'https://www.amadolibros.com') return null;
+  return { apiKey, from, canonicalOrigin };
+}
+
+function isAmadolibrosUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' && (url.hostname === 'amadolibros.com' || url.hostname === 'www.amadolibros.com');
+  } catch {
+    return false;
+  }
+}
+
 function escapeHtml(value) {
   return String(value ?? '')
     .replaceAll('&', '&amp;')
@@ -190,12 +218,93 @@ async function recordNotificationResult(db, waitlistId, result, now) {
   ).bind(status, providerId, errorCode, now.toISOString(), waitlistId).run();
 }
 
+export function buildRegistrationConfirmationEmail({ product, url }) {
+  const subject = `Te avisaremos cuando vuelva «${product.title}»`;
+  const bodyText = 'Registramos tu solicitud. Cuando este libro vuelva a estar disponible te ' +
+    'enviaremos un correo. No es una reserva ni garantiza disponibilidad. Si vuelve a stock, ' +
+    'el precio será el vigente en ese momento.';
+  const text = [subject, '', bodyText, '', `Ver libro: ${url}`].join('\n');
+  const html = `<!doctype html>
+<html lang="es">
+  <body style="font-family:Arial,sans-serif;color:#222;line-height:1.5">
+    <h1 style="font-size:20px">Te avisaremos cuando vuelva «${escapeHtml(product.title)}»</h1>
+    <p>${escapeHtml(bodyText)}</p>
+    <p><a href="${escapeHtml(url)}" style="display:inline-block;padding:12px 18px;background:#a94e3d;color:#fff;text-decoration:none;border-radius:6px;font-weight:bold">Ver libro</a></p>
+  </body>
+</html>`;
+  return { subject, text, html };
+}
+
+async function sendRegistrationConfirmationOnce({ config, email, waitlistId, message, fetchFn }) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), EMAIL_TIMEOUT_MS);
+  try {
+    const response = await fetchFn(RESEND_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        'Content-Type': 'application/json',
+        'Idempotency-Key': `stock-waitlist-confirm/${waitlistId}`,
+      },
+      body: JSON.stringify({ from: config.from, to: [email], ...message }),
+      signal: controller.signal,
+    });
+    let data = null;
+    try { data = await response.json(); } catch { /* respuesta opcional */ }
+    if (response.ok && typeof data?.id === 'string' && data.id) return { ok: true, providerId: data.id };
+    return {
+      ok: false,
+      retryable: response.status === 429 || response.status >= 500,
+      code: `RESEND_HTTP_${response.status}`,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      retryable: true,
+      code: error?.name === 'AbortError' ? 'RESEND_TIMEOUT' : 'RESEND_NETWORK_ERROR',
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Confirmación al cliente: envío inmediato y best-effort, igual en espíritu al
+// aviso interno (sendInternalNotification) pero con reintentos cortos ante
+// errores transitorios de Resend (429/5xx), como ya hace el worker de
+// reposición. Nunca toca internal_notification_status ni
+// customer_notification_status — solo registration_confirmation_status.
+async function sendRegistrationConfirmation({ env, product, email, sourceUrl, waitlistId, fetchFn, sleep }) {
+  const config = resolveConfirmationConfig(env);
+  if (!config) return { ok: false, skipped: true, code: 'EMAIL_CONFIG_MISSING' };
+  if (!isAmadolibrosUrl(sourceUrl)) return { ok: false, skipped: true, code: 'URL_NOT_ALLOWED' };
+
+  const message = buildRegistrationConfirmationEmail({ product, url: sourceUrl });
+  let result;
+  for (let attempt = 1; attempt <= CONFIRMATION_MAX_SEND_ATTEMPTS; attempt++) {
+    result = await sendRegistrationConfirmationOnce({ config, email, waitlistId, message, fetchFn });
+    if (result.ok || !result.retryable || attempt === CONFIRMATION_MAX_SEND_ATTEMPTS) break;
+    await sleep(250 * (2 ** (attempt - 1)));
+  }
+  return result;
+}
+
+async function recordRegistrationConfirmationResult(db, waitlistId, result, now) {
+  const status = result.ok ? 'sent' : result.skipped ? 'skipped' : 'failed';
+  const providerId = result.ok ? result.providerId : null;
+  const errorCode = result.ok ? null : cleanString(result.code).slice(0, 80) || 'RESEND_ERROR';
+  await db.prepare(
+    'UPDATE stock_waitlist SET registration_confirmation_status=?, registration_confirmation_id=?, ' +
+    'registration_confirmation_error=?, updated_at=? WHERE id=?'
+  ).bind(status, providerId, errorCode, now.toISOString(), waitlistId).run();
+}
+
 export function createStockWaitlistHandler({
   fetchCatalog,
   fetchPausedItem,
   verifyTurnstileToken = verifyTurnstile,
   fetchFn = globalThis.fetch,
   getNow = () => new Date(),
+  sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
 } = {}) {
   return async function onRequest(context) {
     const { request, env } = context;
@@ -359,6 +468,28 @@ export function createStockWaitlistHandler({
     })();
     if (typeof context.waitUntil === 'function') context.waitUntil(notificationPromise);
     else await notificationPromise;
+
+    // Confirmación al cliente: solo en el registro realmente nuevo (changes>0
+    // de arriba ya filtró duplicados y doble-submit). Independiente del aviso
+    // interno — su falla nunca afecta al aviso interno ni viceversa.
+    const confirmationPromise = (async () => {
+      const result = await sendRegistrationConfirmation({
+        env,
+        product,
+        email,
+        sourceUrl,
+        waitlistId,
+        fetchFn,
+        sleep,
+      });
+      try {
+        await recordRegistrationConfirmationResult(db, waitlistId, result, getNow());
+      } catch (error) {
+        console.error('[stock-waitlist] confirmation state error', safeErrorName(error));
+      }
+    })();
+    if (typeof context.waitUntil === 'function') context.waitUntil(confirmationPromise);
+    else await confirmationPromise;
 
     return json({ ok: true, registered: true, already_registered: false }, 201);
   };

--- a/migrations/0010_stock_waitlist_registration_confirmation.sql
+++ b/migrations/0010_stock_waitlist_registration_confirmation.sql
@@ -1,0 +1,8 @@
+-- STOCK-AVISO-2: confirmación inmediata al cliente al registrar su solicitud
+-- de aviso de stock. Estado propio y separado de internal_notification_status
+-- (aviso interno al equipo, 0003) y de customer_notification_status (aviso de
+-- reposición al cliente, 0007) — nunca reutilizar ninguna de esas dos.
+ALTER TABLE stock_waitlist ADD COLUMN registration_confirmation_status TEXT NOT NULL DEFAULT 'pending'
+  CHECK (registration_confirmation_status IN ('pending','sent','failed','skipped'));
+ALTER TABLE stock_waitlist ADD COLUMN registration_confirmation_id TEXT;
+ALTER TABLE stock_waitlist ADD COLUMN registration_confirmation_error TEXT;


### PR DESCRIPTION
## Contexto

Auditoría del mecanismo de reposición existente (PR #108) + implementación de la pieza que faltaba: confirmación inmediata al cliente.

## Auditoría de PR #108 (worker de reposición) — sin cambios, ya operativo

Verificado con evidencia real, no supuesta:
- `worker-sync/stock-waitlist-notifier.js` está correctamente diseñado: claim atómico en D1 (evita doble envío), `Idempotency-Key` de Resend, reintento con backoff en 429/5xx, y gate de seguridad (`CANONICAL_ORIGIN` exacto) que impide que Preview mande correos reales.
- Está bien conectado en `runSync()`, después de publicar en R2, con aislamiento de fallas (un error del notifier nunca hace fallar el sync del catálogo).
- El deploy (`deploy-worker-sync.yml`) hace `exit 1` si `RESEND_API_KEY` no está configurada — el streak de deploys verdes desde el merge de #108 confirma que el secret existe, sin necesidad de mostrarlo.
- Evidencia real de ejecución en producción (log de un run reciente): `"stock_notifications":{"status":"ok","examined":4,"matched":0,"sent":0,"failed":0,"truncated":false}`. El pipeline corre correctamente; 0 envíos hasta ahora porque ninguno de los 4 títulos en espera volvió a stock todavía — no es un bug.

**Conclusión: no hacía falta arreglar ni reconstruir nada de #108.**

## Qué faltaba (y se implementa acá)

Hoy, al registrar un "avisame cuando llegue", solo se le avisa al equipo interno — el cliente no recibe ninguna confirmación. Se agrega ese correo:

- **Asunto:** «Te avisaremos cuando vuelva «[Título]»»
- **Cuerpo:** copia exacta pedida (no es reserva, no garantiza disponibilidad, precio vigente al momento de la reposición)
- **CTA opcional:** «Ver libro»

### Diseño

- **Estado propio** (`registration_confirmation_status`, migración `0010`, additiva) — nunca reutiliza `internal_notification_status` (aviso al equipo) ni `customer_notification_status` (aviso de reposición, ya existente).
- **Idempotencia:** el `INSERT OR IGNORE` en `stock_waitlist` ya filtra duplicados y doble-submit; la confirmación solo se dispara cuando el insert crea una fila nueva (`changes > 0`). `Idempotency-Key` propia (`stock-waitlist-confirm/<id>`) para Resend.
- **Nunca pierde el registro:** el alta en D1 ya se confirmó antes de intentar el email; un fallo de Resend no afecta la fila.
- **Reintentos:** 3 intentos con backoff ante 429/5xx, igual que el worker de reposición.
- **Preview-safe:** solo se envía cuando `CANONICAL_ORIGIN === 'https://www.amadolibros.com'` (mismo gate exacto que ya usa el worker). No pude confirmar con certeza si `RESEND_API_KEY` de Pages está scopeado por ambiente a nivel de plataforma, así que se agregó este gate explícito en vez de asumirlo.
- **Validación de URL:** el link del CTA se verifica contra `amadolibros.com`/`www.amadolibros.com` antes de usarse.
- **HTML escapado** en todo el contenido interpolado (título, URL).

## Tests

9 tests nuevos en `functions/api/__tests__/stock_waitlist.test.js` (266/266 pasan en total): registro nuevo confirma una vez, duplicado no repite, honeypot/Turnstile inválido no confirman, libro ya en stock no registra ni confirma, falla persistente de Resend no pierde el registro y reintenta 3 veces, URL fuera de dominio nunca se usa, y HTML escapado.

Suite completa verificada: `worker-sync` (117), `functions` (CRLF-only fail preexistente en `deploy-branch-guards.test.js`, no relacionado — ver nota abajo), `functions/api` (266), `astro-front/src/lib` (29). Build de Astro con checkout ON y OFF, ambos verificados manualmente contra los mismos gates de `scripts/validate-ci.sh`.

**Nota:** `functions/__tests__/deploy-branch-guards.test.js` falla en este entorno Windows por diferencia de line-endings (CRLF vs regex anclada a `\n`) — falla igual en `main` sin tocar, es un artefacto de `core.autocrlf` local, no una regresión de esta rama.

## No se tocó

Checkout, pagos, catálogo, ni ningún otro proyecto en curso (HOME #221, FICHAS-VIDRIERA #217/#218/#219).

## Pendiente antes de mergear

- Aplicar la migración `0010_stock_waitlist_registration_confirmation.sql` a producción (`npx wrangler d1 migrations apply amadolibros-orders-production --remote`) **antes** de mergear a main — mismo procedimiento manual que ya exige el código para `0003`.
- Confirmar en el dashboard de Cloudflare Pages si `RESEND_API_KEY` está efectivamente scopeada a Producción o compartida con Preview (no pude verificarlo desde el repo). El gate por `CANONICAL_ORIGIN` ya protege contra esto en cualquier caso.
- Revisión humana antes de mergear y desplegar — no se hizo merge ni deploy.

🤖 Generado con [Claude Code](https://claude.com/claude-code)