### PR TITLE
FICHAS-VIDRIERA-2: piloto de evidencia oficial curada

### DIFF
--- a/.github/workflows/book-intelligence-official-evidence-pilot-1.yml
+++ b/.github/workflows/book-intelligence-official-evidence-pilot-1.yml
@@ -1,0 +1,120 @@
+name: FICHAS-VIDRIERA-2 official evidence pilot 1
+
+on:
+  push:
+    branches:
+      - agent/fichas-vidriera-v2-official-evidence-pilot-1
+    paths:
+      - '.github/workflows/book-intelligence-official-evidence-pilot-1.yml'
+      - 'scripts/seo/book-intelligence-official-evidence-pilot-data.mjs'
+      - 'scripts/seo/book-intelligence-official-evidence-pilot-run.mjs'
+      - 'functions/__tests__/book-intelligence-official-evidence-pilot.test.js'
+      - 'functions/_shared/book-intelligence-evidence.js'
+  pull_request:
+    paths:
+      - '.github/workflows/book-intelligence-official-evidence-pilot-1.yml'
+      - 'scripts/seo/book-intelligence-official-evidence-pilot-data.mjs'
+      - 'scripts/seo/book-intelligence-official-evidence-pilot-run.mjs'
+      - 'functions/__tests__/book-intelligence-official-evidence-pilot.test.js'
+      - 'functions/_shared/book-intelligence-evidence.js'
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: Cantidad de ISBN con demanda GSC a medir
+        required: true
+        default: '12'
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: book-intelligence-official-evidence-pilot-1-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pilot:
+    name: Google Books + curated official evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Validate curated evidence without network
+        run: |
+          node --check scripts/seo/book-intelligence-official-evidence-pilot-data.mjs
+          node --check scripts/seo/book-intelligence-official-evidence-pilot-run.mjs
+          node --test functions/__tests__/book-intelligence-official-evidence-pilot.test.js functions/__tests__/book-intelligence-evidence.test.js
+
+      - name: Authenticate Google Books through existing Workload Identity
+        id: google_auth
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: amado-libros-analytics
+          workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
+          service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/books
+          create_credentials_file: false
+
+      - name: Execute official evidence pilot
+        id: pilot_run
+        continue-on-error: true
+        env:
+          GOOGLE_BOOKS_ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
+          BOOK_INTELLIGENCE_LIMIT: ${{ inputs.limit || '12' }}
+          BOOK_INTELLIGENCE_OUTPUT_DIR: artifacts/book-intelligence/official-evidence-pilot-1
+        run: node scripts/seo/book-intelligence-official-evidence-pilot-run.mjs --limit "$BOOK_INTELLIGENCE_LIMIT"
+
+      - name: Validate generated report
+        if: steps.pilot_run.outcome == 'success'
+        env:
+          BOOK_INTELLIGENCE_LIMIT: ${{ inputs.limit || '12' }}
+        run: |
+          test -s artifacts/book-intelligence/official-evidence-pilot-1/official-evidence-pilot-1-report.json
+          test -s artifacts/book-intelligence/official-evidence-pilot-1/report-summary.md
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const report = JSON.parse(fs.readFileSync('artifacts/book-intelligence/official-evidence-pilot-1/official-evidence-pilot-1-report.json', 'utf8'));
+          if (report.schema_version !== 1) process.exit(1);
+          if (report.run !== 'FICHAS-VIDRIERA-2/OFFICIAL-EVIDENCE-PILOT-1') process.exit(1);
+          if (report.cohort.selected !== Number(process.env.BOOK_INTELLIGENCE_LIMIT || 12)) process.exit(1);
+          if (report.sources.official.targeted_isbns !== 7) process.exit(1);
+          if (report.sources.google_books.http_successes < 1) process.exit(1);
+          NODE
+
+      - name: Upload official evidence pilot report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: book-intelligence-official-evidence-pilot-1-${{ github.run_id }}
+          path: artifacts/book-intelligence/official-evidence-pilot-1/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Write pilot summary
+        if: always()
+        run: |
+          if [ -f artifacts/book-intelligence/official-evidence-pilot-1/report-summary.md ]; then
+            cat artifacts/book-intelligence/official-evidence-pilot-1/report-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## OFFICIAL-EVIDENCE-PILOT-1 incompleto' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Evidencia curada: sólo facts/temas cortos + URL de auditoría' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Sin publicación de fichas ni deploy' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Modo: read-only' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if pilot did not complete
+        if: steps.pilot_run.outcome != 'success'
+        run: |
+          echo 'OFFICIAL-EVIDENCE-PILOT-1 no completó la corrida real.'
+          exit 1

--- a/functions/__tests__/book-intelligence-official-evidence-pilot.test.js
+++ b/functions/__tests__/book-intelligence-official-evidence-pilot.test.js
@@ -1,0 +1,203 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  BOOK_EVIDENCE_SOURCE_POLICY,
+  classifyBookIntelligenceEvidence,
+} from '../_shared/book-intelligence-evidence.js';
+import {
+  OFFICIAL_EVIDENCE_BY_ISBN,
+  OFFICIAL_EVIDENCE_PILOT_ISBNS,
+  officialEvidenceForIsbn,
+} from '../../scripts/seo/book-intelligence-official-evidence-pilot-data.mjs';
+import {
+  buildPilotResult,
+  pilotMarkdown,
+} from '../../scripts/seo/book-intelligence-official-evidence-pilot-run.mjs';
+
+const ITEMS = Object.freeze({
+  '9791387869380': {
+    id: 'MLU1416777650', isbn: '9791387869380',
+    title: 'Libro Murdoku: 80 Acertijos De Lógica Y Asesinatos, De Garand, Manuel, Vol. 1. Editorial Temas Hoy, Tapa Blanda (2025)',
+    author: 'Manuel Garand', status: 'paused', available_quantity: 0,
+  },
+  '9798181647725': {
+    id: 'MLU1472001988', isbn: '9798181647725',
+    title: 'Sopicidios 80 Crímenes En Sopas De Letras - Vergel',
+    author: 'Daniel Vergel', status: 'paused', available_quantity: 0,
+  },
+  '9789878629933': {
+    id: 'MLU692066314', isbn: '9789878629933',
+    title: '30 Chispas De Luz Reflexiones Cabalisticas Cabala Saban',
+    author: 'SABAN MARIO JAVIER', status: 'paused', available_quantity: 0,
+  },
+  '9791387781323': {
+    id: 'MLU1001329818', isbn: '9791387781323',
+    title: 'My Hero Academia 42 Edicion Especial Cofre, De Kohei Horikoshi. Editorial Planeta Cómic (2025)',
+    author: 'KOHEI HORIKOSHI', status: 'paused', available_quantity: 0,
+  },
+  '9782017312703': {
+    id: 'MLU1224447122', isbn: '9782017312703',
+    title: 'Libro Colorea Y Descubre El Misterio Los Ositos Cariñosos, De Eugénie Varone. Editorial Hachette Little Heroes, Tapa Blanda, En Francés',
+    author: 'Varone, Eugénie', status: 'paused', available_quantity: 0,
+  },
+  '9789878675701': {
+    id: 'MLU616917519', isbn: '9789878675701',
+    title: 'Libro - El Legado - German Beder',
+    author: 'Beder, German', status: 'paused', available_quantity: 0,
+  },
+  '9788416894864': {
+    id: 'MLU709076232', isbn: '9788416894864',
+    title: 'La Jubilación Una Nueva Oportunidad - Bartolomé Freire',
+    author: 'Freire Arteta, Bartolomé', status: 'paused', available_quantity: 0,
+  },
+});
+
+function substantiveGoogleExact(item, topics = ['tema uno', 'tema dos', 'tema tres']) {
+  return {
+    source: 'google_books',
+    source_id: `google-${item.id}`,
+    source_url: 'https://books.google.com/',
+    isbn: item.isbn,
+    title: item.title,
+    author: item.author,
+    topics,
+  };
+}
+
+test('piloto contiene exactamente siete ISBN seleccionados y todos existen en fixtures', () => {
+  assert.equal(OFFICIAL_EVIDENCE_PILOT_ISBNS.length, 7);
+  assert.deepEqual(new Set(OFFICIAL_EVIDENCE_PILOT_ISBNS), new Set(Object.keys(ITEMS)));
+});
+
+test('cada registro usa una familia admitida, URL HTTPS y fecha de verificación', () => {
+  for (const [targetIsbn, records] of Object.entries(OFFICIAL_EVIDENCE_BY_ISBN)) {
+    assert.ok(records.length >= 1, targetIsbn);
+    for (const record of records) {
+      assert.ok(BOOK_EVIDENCE_SOURCE_POLICY[record.source], `${targetIsbn}: source inválida`);
+      assert.match(record.source_url, /^https:\/\//, `${targetIsbn}: URL no HTTPS`);
+      assert.equal(record.verified_at, '2026-08-22');
+      assert.ok(record.source_provider);
+    }
+  }
+});
+
+test('snapshot no guarda sinopsis largas ni copy externo', () => {
+  for (const records of Object.values(OFFICIAL_EVIDENCE_BY_ISBN)) {
+    for (const record of records) {
+      assert.equal(record.description, undefined);
+      assert.equal(record.summary, undefined);
+      assert.equal(record.author_context, undefined);
+      assert.ok((record.audience || '').length <= 100);
+      assert.ok(record.topics.length <= 8);
+      for (const topic of record.topics) assert.ok(topic.length <= 60, topic);
+    }
+  }
+});
+
+test('otra edición nunca hereda el ISBN objetivo: 30 Chispas conserva 9788494017513', () => {
+  const records = officialEvidenceForIsbn('9789878629933');
+  const jojma = records.find(record => record.source_provider === 'jojma_ediciones');
+  const continente = records.find(record => record.source_provider === 'ediciones_continente');
+  assert.equal(jojma.isbn, '9788494017513');
+  assert.notEqual(jojma.isbn, '9789878629933');
+  assert.equal(continente.isbn, '9789878629933');
+});
+
+test('curated-only: Murdoku, Sopicidios, My Hero y Bisounours alcanzan yellow sin fabricar green', () => {
+  for (const isbn of ['9791387869380', '9798181647725', '9791387781323', '9782017312703']) {
+    const result = classifyBookIntelligenceEvidence(ITEMS[isbn], officialEvidenceForIsbn(isbn));
+    assert.equal(result.tier, 'yellow', `${isbn}: ${result.reason}`);
+    assert.equal(result.generation_policy.can_generate_work_content, true);
+    assert.equal(result.generation_policy.can_auto_publish_work_content, false);
+  }
+});
+
+test('30 Chispas alcanza green por dos familias reales sin auto-publicar páginas de otra edición', () => {
+  const item = ITEMS['9789878629933'];
+  const result = classifyBookIntelligenceEvidence(item, officialEvidenceForIsbn(item.isbn));
+  assert.equal(result.tier, 'green');
+  assert.equal(result.independent_work_source_count, 2);
+  assert.equal(result.strong_work_source_count, 1);
+  assert.equal(result.edition_facts.pages.value, 132);
+  assert.equal(result.edition_fields_auto_publishable.pages, false);
+  assert.equal(result.edition_fields_auto_publishable.publisher, false);
+});
+
+test('El Legado y La Jubilación pasan a green cuando se combinan con Google exacto sustantivo', () => {
+  for (const isbn of ['9789878675701', '9788416894864']) {
+    const item = ITEMS[isbn];
+    const baseline = classifyBookIntelligenceEvidence(item, [substantiveGoogleExact(item)]);
+    const finalResult = classifyBookIntelligenceEvidence(item, [
+      substantiveGoogleExact(item),
+      ...officialEvidenceForIsbn(isbn),
+    ]);
+    assert.equal(baseline.tier, 'yellow');
+    assert.equal(finalResult.tier, 'green');
+    assert.equal(finalResult.independent_work_source_count, 2);
+  }
+});
+
+test('Bisounours: una fuente oficial exacta con autor compatible resuelve el falso conflicto de título', () => {
+  const item = ITEMS['9782017312703'];
+  const googleWithoutAuthor = {
+    source: 'google_books',
+    isbn: item.isbn,
+    title: 'Care Bears mystery colouring book',
+    author: '',
+    topics: [],
+  };
+  const baseline = classifyBookIntelligenceEvidence(item, [googleWithoutAuthor]);
+  const finalResult = classifyBookIntelligenceEvidence(item, [
+    googleWithoutAuthor,
+    ...officialEvidenceForIsbn(item.isbn),
+  ]);
+  assert.equal(baseline.tier, 'red');
+  assert.equal(baseline.reason, 'identity_conflict');
+  assert.equal(finalResult.identity_conflicts.length, 0);
+  assert.equal(finalResult.tier, 'yellow');
+});
+
+test('My Hero: datos físicos exactos del distribuidor siguen sin auto-publicarse por confianza insuficiente', () => {
+  const item = ITEMS['9791387781323'];
+  const result = classifyBookIntelligenceEvidence(item, officialEvidenceForIsbn(item.isbn));
+  assert.equal(result.edition_facts.pages.value, 184);
+  assert.equal(result.edition_fields_auto_publishable.pages, false);
+  assert.equal(result.edition_fields_auto_publishable.publisher, false);
+});
+
+test('resultado y markdown reportan el cambio sin incorporar contenido externo', () => {
+  const item = { ...ITEMS['9789878675701'], research: { gsc_impressions: 7, gsc_clicks: 0 } };
+  const google = [substantiveGoogleExact(item)];
+  const official = [...officialEvidenceForIsbn(item.isbn)];
+  const baseline = classifyBookIntelligenceEvidence(item, google);
+  const finalResult = classifyBookIntelligenceEvidence(item, [...google, ...official]);
+  const row = buildPilotResult(item, google, official, baseline, finalResult);
+  assert.equal(row.baseline_tier, 'yellow');
+  assert.equal(row.final_tier, 'green');
+  assert.equal(Object.hasOwn(row, 'description'), false);
+
+  const markdown = pilotMarkdown({
+    generated_at: '2026-08-22T00:00:00.000Z',
+    cohort: { selected: 12 },
+    sources: {
+      official: { targeted_isbns: 7 },
+      google_books: { matched: 4, errors: 0 },
+    },
+    classification: {
+      before: { green: 0, yellow: 2, red: 10 },
+      after: { green: 3, yellow: 4, red: 5 },
+    },
+    impact: {
+      tier_upgrades: 7, red_to_yellow: 4, red_to_green: 1, yellow_to_green: 2,
+      generable_before: 2, generable_after: 7,
+      auto_publish_before: 0, auto_publish_after: 3,
+      five_topics_before: 0, five_topics_after: 7,
+      identity_conflicts_before: 1, identity_conflicts_after: 0,
+    },
+    results: [row],
+  });
+  assert.match(markdown, /No se copian sinopsis externas/);
+  assert.match(markdown, /Otra edición conserva su ISBN real/);
+  assert.match(markdown, /YELLOW → GREEN: 2/);
+});

--- a/scripts/seo/book-intelligence-official-evidence-pilot-data.mjs
+++ b/scripts/seo/book-intelligence-official-evidence-pilot-data.mjs
@@ -1,0 +1,226 @@
+// FICHAS-VIDRIERA-2 / OFFICIAL-EVIDENCE-PILOT-1
+//
+// Snapshot manual, pequeño y auditable, de evidencia primaria/curada encontrada
+// para ISBN con demanda GSC. NO contiene sinopsis copiadas: sólo hechos cortos,
+// temas neutrales derivados de la fuente y la URL que permite revalidarlos.
+//
+// Reglas:
+// - `publisher` / `author_site` sólo cuando el dominio es de la editorial o el autor;
+// - `distributor` para libreros/distribuidores externos aunque el ISBN sea exacto;
+// - una edición distinta conserva SU ISBN real o null; nunca hereda el ISBN objetivo;
+// - los datos físicos sólo pertenecen a registros con ISBN exacto;
+// - este archivo alimenta investigación offline, no el renderer público.
+
+const VERIFIED_AT = '2026-08-22';
+
+function freezeRecords(records) {
+  return Object.freeze(records.map(record => Object.freeze({
+    verified_at: VERIFIED_AT,
+    ...record,
+    topics: Object.freeze([...(record.topics || [])]),
+  })));
+}
+
+export const OFFICIAL_EVIDENCE_BY_ISBN = Object.freeze({
+  // Murdoku — ficha oficial Temas de Hoy / PlanetadeLibros, ISBN exacto.
+  '9791387869380': freezeRecords([
+    {
+      source: 'publisher',
+      source_provider: 'planetadelibros_temas_de_hoy',
+      source_url: 'https://www.planetadelibros.com/libro-murdoku-80-acertijos-de-logica-y-asesinatos/426932',
+      isbn: '9791387869380',
+      title: 'Murdoku: 80 acertijos de lógica y asesinatos',
+      author: 'Manuel Garand',
+      publisher: 'Temas de Hoy',
+      pages: 208,
+      language: 'es',
+      format: 'Rústica con solapas',
+      publication_year: '2025',
+      topics: [
+        'acertijos de lógica',
+        'misterios detectivescos',
+        'sudokus',
+        'resolución de crímenes',
+        'desafíos mentales',
+      ],
+    },
+  ]),
+
+  // SOPICIDIOS 1 — sitio oficial del autor/proyecto. No expone ISBN en página,
+  // por lo que deliberadamente queda como evidencia de OBRA, no de edición.
+  '9798181647725': freezeRecords([
+    {
+      source: 'author_site',
+      source_provider: 'sopicidios_daniel_vergel',
+      source_url: 'https://sopicidios.com/pages/sopicidios-1',
+      isbn: null,
+      title: 'SOPICIDIOS',
+      author: 'Daniel Vergel',
+      topics: [
+        'sopas de letras',
+        'misterios criminales',
+        'deducción',
+        'dificultad progresiva',
+        'casos para resolver',
+        'pasatiempos para adultos',
+      ],
+      audience: 'Lectores de misterio, novela negra y pasatiempos de deducción.',
+    },
+  ]),
+
+  // 30 Chispas — una edición Jojmá de la misma obra + distribuidor argentino
+  // exacto para el ISBN objetivo. La edición Jojmá conserva su ISBN diferente.
+  '9789878629933': freezeRecords([
+    {
+      source: 'publisher',
+      source_provider: 'jojma_ediciones',
+      source_url: 'https://jojmalibros.com/libro/30-chispas-de-luz-reflexiones-cabalisticas-para-el-dia-a-dia/',
+      isbn: '9788494017513',
+      title: '30 Chispas de luz',
+      author: 'Mario Javier Sabán',
+      publisher: 'Jojmá Ediciones',
+      pages: 129,
+      publication_year: '2019',
+      topics: [
+        'Cábala aplicada',
+        'autoconocimiento',
+        'conciencia',
+        'meditación',
+        'amor',
+        'crecimiento espiritual',
+      ],
+    },
+    {
+      source: 'distributor',
+      source_provider: 'ediciones_continente',
+      source_url: 'https://www.edicontinente.com.ar/tpl_libro_item_detail.php?id=SAB038',
+      isbn: '9789878629933',
+      title: '30 Chispas de Luz. Reflexiones cabalísticas para el día a día',
+      author: 'Mario Javier Sabán',
+      publisher: 'Editorial Saban',
+      pages: 132,
+      language: 'es',
+      format: 'Rústica con solapa',
+      publication_year: '2020',
+      topics: [
+        'Cábala',
+        'judaísmo',
+        'espiritualidad cotidiana',
+        'potencial humano',
+      ],
+    },
+  ]),
+
+  // My Hero Academia 42 cofre — Planeta aporta contenido de obra/edición especial,
+  // Norma confirma el ISBN y los hechos físicos; no se usa su sinopsis como una
+  // segunda fuente semántica para fabricar GREEN.
+  '9791387781323': freezeRecords([
+    {
+      source: 'publisher',
+      source_provider: 'planeta_comic',
+      source_url: 'https://proapi.planetadelibros.com/descargas/sala-prensa-libro/sinopsis-y-biografia/428522/my-hero-academia-n-42-edicion-especial-cofre.pdf?_locale=es',
+      isbn: null,
+      title: 'My Hero Academia 42 edición especial cofre',
+      author: 'Kohei Horikoshi',
+      publisher: 'Planeta Cómic',
+      publication_year: '2025',
+      topics: [
+        'cierre de la serie',
+        'escuela de héroes',
+        'amistad y apoyo',
+        'sueños y futuro',
+        'edición especial con extras',
+      ],
+    },
+    {
+      source: 'distributor',
+      source_provider: 'norma_comics',
+      source_url: 'https://www.normacomics.com/my-hero-academia-42-edicion-especial-cofre.html',
+      isbn: '9791387781323',
+      title: 'My Hero Academia 42 edición especial cofre',
+      author: 'Kohei Horikoshi',
+      publisher: 'Planeta Cómic',
+      pages: 184,
+      publication_year: '2025',
+      format: 'Cofre edición especial',
+      topics: [],
+    },
+  ]),
+
+  // Bisounours — ficha oficial Hachette exacta. El autor compatible permite
+  // resolver el falso conflicto de identidad del único registro Google exacto.
+  '9782017312703': freezeRecords([
+    {
+      source: 'publisher',
+      source_provider: 'hachette_heroes',
+      source_url: 'https://www.hachette.fr/livre/coloriages-mysteres-bisounours-9782017312703/',
+      isbn: '9782017312703',
+      title: 'Coloriages mystères - Bisounours',
+      author: 'Eugénie Varone',
+      publisher: 'Hachette Heroes',
+      pages: 112,
+      language: 'fr',
+      format: 'Grand format broché',
+      publication_year: '2025',
+      topics: [
+        'coloriage par numéros',
+        'Bisounours',
+        '50 coloriages mystères',
+        'loisir créatif',
+        'papier premium',
+      ],
+      audience: 'Fans de coloriage y del universo Bisounours de distintas edades.',
+    },
+  ]),
+
+  // El Legado — Básquet Plus declara ser editor del libro y publica una
+  // entrevista original extensa al autor sobre el contenido y la construcción.
+  '9789878675701': freezeRecords([
+    {
+      source: 'publisher',
+      source_provider: 'basquet_plus',
+      source_url: 'https://www.basquetplus.com/node/67934',
+      isbn: null,
+      title: 'El Legado',
+      author: 'Germán Beder',
+      publisher: 'Básquet Plus',
+      topics: [
+        'selección argentina de básquetbol',
+        'Mundial de China 2019',
+        'recambio generacional',
+        'testimonios de jugadores',
+        'liderazgo y presión deportiva',
+        'crónica desde adentro',
+      ],
+    },
+  ]),
+
+  // La jubilación — sitio oficial del autor, centrado en este libro y su
+  // investigación con 150 jubilados. Work-level: no inventa ISBN ni páginas.
+  '9788416894864': freezeRecords([
+    {
+      source: 'author_site',
+      source_provider: 'bartolome_freire',
+      source_url: 'https://www.bartolomefreire.es/la-jubilacion-una-nueva-oportunidad/',
+      isbn: null,
+      title: 'La jubilación, una nueva oportunidad',
+      author: 'Bartolomé Freire',
+      topics: [
+        'transición a la jubilación',
+        'identidad después del trabajo',
+        'gestión del tiempo',
+        'pareja y familia',
+        'estrategias de adaptación',
+        'sentido personal de la nueva etapa',
+      ],
+    },
+  ]),
+});
+
+export const OFFICIAL_EVIDENCE_PILOT_ISBNS = Object.freeze(
+  Object.keys(OFFICIAL_EVIDENCE_BY_ISBN),
+);
+
+export function officialEvidenceForIsbn(isbn) {
+  return OFFICIAL_EVIDENCE_BY_ISBN[String(isbn || '').replace(/[^0-9Xx]/g, '')] || Object.freeze([]);
+}

--- a/scripts/seo/book-intelligence-official-evidence-pilot-run.mjs
+++ b/scripts/seo/book-intelligence-official-evidence-pilot-run.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { fetchAndConsolidate } from '../categorize/fetch-catalog.js';
+import { PAUSED_SEO_COHORT } from '../../functions/_shared/paused-seo-cohort.js';
+import {
+  classifyBookIntelligenceEvidence,
+  summarizeBookIntelligenceEvidence,
+} from '../../functions/_shared/book-intelligence-evidence.js';
+import { fetchGoogleBooksEvidence } from './book-intelligence-sources.mjs';
+import { selectResearchCohort } from './book-intelligence-research-run.mjs';
+import {
+  OFFICIAL_EVIDENCE_PILOT_ISBNS,
+  officialEvidenceForIsbn,
+} from './book-intelligence-official-evidence-pilot-data.mjs';
+
+const DEFAULT_LIMIT = 12;
+const DEFAULT_OUTPUT_DIR = 'artifacts/book-intelligence/official-evidence-pilot-1';
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function tierValue(tier) {
+  return tier === 'green' ? 2 : tier === 'yellow' ? 1 : 0;
+}
+
+function autoEditionFields(result) {
+  return Object.entries(result.edition_fields_auto_publishable || {})
+    .filter(([, allowed]) => allowed)
+    .map(([field]) => field)
+    .sort();
+}
+
+export function buildPilotResult(item, googleRecords, officialRecords, baseline, finalResult) {
+  return {
+    id: String(item?.id || '').toUpperCase(),
+    isbn: clean(item?.isbn),
+    title: clean(item?.title),
+    author: clean(item?.author),
+    gsc_impressions: Number(item?.research?.gsc_impressions) || 0,
+    gsc_clicks: Number(item?.research?.gsc_clicks) || 0,
+    google_records: Array.isArray(googleRecords) ? googleRecords.length : 0,
+    official_records: Array.isArray(officialRecords) ? officialRecords.length : 0,
+    official_sources: [...new Set((officialRecords || []).map(record => record.source_provider || record.source))],
+    baseline_tier: baseline.tier,
+    final_tier: finalResult.tier,
+    tier_upgraded: tierValue(finalResult.tier) > tierValue(baseline.tier),
+    baseline_reason: baseline.reason,
+    final_reason: finalResult.reason,
+    identity_conflicts_before: baseline.identity_conflicts.length,
+    identity_conflicts_after: finalResult.identity_conflicts.length,
+    work_source_count: finalResult.work_source_count,
+    independent_work_source_count: finalResult.independent_work_source_count,
+    strong_work_source_count: finalResult.strong_work_source_count,
+    exact_isbn_source_count: finalResult.exact_isbn_source_count,
+    can_generate_work_content: finalResult.generation_policy.can_generate_work_content,
+    can_auto_publish_work_content: finalResult.generation_policy.can_auto_publish_work_content,
+    can_generate_five_topics: finalResult.generation_policy.can_generate_five_topics,
+    edition_fields_auto_publishable: autoEditionFields(finalResult),
+    edition_fact_conflicts: finalResult.edition_fact_conflicts,
+  };
+}
+
+export function pilotMarkdown(report) {
+  const lines = [
+    '# FICHAS-VIDRIERA-2 — OFFICIAL-EVIDENCE-PILOT-1',
+    '',
+    `- Generado: ${report.generated_at}`,
+    `- Cohorte: ${report.cohort.selected} ISBN con demanda GSC.`,
+    `- ISBN con evidencia oficial curada: ${report.sources.official.targeted_isbns}.`,
+    `- Google Books exacto: ${report.sources.google_books.matched}/${report.cohort.selected} matches; ${report.sources.google_books.errors} errores.`,
+    `- Tiers antes: GREEN ${report.classification.before.green}, YELLOW ${report.classification.before.yellow}, RED ${report.classification.before.red}.`,
+    `- Tiers después: GREEN ${report.classification.after.green}, YELLOW ${report.classification.after.yellow}, RED ${report.classification.after.red}.`,
+    `- Upgrades de tier: ${report.impact.tier_upgrades}.`,
+    `- RED → YELLOW: ${report.impact.red_to_yellow}; RED → GREEN: ${report.impact.red_to_green}; YELLOW → GREEN: ${report.impact.yellow_to_green}.`,
+    `- Generables: ${report.impact.generable_before} → ${report.impact.generable_after}.`,
+    `- Auto-publicables a nivel obra: ${report.impact.auto_publish_before} → ${report.impact.auto_publish_after}.`,
+    `- Con 5 temas habilitados: ${report.impact.five_topics_before} → ${report.impact.five_topics_after}.`,
+    `- Conflictos de identidad: ${report.impact.identity_conflicts_before} → ${report.impact.identity_conflicts_after}.`,
+    '',
+    '## Resultado por ISBN',
+    '',
+    '| MLU | ISBN | GSC imp. | Google | Oficial | Tier antes | Tier final | Conflictos ID | Fuentes oficiales |',
+    '| --- | --- | ---: | ---: | ---: | --- | --- | ---: | --- |',
+    ...report.results.map(result =>
+      `| ${result.id} | ${result.isbn} | ${result.gsc_impressions} | ${result.google_records} | ${result.official_records} | ${result.baseline_tier.toUpperCase()} | ${result.final_tier.toUpperCase()} | ${result.identity_conflicts_after} | ${result.official_sources.join(', ') || '—'} |`,
+    ),
+    '',
+    '## Barreras editoriales',
+    '',
+    '- No se copian sinopsis externas en el dataset curado; sólo temas/facts cortos y URLs de auditoría.',
+    '- Otra edición conserva su ISBN real o null y nunca contamina los datos físicos de la edición vendida.',
+    '- GREEN exige dos familias independientes de evidencia de obra y al menos una fuente fuerte.',
+    '- Un campo físico sólo queda auto-publicable si existe soporte exacto de ISBN con confianza suficiente y sin conflicto.',
+    '- El piloto es read-only: no modifica fichas, renderer, canonical, sitemap, R2, D1, KV ni Producción.',
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+export async function runOfficialEvidencePilot({
+  limit = DEFAULT_LIMIT,
+  outputDir = DEFAULT_OUTPUT_DIR,
+  googleBooksAccessToken = process.env.GOOGLE_BOOKS_ACCESS_TOKEN,
+  googleBooksApiKey = process.env.GOOGLE_BOOKS_API_KEY,
+} = {}) {
+  if (!clean(googleBooksAccessToken) && !clean(googleBooksApiKey)) {
+    throw new Error('OFFICIAL-EVIDENCE-PILOT-1 requiere GOOGLE_BOOKS_ACCESS_TOKEN o GOOGLE_BOOKS_API_KEY.');
+  }
+
+  const catalog = await fetchAndConsolidate();
+  const { selected, missing_catalog_ids: missingCatalogIds } = selectResearchCohort({
+    cohort: PAUSED_SEO_COHORT,
+    catalogItems: catalog.items,
+    limit,
+  });
+
+  const results = [];
+  const baselines = [];
+  const finals = [];
+  const googleAttempts = [];
+
+  for (const item of selected) {
+    let googleRecords = [];
+    try {
+      googleRecords = await fetchGoogleBooksEvidence(item.isbn, {
+        accessToken: googleBooksAccessToken,
+        apiKey: googleBooksApiKey,
+      });
+      googleAttempts.push({ isbn: item.isbn, ok: true, record_count: googleRecords.length });
+    } catch (error) {
+      googleAttempts.push({
+        isbn: item.isbn,
+        ok: false,
+        record_count: 0,
+        error: error?.message || String(error),
+      });
+    }
+
+    const officialRecords = [...officialEvidenceForIsbn(item.isbn)];
+    const baseline = classifyBookIntelligenceEvidence(item, googleRecords);
+    const finalResult = classifyBookIntelligenceEvidence(item, [...googleRecords, ...officialRecords]);
+    baselines.push(baseline);
+    finals.push(finalResult);
+    results.push(buildPilotResult(item, googleRecords, officialRecords, baseline, finalResult));
+  }
+
+  const before = summarizeBookIntelligenceEvidence(baselines);
+  const after = summarizeBookIntelligenceEvidence(finals);
+  const report = {
+    schema_version: 1,
+    run: 'FICHAS-VIDRIERA-2/OFFICIAL-EVIDENCE-PILOT-1',
+    generated_at: new Date().toISOString(),
+    cohort: {
+      requested: positiveInteger(limit, DEFAULT_LIMIT),
+      selected: selected.length,
+      demand_only: true,
+      missing_catalog_ids: missingCatalogIds,
+      total_impressions: selected.reduce((sum, item) => sum + (Number(item.research?.gsc_impressions) || 0), 0),
+      total_clicks: selected.reduce((sum, item) => sum + (Number(item.research?.gsc_clicks) || 0), 0),
+    },
+    catalog: {
+      total_items: catalog.items.length,
+      fetched_at: catalog.fetched_at,
+    },
+    sources: {
+      google_books: {
+        requested: googleAttempts.length,
+        http_successes: googleAttempts.filter(attempt => attempt.ok).length,
+        matched: googleAttempts.filter(attempt => attempt.ok && attempt.record_count > 0).length,
+        errors: googleAttempts.filter(attempt => !attempt.ok).length,
+      },
+      official: {
+        targeted_isbns: OFFICIAL_EVIDENCE_PILOT_ISBNS.length,
+        records: OFFICIAL_EVIDENCE_PILOT_ISBNS.reduce(
+          (sum, isbn) => sum + officialEvidenceForIsbn(isbn).length,
+          0,
+        ),
+      },
+    },
+    classification: { before, after },
+    impact: {
+      tier_upgrades: results.filter(result => result.tier_upgraded).length,
+      red_to_yellow: results.filter(result => result.baseline_tier === 'red' && result.final_tier === 'yellow').length,
+      red_to_green: results.filter(result => result.baseline_tier === 'red' && result.final_tier === 'green').length,
+      yellow_to_green: results.filter(result => result.baseline_tier === 'yellow' && result.final_tier === 'green').length,
+      generable_before: baselines.filter(result => result.generation_policy.can_generate_work_content).length,
+      generable_after: finals.filter(result => result.generation_policy.can_generate_work_content).length,
+      auto_publish_before: baselines.filter(result => result.generation_policy.can_auto_publish_work_content).length,
+      auto_publish_after: finals.filter(result => result.generation_policy.can_auto_publish_work_content).length,
+      five_topics_before: baselines.filter(result => result.generation_policy.can_generate_five_topics).length,
+      five_topics_after: finals.filter(result => result.generation_policy.can_generate_five_topics).length,
+      identity_conflicts_before: baselines.reduce((sum, result) => sum + result.identity_conflicts.length, 0),
+      identity_conflicts_after: finals.reduce((sum, result) => sum + result.identity_conflicts.length, 0),
+    },
+    results,
+    attempts: {
+      google_errors: googleAttempts.filter(attempt => !attempt.ok),
+    },
+  };
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(path.join(outputDir, 'official-evidence-pilot-1-report.json'), JSON.stringify(report, null, 2));
+  await writeFile(path.join(outputDir, 'report-summary.md'), pilotMarkdown(report));
+
+  if (googleAttempts.length && !googleAttempts.some(attempt => attempt.ok)) {
+    throw new Error('Google Books no completó ninguna consulta HTTP.');
+  }
+
+  return report;
+}
+
+function cliOptions(argv) {
+  const options = {
+    limit: positiveInteger(process.env.BOOK_INTELLIGENCE_LIMIT, DEFAULT_LIMIT),
+    outputDir: process.env.BOOK_INTELLIGENCE_OUTPUT_DIR || DEFAULT_OUTPUT_DIR,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (flag === '--limit') options.limit = positiveInteger(argv[++index], DEFAULT_LIMIT);
+    else if (flag === '--output-dir') options.outputDir = argv[++index];
+    else throw new Error(`Argumento desconocido: ${flag}`);
+  }
+  return options;
+}
+
+async function main() {
+  const report = await runOfficialEvidencePilot(cliOptions(process.argv.slice(2)));
+  console.log(JSON.stringify({
+    run: report.run,
+    cohort: report.cohort,
+    sources: report.sources,
+    classification: report.classification,
+    impact: report.impact,
+  }, null, 2));
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  main().catch(error => {
+    console.error(`[official-evidence-pilot-1] ERROR: ${error?.message || error}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Objetivo

Medir cuánto cambia la cobertura real de FICHAS-VIDRIERA-2 cuando, en vez de seguir agregando APIs bibliográficas de baja cobertura, incorporamos evidencia **primaria/oficial** localizada para títulos con demanda GSC.

Este PR está apilado sobre #219 y es exclusivamente investigación/read-only.

## Cohorte

Mismos 12 ISBN de RESEARCH-RUN-1: **559 impresiones y 46 clics históricos**.

El piloto agrega evidencia curada para 7 ISBN:

- Murdoku → Temas de Hoy / PlanetadeLibros;
- SOPICIDIOS → sitio oficial de Daniel Vergel;
- 30 Chispas de Luz → Jojmá Ediciones + Ediciones Continente;
- My Hero Academia 42 cofre → Planeta Cómic + Norma Comics;
- Bisounours → Hachette Heroes;
- El Legado → Básquet Plus, editor del libro;
- La jubilación → sitio oficial de Bartolomé Freire.

## Resultado real

Workflow `FICHAS-VIDRIERA-2 official evidence pilot 1`: **SUCCESS**.

Validación local del snapshot + motor: **29/29 PASS**.

Google Books exacto se mantuvo estable:

- 12/12 consultas HTTP exitosas;
- 4/12 matches exactos;
- 0 errores.

Evidencia oficial curada:

- 7 ISBN objetivo;
- 9 registros;
- sin sinopsis copiadas: sólo facts/temas cortos + URL de auditoría.

### Tiers

| Estado | Antes | Después |
|---|---:|---:|
| GREEN | 0 | **3** |
| YELLOW | 2 | **4** |
| RED | 10 | **5** |

Impacto:

- **7 upgrades de tier**;
- RED → YELLOW: **4**;
- RED → GREEN: **1**;
- YELLOW → GREEN: **2**;
- fichas generables: **2 → 7**;
- auto-publicables a nivel de obra: **0 → 3**;
- con 5 temas habilitados: **0 → 7**;
- conflictos de identidad: **1 → 0**.

### Resultado por título

- Murdoku: RED → **YELLOW**. La fuente oficial Temas de Hoy además deja auto-publicables editorial, páginas e idioma de la edición.
- SOPICIDIOS (9798181647725): RED → **YELLOW**.
- 30 Chispas de Luz: RED → **GREEN**. Los hechos físicos del distribuidor exacto siguen sin auto-publicarse por confianza insuficiente: la separación obra/edición funciona.
- My Hero Academia 42 cofre: RED → **YELLOW**. Norma confirma edición, pero sus hechos físicos no se elevan automáticamente por ser distribuidor.
- Bisounours: RED → **YELLOW** y el conflicto de identidad baja de 1 → 0. Hachette deja auto-publicables idioma, páginas y año.
- El Legado: YELLOW → **GREEN**. La combinación Google Books exacto + Básquet Plus aporta dos familias independientes.
- La jubilación: YELLOW → **GREEN**. Google Books exacto + sitio oficial de Bartolomé Freire aportan dos familias independientes.

Los cinco ISBN no intervenidos permanecen RED, como corresponde.

## Qué demuestra el piloto

El cuello de botella no es el motor ni la autenticación: es la **cobertura semántica de fuentes confiables**.

Agregar otra API bibliográfica genérica no movió los tiers (#224 y #225). En cambio, evidencia primaria/oficial bien identificada movió **7 de 12** fichas sin relajar una sola regla.

Por lo tanto, la dirección correcta para escalar es:

1. mantener Google Books como fuente automática base;
2. construir un registro auditable de fuentes oficiales/editoriales por obra/ISBN;
3. persistir un manifest de enriquecimiento con tier, fuentes, temas y hechos de edición permitidos;
4. sólo GREEN se habilita para auto-publicación de contenido de obra;
5. YELLOW requiere revisión humana o una segunda fuente independiente;
6. RED no genera contenido.

## Barreras editoriales

- otra edición conserva su ISBN real o null;
- nunca hereda el ISBN objetivo;
- datos físicos de otra edición no se trasladan;
- `distributor` sigue teniendo confianza menor y no vuelve auto-publicables hechos físicos por sí solo;
- GREEN mantiene el gate canónico de dos familias independientes y al menos una fuerte;
- no se copian sinopsis externas;
- no se relajan thresholds.

## Seguridad operativa

Sólo lectura. No cambia HTML, fichas públicas, renderer, canonical, sitemap, R2, D1, KV, Worker, checkout ni Producción. No agrega secretos ni deploy.

**MANTENER DRAFT. NO MERGEAR. NO PRODUCCIÓN.**