### PR TITLE
CUSTOMER-REVIEWS-1: Google Customer Reviews lazy opt-in

### DIFF
--- a/astro-front/public/google-customer-reviews.js
+++ b/astro-front/public/google-customer-reviews.js
@@ -57,9 +57,8 @@
     var department = draft && draft.values && draft.values['delivery-departamento'];
     department = String(department || '').trim().toLowerCase();
 
-    // Deliberadamente conservador: la encuesta nunca debería adelantarse a
-    // una entrega real. Pickup: próximo día hábil; Montevideo: 2 hábiles;
-    // resto del país: 5 hábiles.
+    // Conservador: la encuesta no debe llegar antes que el pedido.
+    // Pickup: próximo hábil; Montevideo: +2 hábiles; resto UY: +5.
     var days = deliveryType === 'pickup' ? 1 : (department === 'montevideo' ? 2 : 5);
     return formatIsoDate(addBusinessDays(new Date(), days));
   }
@@ -147,8 +146,9 @@
     if (!heading) return;
 
     var checkApproved = function () {
-      // Esta frase sólo se establece en pedido.astro después de que
-      // /api/orders/status devuelve payment_status=approved.
+      // pedido.astro sólo muestra este texto después de que /api/orders/status
+      // confirma payment_status=approved. El parámetro ?result= por sí solo
+      // nunca es suficiente para disparar Customer Reviews.
       if (String(heading.textContent || '').trim() !== 'Pago confirmado') return;
       var code = new URLSearchParams(global.location.search).get('code');
       requestForOrder(code);
@@ -164,22 +164,11 @@
     }
   }
 
-  function wireTransfer() {
-    var button = document.getElementById('btn-transfer-whatsapp');
-    if (!button) return;
-    button.addEventListener('click', function () {
-      // El flujo indica "Cuando termines: ... enviá el comprobante". Este click
-      // es el punto de finalización observable del checkout por transferencia.
-      var codeNode = document.getElementById('transfer-order-code');
-      requestForOrder(codeNode && codeNode.textContent);
-    }, true);
-  }
-
   function init() {
     var cfg = readConfig();
     if (!cfg.enabled) return;
-    if (global.location.pathname === '/pedido') wirePedido();
-    if (global.location.pathname === '/carrito') wireTransfer();
+    if (global.location.pathname !== '/pedido') return;
+    wirePedido();
   }
 
   global.AmadoGoogleCustomerReviews = {

--- a/astro-front/public/google-customer-reviews.js
+++ b/astro-front/public/google-customer-reviews.js
@@ -1,0 +1,194 @@
+(function (global) {
+  'use strict';
+
+  var CONFIG_SELECTOR = 'meta[name="amado-gcr-config"]';
+  var DRAFT_KEY = 'amado-checkout-draft-v2';
+  var SCRIPT_ID = 'amado-gcr-platform';
+  var SEEN_PREFIX = 'amado-gcr-optin-v1:';
+  var GOOGLE_PLATFORM_SRC = 'https://apis.google.com/js/platform.js?onload=renderOptIn';
+  var pendingPayload = null;
+
+  function readConfig() {
+    var node = document.querySelector(CONFIG_SELECTOR);
+    return {
+      enabled: !!node && node.getAttribute('data-enabled') === 'true',
+      merchantId: node ? String(node.getAttribute('data-merchant-id') || '').trim() : '',
+    };
+  }
+
+  function readDraft() {
+    try {
+      var draft = JSON.parse(sessionStorage.getItem(DRAFT_KEY) || 'null');
+      return draft && typeof draft === 'object' ? draft : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function emailFromDraft(draft) {
+    var value = draft && draft.values && draft.values['buyer-email'];
+    return typeof value === 'string' ? value.trim() : '';
+  }
+
+  function isValidEmail(value) {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(value || ''));
+  }
+
+  function formatIsoDate(date) {
+    var yyyy = date.getFullYear();
+    var mm = String(date.getMonth() + 1).padStart(2, '0');
+    var dd = String(date.getDate()).padStart(2, '0');
+    return yyyy + '-' + mm + '-' + dd;
+  }
+
+  function addBusinessDays(baseDate, businessDays) {
+    var date = new Date(baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate());
+    var remaining = Math.max(0, Number(businessDays) || 0);
+    while (remaining > 0) {
+      date.setDate(date.getDate() + 1);
+      var day = date.getDay();
+      if (day !== 0 && day !== 6) remaining -= 1;
+    }
+    return date;
+  }
+
+  function estimatedDeliveryDate(draft) {
+    var deliveryType = draft && draft.delivery_type;
+    var department = draft && draft.values && draft.values['delivery-departamento'];
+    department = String(department || '').trim().toLowerCase();
+
+    // Deliberadamente conservador: la encuesta nunca debería adelantarse a
+    // una entrega real. Pickup: próximo día hábil; Montevideo: 2 hábiles;
+    // resto del país: 5 hábiles.
+    var days = deliveryType === 'pickup' ? 1 : (department === 'montevideo' ? 2 : 5);
+    return formatIsoDate(addBusinessDays(new Date(), days));
+  }
+
+  function alreadyShown(orderId) {
+    try { return sessionStorage.getItem(SEEN_PREFIX + orderId) === '1'; }
+    catch (_) { return false; }
+  }
+
+  function markShown(orderId) {
+    try { sessionStorage.setItem(SEEN_PREFIX + orderId, '1'); }
+    catch (_) {}
+  }
+
+  function renderPending() {
+    if (!pendingPayload || !global.gapi || typeof global.gapi.load !== 'function') return false;
+    var payload = pendingPayload;
+    pendingPayload = null;
+
+    global.gapi.load('surveyoptin', function () {
+      try {
+        if (!global.gapi.surveyoptin || typeof global.gapi.surveyoptin.render !== 'function') return;
+        global.gapi.surveyoptin.render({
+          merchant_id: Number(payload.merchantId),
+          order_id: payload.orderId,
+          email: payload.email,
+          delivery_country: 'UY',
+          estimated_delivery_date: payload.estimatedDeliveryDate,
+          opt_in_style: 'CENTER_DIALOG',
+        });
+        markShown(payload.orderId);
+      } catch (_) {}
+    });
+    return true;
+  }
+
+  global.renderOptIn = function () {
+    renderPending();
+  };
+
+  function requestForOrder(orderId) {
+    var cfg = readConfig();
+    if (!cfg.enabled) return { started: false, reason: 'disabled' };
+    if (!/^\d+$/.test(cfg.merchantId)) return { started: false, reason: 'merchant_id' };
+
+    var normalizedOrderId = String(orderId || '').trim();
+    if (!normalizedOrderId || normalizedOrderId === '—') return { started: false, reason: 'order_id' };
+    if (alreadyShown(normalizedOrderId)) return { started: false, reason: 'already_shown' };
+
+    var draft = readDraft();
+    var email = emailFromDraft(draft);
+    if (!isValidEmail(email)) return { started: false, reason: 'email' };
+
+    pendingPayload = {
+      merchantId: cfg.merchantId,
+      orderId: normalizedOrderId,
+      email: email,
+      estimatedDeliveryDate: estimatedDeliveryDate(draft),
+    };
+
+    global.___gcfg = global.___gcfg || {};
+    global.___gcfg.lang = 'es-419';
+
+    if (global.gapi && typeof global.gapi.load === 'function') {
+      renderPending();
+      return { started: true, via: 'existing_gapi' };
+    }
+
+    if (document.getElementById(SCRIPT_ID)) {
+      return { started: true, via: 'pending_script' };
+    }
+
+    var script = document.createElement('script');
+    script.id = SCRIPT_ID;
+    script.src = GOOGLE_PLATFORM_SRC;
+    script.async = true;
+    script.defer = true;
+    script.onerror = function () { pendingPayload = null; };
+    document.head.appendChild(script);
+    return { started: true, via: 'lazy_script' };
+  }
+
+  function wirePedido() {
+    var heading = document.getElementById('pedido-h1');
+    if (!heading) return;
+
+    var checkApproved = function () {
+      // Esta frase sólo se establece en pedido.astro después de que
+      // /api/orders/status devuelve payment_status=approved.
+      if (String(heading.textContent || '').trim() !== 'Pago confirmado') return;
+      var code = new URLSearchParams(global.location.search).get('code');
+      requestForOrder(code);
+    };
+
+    checkApproved();
+    if (typeof MutationObserver === 'function') {
+      new MutationObserver(checkApproved).observe(heading, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+      });
+    }
+  }
+
+  function wireTransfer() {
+    var button = document.getElementById('btn-transfer-whatsapp');
+    if (!button) return;
+    button.addEventListener('click', function () {
+      // El flujo indica "Cuando termines: ... enviá el comprobante". Este click
+      // es el punto de finalización observable del checkout por transferencia.
+      var codeNode = document.getElementById('transfer-order-code');
+      requestForOrder(codeNode && codeNode.textContent);
+    }, true);
+  }
+
+  function init() {
+    var cfg = readConfig();
+    if (!cfg.enabled) return;
+    if (global.location.pathname === '/pedido') wirePedido();
+    if (global.location.pathname === '/carrito') wireTransfer();
+  }
+
+  global.AmadoGoogleCustomerReviews = {
+    requestForOrder: requestForOrder,
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})(window);

--- a/astro-front/src/layouts/BaseLayout.astro
+++ b/astro-front/src/layouts/BaseLayout.astro
@@ -25,11 +25,11 @@ const gaId       = import.meta.env.PUBLIC_GA_ID;
 const enableGA4  = (analyticsProp !== undefined ? analyticsProp : indexable) && !!gaId;
 const socialUrl  = canonical || 'https://www.amadolibros.com/';
 
-// CUSTOMER-REVIEWS-1: Google Customer Reviews es exclusivo del cierre de
-// checkout. El helper local puede cargarse en carrito/pedido, pero la llamada
-// externa a Google queda además detrás de PUBLIC_GCR_ENABLED. El merchant ID
-// es público (no es un secreto) y corresponde al Merchant Center de Amado.
-const gcrPath = Astro.url.pathname === '/carrito' || Astro.url.pathname === '/pedido';
+// CUSTOMER-REVIEWS-1: Google exige el opt-in en la página de confirmación del
+// pedido. En Amado esa pantalla es /pedido; /carrito y el paso de transferencia
+// no son confirmaciones de pago. La llamada externa queda además detrás del
+// flag, así que mergear este lote con flag OFF no activa Google Customer Reviews.
+const gcrPath = Astro.url.pathname === '/pedido';
 const gcrEnabled = gcrPath && import.meta.env.PUBLIC_GCR_ENABLED === 'true';
 const gcrMerchantId = String(import.meta.env.PUBLIC_GCR_MERCHANT_ID || '5330457716').trim();
 ---

--- a/astro-front/src/layouts/BaseLayout.astro
+++ b/astro-front/src/layouts/BaseLayout.astro
@@ -24,6 +24,14 @@ const indexable  = indexableProp !== undefined ? indexableProp : import.meta.env
 const gaId       = import.meta.env.PUBLIC_GA_ID;
 const enableGA4  = (analyticsProp !== undefined ? analyticsProp : indexable) && !!gaId;
 const socialUrl  = canonical || 'https://www.amadolibros.com/';
+
+// CUSTOMER-REVIEWS-1: Google Customer Reviews es exclusivo del cierre de
+// checkout. El helper local puede cargarse en carrito/pedido, pero la llamada
+// externa a Google queda además detrás de PUBLIC_GCR_ENABLED. El merchant ID
+// es público (no es un secreto) y corresponde al Merchant Center de Amado.
+const gcrPath = Astro.url.pathname === '/carrito' || Astro.url.pathname === '/pedido';
+const gcrEnabled = gcrPath && import.meta.env.PUBLIC_GCR_ENABLED === 'true';
+const gcrMerchantId = String(import.meta.env.PUBLIC_GCR_MERCHANT_ID || '5330457716').trim();
 ---
 <!doctype html>
 <html lang="es">
@@ -36,6 +44,16 @@ const socialUrl  = canonical || 'https://www.amadolibros.com/';
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v2">
   <link rel="manifest" href="/site.webmanifest?v2">
   <script is:inline src="/whatsapp-messages.js"></script>
+  {gcrPath && (
+    <>
+      <meta
+        name="amado-gcr-config"
+        data-enabled={gcrEnabled ? 'true' : 'false'}
+        data-merchant-id={gcrMerchantId}
+      >
+      <script src="/google-customer-reviews.js" defer></script>
+    </>
+  )}
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="robots" content={indexable ? 'index, follow' : 'noindex, nofollow'}>

--- a/functions/__tests__/google-customer-reviews.test.js
+++ b/functions/__tests__/google-customer-reviews.test.js
@@ -1,0 +1,186 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const helperSource = readFileSync(
+  path.join(ROOT, 'astro-front', 'public', 'google-customer-reviews.js'),
+  'utf8',
+);
+const baseLayout = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'layouts', 'BaseLayout.astro'),
+  'utf8',
+);
+
+function makeHarness({ enabled = true, pathName = '/otro', headingText = '', draft = null, gapi = null } = {}) {
+  const storage = new Map();
+  const appendedScripts = [];
+  const clickListeners = [];
+  const configNode = {
+    getAttribute(name) {
+      if (name === 'data-enabled') return enabled ? 'true' : 'false';
+      if (name === 'data-merchant-id') return '5330457716';
+      return null;
+    },
+  };
+  const heading = { textContent: headingText };
+  const transferCode = { textContent: 'AL-TRANSFER-1' };
+  const transferButton = {
+    addEventListener(type, fn) {
+      if (type === 'click') clickListeners.push(fn);
+    },
+  };
+
+  if (draft) storage.set('amado-checkout-draft-v2', JSON.stringify(draft));
+
+  const sessionStorage = {
+    getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+    setItem(key, value) { storage.set(key, String(value)); },
+  };
+  const document = {
+    readyState: 'complete',
+    querySelector(selector) { return selector === 'meta[name="amado-gcr-config"]' ? configNode : null; },
+    getElementById(id) {
+      if (id === 'pedido-h1') return heading;
+      if (id === 'btn-transfer-whatsapp') return transferButton;
+      if (id === 'transfer-order-code') return transferCode;
+      if (id === 'amado-gcr-platform') return appendedScripts.find((s) => s.id === id) || null;
+      return null;
+    },
+    createElement(tag) { return { tagName: tag.toUpperCase() }; },
+    head: {
+      appendChild(node) { appendedScripts.push(node); },
+    },
+    addEventListener() {},
+  };
+
+  class MutationObserver {
+    constructor(callback) { this.callback = callback; }
+    observe() {}
+  }
+
+  const window = {
+    location: { pathname: pathName, search: '?result=success&code=AL-MP-1' },
+    gapi,
+  };
+  window.window = window;
+
+  const context = vm.createContext({
+    window,
+    document,
+    sessionStorage,
+    MutationObserver,
+    URLSearchParams,
+    Date,
+    Number,
+    String,
+    Math,
+  });
+  vm.runInContext(helperSource, context);
+  return { window, appendedScripts, storage, clickListeners, heading };
+}
+
+const validDraft = {
+  delivery_type: 'shipping',
+  values: {
+    'buyer-email': 'cliente@example.com',
+    'delivery-departamento': 'Montevideo',
+  },
+};
+
+test('BaseLayout limita Customer Reviews a /carrito y /pedido y lo deja detrás de flag', () => {
+  assert.match(baseLayout, /Astro\.url\.pathname === '\/carrito'/);
+  assert.match(baseLayout, /Astro\.url\.pathname === '\/pedido'/);
+  assert.match(baseLayout, /PUBLIC_GCR_ENABLED === 'true'/);
+  assert.match(baseLayout, /PUBLIC_GCR_MERCHANT_ID \|\| '5330457716'/);
+  assert.match(baseLayout, /google-customer-reviews\.js/);
+});
+
+test('flag OFF: no carga platform.js de Google ni inicia opt-in', () => {
+  const h = makeHarness({ enabled: false, draft: validDraft });
+  const result = h.window.AmadoGoogleCustomerReviews.requestForOrder('AL-1');
+  assert.equal(result.started, false);
+  assert.equal(result.reason, 'disabled');
+  assert.equal(h.appendedScripts.length, 0);
+});
+
+test('flag ON: carga platform.js únicamente cuando existe una orden y email válidos', () => {
+  const h = makeHarness({ enabled: true, draft: validDraft });
+  assert.equal(h.appendedScripts.length, 0, 'navegación normal no debe llamar a Google');
+  const result = h.window.AmadoGoogleCustomerReviews.requestForOrder('AL-1');
+  assert.equal(result.started, true);
+  assert.equal(result.via, 'lazy_script');
+  assert.equal(h.appendedScripts.length, 1);
+  assert.equal(h.appendedScripts[0].src, 'https://apis.google.com/js/platform.js?onload=renderOptIn');
+});
+
+test('sin email válido: fail-open y 0 requests a Google', () => {
+  const h = makeHarness({
+    enabled: true,
+    draft: { delivery_type: 'shipping', values: { 'buyer-email': 'no-es-email' } },
+  });
+  const result = h.window.AmadoGoogleCustomerReviews.requestForOrder('AL-2');
+  assert.equal(result.started, false);
+  assert.equal(result.reason, 'email');
+  assert.equal(h.appendedScripts.length, 0);
+});
+
+test('gapi existente: payload usa Merchant 5330457716, UY, CENTER_DIALOG y fecha ISO', () => {
+  let rendered = null;
+  const gapi = {
+    load(name, callback) {
+      assert.equal(name, 'surveyoptin');
+      callback();
+    },
+    surveyoptin: {
+      render(payload) { rendered = payload; },
+    },
+  };
+  const h = makeHarness({ enabled: true, draft: validDraft, gapi });
+  const result = h.window.AmadoGoogleCustomerReviews.requestForOrder('AL-3');
+  assert.equal(result.started, true);
+  assert.equal(result.via, 'existing_gapi');
+  assert.equal(rendered.merchant_id, 5330457716);
+  assert.equal(rendered.order_id, 'AL-3');
+  assert.equal(rendered.email, 'cliente@example.com');
+  assert.equal(rendered.delivery_country, 'UY');
+  assert.equal(rendered.opt_in_style, 'CENTER_DIALOG');
+  assert.match(rendered.estimated_delivery_date, /^\d{4}-\d{2}-\d{2}$/);
+  assert.equal(h.window.___gcfg.lang, 'es-419');
+});
+
+test('una orden no muestra el opt-in dos veces en la misma sesión', () => {
+  const gapi = {
+    load(_name, callback) { callback(); },
+    surveyoptin: { render() {} },
+  };
+  const h = makeHarness({ enabled: true, draft: validDraft, gapi });
+  assert.equal(h.window.AmadoGoogleCustomerReviews.requestForOrder('AL-4').started, true);
+  const second = h.window.AmadoGoogleCustomerReviews.requestForOrder('AL-4');
+  assert.equal(second.started, false);
+  assert.equal(second.reason, 'already_shown');
+});
+
+test('/pedido sólo dispara automáticamente después de texto Pago confirmado', () => {
+  const pending = makeHarness({ enabled: true, pathName: '/pedido', headingText: 'Estamos verificando el pago…', draft: validDraft });
+  assert.equal(pending.appendedScripts.length, 0);
+
+  const approved = makeHarness({ enabled: true, pathName: '/pedido', headingText: 'Pago confirmado', draft: validDraft });
+  assert.equal(approved.appendedScripts.length, 1);
+});
+
+test('/carrito engancha el opt-in al click final de comprobante de transferencia', () => {
+  const h = makeHarness({ enabled: true, pathName: '/carrito', draft: validDraft });
+  assert.equal(h.appendedScripts.length, 0);
+  assert.equal(h.clickListeners.length, 1);
+  h.clickListeners[0]();
+  assert.equal(h.appendedScripts.length, 1);
+});
+
+test('fase 1 no inventa GTINs/product reviews: sólo store review hasta tener ISBN/GTIN confiable por item', () => {
+  assert.doesNotMatch(helperSource, /products\s*:/);
+  assert.doesNotMatch(helperSource, /gtin\s*:/);
+});

--- a/functions/__tests__/google-customer-reviews.test.js
+++ b/functions/__tests__/google-customer-reviews.test.js
@@ -18,7 +18,6 @@ const baseLayout = readFileSync(
 function makeHarness({ enabled = true, pathName = '/otro', headingText = '', draft = null, gapi = null } = {}) {
   const storage = new Map();
   const appendedScripts = [];
-  const clickListeners = [];
   const configNode = {
     getAttribute(name) {
       if (name === 'data-enabled') return enabled ? 'true' : 'false';
@@ -27,12 +26,6 @@ function makeHarness({ enabled = true, pathName = '/otro', headingText = '', dra
     },
   };
   const heading = { textContent: headingText };
-  const transferCode = { textContent: 'AL-TRANSFER-1' };
-  const transferButton = {
-    addEventListener(type, fn) {
-      if (type === 'click') clickListeners.push(fn);
-    },
-  };
 
   if (draft) storage.set('amado-checkout-draft-v2', JSON.stringify(draft));
 
@@ -45,8 +38,6 @@ function makeHarness({ enabled = true, pathName = '/otro', headingText = '', dra
     querySelector(selector) { return selector === 'meta[name="amado-gcr-config"]' ? configNode : null; },
     getElementById(id) {
       if (id === 'pedido-h1') return heading;
-      if (id === 'btn-transfer-whatsapp') return transferButton;
-      if (id === 'transfer-order-code') return transferCode;
       if (id === 'amado-gcr-platform') return appendedScripts.find((s) => s.id === id) || null;
       return null;
     },
@@ -80,7 +71,7 @@ function makeHarness({ enabled = true, pathName = '/otro', headingText = '', dra
     Math,
   });
   vm.runInContext(helperSource, context);
-  return { window, appendedScripts, storage, clickListeners, heading };
+  return { window, appendedScripts, storage, heading };
 }
 
 const validDraft = {
@@ -91,9 +82,9 @@ const validDraft = {
   },
 };
 
-test('BaseLayout limita Customer Reviews a /carrito y /pedido y lo deja detrás de flag', () => {
-  assert.match(baseLayout, /Astro\.url\.pathname === '\/carrito'/);
-  assert.match(baseLayout, /Astro\.url\.pathname === '\/pedido'/);
+test('BaseLayout carga Customer Reviews únicamente en /pedido y detrás de flag', () => {
+  assert.match(baseLayout, /const gcrPath = Astro\.url\.pathname === '\/pedido';/);
+  assert.doesNotMatch(baseLayout, /Astro\.url\.pathname === '\/carrito' \|\|/);
   assert.match(baseLayout, /PUBLIC_GCR_ENABLED === 'true'/);
   assert.match(baseLayout, /PUBLIC_GCR_MERCHANT_ID \|\| '5330457716'/);
   assert.match(baseLayout, /google-customer-reviews\.js/);
@@ -128,7 +119,7 @@ test('sin email válido: fail-open y 0 requests a Google', () => {
   assert.equal(h.appendedScripts.length, 0);
 });
 
-test('gapi existente: payload usa Merchant 5330457716, UY, CENTER_DIALOG y fecha ISO', () => {
+test('gapi existente: payload contiene todos los campos requeridos por Google', () => {
   let rendered = null;
   const gapi = {
     load(name, callback) {
@@ -164,23 +155,32 @@ test('una orden no muestra el opt-in dos veces en la misma sesión', () => {
   assert.equal(second.reason, 'already_shown');
 });
 
-test('/pedido sólo dispara automáticamente después de texto Pago confirmado', () => {
-  const pending = makeHarness({ enabled: true, pathName: '/pedido', headingText: 'Estamos verificando el pago…', draft: validDraft });
+test('/pedido sólo dispara automáticamente después de confirmación real del pago', () => {
+  const pending = makeHarness({
+    enabled: true,
+    pathName: '/pedido',
+    headingText: 'Estamos verificando el pago…',
+    draft: validDraft,
+  });
   assert.equal(pending.appendedScripts.length, 0);
 
-  const approved = makeHarness({ enabled: true, pathName: '/pedido', headingText: 'Pago confirmado', draft: validDraft });
+  const approved = makeHarness({
+    enabled: true,
+    pathName: '/pedido',
+    headingText: 'Pago confirmado',
+    draft: validDraft,
+  });
   assert.equal(approved.appendedScripts.length, 1);
 });
 
-test('/carrito engancha el opt-in al click final de comprobante de transferencia', () => {
+test('/carrito y transferencia quedan fuera de fase 1', () => {
   const h = makeHarness({ enabled: true, pathName: '/carrito', draft: validDraft });
   assert.equal(h.appendedScripts.length, 0);
-  assert.equal(h.clickListeners.length, 1);
-  h.clickListeners[0]();
-  assert.equal(h.appendedScripts.length, 1);
+  assert.doesNotMatch(helperSource, /btn-transfer-whatsapp/);
+  assert.doesNotMatch(helperSource, /transfer-order-code/);
 });
 
-test('fase 1 no inventa GTINs/product reviews: sólo store review hasta tener ISBN/GTIN confiable por item', () => {
+test('fase 1 no inventa GTINs/product reviews: sólo store review', () => {
   assert.doesNotMatch(helperSource, /products\s*:/);
   assert.doesNotMatch(helperSource, /gtin\s*:/);
 });


### PR DESCRIPTION
## Objetivo
Integrar Google Customer Reviews de forma segura y lazy en la confirmación real de compra de Amado Libros, sin tocar producción hasta activar y firmar el programa en Merchant Center.

## Alcance
- Sólo `/pedido` carga el helper local.
- `PUBLIC_GCR_ENABLED` controla la activación; por defecto queda OFF.
- Merchant Center público: `5330457716` (override por `PUBLIC_GCR_MERCHANT_ID`).
- Cero request a `apis.google.com` durante navegación normal.
- Mercado Pago: el opt-in se inicia únicamente cuando `/pedido` alcanza `Pago confirmado`, estado que hoy sólo se establece después de `payment_status=approved` leído desde `/api/orders/status`.
- Email reutilizado desde el draft de checkout en `sessionStorage`; no se amplía `/api/orders/status` ni se expone `buyer_email` desde D1.
- `delivery_country=UY`, idioma `es-419`, `CENTER_DIALOG`.
- Fecha estimada conservadora: pickup +1 día hábil; Montevideo +2; resto de Uruguay +5.
- Dedupe por `order_id` en la sesión.
- Fail-open: email/config inválidos o fallo del script de Google no interfieren con pago, carrito ni WhatsApp.
- Fase 1: store review solamente; no se inventan GTIN/ISBN para Product Ratings.
- Transferencia queda fuera de Fase 1: enviar el comprobante no equivale a pago confirmado. Se incorporará sólo cuando exista una confirmación verificable de pago/entrega para ese flujo.

## Fundamento Google
Google exige el módulo de opt-in en la página de confirmación del pedido y requiere merchant_id, order_id, email, delivery_country y estimated_delivery_date. Uruguay está admitido por Google Customer Reviews.

## Gate
- Tests para flag OFF/ON, lazy load, payload, dedupe y Mercado Pago realmente aprobado.
- Mantener Draft.
- NO merge / NO producción hasta confirmar Merchant Center → Google Customer Reviews → acuerdo firmado y ejecutar Preview final con el flag ON.