### PR TITLE
FICHAS-VIDRIERA-2: persistencia R2 aislada del manifest en Preview

### DIFF
--- a/.github/workflows/book-intelligence-enrichment-r2-preview-1.yml
+++ b/.github/workflows/book-intelligence-enrichment-r2-preview-1.yml
@@ -1,0 +1,107 @@
+name: FICHAS-VIDRIERA-2 enrichment R2 Preview 1
+
+on:
+  push:
+    branches:
+      - agent/fichas-vidriera-v2-enrichment-r2-preview-1
+    paths:
+      - '.github/workflows/book-intelligence-enrichment-r2-preview-1.yml'
+      - 'scripts/seo/publish-book-intelligence-preview-r2.sh'
+      - 'scripts/seo/book-intelligence-enrichment-manifest.mjs'
+      - 'scripts/seo/book-intelligence-enrichment-manifest-run.mjs'
+      - 'scripts/seo/book-intelligence-official-evidence-pilot-data.mjs'
+      - 'functions/__tests__/book-intelligence-preview-r2-publish.test.js'
+      - 'functions/__tests__/book-intelligence-enrichment-manifest.test.js'
+      - 'functions/_shared/book-intelligence-evidence.js'
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: Cantidad de ISBN con demanda GSC a persistir en Preview
+        required: true
+        default: '12'
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: book-intelligence-enrichment-r2-preview-1
+  cancel-in-progress: true
+
+jobs:
+  publish-preview:
+    name: Build, publish and read back Preview manifest
+    if: github.ref_name == 'agent/fichas-vidriera-v2-enrichment-r2-preview-1'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: preview
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Validate Preview-only persistence contract
+        run: |
+          bash -n scripts/seo/publish-book-intelligence-preview-r2.sh
+          node --check scripts/seo/book-intelligence-enrichment-manifest.mjs
+          node --check scripts/seo/book-intelligence-enrichment-manifest-run.mjs
+          node --test \
+            functions/__tests__/book-intelligence-preview-r2-publish.test.js \
+            functions/__tests__/book-intelligence-enrichment-manifest.test.js \
+            functions/__tests__/book-intelligence-official-evidence-pilot.test.js \
+            functions/__tests__/book-intelligence-evidence.test.js
+
+      - name: Authenticate Google Books through existing Workload Identity
+        id: google_auth
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: amado-libros-analytics
+          workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
+          service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/books
+          create_credentials_file: false
+
+      - name: Build fresh enrichment manifest
+        env:
+          GOOGLE_BOOKS_ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
+          BOOK_INTELLIGENCE_LIMIT: ${{ inputs.limit || '12' }}
+          BOOK_INTELLIGENCE_OUTPUT_DIR: artifacts/book-intelligence/enrichment-manifest-1
+        run: node scripts/seo/book-intelligence-enrichment-manifest-run.mjs --limit "$BOOK_INTELLIGENCE_LIMIT"
+
+      - name: Publish isolated R2 Preview namespace and verify readback
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BOOK_INTELLIGENCE_PREVIEW_BUCKET: amadolibros-catalog
+        run: bash scripts/seo/publish-book-intelligence-preview-r2.sh
+
+      - name: Upload exact persisted artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: book-intelligence-enrichment-r2-preview-1-${{ github.run_id }}
+          path: artifacts/book-intelligence/enrichment-manifest-1/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Summary
+        if: always()
+        run: |
+          echo '## FICHAS-VIDRIERA-2 — R2 Preview persistence' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Namespace: `book-intelligence/preview/v1/*`' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Bucket: `amadolibros-catalog` (prefijo aislado; no toca catalog.json ni showcase)' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Producción Pages no tiene binding `CATALOG_BUCKET`' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Sin deploy de Pages/Worker' >> "$GITHUB_STEP_SUMMARY"
+          if [ -f artifacts/book-intelligence/enrichment-manifest-1/report-summary.md ]; then
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            cat artifacts/book-intelligence/enrichment-manifest-1/report-summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/book-intelligence-enrichment-r2-preview-1.yml
+++ b/.github/workflows/book-intelligence-enrichment-r2-preview-1.yml
@@ -13,6 +13,19 @@ on:
       - 'functions/__tests__/book-intelligence-preview-r2-publish.test.js'
       - 'functions/__tests__/book-intelligence-enrichment-manifest.test.js'
       - 'functions/_shared/book-intelligence-evidence.js'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - agent/fichas-vidriera-v2-enrichment-manifest-1
+    paths:
+      - '.github/workflows/book-intelligence-enrichment-r2-preview-1.yml'
+      - 'scripts/seo/publish-book-intelligence-preview-r2.sh'
+      - 'scripts/seo/book-intelligence-enrichment-manifest.mjs'
+      - 'scripts/seo/book-intelligence-enrichment-manifest-run.mjs'
+      - 'scripts/seo/book-intelligence-official-evidence-pilot-data.mjs'
+      - 'functions/__tests__/book-intelligence-preview-r2-publish.test.js'
+      - 'functions/__tests__/book-intelligence-enrichment-manifest.test.js'
+      - 'functions/_shared/book-intelligence-evidence.js'
   workflow_dispatch:
     inputs:
       limit:
@@ -26,13 +39,15 @@ permissions:
   id-token: write
 
 concurrency:
-  group: book-intelligence-enrichment-r2-preview-1
+  group: book-intelligence-enrichment-r2-preview-1-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   publish-preview:
     name: Build, publish and read back Preview manifest
-    if: github.ref_name == 'agent/fichas-vidriera-v2-enrichment-r2-preview-1'
+    if: >-
+      (github.event_name == 'push' && github.ref_name == 'agent/fichas-vidriera-v2-enrichment-r2-preview-1') ||
+      (github.event_name == 'pull_request' && github.head_ref == 'agent/fichas-vidriera-v2-enrichment-r2-preview-1' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment:

--- a/functions/__tests__/book-intelligence-preview-r2-publish.test.js
+++ b/functions/__tests__/book-intelligence-preview-r2-publish.test.js
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const script = fs.readFileSync('scripts/seo/publish-book-intelligence-preview-r2.sh', 'utf8');
+const wrangler = fs.readFileSync('wrangler.toml', 'utf8');
+const workflow = fs.readFileSync('.github/workflows/book-intelligence-enrichment-r2-preview-1.yml', 'utf8');
+
+test('publisher queda encerrado en book-intelligence/preview/v1', () => {
+  assert.match(script, /PREFIX="book-intelligence\/preview\/v1"/);
+  assert.match(script, /objects\/\$SHA\.json/);
+  assert.match(script, /manifest\.json/);
+  assert.doesNotMatch(script, /book-intelligence\/production/);
+  assert.doesNotMatch(script, /showcase\/v[12]\/cohort\.json/);
+  assert.doesNotMatch(script, /staging\/catalog\.json/);
+});
+
+test('publisher usa objeto content-addressed, readback y puntero último', () => {
+  const putObject = script.indexOf('r2 object put \\\n  "$BUCKET/$OBJECT_KEY"');
+  const getObject = script.indexOf('r2 object get \\\n  "$BUCKET/$OBJECT_KEY"');
+  const putPointer = script.indexOf('r2 object put \\\n  "$BUCKET/$POINTER_KEY"');
+  const getPointer = script.indexOf('r2 object get \\\n  "$BUCKET/$POINTER_KEY"');
+  assert.ok(putObject >= 0 && getObject > putObject);
+  assert.ok(putPointer > getObject);
+  assert.ok(getPointer > putPointer);
+  assert.match(script, /REMOTE_SHA/);
+  assert.match(script, /cmp "\$POINTER_FILE" "\$REMOTE_POINTER"/);
+});
+
+test('manifest remoto conserva entorno preview, SHA y conteos', () => {
+  assert.match(script, /environment: 'preview'/);
+  assert.match(script, /pointer\.current\.sha256 !== sha/);
+  assert.match(script, /pointer\.current\.counts\.total !== object\.entries\.length/);
+});
+
+test('workflow sólo publica desde la rama aislada y usa environment preview', () => {
+  assert.match(workflow, /agent\/fichas-vidriera-v2-enrichment-r2-preview-1/);
+  assert.match(workflow, /environment:\s*\n\s*name: preview/);
+  assert.match(workflow, /CLOUDFLARE_API_TOKEN/);
+  assert.match(workflow, /CLOUDFLARE_ACCOUNT_ID/);
+  assert.doesNotMatch(workflow, /environment:\s*\n\s*name: production/);
+  assert.doesNotMatch(workflow, /pages deploy/);
+});
+
+test('Pages Production no recibe CATALOG_BUCKET; sólo Preview puede leer el catálogo R2 directo', () => {
+  const previewStart = wrangler.indexOf('[[env.preview.r2_buckets]]');
+  const productionStart = wrangler.indexOf('[[env.production.kv_namespaces]]');
+  assert.ok(previewStart >= 0 && productionStart > previewStart);
+  const previewBlock = wrangler.slice(previewStart, productionStart);
+  const productionBlock = wrangler.slice(productionStart);
+  assert.match(previewBlock, /binding\s*=\s*"CATALOG_BUCKET"/);
+  assert.match(previewBlock, /bucket_name\s*=\s*"amadolibros-catalog"/);
+  assert.doesNotMatch(productionBlock, /binding\s*=\s*"CATALOG_BUCKET"/);
+});

--- a/scripts/seo/publish-book-intelligence-preview-r2.sh
+++ b/scripts/seo/publish-book-intelligence-preview-r2.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT_FILE="${1:-artifacts/book-intelligence/enrichment-manifest-1/enrichment-manifest.json}"
+BUCKET="${BOOK_INTELLIGENCE_PREVIEW_BUCKET:-amadolibros-catalog}"
+PREFIX="book-intelligence/preview/v1"
+WRANGLER_VERSION="${WRANGLER_VERSION:-4.107.0}"
+
+if [ ! -s "$INPUT_FILE" ]; then
+  echo "Manifest inexistente o vacío: $INPUT_FILE" >&2
+  exit 1
+fi
+
+node - "$INPUT_FILE" <<'NODE'
+const fs = require('node:fs');
+const file = process.argv[2];
+const manifest = JSON.parse(fs.readFileSync(file, 'utf8'));
+if (manifest.schema_version !== 1) throw new Error('schema_version inválido');
+if (!Array.isArray(manifest.entries) || manifest.entries.length < 1) throw new Error('entries vacío');
+if (manifest.counts?.total !== manifest.entries.length) throw new Error('counts.total inconsistente');
+if ((manifest.counts.auto_publish || 0) + (manifest.counts.review || 0) + (manifest.counts.hold || 0) !== manifest.entries.length) {
+  throw new Error('conteos de decisiones inconsistentes');
+}
+for (const entry of manifest.entries) {
+  if (!/^MLU\d+$/.test(String(entry.product_id || ''))) throw new Error(`product_id inválido: ${entry.product_id}`);
+  if (!['auto_publish', 'review', 'hold'].includes(entry.decision)) throw new Error(`decisión inválida: ${entry.decision}`);
+  if (entry.decision === 'hold') {
+    if (entry.work?.topic_seeds?.length) throw new Error(`hold con temas: ${entry.product_id}`);
+    if (Object.keys(entry.edition?.auto_publishable_fields || {}).length) throw new Error(`hold con hechos de edición: ${entry.product_id}`);
+  }
+  const raw = JSON.stringify(entry).toLowerCase();
+  if (raw.includes('"description"') || raw.includes('"summary"') || raw.includes('"author_context"')) {
+    throw new Error(`copy externo prohibido: ${entry.product_id}`);
+  }
+}
+NODE
+
+SHA="$(sha256sum "$INPUT_FILE" | cut -d' ' -f1)"
+BYTES="$(wc -c < "$INPUT_FILE" | tr -d ' ')"
+OBJECT_KEY="$PREFIX/objects/$SHA.json"
+POINTER_KEY="$PREFIX/manifest.json"
+STAGING_KEY="$PREFIX/staging/manifest-${GITHUB_RUN_ID:-manual}.json"
+REMOTE_OBJECT="/tmp/book-intelligence-r2-object.json"
+REMOTE_STAGING="/tmp/book-intelligence-r2-staging.json"
+REMOTE_POINTER="/tmp/book-intelligence-r2-pointer.json"
+POINTER_FILE="/tmp/book-intelligence-preview-pointer.json"
+
+# Objeto content-addressed primero. Puede quedar huérfano ante un corte, pero
+# nunca queda anunciado por el puntero si el readback no verifica su SHA.
+npx "wrangler@$WRANGLER_VERSION" r2 object put \
+  "$BUCKET/$OBJECT_KEY" --remote --file "$INPUT_FILE" \
+  --content-type application/json \
+  --cache-control 'public, max-age=31536000, immutable'
+
+npx "wrangler@$WRANGLER_VERSION" r2 object get \
+  "$BUCKET/$OBJECT_KEY" --remote --file "$REMOTE_OBJECT"
+REMOTE_SHA="$(sha256sum "$REMOTE_OBJECT" | cut -d' ' -f1)"
+if [ "$REMOTE_SHA" != "$SHA" ]; then
+  echo "SHA remoto inválido: esperado=$SHA recibido=$REMOTE_SHA" >&2
+  exit 1
+fi
+
+node - "$INPUT_FILE" "$POINTER_FILE" "$OBJECT_KEY" "$SHA" "$BYTES" <<'NODE'
+const fs = require('node:fs');
+const [input, output, objectKey, sha256, bytesRaw] = process.argv.slice(2);
+const manifest = JSON.parse(fs.readFileSync(input, 'utf8'));
+const pointer = {
+  schema_version: 1,
+  environment: 'preview',
+  generated_at: manifest.generated_at || null,
+  catalog_version: manifest.catalog_version || null,
+  current: {
+    object_key: objectKey,
+    sha256,
+    bytes: Number(bytesRaw),
+    counts: manifest.counts,
+  },
+};
+fs.writeFileSync(output, `${JSON.stringify(pointer, null, 2)}\n`);
+NODE
+
+# Staging del puntero + readback antes de tocar el puntero estable.
+npx "wrangler@$WRANGLER_VERSION" r2 object put \
+  "$BUCKET/$STAGING_KEY" --remote --file "$POINTER_FILE" \
+  --content-type application/json --cache-control no-store
+npx "wrangler@$WRANGLER_VERSION" r2 object get \
+  "$BUCKET/$STAGING_KEY" --remote --file "$REMOTE_STAGING"
+cmp "$POINTER_FILE" "$REMOTE_STAGING"
+
+# Puntero estable, siempre último. Producción no tiene CATALOG_BUCKET y ningún
+# runtime actual conoce este namespace `book-intelligence/preview/v1`.
+npx "wrangler@$WRANGLER_VERSION" r2 object put \
+  "$BUCKET/$POINTER_KEY" --remote --file "$POINTER_FILE" \
+  --content-type application/json --cache-control no-store
+npx "wrangler@$WRANGLER_VERSION" r2 object get \
+  "$BUCKET/$POINTER_KEY" --remote --file "$REMOTE_POINTER"
+cmp "$POINTER_FILE" "$REMOTE_POINTER"
+
+node - "$REMOTE_POINTER" "$REMOTE_OBJECT" <<'NODE'
+const fs = require('node:fs');
+const crypto = require('node:crypto');
+const [pointerPath, objectPath] = process.argv.slice(2);
+const pointer = JSON.parse(fs.readFileSync(pointerPath, 'utf8'));
+const object = JSON.parse(fs.readFileSync(objectPath, 'utf8'));
+const sha = crypto.createHash('sha256').update(fs.readFileSync(objectPath)).digest('hex');
+if (pointer.environment !== 'preview') throw new Error('pointer no es Preview');
+if (pointer.current.sha256 !== sha) throw new Error('pointer SHA no coincide con objeto');
+if (pointer.current.object_key !== `book-intelligence/preview/v1/objects/${sha}.json`) throw new Error('object_key fuera del namespace');
+if (pointer.current.counts.total !== object.entries.length) throw new Error('pointer total inconsistente');
+console.log(JSON.stringify({
+  environment: pointer.environment,
+  object_key: pointer.current.object_key,
+  sha256: pointer.current.sha256,
+  bytes: pointer.current.bytes,
+  counts: pointer.current.counts,
+}, null, 2));
+NODE
+
+echo "Preview R2 publicado: $BUCKET/$POINTER_KEY -> $OBJECT_KEY ($BYTES bytes)."


### PR DESCRIPTION
## Objetivo

Persistir el manifest seguro de #227 en R2 de forma versionada y rollback-safe, **únicamente bajo un namespace Preview que ningún runtime productivo consume**.

Este PR está apilado sobre #227.

## Namespace aislado

Bucket existente: `amadolibros-catalog`.

Claves nuevas y exclusivas:

- `book-intelligence/preview/v1/objects/<sha256>.json` — objeto content-addressed e inmutable;
- `book-intelligence/preview/v1/staging/manifest-<run>.json` — puntero de staging;
- `book-intelligence/preview/v1/manifest.json` — puntero estable de Preview, publicado último.

No se escribe ni modifica `catalog.json`, `meta.json`, `showcase/v1/cohort.json`, `showcase/v2/cohort.json` ni ningún namespace productivo/live.

## Resultado real

Workflow `FICHAS-VIDRIERA-2 enrichment R2 Preview 1`: **SUCCESS**.

Validación local: **41/41 PASS**.

Manifest reconstruido contra catálogo real:

- 12 ISBN seleccionados;
- 12/12 consultas Google Books HTTP exitosas;
- 4 matches exactos;
- 7 entradas con temas oficiales;
- 4 con campos de edición permitidos;
- 3 `auto_publish` / 4 `review` / 5 `hold`.

### Persistencia R2 verificada

Bucket: `amadolibros-catalog`.

Objeto content-addressed publicado y leído de vuelta:

`book-intelligence/preview/v1/objects/e5474e04316554ba482082cbc89b33ed4d26da7013deba9acb21e47ef365de0d.json`

- SHA-256: `e5474e04316554ba482082cbc89b33ed4d26da7013deba9acb21e47ef365de0d`;
- tamaño: **22.846 bytes**;
- readback remoto: **PASS**.

Puntero de staging:

`book-intelligence/preview/v1/staging/manifest-32603931803.json`

- write + readback + `cmp`: **PASS**.

Puntero estable, publicado último:

`book-intelligence/preview/v1/manifest.json`

- write + readback + `cmp`: **PASS**;
- `environment: preview`;
- `counts.total: 12`;
- `auto_publish: 3`;
- `review: 4`;
- `hold: 5`;
- puntero SHA ↔ objeto SHA: **PASS**.

## Aislamiento confirmado

Pages Preview tiene binding `CATALOG_BUCKET`; Pages Production no lo tiene. El workflow sólo corre para la rama exacta `agent/fichas-vidriera-v2-enrichment-r2-preview-1`, usa environment `preview` y no despliega Pages ni Worker.

La publicación quedó confinada a `book-intelligence/preview/v1/*`; no se tocó el catálogo live ni las cohortes v1/v2.

## Protocolo probado

1. manifest fresco;
2. validación editorial;
3. SHA-256;
4. objeto content-addressed;
5. readback y SHA remoto;
6. puntero Preview;
7. staging + readback;
8. puntero estable último;
9. readback final puntero ↔ objeto.

Un corte puede dejar un objeto huérfano; nunca un puntero que anuncie bytes no verificados.

## Siguiente gate

Agregar lector runtime **Preview-only** que:

- use exclusivamente `CATALOG_BUCKET`;
- valide puntero, namespace y SHA;
- fail-open si falta/corrompe el manifest;
- exponga únicamente entradas `auto_publish` para el primer Preview visual;
- Producción permanezca sin acceso y sin cambios.

**MANTENER DRAFT. NO MERGEAR. NO PRODUCCIÓN.**