### PR TITLE
SEARCH-QUALITY-1: baseline real del buscador antes de Algolia

### DIFF
--- a/.github/workflows/search-quality-1.yml
+++ b/.github/workflows/search-quality-1.yml
@@ -1,0 +1,45 @@
+name: SEARCH-QUALITY-1 baseline
+
+on:
+  push:
+    branches: [agent/search-quality-1]
+    paths:
+      - 'scripts/seo/search-quality-benchmark.mjs'
+      - '.github/workflows/search-quality-1.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/seo/search-quality-benchmark.mjs'
+      - '.github/workflows/search-quality-1.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+      - name: Run current production search baseline
+        env:
+          SEARCH_BENCHMARK_ORIGIN: https://www.amadolibros.com
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/search-quality-1
+          node scripts/seo/search-quality-benchmark.mjs | tee artifacts/search-quality-1/baseline.json
+          node - <<'NODE'
+          const fs=require('node:fs');
+          const r=JSON.parse(fs.readFileSync('artifacts/search-quality-1/baseline.json','utf8'));
+          console.log(`cases=${r.summary.cases} no_results=${r.summary.no_results} rate=${r.summary.no_result_rate} errors=${r.summary.errors}`);
+          for(const c of r.cases) console.log(`${c.no_results?'MISS':'HIT '} [${c.intent}] ${c.q} -> ${(c.top5||[]).slice(0,3).map(x=>x.title).join(' | ')}`);
+          NODE
+      - uses: actions/upload-artifact@v4
+        with:
+          name: search-quality-1-baseline
+          path: artifacts/search-quality-1/baseline.json
+          retention-days: 14

--- a/docs/seo/search-quality-1.md
+++ b/docs/seo/search-quality-1.md
@@ -1,0 +1,16 @@
+# SEARCH-QUALITY-1
+
+Objetivo: medir la calidad del buscador actual de Amado Libros antes de comprar o migrar a un motor externo.
+
+## Hipótesis
+
+El catálogo actual (~miles de libros) no necesita automáticamente Algolia. Primero hay que separar fallos de contenido/datos de fallos reales de recuperación: typo tolerance, sinónimos, abreviaturas, orden de palabras, acentos e intención.
+
+## Gate
+
+1. Ejecutar 20 consultas comerciales representativas contra Producción, read-only.
+2. Guardar top 5 y tasa de 0 resultados por clase de intención.
+3. Si los fallos se concentran en sinónimos/typos y pueden resolverse con una capa local pequeña y testeable, probarla en un PR separado.
+4. Sólo comparar Algolia / Typesense / Meilisearch cuando el baseline demuestre una brecha que justifique servicio externo.
+
+Este lote no cambia ranking, UX, catálogo ni Producción.

--- a/functions/__tests__/search-quality-benchmark.test.js
+++ b/functions/__tests__/search-quality-benchmark.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT=path.resolve(path.dirname(fileURLToPath(import.meta.url)),'..','..');
+const source=readFileSync(path.join(ROOT,'scripts','seo','search-quality-benchmark.mjs'),'utf8');
+
+test('benchmark cubre Tarot, Biblias, typo, acentos, abreviatura e ISBN',()=>{
+  for (const expected of ['tarot','rider wait','oráculo','reina valera 1960','rvr 1960','biblia católica','9781602552951']) {
+    assert.match(source,new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g,'\\$&'),'i'));
+  }
+  for (const intent of ['typo','accent','abbreviation','isbn','word_order','attribute']) assert.match(source,new RegExp(`intent: '${intent}'`));
+});
+
+test('benchmark es read-only contra /catalogo y no llama APIs de escritura',()=>{
+  assert.match(source,/\/catalogo\?q=/);
+  assert.doesNotMatch(source,/method:\s*['"]POST['"]/);
+  assert.doesNotMatch(source,/\/api\/orders|\/api\/preferences|DELETE|PUT|PATCH/);
+});
+
+test('benchmark reporta no-result rate y top5',()=>{
+  assert.match(source,/no_result_rate/);
+  assert.match(source,/top5/);
+});

--- a/scripts/seo/search-quality-benchmark.mjs
+++ b/scripts/seo/search-quality-benchmark.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import process from 'node:process';
+
+const ORIGIN = String(process.env.SEARCH_BENCHMARK_ORIGIN || 'https://www.amadolibros.com').replace(/\/+$/, '');
+const TIMEOUT_MS = 15000;
+const CASES = [
+  { q: 'tarot', intent: 'category' }, { q: 'tarot rider', intent: 'product_family' },
+  { q: 'rider waite', intent: 'product_family' }, { q: 'rider wait', intent: 'typo' },
+  { q: 'oraculo', intent: 'accent' }, { q: 'oráculo', intent: 'category' },
+  { q: 'lenormand', intent: 'product_family' }, { q: 'marsella tarot', intent: 'word_order' },
+  { q: 'thoth tarot', intent: 'product_family' }, { q: 'tarot principiantes', intent: 'intent_synonym' },
+  { q: 'reina valera', intent: 'product_family' }, { q: 'reina valera 1960', intent: 'product_family' },
+  { q: 'rvr 1960', intent: 'abbreviation' }, { q: 'biblia catolica', intent: 'accent' },
+  { q: 'biblia católica', intent: 'category' }, { q: 'biblia letra grande', intent: 'attribute' },
+  { q: 'biblia estudio', intent: 'attribute' }, { q: '9781602552951', intent: 'isbn' },
+  { q: 'macarthur reina valera', intent: 'title_author' }, { q: 'despertando gigante interior', intent: 'title' },
+];
+
+function stripHtml(value='') {
+  return String(value).replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi,' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi,' ').replace(/<[^>]+>/g,' ')
+    .replace(/&nbsp;/gi,' ').replace(/&amp;/gi,'&').replace(/\s+/g,' ').trim();
+}
+function decodeEntities(value='') { return String(value).replace(/&#39;/g,"'").replace(/&quot;/g,'"').replace(/&amp;/g,'&').replace(/&lt;/g,'<').replace(/&gt;/g,'>'); }
+function extractResults(html) {
+  const cards=[]; const re=/<article\b[^>]*class="[^"]*book-card[^"]*"[^>]*>([\s\S]*?)<\/article>/gi; let match;
+  while ((match=re.exec(html))) {
+    const block=match[1];
+    const href=block.match(/href="([^"]*\/libro\/[^"]+)"/i)?.[1]||null;
+    const title=decodeEntities(stripHtml(block.match(/<h2\b[^>]*>([\s\S]*?)<\/h2>/i)?.[1]||''));
+    const author=decodeEntities(stripHtml(block.match(/class="book-author"[^>]*>([\s\S]*?)<\/p>/i)?.[1]||''));
+    if(title||href) cards.push({title,author,href});
+  }
+  return cards;
+}
+async function fetchCase(testCase) {
+  const url=`${ORIGIN}/catalogo?q=${encodeURIComponent(testCase.q)}`;
+  const controller=new AbortController(); const timer=setTimeout(()=>controller.abort(),TIMEOUT_MS); const started=performance.now(); let response;
+  try { response=await fetch(url,{headers:{Accept:'text/html'},signal:controller.signal,redirect:'follow'}); } finally { clearTimeout(timer); }
+  const latencyMs=Math.round(performance.now()-started); const html=await response.text(); const results=extractResults(html);
+  return {...testCase,url,http:response.status,bytes:Buffer.byteLength(html),latency_ms:latencyMs,result_count_page:results.length,no_results:results.length===0,top5:results.slice(0,5)};
+}
+
+const rows=[];
+for (const c of CASES) {
+  try { rows.push(await fetchCase(c)); }
+  catch(error) { rows.push({...c,error:error?.name||'error',message:String(error?.message||error).slice(0,160),no_results:true,top5:[]}); }
+}
+const byIntent={};
+for (const row of rows) { const b=byIntent[row.intent]||=( {total:0,no_results:0} ); b.total++; if(row.no_results)b.no_results++; }
+const noResults=rows.filter(r=>r.no_results).length; const errors=rows.filter(r=>r.error).length;
+console.log(JSON.stringify({schema_version:1,run:'SEARCH-QUALITY-1/baseline',generated_at:new Date().toISOString(),origin:ORIGIN,summary:{cases:rows.length,no_results:noResults,no_result_rate:Number((noResults/rows.length).toFixed(4)),errors},by_intent:byIntent,cases:rows},null,2));
+if(errors) process.exitCode=2;

--- a/scripts/seo/search-quality-benchmark.mjs
+++ b/scripts/seo/search-quality-benchmark.mjs
@@ -23,12 +23,14 @@ function stripHtml(value='') {
 }
 function decodeEntities(value='') { return String(value).replace(/&#39;/g,"'").replace(/&quot;/g,'"').replace(/&amp;/g,'&').replace(/&lt;/g,'<').replace(/&gt;/g,'>'); }
 function extractResults(html) {
-  const cards=[]; const re=/<article\b[^>]*class="[^"]*book-card[^"]*"[^>]*>([\s\S]*?)<\/article>/gi; let match;
+  const cards=[];
+  const re=/<article\b[^>]*class="[^"]*rc-card[^"]*"[^>]*>([\s\S]*?)<\/article>/gi;
+  let match;
   while ((match=re.exec(html))) {
     const block=match[1];
     const href=block.match(/href="([^"]*\/libro\/[^"]+)"/i)?.[1]||null;
-    const title=decodeEntities(stripHtml(block.match(/<h2\b[^>]*>([\s\S]*?)<\/h2>/i)?.[1]||''));
-    const author=decodeEntities(stripHtml(block.match(/class="book-author"[^>]*>([\s\S]*?)<\/p>/i)?.[1]||''));
+    const title=decodeEntities(stripHtml(block.match(/class="rc-title"[^>]*>([\s\S]*?)<\/p>/i)?.[1]||''));
+    const author=decodeEntities(stripHtml(block.match(/class="rc-author"[^>]*>([\s\S]*?)<\/p>/i)?.[1]||''));
     if(title||href) cards.push({title,author,href});
   }
   return cards;


### PR DESCRIPTION
## Objetivo
Medir la calidad real del buscador actual de Amado Libros antes de comprar o migrar a Algolia/Typesense/Meilisearch.

## Resultado real (Producción, 20 consultas)

Baseline corregido contra el markup live `rc-card`:

- 20/20 consultas con resultados;
- 0 errores;
- 0 búsquedas sin resultado;
- mediana de latencia observada del request SSR: ~683 ms;
- typo `rider wait` → 14 resultados relevantes de Rider-Waite;
- `oraculo` y `oráculo` → 48 resultados;
- `rvr 1960` → 30 resultados;
- `biblia catolica` y `biblia católica` → 18 resultados;
- ISBN `9781602552951` → 1 resultado exacto (Biblia MacArthur RVR60);
- `macarthur reina valera` → 1 resultado;
- `despertando gigante interior` → 1 resultado.

La primera corrida del benchmark reportó falsamente 20/20 misses porque el parser esperaba `book-card` y Producción usa `rc-card`; se corrigió antes de sacar conclusiones.

## Dictamen

**NO comprar/migrar a Algolia ahora.** El buscador actual ya cubre recuperación básica, acentos, prefijos y typo liviano para esta cohorte. Antes de introducir un SaaS de búsqueda conviene medir y mejorar, en lotes separados:

1. calidad del ranking/top-N con demanda real;
2. latencia SSR/cache;
3. sinónimos comerciales que realmente falten;
4. medición de búsquedas/clics/conversión sin PII.

Sólo reconsiderar Algolia / Typesense / Meilisearch si esos gates muestran una brecha que justifique costo y complejidad externa.

## Alcance de este PR
- Read-only: no cambia ranking, UI ni Producción.
- 20 consultas comerciales de Tarot, Biblias, ISBN, acentos, typos, abreviaturas, atributos y orden de palabras.
- Artefacto CI reproducible.

**MANTENER DRAFT. NO MERGEAR. NO CAMBIOS DE PRODUCCIÓN.**