### PR TITLE
FICHAS-VIDRIERA-2: SOURCE-COVERAGE-3 con Biblioteca Nacional de España

### DIFF
--- a/.github/workflows/book-intelligence-source-coverage-3-bne.yml
+++ b/.github/workflows/book-intelligence-source-coverage-3-bne.yml
@@ -1,0 +1,124 @@
+name: FICHAS-VIDRIERA-2 source coverage 3 BNE
+
+on:
+  push:
+    branches:
+      - agent/fichas-vidriera-v2-source-coverage-3-bne
+    paths:
+      - '.github/workflows/book-intelligence-source-coverage-3-bne.yml'
+      - 'scripts/seo/book-intelligence-bne.mjs'
+      - 'scripts/seo/book-intelligence-source-coverage-3-bne.mjs'
+      - 'functions/__tests__/book-intelligence-bne.test.js'
+      - 'functions/__tests__/book-intelligence-source-coverage-3-bne.test.js'
+      - 'functions/_shared/book-intelligence-evidence.js'
+  pull_request:
+    paths:
+      - '.github/workflows/book-intelligence-source-coverage-3-bne.yml'
+      - 'scripts/seo/book-intelligence-bne.mjs'
+      - 'scripts/seo/book-intelligence-source-coverage-3-bne.mjs'
+      - 'functions/__tests__/book-intelligence-bne.test.js'
+      - 'functions/__tests__/book-intelligence-source-coverage-3-bne.test.js'
+      - 'functions/_shared/book-intelligence-evidence.js'
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: Cantidad de ISBN con demanda GSC a medir
+        required: true
+        default: '12'
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: book-intelligence-source-coverage-3-bne-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: Google Books + BNE coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Validate BNE adapter without network
+        run: |
+          node --check scripts/seo/book-intelligence-bne.mjs
+          node --check scripts/seo/book-intelligence-source-coverage-3-bne.mjs
+          node --test functions/__tests__/book-intelligence-bne.test.js functions/__tests__/book-intelligence-source-coverage-3-bne.test.js functions/__tests__/book-intelligence-evidence.test.js
+
+      - name: Authenticate Google Books through existing Workload Identity
+        id: google_auth
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: amado-libros-analytics
+          workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
+          service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/books
+          create_credentials_file: false
+
+      - name: Execute BNE coverage run
+        id: coverage_run
+        continue-on-error: true
+        env:
+          GOOGLE_BOOKS_ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
+          BOOK_INTELLIGENCE_LIMIT: ${{ inputs.limit || '12' }}
+          BOOK_INTELLIGENCE_OUTPUT_DIR: artifacts/book-intelligence/source-coverage-3-bne
+          BNE_DELAY_MS: '150'
+        run: node scripts/seo/book-intelligence-source-coverage-3-bne.mjs --limit "$BOOK_INTELLIGENCE_LIMIT"
+
+      - name: Validate generated report
+        if: steps.coverage_run.outcome == 'success'
+        env:
+          BOOK_INTELLIGENCE_LIMIT: ${{ inputs.limit || '12' }}
+        run: |
+          test -s artifacts/book-intelligence/source-coverage-3-bne/source-coverage-3-bne-report.json
+          test -s artifacts/book-intelligence/source-coverage-3-bne/report-summary.md
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const report = JSON.parse(fs.readFileSync('artifacts/book-intelligence/source-coverage-3-bne/source-coverage-3-bne-report.json', 'utf8'));
+          if (report.schema_version !== 1) process.exit(1);
+          if (report.run !== 'FICHAS-VIDRIERA-2/SOURCE-COVERAGE-3-BNE') process.exit(1);
+          if (report.cohort.selected !== Number(process.env.BOOK_INTELLIGENCE_LIMIT || 12)) process.exit(1);
+          if (report.sources.bne.http_successes < 1) process.exit(1);
+          NODE
+
+      - name: Upload BNE coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: book-intelligence-source-coverage-3-bne-${{ github.run_id }}
+          path: artifacts/book-intelligence/source-coverage-3-bne/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Write BNE coverage summary
+        if: always()
+        run: |
+          if [ -f artifacts/book-intelligence/source-coverage-3-bne/report-summary.md ]; then
+            cat artifacts/book-intelligence/source-coverage-3-bne/report-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## SOURCE-COVERAGE-3 BNE incompleto' >> "$GITHUB_STEP_SUMMARY"
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo 'No se generó reporte. Revisar tests o conectividad SRU.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '- BNE: SRU oficial, datos bibliográficos CC0, sin secreto' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Modo: sólo lectura' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Deploy: no se ejecuta' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if BNE coverage did not complete
+        if: steps.coverage_run.outcome != 'success'
+        run: |
+          echo 'SOURCE-COVERAGE-3 BNE no completó la corrida real.'
+          exit 1

--- a/functions/__tests__/book-intelligence-bne.test.js
+++ b/functions/__tests__/book-intelligence-bne.test.js
@@ -1,0 +1,116 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildBneUrl,
+  fetchBneEvidence,
+  parseBneEvidence,
+} from '../../scripts/seo/book-intelligence-bne.mjs';
+
+const ISBN = '9788496836693';
+const OTHER_ISBN = '9780194527552';
+
+function marcRecord({ isbn = ISBN, title = 'Padres fuertes, hijas felices', author = 'Meeker, Meg' } = {}) {
+  return `
+    <record xmlns="http://www.loc.gov/MARC21/slim">
+      <leader>00000nam a2200000 i 4500</leader>
+      <controlfield tag="001">BNE12345678</controlfield>
+      <datafield tag="020" ind1=" " ind2=" "><subfield code="a">${isbn}</subfield></datafield>
+      <datafield tag="100" ind1="1" ind2=" "><subfield code="a">${author},</subfield></datafield>
+      <datafield tag="245" ind1="1" ind2="0">
+        <subfield code="a">${title} :</subfield>
+        <subfield code="b">10 secretos que todo padre debería conocer /</subfield>
+      </datafield>
+      <datafield tag="264" ind1=" " ind2="1">
+        <subfield code="b">Ciudadela Libros,</subfield>
+        <subfield code="c">2008.</subfield>
+      </datafield>
+      <datafield tag="300" ind1=" " ind2=" "><subfield code="a">304 p. ;</subfield></datafield>
+      <datafield tag="041" ind1="0" ind2=" "><subfield code="a">spa</subfield></datafield>
+      <datafield tag="520" ind1=" " ind2=" ">
+        <subfield code="a">Registro bibliográfico con una descripción suficientemente extensa para comprobar la extracción semántica del adaptador.</subfield>
+      </datafield>
+      <datafield tag="650" ind1=" " ind2="0"><subfield code="a">Padres e hijas.</subfield></datafield>
+      <datafield tag="650" ind1=" " ind2="0"><subfield code="a">Relaciones familiares.</subfield></datafield>
+      <datafield tag="650" ind1=" " ind2="0"><subfield code="a">Educación familiar.</subfield></datafield>
+    </record>`;
+}
+
+function sruResponse(records) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+    <searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+      <version>1.2</version>
+      <numberOfRecords>${records.length}</numberOfRecords>
+      <records>
+        ${records.map(record => `<record><recordSchema>marcxml</recordSchema><recordData>${record}</recordData></record>`).join('')}
+      </records>
+    </searchRetrieveResponse>`;
+}
+
+test('URL BNE usa alma.isbn exacto, SRU 1.2 y MARCXML oficial', () => {
+  const url = new URL(buildBneUrl(ISBN));
+  assert.equal(url.origin, 'https://catalogo.bne.es');
+  assert.equal(url.pathname, '/view/sru/34BNE_INST');
+  assert.equal(url.searchParams.get('operation'), 'searchRetrieve');
+  assert.equal(url.searchParams.get('version'), '1.2');
+  assert.equal(url.searchParams.get('query'), `alma.isbn="${ISBN}"`);
+  assert.equal(url.searchParams.get('recordSchema'), 'marcxml');
+  assert.equal(url.searchParams.get('startRecord'), '1');
+});
+
+test('parser BNE revalida 020$a y extrae evidencia bibliográfica fuerte', () => {
+  const xml = sruResponse([
+    marcRecord(),
+    marcRecord({ isbn: OTHER_ISBN, title: 'Otra obra', author: 'Otra, Persona' }),
+  ]);
+  const records = parseBneEvidence(xml, ISBN);
+  assert.equal(records.length, 1);
+  const record = records[0];
+  assert.equal(record.source, 'library_catalog');
+  assert.equal(record.source_provider, 'biblioteca_nacional_espana');
+  assert.equal(record.source_id, 'BNE12345678');
+  assert.equal(record.isbn, ISBN);
+  assert.match(record.title, /Padres fuertes, hijas felices/);
+  assert.match(record.title, /10 secretos/);
+  assert.equal(record.author, 'Meeker, Meg');
+  assert.equal(record.publisher, 'Ciudadela Libros');
+  assert.equal(record.pages, 304);
+  assert.equal(record.language, 'spa');
+  assert.equal(record.publication_year, '2008');
+  assert.equal(record.topics.length, 3);
+  assert.equal(record.raw_quality.exact_isbn, true);
+  assert.equal(record.raw_quality.catalog, 'BNE');
+});
+
+test('un registro sin el ISBN solicitado nunca se convierte en evidencia', () => {
+  const records = parseBneEvidence(sruResponse([marcRecord({ isbn: OTHER_ISBN })]), ISBN);
+  assert.deepEqual(records, []);
+});
+
+test('fetch BNE es inyectable, pide XML y no requiere secreto', async () => {
+  let requestedUrl = null;
+  let requestedOptions = null;
+  const records = await fetchBneEvidence(ISBN, {
+    fetchImpl: async (url, options) => {
+      requestedUrl = String(url);
+      requestedOptions = options;
+      return {
+        ok: true,
+        status: 200,
+        async text() { return sruResponse([marcRecord()]); },
+      };
+    },
+  });
+  assert.equal(new URL(requestedUrl).searchParams.get('query'), `alma.isbn="${ISBN}"`);
+  assert.match(requestedOptions.headers.accept, /xml/);
+  assert.equal(records.length, 1);
+});
+
+test('error HTTP se propaga y no se convierte en no-match', async () => {
+  await assert.rejects(
+    () => fetchBneEvidence(ISBN, {
+      fetchImpl: async () => ({ ok: false, status: 503, async text() { return ''; } }),
+    }),
+    /HTTP 503/,
+  );
+});

--- a/functions/__tests__/book-intelligence-source-coverage-3-bne.test.js
+++ b/functions/__tests__/book-intelligence-source-coverage-3-bne.test.js
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildCoverageResult,
+  coverageMarkdown,
+} from '../../scripts/seo/book-intelligence-source-coverage-3-bne.mjs';
+
+const classification = {
+  tier: 'green',
+  reason: 'evidencia corroborada',
+  exact_isbn_source_count: 2,
+  independent_work_source_count: 2,
+  strong_work_source_count: 2,
+  identity_conflicts: [],
+  generation_policy: { auto_publish_work_content: true },
+};
+
+test('resultado de coverage cuenta BNE y evidencia semántica sin publicar texto externo', () => {
+  const item = {
+    id: 'MLU123',
+    isbn: '9788496836693',
+    title: 'Padres fuertes, hijas felices',
+    author: 'Meg Meeker',
+    research: { gsc_impressions: 120, gsc_clicks: 10 },
+  };
+  const google = [{ source: 'google_books' }];
+  const bne = [{
+    source: 'library_catalog',
+    description: 'x'.repeat(90),
+    topics: [],
+  }];
+  const result = buildCoverageResult(item, classification, google, bne);
+  assert.equal(result.google_books_records, 1);
+  assert.equal(result.bne_records, 1);
+  assert.equal(result.bne_substantive_records, 1);
+  assert.equal(result.tier, 'green');
+  assert.equal(result.gsc_impressions, 120);
+  assert.equal(Object.hasOwn(result, 'description'), false);
+});
+
+test('markdown declara Google+BNE, tiers y contrato read-only', () => {
+  const report = {
+    generated_at: '2026-08-22T00:00:00.000Z',
+    cohort: { selected: 12 },
+    sources: {
+      google_books: { matched: 4, errors: 0 },
+      bne: { matched: 6, errors: 0, substantive_matches: 3 },
+    },
+    classification: { green: 2, yellow: 4, red: 6, auto_publish_work_content: 2 },
+    results: [{
+      id: 'MLU123', isbn: '9788496836693', gsc_impressions: 120,
+      google_books_records: 1, bne_records: 1, bne_substantive_records: 1,
+      tier: 'green', reason: 'evidencia corroborada',
+    }],
+  };
+  const markdown = coverageMarkdown(report);
+  assert.match(markdown, /SOURCE-COVERAGE-3 BNE/);
+  assert.match(markdown, /Google \+ BNE/);
+  assert.match(markdown, /Sólo lectura/);
+  assert.match(markdown, /No se modifica ninguna ficha/);
+  assert.doesNotMatch(markdown, /descripción suficientemente extensa/i);
+});

--- a/scripts/seo/book-intelligence-bne.mjs
+++ b/scripts/seo/book-intelligence-bne.mjs
@@ -1,0 +1,260 @@
+// FICHAS-VIDRIERA-2 / SOURCE-COVERAGE-3
+// Adaptador oficial de Biblioteca Nacional de España (BNE) vía SRU 1.2 + MARCXML.
+//
+// Contrato:
+// - consulta por alma.isbn exacto;
+// - revalida el ISBN dentro de MARC 020$a;
+// - no requiere API key ni usuario/contraseña;
+// - devuelve evidencia `library_catalog`, nunca copy final;
+// - sólo se usa offline/batch, nunca en una request de cliente.
+
+import { normalizeValidIsbn } from '../../functions/_shared/showcase-ranking.js';
+
+export const BNE_SRU_BASE = 'https://catalogo.bne.es/view/sru/34BNE_INST';
+export const BNE_MAX_RECORDS = 5;
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function decodeXml(value) {
+  return clean(String(value ?? '')
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#([0-9]+);/g, (_, decimal) => String.fromCodePoint(Number.parseInt(decimal, 10)))
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;/gi, "'"));
+}
+
+function attrValue(attributes, name) {
+  const match = String(attributes ?? '').match(new RegExp(`${name}\\s*=\\s*["']([^"']*)["']`, 'i'));
+  return match ? decodeXml(match[1]) : '';
+}
+
+function blocks(xml, tagName) {
+  const pattern = new RegExp(
+    `<(?:[\\w.-]+:)?${tagName}\\b([^>]*)>([\\s\\S]*?)<\\/(?:[\\w.-]+:)?${tagName}>`,
+    'gi',
+  );
+  return [...String(xml ?? '').matchAll(pattern)].map(match => ({
+    attributes: match[1] || '',
+    body: match[2] || '',
+  }));
+}
+
+function unprefixedBlocks(xml, tagName) {
+  const pattern = new RegExp(
+    `<${tagName}\\b([^>]*)>([\\s\\S]*?)<\\/${tagName}>`,
+    'gi',
+  );
+  return [...String(xml ?? '').matchAll(pattern)].map(match => ({
+    attributes: match[1] || '',
+    body: match[2] || '',
+  }));
+}
+
+function parseMarcRecord(xml) {
+  const controlfields = blocks(xml, 'controlfield').map(block => ({
+    tag: attrValue(block.attributes, 'tag'),
+    value: decodeXml(block.body.replace(/<[^>]+>/g, ' ')),
+  }));
+
+  const datafields = blocks(xml, 'datafield').map(field => ({
+    tag: attrValue(field.attributes, 'tag'),
+    subfields: blocks(field.body, 'subfield').map(subfield => ({
+      code: attrValue(subfield.attributes, 'code'),
+      value: decodeXml(subfield.body.replace(/<[^>]+>/g, ' ')),
+    })),
+  }));
+
+  return { controlfields, datafields };
+}
+
+function fields(record, tags) {
+  const wanted = new Set(Array.isArray(tags) ? tags : [tags]);
+  return record.datafields.filter(field => wanted.has(field.tag));
+}
+
+function subfieldValues(record, tags, codes) {
+  const wantedCodes = new Set(Array.isArray(codes) ? codes : [codes]);
+  return fields(record, tags).flatMap(field =>
+    field.subfields
+      .filter(subfield => wantedCodes.has(subfield.code))
+      .map(subfield => clean(subfield.value))
+      .filter(Boolean),
+  );
+}
+
+function firstSubfield(record, tags, codes) {
+  return subfieldValues(record, tags, codes)[0] || '';
+}
+
+function controlfield(record, tag) {
+  return record.controlfields.find(field => field.tag === tag)?.value || '';
+}
+
+function normalizeIsbnText(value) {
+  const direct = normalizeValidIsbn(clean(value));
+  if (direct) return direct;
+  const candidates = String(value ?? '').match(/(?:97[89][0-9\s-]{10,20}|[0-9][0-9Xx\s-]{8,18})/g) || [];
+  for (const candidate of candidates) {
+    const normalized = normalizeValidIsbn(candidate);
+    if (normalized) return normalized;
+  }
+  return null;
+}
+
+function recordIsbns(record) {
+  return [...new Set(
+    subfieldValues(record, '020', 'a')
+      .map(normalizeIsbnText)
+      .filter(Boolean),
+  )];
+}
+
+function stripTerminalPunctuation(value) {
+  return clean(value).replace(/[\s\/:;,=]+$/g, '').trim();
+}
+
+function titleValue(record) {
+  return stripTerminalPunctuation(
+    subfieldValues(record, '245', ['a', 'b', 'n', 'p'])
+      .map(stripTerminalPunctuation)
+      .filter(Boolean)
+      .join(' : '),
+  );
+}
+
+function authorValue(record) {
+  const main = firstSubfield(record, ['100', '110', '111'], 'a');
+  if (main) return stripTerminalPunctuation(main);
+  return stripTerminalPunctuation(firstSubfield(record, '700', 'a'));
+}
+
+function publisherValue(record) {
+  return stripTerminalPunctuation(
+    firstSubfield(record, '264', 'b') || firstSubfield(record, '260', 'b'),
+  ) || null;
+}
+
+function yearFromDate(value) {
+  const match = clean(value).match(/\b(1[5-9]\d{2}|20\d{2}|21\d{2})\b/);
+  return match ? match[1] : null;
+}
+
+function publicationYear(record) {
+  return yearFromDate(firstSubfield(record, '264', 'c') || firstSubfield(record, '260', 'c'));
+}
+
+function pageCount(record) {
+  const physical = firstSubfield(record, '300', 'a');
+  const match = physical.match(/\b(\d{1,5})\s*(?:p\.?|pages?|p[aá]g(?:inas?)?\.?)/i);
+  if (!match) return null;
+  const pages = Number(match[1]);
+  return Number.isInteger(pages) && pages > 0 ? pages : null;
+}
+
+function languageValue(record) {
+  const values = [...new Set(subfieldValues(record, '041', ['a', 'd', 'h']))];
+  return values.length ? values.join(', ') : null;
+}
+
+function summaryValue(record) {
+  return subfieldValues(record, '520', ['a', 'b'])
+    .map(stripTerminalPunctuation)
+    .filter(Boolean)
+    .join(' ');
+}
+
+function topicValues(record) {
+  const subjectTags = new Set(['600', '610', '611', '630', '648', '650', '651', '655']);
+  const topics = [];
+  for (const field of record.datafields) {
+    if (!subjectTags.has(field.tag)) continue;
+    const parts = field.subfields
+      .filter(subfield => ['a', 'x', 'y', 'z', 'v'].includes(subfield.code))
+      .map(subfield => stripTerminalPunctuation(subfield.value))
+      .filter(Boolean);
+    if (parts.length) topics.push(parts.join(' — '));
+  }
+  return [...new Set(topics)].slice(0, 12);
+}
+
+export function buildBneUrl(isbn, { maximumRecords = BNE_MAX_RECORDS } = {}) {
+  const normalized = normalizeValidIsbn(isbn);
+  if (!normalized) throw new Error('ISBN inválido para BNE.');
+  const limit = Number.isInteger(Number(maximumRecords))
+    ? Math.min(Math.max(Number(maximumRecords), 1), 50)
+    : BNE_MAX_RECORDS;
+  const url = new URL(BNE_SRU_BASE);
+  url.searchParams.set('operation', 'searchRetrieve');
+  url.searchParams.set('version', '1.2');
+  url.searchParams.set('query', `alma.isbn="${normalized}"`);
+  url.searchParams.set('recordSchema', 'marcxml');
+  url.searchParams.set('startRecord', '1');
+  url.searchParams.set('maximumRecords', String(limit));
+  return url.toString();
+}
+
+export function parseBneEvidence(xml, isbn) {
+  const target = normalizeValidIsbn(isbn);
+  if (!target) return [];
+  const output = [];
+  for (const recordBlock of unprefixedBlocks(xml, 'record')) {
+    const record = parseMarcRecord(recordBlock.body);
+    const identifiers = recordIsbns(record);
+    if (!identifiers.includes(target)) continue;
+    output.push({
+      source: 'library_catalog',
+      source_provider: 'biblioteca_nacional_espana',
+      source_id: clean(controlfield(record, '001')) || null,
+      source_url: buildBneUrl(target),
+      isbn: target,
+      title: titleValue(record),
+      author: authorValue(record),
+      description: summaryValue(record),
+      publisher: publisherValue(record),
+      pages: pageCount(record),
+      language: languageValue(record),
+      publication_year: publicationYear(record),
+      format: null,
+      topics: topicValues(record),
+      raw_quality: {
+        exact_isbn: true,
+        identifiers,
+        catalog: 'BNE',
+      },
+    });
+  }
+  return output;
+}
+
+async function fetchText(url, {
+  fetchImpl = globalThis.fetch,
+  timeoutMs = 12_000,
+} = {}) {
+  if (typeof fetchImpl !== 'function') throw new Error('fetch no disponible.');
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      headers: {
+        accept: 'application/xml,text/xml;q=0.9,*/*;q=0.1',
+        'user-agent': 'AmadoLibros-BookIntelligence/1.0',
+      },
+      signal: controller.signal,
+    });
+    if (!response?.ok) throw new Error(`HTTP ${response?.status || 0}`);
+    return await response.text();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function fetchBneEvidence(isbn, { fetchImpl, timeoutMs } = {}) {
+  const url = buildBneUrl(isbn);
+  const xml = await fetchText(url, { fetchImpl, timeoutMs });
+  return parseBneEvidence(xml, isbn);
+}

--- a/scripts/seo/book-intelligence-source-coverage-3-bne.mjs
+++ b/scripts/seo/book-intelligence-source-coverage-3-bne.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { fetchAndConsolidate } from '../categorize/fetch-catalog.js';
+import { PAUSED_SEO_COHORT } from '../../functions/_shared/paused-seo-cohort.js';
+import {
+  classifyBookIntelligenceEvidence,
+  summarizeBookIntelligenceEvidence,
+} from '../../functions/_shared/book-intelligence-evidence.js';
+import { fetchGoogleBooksEvidence } from './book-intelligence-sources.mjs';
+import { fetchBneEvidence } from './book-intelligence-bne.mjs';
+import { selectResearchCohort } from './book-intelligence-research-run.mjs';
+
+const DEFAULT_LIMIT = 12;
+const DEFAULT_OUTPUT_DIR = 'artifacts/book-intelligence/source-coverage-3-bne';
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function sourceSummary(attempts) {
+  return {
+    requested: attempts.length,
+    http_successes: attempts.filter(attempt => attempt.ok).length,
+    matched: attempts.filter(attempt => attempt.ok && attempt.record_count > 0).length,
+    no_match: attempts.filter(attempt => attempt.ok && attempt.record_count === 0).length,
+    errors: attempts.filter(attempt => !attempt.ok).length,
+  };
+}
+
+export function buildCoverageResult(item, classification, googleRecords, bneRecords) {
+  const bne = Array.isArray(bneRecords) ? bneRecords : [];
+  return {
+    id: String(item?.id || '').toUpperCase(),
+    isbn: clean(item?.isbn),
+    title: clean(item?.title),
+    author: clean(item?.author),
+    gsc_impressions: Number(item?.research?.gsc_impressions) || 0,
+    gsc_clicks: Number(item?.research?.gsc_clicks) || 0,
+    google_books_records: Array.isArray(googleRecords) ? googleRecords.length : 0,
+    bne_records: bne.length,
+    bne_substantive_records: bne.filter(record =>
+      clean(record.description).length >= 80 || (Array.isArray(record.topics) && record.topics.length >= 3),
+    ).length,
+    tier: classification.tier,
+    reason: classification.reason,
+    exact_isbn_source_count: classification.exact_isbn_source_count,
+    independent_work_source_count: classification.independent_work_source_count,
+    strong_work_source_count: classification.strong_work_source_count,
+    identity_conflicts: classification.identity_conflicts,
+    generation_policy: classification.generation_policy,
+  };
+}
+
+export function coverageMarkdown(report) {
+  const lines = [
+    '# FICHAS-VIDRIERA-2 — SOURCE-COVERAGE-3 BNE',
+    '',
+    `- Generado: ${report.generated_at}`,
+    `- Cohorte: ${report.cohort.selected} ISBN con demanda GSC.`,
+    `- Google Books: ${report.sources.google_books.matched}/${report.cohort.selected} matches exactos; ${report.sources.google_books.errors} errores.`,
+    `- BNE: ${report.sources.bne.matched}/${report.cohort.selected} matches exactos; ${report.sources.bne.errors} errores.`,
+    `- BNE con evidencia semántica suficiente: ${report.sources.bne.substantive_matches}/${report.cohort.selected}.`,
+    `- Tiers combinados Google + BNE: GREEN ${report.classification.green}, YELLOW ${report.classification.yellow}, RED ${report.classification.red}.`,
+    `- Auto-publicables: ${report.classification.auto_publish_work_content}.`,
+    '',
+    '## Resultado por ISBN',
+    '',
+    '| MLU | ISBN | GSC imp. | Google | BNE | BNE sust. | Tier | Razón |',
+    '| --- | --- | ---: | ---: | ---: | ---: | --- | --- |',
+    ...report.results.map(result =>
+      `| ${result.id} | ${result.isbn} | ${result.gsc_impressions} | ${result.google_books_records} | ${result.bne_records} | ${result.bne_substantive_records} | ${result.tier.toUpperCase()} | ${result.reason} |`,
+    ),
+    '',
+    '## Contrato',
+    '',
+    '- Sólo lectura contra R2, Google Books y el SRU oficial de la Biblioteca Nacional de España.',
+    '- BNE se consulta por alma.isbn y cada resultado se revalida contra MARC 020$a.',
+    '- No se modifica ninguna ficha, sitemap, canonical, Worker, R2, D1, KV ni Producción.',
+    '- No se guarda el token OAuth y BNE no requiere secreto.',
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+export async function runSourceCoverage({
+  limit = DEFAULT_LIMIT,
+  outputDir = DEFAULT_OUTPUT_DIR,
+  googleBooksAccessToken = process.env.GOOGLE_BOOKS_ACCESS_TOKEN,
+  googleBooksApiKey = process.env.GOOGLE_BOOKS_API_KEY,
+  bneDelayMs = Number(process.env.BNE_DELAY_MS ?? 150),
+} = {}) {
+  if (!clean(googleBooksAccessToken) && !clean(googleBooksApiKey)) {
+    throw new Error('SOURCE-COVERAGE-3 requiere GOOGLE_BOOKS_ACCESS_TOKEN o GOOGLE_BOOKS_API_KEY.');
+  }
+
+  const catalog = await fetchAndConsolidate();
+  const { selected, missing_catalog_ids: missingCatalogIds } = selectResearchCohort({
+    cohort: PAUSED_SEO_COHORT,
+    catalogItems: catalog.items,
+    limit,
+  });
+
+  const googleByIsbn = new Map();
+  const bneByIsbn = new Map();
+  const googleAttempts = [];
+  const bneAttempts = [];
+
+  for (const item of selected) {
+    try {
+      const records = await fetchGoogleBooksEvidence(item.isbn, {
+        accessToken: googleBooksAccessToken,
+        apiKey: googleBooksApiKey,
+      });
+      googleByIsbn.set(item.isbn, records);
+      googleAttempts.push({ isbn: item.isbn, ok: true, record_count: records.length });
+    } catch (error) {
+      googleByIsbn.set(item.isbn, []);
+      googleAttempts.push({ isbn: item.isbn, ok: false, record_count: 0, error: error?.message || String(error) });
+    }
+
+    try {
+      const records = await fetchBneEvidence(item.isbn);
+      bneByIsbn.set(item.isbn, records);
+      bneAttempts.push({ isbn: item.isbn, ok: true, record_count: records.length });
+    } catch (error) {
+      bneByIsbn.set(item.isbn, []);
+      bneAttempts.push({ isbn: item.isbn, ok: false, record_count: 0, error: error?.message || String(error) });
+    }
+
+    if (Number.isFinite(bneDelayMs) && bneDelayMs > 0) await sleep(Math.min(bneDelayMs, 2_000));
+  }
+
+  const classifications = selected.map(item => classifyBookIntelligenceEvidence(item, [
+    ...(googleByIsbn.get(item.isbn) || []),
+    ...(bneByIsbn.get(item.isbn) || []),
+  ]));
+  const results = selected.map((item, index) => buildCoverageResult(
+    item,
+    classifications[index],
+    googleByIsbn.get(item.isbn) || [],
+    bneByIsbn.get(item.isbn) || [],
+  ));
+  const bneSummary = sourceSummary(bneAttempts);
+  bneSummary.substantive_matches = results.filter(result => result.bne_substantive_records > 0).length;
+
+  const report = {
+    schema_version: 1,
+    run: 'FICHAS-VIDRIERA-2/SOURCE-COVERAGE-3-BNE',
+    generated_at: new Date().toISOString(),
+    cohort: {
+      requested: positiveInteger(limit, DEFAULT_LIMIT),
+      selected: selected.length,
+      demand_only: true,
+      missing_catalog_ids: missingCatalogIds,
+      total_impressions: selected.reduce((sum, item) => sum + (Number(item.research?.gsc_impressions) || 0), 0),
+      total_clicks: selected.reduce((sum, item) => sum + (Number(item.research?.gsc_clicks) || 0), 0),
+    },
+    catalog: {
+      fetched_at: catalog.fetched_at,
+      total_items: catalog.items.length,
+      active_total_raw: catalog.sources?.active_total_raw ?? null,
+      paused_total_raw: catalog.sources?.paused_total_raw ?? null,
+      paused_manifest_version: catalog.sources?.paused_manifest_version ?? null,
+    },
+    sources: {
+      google_books: sourceSummary(googleAttempts),
+      bne: bneSummary,
+    },
+    classification: summarizeBookIntelligenceEvidence(classifications),
+    results,
+    attempts: {
+      bne_errors: bneAttempts.filter(attempt => !attempt.ok),
+    },
+  };
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(path.join(outputDir, 'source-coverage-3-bne-report.json'), JSON.stringify(report, null, 2));
+  await writeFile(path.join(outputDir, 'report-summary.md'), coverageMarkdown(report));
+
+  if (googleAttempts.length && !googleAttempts.some(attempt => attempt.ok)) {
+    throw new Error('Google Books no completó ninguna consulta HTTP.');
+  }
+  if (bneAttempts.length && !bneAttempts.some(attempt => attempt.ok)) {
+    const sample = bneAttempts.find(attempt => attempt.error)?.error || 'sin detalle';
+    throw new Error(`BNE SRU no completó ninguna consulta HTTP. Primer error: ${sample}`);
+  }
+
+  return report;
+}
+
+function cliOptions(argv) {
+  const options = {
+    limit: positiveInteger(process.env.BOOK_INTELLIGENCE_LIMIT, DEFAULT_LIMIT),
+    outputDir: process.env.BOOK_INTELLIGENCE_OUTPUT_DIR || DEFAULT_OUTPUT_DIR,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (flag === '--limit') options.limit = positiveInteger(argv[++index], DEFAULT_LIMIT);
+    else if (flag === '--output-dir') options.outputDir = argv[++index];
+    else throw new Error(`Argumento desconocido: ${flag}`);
+  }
+  return options;
+}
+
+async function main() {
+  const report = await runSourceCoverage(cliOptions(process.argv.slice(2)));
+  console.log(JSON.stringify({
+    run: report.run,
+    cohort: report.cohort,
+    sources: report.sources,
+    classification: report.classification,
+  }, null, 2));
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  main().catch(error => {
+    console.error(`[source-coverage-3-bne] ERROR: ${error?.message || error}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Objetivo

Medir una segunda familia bibliográfica fuerte y con mejor cobertura esperada para libros en español: **Biblioteca Nacional de España (BNE)**.

Este PR está apilado sobre #219 y es sólo investigación/read-only. No modifica fichas públicas ni Producción.

## Por qué BNE

SOURCE-COVERAGE-2 confirmó que el gateway SRU de Library of Congress, aun con URL oficial correcta, no completó ninguna consulta HTTP desde GitHub Actions. Se conserva #220 como evidencia de ese resultado y no se insiste con una fuente operacionalmente inaccesible.

BNE expone SRU 1.2 oficial sobre `catalogo.bne.es`, índice `alma.isbn`, MARCXML, sin API key y con catálogo reutilizable CC0.

## Qué agrega

- adaptador `book-intelligence-bne.mjs`;
- búsqueda exacta `alma.isbn="ISBN"`;
- revalidación obligatoria del ISBN dentro de MARC `020$a`;
- extracción de título, autor, editorial, año, páginas, idioma, resumen y materias;
- evidencia etiquetada como `library_catalog` + provider `biblioteca_nacional_espana`;
- corrida controlada Google Books + BNE sobre la misma cohorte de 12 ISBN `gsc-demand` de #219;
- reporte GREEN/YELLOW/RED, cobertura exacta y cobertura semántica;
- tests sintéticos y workflow real de GitHub Actions.

## Resultado real — SOURCE-COVERAGE-3 BNE

Cohorte idéntica a #219: **12 ISBN con demanda GSC**, 559 impresiones y 46 clics históricos.

Catálogo resuelto en la corrida: **17.201 MLU únicos** (7.111 activos + 10.096 pausados).

Validación técnica:

- adapter/tests: **26/26 PASS**;
- WIF/OAuth Google Books: **PASS**;
- Google Books: 12/12 HTTP exitosas, **4/12 matches exactos**, 0 errores;
- BNE: 12/12 HTTP exitosas, **2/12 matches exactos**, 0 errores;
- BNE con evidencia semántica suficiente: **0/12**.

Clasificación combinada Google Books + BNE:

- **GREEN: 0**;
- **YELLOW: 2**;
- **RED: 10**;
- auto-publicables: **0**;
- generación de 5 temas: **0**;
- conflictos de identidad: 1;
- conflictos de hechos de edición: 2.

## Decisión técnica

BNE queda validada como fuente operativa y útil para corroborar identidad/datos bibliográficos cuando existe registro exacto, pero **no mejora el tier de ningún ISBN en esta muestra** y no aporta evidencia semántica suficiente para justificar generación masiva de contenido.

Por lo tanto:

- **NO** se escala todavía BNE a 100–250 ISBN;
- **NO** se relajan umbrales GREEN/YELLOW para fabricar progreso;
- el siguiente experimento debe ser una familia de fuente con contenido semántico real (temas/descripción/entidades), no otra fuente puramente catalográfica;
- #224 permanece como evidencia reproducible del resultado y no cambia la web pública.

## Gate cumplido

1. tests del adapter y del reporte: PASS;
2. conectividad BNE real: PASS, 12/12 HTTP;
3. cohorte completa: 12/12;
4. matches exactos BNE: 2/12;
5. cambio de tiers vs #219: **ninguno**;
6. decisión de escala: **NO escalar esta fuente por sí sola**.

## Seguridad

Sólo lectura. No cambia HTML, renderer, canonical, sitemap, R2, D1, KV, Worker, checkout ni Producción. No agrega secretos.

**MANTENER DRAFT. NO MERGEAR. NO PRODUCCIÓN.**