### PR TITLE
FICHAS-VIDRIERA-2: rescate semántico por obra en Google Books

### DIFF
--- a/.github/workflows/book-intelligence-google-work-fallback-1.yml
+++ b/.github/workflows/book-intelligence-google-work-fallback-1.yml
@@ -1,0 +1,123 @@
+name: FICHAS-VIDRIERA-2 Google work fallback 1
+
+on:
+  push:
+    branches:
+      - agent/fichas-vidriera-v2-google-work-fallback-1
+    paths:
+      - '.github/workflows/book-intelligence-google-work-fallback-1.yml'
+      - 'scripts/seo/book-intelligence-google-work.mjs'
+      - 'scripts/seo/book-intelligence-google-work-fallback-run.mjs'
+      - 'functions/__tests__/book-intelligence-google-work.test.js'
+      - 'functions/__tests__/book-intelligence-google-work-fallback-run.test.js'
+      - 'functions/_shared/book-intelligence-evidence.js'
+      - 'functions/_shared/book-display-title.js'
+  pull_request:
+    paths:
+      - '.github/workflows/book-intelligence-google-work-fallback-1.yml'
+      - 'scripts/seo/book-intelligence-google-work.mjs'
+      - 'scripts/seo/book-intelligence-google-work-fallback-run.mjs'
+      - 'functions/__tests__/book-intelligence-google-work.test.js'
+      - 'functions/__tests__/book-intelligence-google-work-fallback-run.test.js'
+      - 'functions/_shared/book-intelligence-evidence.js'
+      - 'functions/_shared/book-display-title.js'
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: Cantidad de ISBN con demanda GSC a medir
+        required: true
+        default: '12'
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: book-intelligence-google-work-fallback-1-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fallback:
+    name: Google Books exact + work fallback
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Validate fallback without network
+        run: |
+          node --check scripts/seo/book-intelligence-google-work.mjs
+          node --check scripts/seo/book-intelligence-google-work-fallback-run.mjs
+          node --test functions/__tests__/book-intelligence-google-work.test.js functions/__tests__/book-intelligence-google-work-fallback-run.test.js functions/__tests__/book-intelligence-evidence.test.js
+
+      - name: Authenticate Google Books through existing Workload Identity
+        id: google_auth
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: amado-libros-analytics
+          workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
+          service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/books
+          create_credentials_file: false
+
+      - name: Execute Google work fallback run
+        id: fallback_run
+        continue-on-error: true
+        env:
+          GOOGLE_BOOKS_ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
+          BOOK_INTELLIGENCE_LIMIT: ${{ inputs.limit || '12' }}
+          BOOK_INTELLIGENCE_OUTPUT_DIR: artifacts/book-intelligence/google-work-fallback-1
+        run: node scripts/seo/book-intelligence-google-work-fallback-run.mjs --limit "$BOOK_INTELLIGENCE_LIMIT"
+
+      - name: Validate generated report
+        if: steps.fallback_run.outcome == 'success'
+        env:
+          BOOK_INTELLIGENCE_LIMIT: ${{ inputs.limit || '12' }}
+        run: |
+          test -s artifacts/book-intelligence/google-work-fallback-1/google-work-fallback-1-report.json
+          test -s artifacts/book-intelligence/google-work-fallback-1/report-summary.md
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const report = JSON.parse(fs.readFileSync('artifacts/book-intelligence/google-work-fallback-1/google-work-fallback-1-report.json', 'utf8'));
+          if (report.schema_version !== 1) process.exit(1);
+          if (report.run !== 'FICHAS-VIDRIERA-2/GOOGLE-WORK-FALLBACK-1') process.exit(1);
+          if (report.cohort.selected !== Number(process.env.BOOK_INTELLIGENCE_LIMIT || 12)) process.exit(1);
+          if (report.sources.exact.http_successes < 1) process.exit(1);
+          NODE
+
+      - name: Upload fallback report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: book-intelligence-google-work-fallback-1-${{ github.run_id }}
+          path: artifacts/book-intelligence/google-work-fallback-1/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Write fallback summary
+        if: always()
+        run: |
+          if [ -f artifacts/book-intelligence/google-work-fallback-1/report-summary.md ]; then
+            cat artifacts/book-intelligence/google-work-fallback-1/report-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## GOOGLE-WORK-FALLBACK-1 incompleto' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Google Books: búsqueda exacta y, sólo ante 0 match, título+autor' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Datos de otra edición: sólo contenido de obra; nunca hechos físicos de la edición vendida' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Modo: sólo lectura; sin deploy' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if fallback run did not complete
+        if: steps.fallback_run.outcome != 'success'
+        run: |
+          echo 'GOOGLE-WORK-FALLBACK-1 no completó la corrida real.'
+          exit 1

--- a/functions/__tests__/book-intelligence-google-work-fallback-run.test.js
+++ b/functions/__tests__/book-intelligence-google-work-fallback-run.test.js
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildFallbackResult,
+  fallbackMarkdown,
+} from '../../scripts/seo/book-intelligence-google-work-fallback-run.mjs';
+
+const item = {
+  id: 'MLU123', isbn: '9789878675701', title: 'El legado', author: 'Germán Beder',
+  research: { gsc_impressions: 100, gsc_clicks: 8 },
+};
+
+function classification(tier, { work = 0, exact = 0, auto = false, generate = false } = {}) {
+  return {
+    tier,
+    reason: tier === 'red' ? 'insufficient_evidence' : 'single_strong_source',
+    work_source_count: work,
+    independent_work_source_count: work ? 1 : 0,
+    strong_work_source_count: work ? 1 : 0,
+    exact_isbn_source_count: exact,
+    edition_fields_auto_publishable: { publisher: false, pages: false },
+    generation_policy: {
+      can_generate_work_content: generate,
+      can_auto_publish_work_content: auto,
+    },
+    identity_conflicts: [],
+  };
+}
+
+test('resultado muestra el upgrade sin copiar descripción externa', () => {
+  const result = buildFallbackResult(
+    item,
+    [],
+    [{ description: 'x'.repeat(130), topics: [] }],
+    classification('red'),
+    classification('yellow', { work: 1, generate: true }),
+  );
+  assert.equal(result.baseline_tier, 'red');
+  assert.equal(result.final_tier, 'yellow');
+  assert.equal(result.work_search_substantive_candidates, 1);
+  assert.equal(result.accepted_work_source_count, 1);
+  assert.equal(Object.hasOwn(result, 'description'), false);
+});
+
+test('markdown deja explícita la barrera entre obra y edición', () => {
+  const report = {
+    generated_at: '2026-08-22T00:00:00.000Z',
+    cohort: { selected: 12 },
+    sources: {
+      exact: { matched: 4 },
+      work_fallback: { attempted: 8, http_successes: 8, errors: 0 },
+    },
+    impact: {
+      tier_upgrades: 3,
+      red_to_yellow: 3,
+      red_to_green: 0,
+      generable_before: 2,
+      generable_after: 5,
+      auto_publish_before: 0,
+      auto_publish_after: 0,
+    },
+    results: [{
+      id: 'MLU123', isbn: item.isbn, gsc_impressions: 100,
+      exact_records: 0, work_search_candidates: 2, work_search_substantive_candidates: 1,
+      baseline_tier: 'red', final_tier: 'yellow',
+    }],
+  };
+  const markdown = fallbackMarkdown(report);
+  assert.match(markdown, /título\+autor/);
+  assert.match(markdown, /Nunca heredan el ISBN/);
+  assert.match(markdown, /Publisher, páginas, formato, año e idioma de otra edición no se publican/);
+  assert.match(markdown, /RED → YELLOW: 3/);
+});

--- a/functions/__tests__/book-intelligence-google-work.test.js
+++ b/functions/__tests__/book-intelligence-google-work.test.js
@@ -1,0 +1,134 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { classifyBookIntelligenceEvidence } from '../_shared/book-intelligence-evidence.js';
+import {
+  buildGoogleBooksWorkUrl,
+  fetchGoogleBooksWorkEvidence,
+  googleWorkIdentity,
+  parseGoogleBooksWorkEvidence,
+} from '../../scripts/seo/book-intelligence-google-work.mjs';
+
+const ITEM = {
+  id: 'MLU123456789',
+  isbn: '9789878675701',
+  title: 'El legado, de Germán Beder. Editorial Ejemplo, tapa blanda en español',
+  author: 'Germán Beder',
+  status: 'paused',
+  available_quantity: 0,
+};
+
+const OTHER_EDITION_ISBN = '9788496836693';
+
+function payload({ description = 'Una descripción extensa '.repeat(8), categories = ['Biografías', 'Deportes', 'Cultura'] } = {}) {
+  return {
+    items: [{
+      id: 'google-volume-1',
+      selfLink: 'https://www.googleapis.com/books/v1/volumes/google-volume-1',
+      volumeInfo: {
+        title: 'El legado',
+        authors: ['German Beder'],
+        description,
+        publisher: 'OTRA EDITORIAL',
+        pageCount: 999,
+        publishedDate: '2022-01-01',
+        language: 'es',
+        printType: 'BOOK',
+        categories,
+        industryIdentifiers: [{ type: 'ISBN_13', identifier: OTHER_EDITION_ISBN }],
+      },
+    }],
+  };
+}
+
+test('identidad de búsqueda usa título limpio + autor confiable', () => {
+  const identity = googleWorkIdentity(ITEM);
+  assert.ok(identity);
+  assert.equal(identity.author, 'Germán Beder');
+  assert.equal(identity.title, 'El legado');
+});
+
+test('no ejecuta fallback si falta autor confiable', () => {
+  assert.equal(googleWorkIdentity({ ...ITEM, author: 'Varios' }), null);
+  assert.throws(
+    () => buildGoogleBooksWorkUrl({ ...ITEM, author: 'Varios' }, { accessToken: 'token' }),
+    /título y autor confiables/i,
+  );
+});
+
+test('URL oficial usa intitle + inauthor y OAuth nunca viaja en query', () => {
+  const url = new URL(buildGoogleBooksWorkUrl(ITEM, { accessToken: 'secret-token', maxResults: 10 }));
+  assert.equal(url.origin, 'https://www.googleapis.com');
+  assert.equal(url.pathname, '/books/v1/volumes');
+  assert.match(url.searchParams.get('q'), /intitle:"El legado"/);
+  assert.match(url.searchParams.get('q'), /inauthor:"Germán Beder"/);
+  assert.equal(url.searchParams.get('projection'), 'full');
+  assert.equal(url.searchParams.get('maxResults'), '10');
+  assert.equal(url.searchParams.has('key'), false);
+  assert.doesNotMatch(url.toString(), /secret-token/);
+});
+
+test('parser conserva el ISBN real de la otra edición y contenido semántico', () => {
+  const records = parseGoogleBooksWorkEvidence(payload());
+  assert.equal(records.length, 1);
+  assert.equal(records[0].source, 'google_books');
+  assert.equal(records[0].isbn, OTHER_EDITION_ISBN);
+  assert.equal(records[0].raw_quality.exact_isbn, false);
+  assert.equal(records[0].raw_quality.discovery, 'title_author');
+  assert.equal(records[0].publisher, 'OTRA EDITORIAL');
+  assert.equal(records[0].pages, 999);
+  assert.equal(records[0].topics.length, 3);
+});
+
+test('motor canónico acepta contenido de la obra pero NO traslada hechos físicos de otra edición', () => {
+  const records = parseGoogleBooksWorkEvidence(payload());
+  const result = classifyBookIntelligenceEvidence(ITEM, records);
+  assert.equal(result.tier, 'yellow');
+  assert.equal(result.reason, 'single_strong_source');
+  assert.equal(result.generation_policy.can_generate_work_content, true);
+  assert.equal(result.generation_policy.can_auto_publish_work_content, false);
+  assert.equal(result.exact_isbn_source_count, 0);
+  assert.equal(result.edition_facts.publisher.value, null);
+  assert.equal(result.edition_facts.pages.value, null);
+  assert.equal(result.edition_fields_auto_publishable.publisher, false);
+  assert.equal(result.edition_fields_auto_publishable.pages, false);
+});
+
+test('título similar con autor distinto no rescata la obra', () => {
+  const records = parseGoogleBooksWorkEvidence({
+    items: [{
+      id: 'wrong-author',
+      volumeInfo: {
+        title: 'El legado',
+        authors: ['Otra Persona'],
+        description: 'Una descripción suficientemente extensa '.repeat(6),
+        categories: ['Tema 1', 'Tema 2', 'Tema 3'],
+        industryIdentifiers: [{ type: 'ISBN_13', identifier: OTHER_EDITION_ISBN }],
+      },
+    }],
+  });
+  const result = classifyBookIntelligenceEvidence(ITEM, records);
+  assert.equal(result.tier, 'red');
+  assert.equal(result.work_source_count, 0);
+});
+
+test('fetch usa Bearer en header y propaga errores HTTP', async () => {
+  let seenHeaders = null;
+  const records = await fetchGoogleBooksWorkEvidence(ITEM, {
+    accessToken: 'secret-token',
+    fetchImpl: async (_url, options) => {
+      seenHeaders = options.headers;
+      return { ok: true, status: 200, async json() { return payload(); } };
+    },
+  });
+  assert.equal(seenHeaders.authorization, 'Bearer secret-token');
+  assert.equal(records.length, 1);
+
+  await assert.rejects(
+    () => fetchGoogleBooksWorkEvidence(ITEM, {
+      accessToken: 'secret-token',
+      fetchImpl: async () => ({ ok: false, status: 503, async json() { return {}; } }),
+    }),
+    /HTTP 503/,
+  );
+});

--- a/scripts/seo/book-intelligence-google-work-fallback-run.mjs
+++ b/scripts/seo/book-intelligence-google-work-fallback-run.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { fetchAndConsolidate } from '../categorize/fetch-catalog.js';
+import { PAUSED_SEO_COHORT } from '../../functions/_shared/paused-seo-cohort.js';
+import {
+  classifyBookIntelligenceEvidence,
+  summarizeBookIntelligenceEvidence,
+} from '../../functions/_shared/book-intelligence-evidence.js';
+import { fetchGoogleBooksEvidence } from './book-intelligence-sources.mjs';
+import {
+  fetchGoogleBooksWorkEvidence,
+  googleWorkIdentity,
+} from './book-intelligence-google-work.mjs';
+import { selectResearchCohort } from './book-intelligence-research-run.mjs';
+
+const DEFAULT_LIMIT = 12;
+const DEFAULT_OUTPUT_DIR = 'artifacts/book-intelligence/google-work-fallback-1';
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function sourceRecordIsSubstantive(record) {
+  const topics = Array.isArray(record?.topics) ? record.topics.filter(Boolean) : [];
+  return clean(record?.description).length >= 120 || topics.length >= 3;
+}
+
+export function buildFallbackResult(item, exactRecords, workRecords, baseline, combined) {
+  const substantiveWorkCandidates = (Array.isArray(workRecords) ? workRecords : [])
+    .filter(sourceRecordIsSubstantive).length;
+  return {
+    id: String(item?.id || '').toUpperCase(),
+    isbn: clean(item?.isbn),
+    title: clean(item?.title),
+    author: clean(item?.author),
+    gsc_impressions: Number(item?.research?.gsc_impressions) || 0,
+    gsc_clicks: Number(item?.research?.gsc_clicks) || 0,
+    exact_records: Array.isArray(exactRecords) ? exactRecords.length : 0,
+    work_search_candidates: Array.isArray(workRecords) ? workRecords.length : 0,
+    work_search_substantive_candidates: substantiveWorkCandidates,
+    baseline_tier: baseline.tier,
+    final_tier: combined.tier,
+    baseline_reason: baseline.reason,
+    final_reason: combined.reason,
+    accepted_work_source_count: combined.work_source_count,
+    independent_work_source_count: combined.independent_work_source_count,
+    strong_work_source_count: combined.strong_work_source_count,
+    exact_isbn_source_count: combined.exact_isbn_source_count,
+    edition_fields_auto_publishable: combined.edition_fields_auto_publishable,
+    generation_policy: combined.generation_policy,
+    identity_conflicts: combined.identity_conflicts,
+  };
+}
+
+function tierValue(tier) {
+  return tier === 'green' ? 2 : tier === 'yellow' ? 1 : 0;
+}
+
+export function fallbackMarkdown(report) {
+  const lines = [
+    '# FICHAS-VIDRIERA-2 — GOOGLE-WORK-FALLBACK-1',
+    '',
+    `- Generado: ${report.generated_at}`,
+    `- Cohorte: ${report.cohort.selected} ISBN con demanda GSC.`,
+    `- Google Books exacto: ${report.sources.exact.matched}/${report.cohort.selected} matches.`,
+    `- Fallback título+autor intentado: ${report.sources.work_fallback.attempted}.`,
+    `- Fallback HTTP exitoso: ${report.sources.work_fallback.http_successes}; errores: ${report.sources.work_fallback.errors}.`,
+    `- ISBN rescatados a un tier superior: ${report.impact.tier_upgrades}.`,
+    `- RED → YELLOW: ${report.impact.red_to_yellow}; RED → GREEN: ${report.impact.red_to_green}.`,
+    `- Generables antes/después: ${report.impact.generable_before} → ${report.impact.generable_after}.`,
+    `- Auto-publicables antes/después: ${report.impact.auto_publish_before} → ${report.impact.auto_publish_after}.`,
+    '',
+    '## Resultado por ISBN',
+    '',
+    '| MLU | ISBN | GSC imp. | Exacto | Candidatos obra | Sust. | Tier antes | Tier final |',
+    '| --- | --- | ---: | ---: | ---: | ---: | --- | --- |',
+    ...report.results.map(result =>
+      `| ${result.id} | ${result.isbn} | ${result.gsc_impressions} | ${result.exact_records} | ${result.work_search_candidates} | ${result.work_search_substantive_candidates} | ${result.baseline_tier.toUpperCase()} | ${result.final_tier.toUpperCase()} |`,
+    ),
+    '',
+    '## Regla de seguridad',
+    '',
+    '- El fallback sólo se ejecuta cuando el ISBN exacto no devolvió registros y existe título+autor confiable.',
+    '- Los resultados conservan su ISBN propio. Nunca heredan el ISBN de Amado Libros.',
+    '- El motor canónico sólo acepta contenido de otra edición cuando título+autor representan la misma obra.',
+    '- Publisher, páginas, formato, año e idioma de otra edición no se publican como hechos de la edición de Amado Libros.',
+    '- Sólo lectura. No cambia fichas, renderer, sitemap, canonical, R2, D1, KV ni Producción.',
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+export async function runGoogleWorkFallback({
+  limit = DEFAULT_LIMIT,
+  outputDir = DEFAULT_OUTPUT_DIR,
+  googleBooksAccessToken = process.env.GOOGLE_BOOKS_ACCESS_TOKEN,
+  googleBooksApiKey = process.env.GOOGLE_BOOKS_API_KEY,
+} = {}) {
+  if (!clean(googleBooksAccessToken) && !clean(googleBooksApiKey)) {
+    throw new Error('GOOGLE-WORK-FALLBACK-1 requiere GOOGLE_BOOKS_ACCESS_TOKEN o GOOGLE_BOOKS_API_KEY.');
+  }
+
+  const catalog = await fetchAndConsolidate();
+  const { selected, missing_catalog_ids: missingCatalogIds } = selectResearchCohort({
+    cohort: PAUSED_SEO_COHORT,
+    catalogItems: catalog.items,
+    limit,
+  });
+
+  const results = [];
+  const baselines = [];
+  const finals = [];
+  const exactAttempts = [];
+  const workAttempts = [];
+
+  for (const item of selected) {
+    let exactRecords = [];
+    try {
+      exactRecords = await fetchGoogleBooksEvidence(item.isbn, {
+        accessToken: googleBooksAccessToken,
+        apiKey: googleBooksApiKey,
+      });
+      exactAttempts.push({ isbn: item.isbn, ok: true, record_count: exactRecords.length });
+    } catch (error) {
+      exactAttempts.push({ isbn: item.isbn, ok: false, record_count: 0, error: error?.message || String(error) });
+    }
+
+    const baseline = classifyBookIntelligenceEvidence(item, exactRecords);
+    baselines.push(baseline);
+
+    let workRecords = [];
+    if (exactRecords.length === 0) {
+      const identity = googleWorkIdentity(item);
+      if (!identity) {
+        workAttempts.push({ isbn: item.isbn, ok: true, skipped: true, reason: 'missing_reliable_title_author', record_count: 0 });
+      } else {
+        try {
+          workRecords = await fetchGoogleBooksWorkEvidence(item, {
+            accessToken: googleBooksAccessToken,
+            apiKey: googleBooksApiKey,
+            maxResults: 10,
+          });
+          workAttempts.push({ isbn: item.isbn, ok: true, skipped: false, record_count: workRecords.length });
+        } catch (error) {
+          workAttempts.push({ isbn: item.isbn, ok: false, skipped: false, record_count: 0, error: error?.message || String(error) });
+        }
+      }
+    }
+
+    const combined = classifyBookIntelligenceEvidence(item, [...exactRecords, ...workRecords]);
+    finals.push(combined);
+    results.push(buildFallbackResult(item, exactRecords, workRecords, baseline, combined));
+  }
+
+  const baselineSummary = summarizeBookIntelligenceEvidence(baselines);
+  const finalSummary = summarizeBookIntelligenceEvidence(finals);
+  const tierUpgrades = results.filter(result => tierValue(result.final_tier) > tierValue(result.baseline_tier));
+
+  const report = {
+    schema_version: 1,
+    run: 'FICHAS-VIDRIERA-2/GOOGLE-WORK-FALLBACK-1',
+    generated_at: new Date().toISOString(),
+    cohort: {
+      requested: positiveInteger(limit, DEFAULT_LIMIT),
+      selected: selected.length,
+      demand_only: true,
+      missing_catalog_ids: missingCatalogIds,
+      total_impressions: selected.reduce((sum, item) => sum + (Number(item.research?.gsc_impressions) || 0), 0),
+      total_clicks: selected.reduce((sum, item) => sum + (Number(item.research?.gsc_clicks) || 0), 0),
+    },
+    catalog: {
+      total_items: catalog.items.length,
+      fetched_at: catalog.fetched_at,
+    },
+    sources: {
+      exact: {
+        requested: exactAttempts.length,
+        http_successes: exactAttempts.filter(attempt => attempt.ok).length,
+        matched: exactAttempts.filter(attempt => attempt.ok && attempt.record_count > 0).length,
+        errors: exactAttempts.filter(attempt => !attempt.ok).length,
+      },
+      work_fallback: {
+        attempted: workAttempts.filter(attempt => !attempt.skipped).length,
+        skipped_missing_identity: workAttempts.filter(attempt => attempt.skipped).length,
+        http_successes: workAttempts.filter(attempt => !attempt.skipped && attempt.ok).length,
+        with_any_candidates: workAttempts.filter(attempt => !attempt.skipped && attempt.ok && attempt.record_count > 0).length,
+        errors: workAttempts.filter(attempt => !attempt.skipped && !attempt.ok).length,
+      },
+    },
+    classification: {
+      before: baselineSummary,
+      after: finalSummary,
+    },
+    impact: {
+      tier_upgrades: tierUpgrades.length,
+      red_to_yellow: results.filter(result => result.baseline_tier === 'red' && result.final_tier === 'yellow').length,
+      red_to_green: results.filter(result => result.baseline_tier === 'red' && result.final_tier === 'green').length,
+      generable_before: baselines.filter(result => result.generation_policy.can_generate_work_content).length,
+      generable_after: finals.filter(result => result.generation_policy.can_generate_work_content).length,
+      auto_publish_before: baselines.filter(result => result.generation_policy.can_auto_publish_work_content).length,
+      auto_publish_after: finals.filter(result => result.generation_policy.can_auto_publish_work_content).length,
+    },
+    results,
+    attempts: {
+      exact_errors: exactAttempts.filter(attempt => !attempt.ok),
+      work_errors: workAttempts.filter(attempt => !attempt.ok),
+    },
+  };
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(path.join(outputDir, 'google-work-fallback-1-report.json'), JSON.stringify(report, null, 2));
+  await writeFile(path.join(outputDir, 'report-summary.md'), fallbackMarkdown(report));
+
+  if (exactAttempts.length && !exactAttempts.some(attempt => attempt.ok)) {
+    throw new Error('Google Books exacto no completó ninguna consulta HTTP.');
+  }
+  const plannedWork = workAttempts.filter(attempt => !attempt.skipped);
+  if (plannedWork.length && !plannedWork.some(attempt => attempt.ok)) {
+    throw new Error('Google Books título+autor no completó ninguna consulta HTTP.');
+  }
+
+  return report;
+}
+
+function cliOptions(argv) {
+  const options = {
+    limit: positiveInteger(process.env.BOOK_INTELLIGENCE_LIMIT, DEFAULT_LIMIT),
+    outputDir: process.env.BOOK_INTELLIGENCE_OUTPUT_DIR || DEFAULT_OUTPUT_DIR,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (flag === '--limit') options.limit = positiveInteger(argv[++index], DEFAULT_LIMIT);
+    else if (flag === '--output-dir') options.outputDir = argv[++index];
+    else throw new Error(`Argumento desconocido: ${flag}`);
+  }
+  return options;
+}
+
+async function main() {
+  const report = await runGoogleWorkFallback(cliOptions(process.argv.slice(2)));
+  console.log(JSON.stringify({
+    run: report.run,
+    cohort: report.cohort,
+    sources: report.sources,
+    classification: report.classification,
+    impact: report.impact,
+  }, null, 2));
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  main().catch(error => {
+    console.error(`[google-work-fallback-1] ERROR: ${error?.message || error}`);
+    process.exit(1);
+  });
+}

--- a/scripts/seo/book-intelligence-google-work.mjs
+++ b/scripts/seo/book-intelligence-google-work.mjs
@@ -4,7 +4,9 @@
 //
 // Seguridad editorial:
 // - la búsqueda exige título + autor;
-// - el título consultado usa el display title conservador del repo;
+// - el título público del sitio NO se modifica; para investigación se permite
+//   una poda adicional sólo ante el autor exacto conocido o metadatos
+//   inequívocos;
 // - los resultados conservan su propio ISBN, nunca heredan el ISBN pedido;
 // - el motor canónico book-intelligence-evidence decide si título+autor
 //   representan realmente la misma obra;
@@ -21,6 +23,54 @@ const GOOGLE_BOOKS_BASE = 'https://www.googleapis.com/books/v1/volumes';
 
 function clean(value) {
   return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function escapeRegExp(value) {
+  return String(value ?? '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function trimResearchTitle(value) {
+  return clean(value).replace(/[\s|,;:.-]+$/u, '').trim();
+}
+
+function researchTitle(item = {}) {
+  const explicit = clean(item?.showcase_display_title);
+  if (explicit.length >= 3) return explicit;
+
+  const derived = deriveBookDisplayTitle(item);
+  if (derived.changed && derived.title.length >= 3) return derived.title;
+
+  const raw = clean(item?.title);
+  const author = clean(item?.author);
+  if (raw.length < 3) return raw;
+
+  // El limpiador público tiene una barrera de longitud deliberadamente
+  // conservadora. Para una query de investigación podemos cortar antes de un
+  // sufijo que nombra EXACTAMENTE al autor conocido, porque ese texto no forma
+  // parte del título de la obra y nunca se publica como resultado de esta poda.
+  if (author && !isGenericAuthor(author)) {
+    const authorPattern = escapeRegExp(author);
+    const authorSuffix = new RegExp(
+      `(?:\\s*[,|–—-]\\s*|\\s+)(?:de\\s+|autor(?:a|es)?\\s*:?\\s*)${authorPattern}(?=\\s*(?:[.,;|–—-]|$))`,
+      'iu',
+    );
+    const match = authorSuffix.exec(raw);
+    if (match?.index >= 3) {
+      const prefix = trimResearchTitle(raw.slice(0, match.index));
+      if (prefix.length >= 3) return prefix;
+    }
+  }
+
+  // Segunda salida, sólo con etiquetas inequívocas de catálogo. No corta en
+  // dos puntos ni guiones genéricos para no perder subtítulos legítimos.
+  const metadataSuffix = /\s*(?:,|\.)\s*(?:editorial\b|tapa\s+(?:blanda|dura)\b|encuadernaci[oó]n\b|formato\b|idioma\b|en\s+(?:espa[nñ]ol|ingl[eé]s|portugu[eé]s|franc[eé]s|italiano|alem[aá]n)\b)/iu;
+  const metadataMatch = metadataSuffix.exec(raw);
+  if (metadataMatch?.index >= 3) {
+    const prefix = trimResearchTitle(raw.slice(0, metadataMatch.index));
+    if (prefix.length >= 3) return prefix;
+  }
+
+  return raw;
 }
 
 function plainText(value) {
@@ -50,7 +100,7 @@ function identifiers(volumeInfo = {}) {
 }
 
 export function googleWorkIdentity(item = {}) {
-  const title = deriveBookDisplayTitle(item).title;
+  const title = researchTitle(item);
   const author = clean(item?.author);
   if (title.length < 3 || isGenericAuthor(author)) return null;
   return { title, author };

--- a/scripts/seo/book-intelligence-google-work.mjs
+++ b/scripts/seo/book-intelligence-google-work.mjs
@@ -1,0 +1,151 @@
+// FICHAS-VIDRIERA-2 / GOOGLE-WORK-FALLBACK-1
+// Recupera evidencia semántica de OTRA edición de la misma obra cuando
+// Google Books no encuentra el ISBN exacto.
+//
+// Seguridad editorial:
+// - la búsqueda exige título + autor;
+// - el título consultado usa el display title conservador del repo;
+// - los resultados conservan su propio ISBN, nunca heredan el ISBN pedido;
+// - el motor canónico book-intelligence-evidence decide si título+autor
+//   representan realmente la misma obra;
+// - por lo tanto publisher/pages/year de otra edición nunca se vuelven hechos
+//   de la edición vendida.
+
+import { deriveBookDisplayTitle } from '../../functions/_shared/book-display-title.js';
+import {
+  isGenericAuthor,
+  normalizeValidIsbn,
+} from '../../functions/_shared/showcase-ranking.js';
+
+const GOOGLE_BOOKS_BASE = 'https://www.googleapis.com/books/v1/volumes';
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function plainText(value) {
+  return clean(String(value ?? '')
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'"));
+}
+
+function yearFromDate(value) {
+  const match = clean(value).match(/\b(1[5-9]\d{2}|20\d{2}|21\d{2})\b/);
+  return match ? match[1] : null;
+}
+
+function identifiers(volumeInfo = {}) {
+  return [...new Set(
+    (Array.isArray(volumeInfo.industryIdentifiers) ? volumeInfo.industryIdentifiers : [])
+      .map(identifier => normalizeValidIsbn(identifier?.identifier))
+      .filter(Boolean),
+  )];
+}
+
+export function googleWorkIdentity(item = {}) {
+  const title = deriveBookDisplayTitle(item).title;
+  const author = clean(item?.author);
+  if (title.length < 3 || isGenericAuthor(author)) return null;
+  return { title, author };
+}
+
+export function buildGoogleBooksWorkUrl(item, {
+  apiKey,
+  accessToken,
+  maxResults = 10,
+} = {}) {
+  const identity = googleWorkIdentity(item);
+  if (!identity) throw new Error('La búsqueda de obra requiere título y autor confiables.');
+  if (!clean(apiKey) && !clean(accessToken)) {
+    throw new Error('Google Books requiere API key u OAuth access token.');
+  }
+  const safeMax = Math.min(Math.max(Math.floor(Number(maxResults) || 10), 1), 20);
+  const url = new URL(GOOGLE_BOOKS_BASE);
+  url.searchParams.set('q', `intitle:"${identity.title}" inauthor:"${identity.author}"`);
+  url.searchParams.set('printType', 'books');
+  url.searchParams.set('projection', 'full');
+  url.searchParams.set('maxResults', String(safeMax));
+  if (clean(apiKey)) url.searchParams.set('key', clean(apiKey));
+  return url.toString();
+}
+
+export function parseGoogleBooksWorkEvidence(payload) {
+  const output = [];
+  const seen = new Set();
+  for (const item of Array.isArray(payload?.items) ? payload.items : []) {
+    const info = item?.volumeInfo || {};
+    const authors = Array.isArray(info.authors) ? info.authors.map(clean).filter(Boolean) : [];
+    const volumeIsbns = identifiers(info);
+    const isbn = volumeIsbns[0] || null;
+    const sourceId = clean(item?.id) || null;
+    const key = sourceId || `${clean(info.title)}|${authors.join(', ')}|${isbn || ''}`;
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    const pages = Number(info.pageCount);
+    output.push({
+      source: 'google_books',
+      source_id: sourceId,
+      source_url: clean(info.infoLink) || clean(item?.selfLink) || null,
+      isbn,
+      title: clean(info.title),
+      author: authors.join(', '),
+      description: plainText(info.description),
+      publisher: clean(info.publisher) || null,
+      pages: Number.isInteger(pages) && pages > 0 ? pages : null,
+      language: clean(info.language) || null,
+      publication_year: yearFromDate(info.publishedDate),
+      format: clean(info.printType) || null,
+      topics: Array.isArray(info.categories)
+        ? info.categories.map(clean).filter(Boolean).slice(0, 12)
+        : [],
+      raw_quality: {
+        exact_isbn: false,
+        identifiers: volumeIsbns,
+        discovery: 'title_author',
+      },
+    });
+  }
+  return output;
+}
+
+async function fetchJson(url, {
+  fetchImpl = globalThis.fetch,
+  headers = {},
+  timeoutMs = 10_000,
+} = {}) {
+  if (typeof fetchImpl !== 'function') throw new Error('fetch no disponible.');
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      headers: { accept: 'application/json', ...headers },
+      signal: controller.signal,
+    });
+    if (!response?.ok) throw new Error(`HTTP ${response?.status || 0}`);
+    return await response.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function fetchGoogleBooksWorkEvidence(item, {
+  apiKey,
+  accessToken,
+  fetchImpl,
+  timeoutMs,
+  maxResults,
+} = {}) {
+  const url = buildGoogleBooksWorkUrl(item, { apiKey, accessToken, maxResults });
+  const headers = clean(accessToken)
+    ? { authorization: `Bearer ${clean(accessToken)}` }
+    : {};
+  const payload = await fetchJson(url, { fetchImpl, timeoutMs, headers });
+  return parseGoogleBooksWorkEvidence(payload);
+}


### PR DESCRIPTION
## Objetivo

Recuperar contenido semántico de la misma **obra** cuando Google Books no encuentra el ISBN exacto de la edición de Amado Libros, sin mezclar datos físicos entre ediciones.

Este PR está apilado sobre #219 y es exclusivamente investigación/read-only.

## Hipótesis

RESEARCH-RUN-1 obtuvo Google Books exacto en 4/12 ISBN. El motor de evidencia ya contempla otra edición de la misma obra cuando coinciden título + autor, pero hasta ahora el cliente sólo buscaba por `isbn:`.

Google Books soporta `intitle:` e `inauthor:`. Por eso, ante 0 exactos, este PR mide un fallback de obra con título de investigación + autor confiable.

## Seguridad editorial

- el fallback sólo corre si el ISBN exacto dio 0;
- exige título + autor confiable;
- el título público de la web no cambia: la poda adicional existe sólo para la consulta de investigación y sólo corta ante autor exacto conocido o metadatos inequívocos;
- cada resultado conserva **su propio ISBN**; nunca hereda el ISBN pedido;
- el motor canónico decide si título+autor realmente representan la misma obra;
- descripción/categorías de otra edición pueden aportar contenido de obra únicamente si pasan ese gate;
- publisher, páginas, idioma, formato y año de otra edición **no** pueden convertirse en hechos de la edición vendida;
- no se cambia el umbral GREEN/YELLOW/RED.

## Resultado real — 12 ISBN con demanda GSC

Cohorte idéntica a #219: 12 ISBN, 559 impresiones y 46 clics.

Validación:

- tests del fallback + motor de evidencia: **28/28 PASS**;
- WIF/OAuth Google Books: **PASS**;
- Google Books exacto: 12/12 HTTP exitosas, **4/12 matches**, 0 errores;
- fallback título+autor: **8/8 HTTP exitosas**;
- fallback con algún candidato: **1/8**;
- errores de fallback: 0.

Impacto real:

- tiers antes: GREEN 0 / YELLOW 2 / RED 10;
- tiers después: **GREEN 0 / YELLOW 2 / RED 10**;
- upgrades de tier: **0**;
- RED → YELLOW: **0**;
- RED → GREEN: **0**;
- fichas generables: **2 → 2**;
- auto-publicables: **0 → 0**.

## Decisión técnica

El fallback es seguro y el contrato obra/edición quedó validado, pero **no mejora la cobertura de forma material** en la cohorte real. Por lo tanto:

- NO se incorpora todavía al pipeline batch permanente;
- NO se escala esta estrategia por sí sola;
- NO se relajan los gates de identidad ni de contenido para forzar rescates;
- el siguiente paso es un piloto de fuentes oficiales concretas por ISBN/obra (editorial/autor/institución) sobre los títulos con demanda, para identificar familias de dominios que sí aporten evidencia semántica suficiente.

## Gate cumplido

1. URL/auth segura: PASS;
2. no contaminación entre ediciones: PASS;
3. 12 ISBN reales: PASS;
4. mejora de tiers: **0**;
5. decisión de permanencia: **NO promover este fallback todavía**.

## Seguridad operativa

Sólo lectura. No cambia HTML, renderer, sitemap, canonical, R2, D1, KV, Worker, checkout ni Producción. No agrega secretos ni deploy.

**MANTENER DRAFT. NO MERGEAR. NO PRODUCCIÓN.**