### PR TITLE
GSC-BQ-VERTICALS-1: oportunidades Tarot y Biblias

### DIFF
--- a/.github/workflows/gsc-bigquery-vertical-report.yml
+++ b/.github/workflows/gsc-bigquery-vertical-report.yml
@@ -1,0 +1,102 @@
+name: GSC BigQuery vertical opportunities
+
+on:
+  push:
+    branches:
+      - agent/gsc-bigquery-verticals-1
+    paths:
+      - '.github/workflows/gsc-bigquery-vertical-report.yml'
+      - 'scripts/seo/gsc-bigquery-vertical-report.sh'
+      - 'functions/__tests__/gsc-bigquery-vertical-report.test.js'
+  pull_request:
+    paths:
+      - '.github/workflows/gsc-bigquery-vertical-report.yml'
+      - 'scripts/seo/gsc-bigquery-vertical-report.sh'
+      - 'functions/__tests__/gsc-bigquery-vertical-report.test.js'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: gsc-bigquery-verticals-${{ github.event_name }}
+  cancel-in-progress: false
+
+jobs:
+  report:
+    name: Analyze Tarot and Bible demand
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Validate read-only report
+        run: |
+          bash -n scripts/seo/gsc-bigquery-vertical-report.sh
+          node --test functions/__tests__/gsc-bigquery-vertical-report.test.js
+
+      - name: Authenticate with Google
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: amado-libros-analytics
+          workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
+          service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/bigquery.readonly
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          project_id: amado-libros-analytics
+
+      - name: Generate vertical opportunity reports
+        env:
+          GSC_BQ_PROJECT_ID: amado-libros-analytics
+          GSC_BQ_PROJECT_NUMBER: '667747565315'
+          GSC_BQ_DATASET_ID: searchconsole
+          GSC_BQ_LOCATION: US
+          GSC_BQ_SITE_URL: sc-domain:amadolibros.com
+          GSC_BQ_OUTPUT_DIR: artifacts/gsc-bigquery-verticals
+          GSC_BQ_MIN_IMPRESSIONS: '3'
+          GSC_BQ_MAX_BYTES_BILLED: '1000000000'
+        run: bash scripts/seo/gsc-bigquery-vertical-report.sh
+
+      - name: Validate artifacts
+        run: |
+          test -s artifacts/gsc-bigquery-verticals/availability.json
+          test -s artifacts/gsc-bigquery-verticals/summary.md
+          test -s artifacts/gsc-bigquery-verticals/28d/vertical-summary.json
+          test -s artifacts/gsc-bigquery-verticals/90d/vertical-summary.json
+
+      - name: Write run summary
+        if: always()
+        run: |
+          if [ -s artifacts/gsc-bigquery-verticals/summary.md ]; then
+            cat artifacts/gsc-bigquery-verticals/summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## GSC BigQuery vertical report incompleto' >> "$GITHUB_STEP_SUMMARY"
+            echo 'No se generó summary.md; revisar permisos BigQuery y disponibilidad de tablas.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Modo: sólo lectura (SELECT)' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Deploy web/Worker: no' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gsc-bigquery-verticals-${{ github.run_id }}
+          path: artifacts/gsc-bigquery-verticals/
+          if-no-files-found: warn
+          retention-days: 30
+

--- a/.github/workflows/gsc-bigquery-vertical-report.yml
+++ b/.github/workflows/gsc-bigquery-vertical-report.yml
@@ -26,8 +26,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate:
+    name: Validate read-only GSC report
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Validate implementation
+        run: |
+          bash -n scripts/seo/gsc-bigquery-vertical-report.sh
+          node --check scripts/seo/gsc-bigquery-vertical-analysis.mjs
+          node --test functions/__tests__/gsc-bigquery-vertical-report.test.js
+
   report:
     name: Analyze Tarot and Bible demand
+    if: github.event_name == 'workflow_dispatch'
+    needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -39,12 +61,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22.12.0'
-
-      - name: Validate read-only report
-        run: |
-          bash -n scripts/seo/gsc-bigquery-vertical-report.sh
-          node --check scripts/seo/gsc-bigquery-vertical-analysis.mjs
-          node --test functions/__tests__/gsc-bigquery-vertical-report.test.js
 
       - name: Authenticate with Google
         uses: google-github-actions/auth@v3
@@ -85,7 +101,7 @@ jobs:
             cat artifacts/gsc-bigquery-verticals/summary.md >> "$GITHUB_STEP_SUMMARY"
           else
             echo '## GSC BigQuery vertical report incompleto' >> "$GITHUB_STEP_SUMMARY"
-            echo 'No se generó summary.md; revisar permisos BigQuery y disponibilidad de tablas.' >> "$GITHUB_STEP_SUMMARY"
+            echo 'No se generó summary.md; revisar bigquery.tables.getData y la disponibilidad de filas.' >> "$GITHUB_STEP_SUMMARY"
           fi
           echo '' >> "$GITHUB_STEP_SUMMARY"
           echo '- Modo: sólo lectura (metadatos + tabledata; sin query jobs)' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/gsc-bigquery-vertical-report.yml
+++ b/.github/workflows/gsc-bigquery-vertical-report.yml
@@ -52,8 +52,6 @@ jobs:
           project_id: amado-libros-analytics
           workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
           service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
-          token_format: access_token
-          access_token_scopes: https://www.googleapis.com/auth/bigquery.readonly
           create_credentials_file: true
           export_environment_variables: true
 

--- a/.github/workflows/gsc-bigquery-vertical-report.yml
+++ b/.github/workflows/gsc-bigquery-vertical-report.yml
@@ -7,11 +7,13 @@ on:
     paths:
       - '.github/workflows/gsc-bigquery-vertical-report.yml'
       - 'scripts/seo/gsc-bigquery-vertical-report.sh'
+      - 'scripts/seo/gsc-bigquery-vertical-analysis.mjs'
       - 'functions/__tests__/gsc-bigquery-vertical-report.test.js'
   pull_request:
     paths:
       - '.github/workflows/gsc-bigquery-vertical-report.yml'
       - 'scripts/seo/gsc-bigquery-vertical-report.sh'
+      - 'scripts/seo/gsc-bigquery-vertical-analysis.mjs'
       - 'functions/__tests__/gsc-bigquery-vertical-report.test.js'
   workflow_dispatch:
 
@@ -41,6 +43,7 @@ jobs:
       - name: Validate read-only report
         run: |
           bash -n scripts/seo/gsc-bigquery-vertical-report.sh
+          node --check scripts/seo/gsc-bigquery-vertical-analysis.mjs
           node --test functions/__tests__/gsc-bigquery-vertical-report.test.js
 
       - name: Authenticate with Google
@@ -64,11 +67,10 @@ jobs:
           GSC_BQ_PROJECT_ID: amado-libros-analytics
           GSC_BQ_PROJECT_NUMBER: '667747565315'
           GSC_BQ_DATASET_ID: searchconsole
-          GSC_BQ_LOCATION: US
           GSC_BQ_SITE_URL: sc-domain:amadolibros.com
           GSC_BQ_OUTPUT_DIR: artifacts/gsc-bigquery-verticals
           GSC_BQ_MIN_IMPRESSIONS: '3'
-          GSC_BQ_MAX_BYTES_BILLED: '1000000000'
+          GSC_BQ_MAX_ROWS: '250000'
         run: bash scripts/seo/gsc-bigquery-vertical-report.sh
 
       - name: Validate artifacts
@@ -88,7 +90,7 @@ jobs:
             echo 'No se generó summary.md; revisar permisos BigQuery y disponibilidad de tablas.' >> "$GITHUB_STEP_SUMMARY"
           fi
           echo '' >> "$GITHUB_STEP_SUMMARY"
-          echo '- Modo: sólo lectura (SELECT)' >> "$GITHUB_STEP_SUMMARY"
+          echo '- Modo: sólo lectura (metadatos + tabledata; sin query jobs)' >> "$GITHUB_STEP_SUMMARY"
           echo '- Deploy web/Worker: no' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload reports
@@ -99,4 +101,3 @@ jobs:
           path: artifacts/gsc-bigquery-verticals/
           if-no-files-found: warn
           retention-days: 30
-

--- a/functions/__tests__/gsc-bigquery-vertical-report.test.js
+++ b/functions/__tests__/gsc-bigquery-vertical-report.test.js
@@ -52,7 +52,7 @@ test('calcula posición con sum_position / impressions + 1', () => {
     url: '/libros/esoterismo-tarot', query: 'tarot uruguay', isAnonymizedQuery: false,
     country: 'ury', device: 'MOBILE', clicks: 2, impressions: 10, sumPosition: 40
   }];
-  const report = analyzeWindow(rows, { days: 28, maxDate: '2026-08-22', minImpressions: 3 });
+  const report = analyzeWindow(rows, { days: 28, minDate: '2026-08-22', maxDate: '2026-08-22', minImpressions: 3 });
   assert.equal(report.summaryRows[0].average_position, 5);
   assert.equal(report.summaryRows[0].ctr, 0.2);
   assert.equal(report.queryRows.length, 1);
@@ -67,9 +67,25 @@ test('marca posible canibalización sólo con más de una URL para la misma quer
   const report = analyzeWindow([
     { ...base, url: '/libro/a' },
     { ...base, url: '/libro/b' }
-  ], { days: 28, maxDate: '2026-08-22', minImpressions: 3 });
+  ], { days: 28, minDate: '2026-08-22', maxDate: '2026-08-22', minImpressions: 3 });
   assert.equal(report.cannibalizationRows.length, 1);
   assert.equal(report.cannibalizationRows[0].url_count, 2);
+});
+
+test('distingue ventana solicitada de cobertura efectiva y retención', () => {
+  const report = analyzeWindow([], {
+    days: 90,
+    minDate: '2026-08-14',
+    maxDate: '2026-08-22',
+    minImpressions: 3
+  });
+  assert.equal(report.requestedStartDate, '2026-05-25');
+  assert.equal(report.startDate, '2026-08-14');
+  assert.equal(report.fullCalendarRangeAvailable, false);
+  assert.equal(report.observedDataDays, 0);
+  const source = analysis();
+  assert.match(source, /partitionExpirationDays/);
+  assert.match(source, /Advertencia de retención/);
 });
 
 test('genera ventanas 28/90, CSV seguro y artefactos auditables', () => {

--- a/functions/__tests__/gsc-bigquery-vertical-report.test.js
+++ b/functions/__tests__/gsc-bigquery-vertical-report.test.js
@@ -32,6 +32,8 @@ test('el contrato BigQuery es de sólo lectura y evita informes parciales', () =
   const source = shell();
   assert.match(source, /MAX_ROWS/);
   assert.match(source, /lectura incompleta/);
+  assert.match(source, /sed -n '\/\^\[\[:space:\]\]\*\\\[/);
+  assert.match(source, /jq -e 'type == "array"'/);
   assert.doesNotMatch(source, /\bbq\s+(?:rm|mk|load|cp|update|query)\b/i);
 });
 

--- a/functions/__tests__/gsc-bigquery-vertical-report.test.js
+++ b/functions/__tests__/gsc-bigquery-vertical-report.test.js
@@ -16,7 +16,8 @@ test('el workflow corre en rama aislada y no despliega web o Worker', () => {
   assert.match(source, /- agent\/gsc-bigquery-verticals-1/);
   assert.doesNotMatch(source, /branches:\s*\[?main\]?/);
   assert.doesNotMatch(source, /wrangler|pages deploy|cloudflare\/pages-action|deploy-worker/i);
-  assert.match(source, /bigquery\.readonly/);
+  assert.match(source, /contents: read/);
+  assert.match(source, /create_credentials_file: true/);
 });
 
 test('lee sólo la tabla oficial por URL sin crear query jobs', () => {

--- a/functions/__tests__/gsc-bigquery-vertical-report.test.js
+++ b/functions/__tests__/gsc-bigquery-vertical-report.test.js
@@ -18,6 +18,7 @@ test('el workflow corre en rama aislada y no despliega web o Worker', () => {
   assert.doesNotMatch(source, /wrangler|pages deploy|cloudflare\/pages-action|deploy-worker/i);
   assert.match(source, /contents: read/);
   assert.match(source, /create_credentials_file: true/);
+  assert.match(source, /if: github\.event_name == 'workflow_dispatch'/);
 });
 
 test('lee sólo la tabla oficial por URL sin crear query jobs', () => {
@@ -34,6 +35,7 @@ test('el contrato BigQuery es de sólo lectura y evita informes parciales', () =
   assert.match(source, /lectura incompleta/);
   assert.match(source, /sed -n '\/\^\[\[:space:\]\]\*\\\[/);
   assert.match(source, /jq -e 'type == "array"'/);
+  assert.match(source, /verificar bigquery\.tables\.getData/);
   assert.doesNotMatch(source, /\bbq\s+(?:rm|mk|load|cp|update|query)\b/i);
 });
 

--- a/functions/__tests__/gsc-bigquery-vertical-report.test.js
+++ b/functions/__tests__/gsc-bigquery-vertical-report.test.js
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const workflowPath = '.github/workflows/gsc-bigquery-vertical-report.yml';
+const scriptPath = 'scripts/seo/gsc-bigquery-vertical-report.sh';
+
+function workflow() {
+  return readFileSync(workflowPath, 'utf8');
+}
+
+function script() {
+  return readFileSync(scriptPath, 'utf8');
+}
+
+test('el workflow corre en rama aislada y no despliega web o Worker', () => {
+  const source = workflow();
+  assert.match(source, /- agent\/gsc-bigquery-verticals-1/);
+  assert.doesNotMatch(source, /branches:\s*\[?main\]?/);
+  assert.doesNotMatch(source, /wrangler|pages deploy|cloudflare\/pages-action|deploy-worker/i);
+  assert.match(source, /bigquery\.readonly/);
+});
+
+test('consulta sólo la tabla oficial de impresiones por URL', () => {
+  const source = script();
+  assert.match(source, /searchdata_url_impression/);
+  assert.match(source, /site_url = '\$\{SITE_URL\}'/);
+  assert.match(source, /search_type = 'web'/);
+  assert.doesNotMatch(source, /searchdata_site_impression/);
+});
+
+test('el contrato BigQuery es de sólo lectura y tiene límite de costo', () => {
+  const source = script();
+  assert.match(source, /--maximum_bytes_billed="\$MAX_BYTES_BILLED"/);
+  assert.doesNotMatch(source, /\b(?:CREATE|INSERT|UPDATE|DELETE|MERGE|DROP|ALTER|TRUNCATE)\b/i);
+  assert.doesNotMatch(source, /\bbq\s+(?:rm|mk|load|cp|update)\b/i);
+});
+
+test('calcula posición media según el esquema oficial de Search Console', () => {
+  const source = script();
+  assert.match(source, /SAFE_DIVIDE\(SUM\(sum_position\), SUM\(impressions\)\) \+ 1 AS average_position/);
+  assert.match(source, /SUM\(clicks\) AS clicks/);
+  assert.match(source, /SUM\(impressions\) AS impressions/);
+});
+
+test('separa Tarot y Biblias con señales de query y URL', () => {
+  const source = script();
+  assert.match(source, /libros\/esoterismo-tarot/);
+  assert.match(source, /rider\[ -\]\?waite/);
+  assert.match(source, /reina\[ -\]\?valera/);
+  assert.match(source, /rvr\[ -\]\?/);
+  assert.match(source, /jerusal\[ée\]n/);
+  assert.match(source, /THEN 'tarot'/);
+  assert.match(source, /THEN 'biblias'/);
+});
+
+test('genera ventanas 28/90 y detecta oportunidades y canibalización', () => {
+  const source = script();
+  assert.match(source, /run_window 28/);
+  assert.match(source, /run_window 90/);
+  assert.match(source, /BETWEEN 4 AND 20/);
+  assert.match(source, /HAVING COUNT\(\*\) > 1/);
+  assert.match(source, /vertical-cannibalization\.json/);
+  assert.match(source, /recortadas automáticamente a los datos realmente disponibles/);
+});
+

--- a/functions/__tests__/gsc-bigquery-vertical-report.test.js
+++ b/functions/__tests__/gsc-bigquery-vertical-report.test.js
@@ -1,17 +1,15 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
+import { analyzeWindow, classifyVertical } from '../../scripts/seo/gsc-bigquery-vertical-analysis.mjs';
 
 const workflowPath = '.github/workflows/gsc-bigquery-vertical-report.yml';
-const scriptPath = 'scripts/seo/gsc-bigquery-vertical-report.sh';
+const shellPath = 'scripts/seo/gsc-bigquery-vertical-report.sh';
+const analysisPath = 'scripts/seo/gsc-bigquery-vertical-analysis.mjs';
 
-function workflow() {
-  return readFileSync(workflowPath, 'utf8');
-}
-
-function script() {
-  return readFileSync(scriptPath, 'utf8');
-}
+const workflow = () => readFileSync(workflowPath, 'utf8');
+const shell = () => readFileSync(shellPath, 'utf8');
+const analysis = () => readFileSync(analysisPath, 'utf8');
 
 test('el workflow corre en rama aislada y no despliega web o Worker', () => {
   const source = workflow();
@@ -21,46 +19,60 @@ test('el workflow corre en rama aislada y no despliega web o Worker', () => {
   assert.match(source, /bigquery\.readonly/);
 });
 
-test('consulta sólo la tabla oficial de impresiones por URL', () => {
-  const source = script();
+test('lee sólo la tabla oficial por URL sin crear query jobs', () => {
+  const source = shell();
   assert.match(source, /searchdata_url_impression/);
-  assert.match(source, /site_url = '\$\{SITE_URL\}'/);
-  assert.match(source, /search_type = 'web'/);
-  assert.doesNotMatch(source, /searchdata_site_impression/);
+  assert.match(source, /\bbq\b[^\n]* show /);
+  assert.match(source, /\bbq\b[^\n]* head /);
+  assert.doesNotMatch(source, /searchdata_site_impression|\bbq\b[^\n]* query /);
 });
 
-test('el contrato BigQuery es de sólo lectura y tiene límite de costo', () => {
-  const source = script();
-  assert.match(source, /--maximum_bytes_billed="\$MAX_BYTES_BILLED"/);
-  assert.doesNotMatch(source, /\b(?:CREATE|INSERT|UPDATE|DELETE|MERGE|DROP|ALTER|TRUNCATE)\b/i);
-  assert.doesNotMatch(source, /\bbq\s+(?:rm|mk|load|cp|update)\b/i);
+test('el contrato BigQuery es de sólo lectura y evita informes parciales', () => {
+  const source = shell();
+  assert.match(source, /MAX_ROWS/);
+  assert.match(source, /lectura incompleta/);
+  assert.doesNotMatch(source, /\bbq\s+(?:rm|mk|load|cp|update|query)\b/i);
 });
 
-test('calcula posición media según el esquema oficial de Search Console', () => {
-  const source = script();
-  assert.match(source, /SAFE_DIVIDE\(SUM\(sum_position\), SUM\(impressions\)\) \+ 1 AS average_position/);
-  assert.match(source, /SUM\(clicks\) AS clicks/);
-  assert.match(source, /SUM\(impressions\) AS impressions/);
+test('clasifica Tarot y Biblias mediante query o URL', () => {
+  assert.equal(classifyVertical({ query: 'Tarot Rider Waite', url: '' }), 'tarot');
+  assert.equal(classifyVertical({ query: '', url: 'https://www.amadolibros.com/libros/esoterismo-tarot' }), 'tarot');
+  assert.equal(classifyVertical({ query: 'Biblia Reina Valera 1960', url: '' }), 'biblias');
+  assert.equal(classifyVertical({ query: 'novela uruguaya', url: '/catalogo' }), null);
 });
 
-test('separa Tarot y Biblias con señales de query y URL', () => {
-  const source = script();
-  assert.match(source, /libros\/esoterismo-tarot/);
-  assert.match(source, /rider\[ -\]\?waite/);
-  assert.match(source, /reina\[ -\]\?valera/);
-  assert.match(source, /rvr\[ -\]\?/);
-  assert.match(source, /jerusal\[ée\]n/);
-  assert.match(source, /THEN 'tarot'/);
-  assert.match(source, /THEN 'biblias'/);
+test('calcula posición con sum_position / impressions + 1', () => {
+  const rows = [{
+    dataDate: '2026-08-22', siteUrl: 'sc-domain:amadolibros.com', searchType: 'web',
+    url: '/libros/esoterismo-tarot', query: 'tarot uruguay', isAnonymizedQuery: false,
+    country: 'ury', device: 'MOBILE', clicks: 2, impressions: 10, sumPosition: 40
+  }];
+  const report = analyzeWindow(rows, { days: 28, maxDate: '2026-08-22', minImpressions: 3 });
+  assert.equal(report.summaryRows[0].average_position, 5);
+  assert.equal(report.summaryRows[0].ctr, 0.2);
+  assert.equal(report.queryRows.length, 1);
 });
 
-test('genera ventanas 28/90 y detecta oportunidades y canibalización', () => {
-  const source = script();
-  assert.match(source, /run_window 28/);
-  assert.match(source, /run_window 90/);
-  assert.match(source, /BETWEEN 4 AND 20/);
-  assert.match(source, /HAVING COUNT\(\*\) > 1/);
-  assert.match(source, /vertical-cannibalization\.json/);
-  assert.match(source, /recortadas automáticamente a los datos realmente disponibles/);
+test('marca posible canibalización sólo con más de una URL para la misma query', () => {
+  const base = {
+    dataDate: '2026-08-22', siteUrl: 'sc-domain:amadolibros.com', searchType: 'web',
+    query: 'biblia reina valera', isAnonymizedQuery: false, country: 'ury', device: 'MOBILE',
+    clicks: 0, impressions: 3, sumPosition: 15
+  };
+  const report = analyzeWindow([
+    { ...base, url: '/libro/a' },
+    { ...base, url: '/libro/b' }
+  ], { days: 28, maxDate: '2026-08-22', minImpressions: 3 });
+  assert.equal(report.cannibalizationRows.length, 1);
+  assert.equal(report.cannibalizationRows[0].url_count, 2);
 });
 
+test('genera ventanas 28/90, CSV seguro y artefactos auditables', () => {
+  const source = analysis();
+  assert.match(source, /\[28, 90\]/);
+  assert.match(source, /average_position >= 4/);
+  assert.match(source, /cannibalization: window\.cannibalizationRows/);
+  assert.match(source, /`vertical-\$\{name\}\.json`/);
+  assert.match(source, /\^\[=\+\\-@\\t\\r\]/);
+  assert.match(source, /no crea query jobs/);
+});

--- a/scripts/seo/gsc-bigquery-vertical-analysis.mjs
+++ b/scripts/seo/gsc-bigquery-vertical-analysis.mjs
@@ -75,9 +75,11 @@ function sortMetrics(rows) {
   return rows.sort((a, b) => b.impressions - a.impressions || b.clicks - a.clicks || (a.average_position ?? Infinity) - (b.average_position ?? Infinity));
 }
 
-export function analyzeWindow(rows, { days, maxDate, minImpressions }) {
-  const startDate = dateMinus(maxDate, days - 1);
+export function analyzeWindow(rows, { days, minDate, maxDate, minImpressions }) {
+  const requestedStartDate = dateMinus(maxDate, days - 1);
+  const startDate = minDate && minDate > requestedStartDate ? minDate : requestedStartDate;
   const selected = rows.filter(row => row.dataDate >= startDate && row.dataDate <= maxDate);
+  const observedDataDays = new Set(selected.map(row => row.dataDate)).size;
   const summary = new Map();
   const queries = new Map();
   const pages = new Map();
@@ -147,7 +149,18 @@ export function analyzeWindow(rows, { days, maxDate, minImpressions }) {
       top_urls: row.urls.sort((a, b) => b.impressions - a.impressions).slice(0, 5).map(item => item.url).join(' | ')
     }))).slice(0, 500);
 
-  return { days, startDate, endDate: maxDate, summaryRows, queryRows, pageRows, cannibalizationRows };
+  return {
+    days,
+    requestedStartDate,
+    startDate,
+    endDate: maxDate,
+    observedDataDays,
+    fullCalendarRangeAvailable: startDate === requestedStartDate,
+    summaryRows,
+    queryRows,
+    pageRows,
+    cannibalizationRows
+  };
 }
 
 function safeCsv(value) {
@@ -177,7 +190,10 @@ async function writeReport(outputDir, window, availability) {
   }
   await writeFile(path.join(windowDir, 'metadata.json'), `${JSON.stringify({
     windowDays: window.days,
-    requestedRange: { startDate: window.startDate, endDate: window.endDate },
+    requestedRange: { startDate: window.requestedStartDate, endDate: window.endDate },
+    effectiveRange: { startDate: window.startDate, endDate: window.endDate },
+    observedDataDays: window.observedDataDays,
+    fullCalendarRangeAvailable: window.fullCalendarRangeAvailable,
     availableRange: availability
   }, null, 2)}\n`);
 }
@@ -211,12 +227,20 @@ export async function run(argv = process.argv.slice(2)) {
     maxDate: dates.at(-1),
     days: dates.length,
     tableRows: number(args['table-row-count']),
-    usableWebRows: rows.length
+    usableWebRows: rows.length,
+    partitionExpirationDays: number(args['partition-expiration-ms']) > 0
+      ? number(args['partition-expiration-ms']) / 86400000
+      : null
   };
   await mkdir(args.output, { recursive: true });
   await writeFile(path.join(args.output, 'availability.json'), `${JSON.stringify(availability, null, 2)}\n`);
 
-  const windows = [28, 90].map(days => analyzeWindow(rows, { days, maxDate: availability.maxDate, minImpressions }));
+  const windows = [28, 90].map(days => analyzeWindow(rows, {
+    days,
+    minDate: availability.minDate,
+    maxDate: availability.maxDate,
+    minImpressions
+  }));
   for (const window of windows) await writeReport(args.output, window, availability);
 
   const lines = [
@@ -226,12 +250,23 @@ export async function run(argv = process.argv.slice(2)) {
     `- Tabla: \`${args.table}\``,
     `- Datos disponibles: **${availability.minDate} a ${availability.maxDate}** (${availability.days} días; ${availability.usableWebRows} filas web de ${availability.tableRows} totales)`,
     '- Ventanas solicitadas: 28 y 90 días, recortadas automáticamente a los datos realmente disponibles.',
+    availability.partitionExpirationDays
+      ? `- Retención configurada de particiones: ${availability.partitionExpirationDays} días.`
+      : '- Retención configurada de particiones: no informada.',
     `- Oportunidades: posición 4–20 y al menos ${minImpressions} impresiones.`,
     '- Acceso BigQuery: metadatos + tabledata de sólo lectura; no crea query jobs.',
     ''
   ];
   for (const window of windows) {
-    lines.push(`## Ventana ${window.days} días`, '');
+    lines.push(`## Ventana solicitada: ${window.days} días`, '');
+    lines.push(`- Cobertura efectiva: ${window.startDate} a ${window.endDate} (${window.observedDataDays} fechas con datos).`);
+    if (!window.fullCalendarRangeAvailable) {
+      lines.push(`- Advertencia: todavía no hay ${window.days} días calendario disponibles; no comparar este corte como una ventana completa.`);
+    }
+    if (availability.partitionExpirationDays && window.days > availability.partitionExpirationDays) {
+      lines.push(`- Advertencia de retención: la política actual de ${availability.partitionExpirationDays} días impide conservar una ventana completa de ${window.days} días cuando madure el histórico.`);
+    }
+    lines.push('');
     if (!window.summaryRows.length) lines.push('- Sin filas clasificadas para Tarot o Biblias.');
     for (const row of window.summaryRows) {
       lines.push(`- ${row.vertical}: ${row.clicks} clics, ${row.impressions} impresiones, CTR ${(row.ctr * 100).toFixed(2)}%, posición media ${row.average_position.toFixed(1)}, ${row.urls} URLs, ${row.data_days} días con datos.`);

--- a/scripts/seo/gsc-bigquery-vertical-analysis.mjs
+++ b/scripts/seo/gsc-bigquery-vertical-analysis.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const TAROT_QUERY = /(tarot|or[áa]culo|rider[ -]?waite|marsella|baraja adivinatoria|mazo de cartas)/i;
+const TAROT_URL = /(\/libros\/esoterismo-tarot|tarot|oraculo|oráculo|rider-waite|marsella)/i;
+const BIBLE_QUERY = /(biblia|reina[ -]?valera|rvr[ -]?(1960|60)|rvc|nvi|ntv|dhh|jerusal[ée]n|latinoamericana|nuevo testamento)/i;
+const BIBLE_URL = /(biblia|reina-valera|rvr-?(1960|60)|jerusalen|latinoamericana|nuevo-testamento)/i;
+
+function number(value) {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function boolean(value) {
+  return value === true || String(value).toLowerCase() === 'true';
+}
+
+export function classifyVertical(row) {
+  const query = String(row.query ?? '');
+  const url = String(row.url ?? '');
+  if (TAROT_QUERY.test(query) || TAROT_URL.test(url)) return 'tarot';
+  if (BIBLE_QUERY.test(query) || BIBLE_URL.test(url)) return 'biblias';
+  return null;
+}
+
+function normalizeRow(row) {
+  return {
+    dataDate: String(row.data_date ?? ''),
+    siteUrl: String(row.site_url ?? ''),
+    searchType: String(row.search_type ?? ''),
+    url: String(row.url ?? ''),
+    query: String(row.query ?? ''),
+    isAnonymizedQuery: boolean(row.is_anonymized_query),
+    country: String(row.country ?? ''),
+    device: String(row.device ?? ''),
+    clicks: number(row.clicks),
+    impressions: number(row.impressions),
+    sumPosition: number(row.sum_position)
+  };
+}
+
+function addMetric(target, row) {
+  target.clicks += row.clicks;
+  target.impressions += row.impressions;
+  target.sumPosition += row.sumPosition;
+}
+
+function finishMetric(target) {
+  return {
+    clicks: target.clicks,
+    impressions: target.impressions,
+    ctr: target.impressions ? target.clicks / target.impressions : 0,
+    average_position: target.impressions ? target.sumPosition / target.impressions + 1 : null
+  };
+}
+
+function blankMetric(extra = {}) {
+  return { ...extra, clicks: 0, impressions: 0, sumPosition: 0 };
+}
+
+function dateMinus(date, days) {
+  const value = new Date(`${date}T00:00:00Z`);
+  value.setUTCDate(value.getUTCDate() - days);
+  return value.toISOString().slice(0, 10);
+}
+
+function groupByKey(map, key, factory) {
+  if (!map.has(key)) map.set(key, factory());
+  return map.get(key);
+}
+
+function sortMetrics(rows) {
+  return rows.sort((a, b) => b.impressions - a.impressions || b.clicks - a.clicks || (a.average_position ?? Infinity) - (b.average_position ?? Infinity));
+}
+
+export function analyzeWindow(rows, { days, maxDate, minImpressions }) {
+  const startDate = dateMinus(maxDate, days - 1);
+  const selected = rows.filter(row => row.dataDate >= startDate && row.dataDate <= maxDate);
+  const summary = new Map();
+  const queries = new Map();
+  const pages = new Map();
+  const queryPages = new Map();
+
+  for (const row of selected) {
+    const vertical = classifyVertical(row);
+    if (!vertical) continue;
+
+    const summaryRow = groupByKey(summary, vertical, () => blankMetric({ vertical, urls: new Set(), queries: new Set(), dates: new Set() }));
+    addMetric(summaryRow, row);
+    if (row.url) summaryRow.urls.add(row.url);
+    if (row.query && !row.isAnonymizedQuery) summaryRow.queries.add(row.query);
+    if (row.dataDate) summaryRow.dates.add(row.dataDate);
+
+    if (row.url) {
+      const key = JSON.stringify([vertical, row.url]);
+      const page = groupByKey(pages, key, () => blankMetric({ vertical, url: row.url, queries: new Set() }));
+      addMetric(page, row);
+      if (row.query && !row.isAnonymizedQuery) page.queries.add(row.query);
+    }
+
+    if (!row.isAnonymizedQuery && row.query) {
+      const queryKey = JSON.stringify([vertical, row.query, row.country, row.device]);
+      addMetric(groupByKey(queries, queryKey, () => blankMetric({ vertical, query: row.query, country: row.country, device: row.device })), row);
+      if (row.url) {
+        const queryPageKey = JSON.stringify([vertical, row.query, row.url]);
+        addMetric(groupByKey(queryPages, queryPageKey, () => blankMetric({ vertical, query: row.query, url: row.url })), row);
+      }
+    }
+  }
+
+  const summaryRows = [...summary.values()].map(row => ({
+    vertical: row.vertical,
+    ...finishMetric(row),
+    urls: row.urls.size,
+    queries: row.queries.size,
+    data_days: row.dates.size
+  })).sort((a, b) => a.vertical.localeCompare(b.vertical));
+
+  const queryRows = sortMetrics([...queries.values()].map(row => ({ ...row, ...finishMetric(row) })))
+    .filter(row => row.impressions >= minImpressions && row.average_position >= 4 && row.average_position <= 20)
+    .slice(0, 1000)
+    .map(({ sumPosition, ...row }) => row);
+
+  const pageRows = sortMetrics([...pages.values()].map(row => ({
+    vertical: row.vertical,
+    url: row.url,
+    ...finishMetric(row),
+    queries: row.queries.size
+  }))).slice(0, 2000);
+
+  const cannibalizationGroups = new Map();
+  for (const row of queryPages.values()) {
+    const key = JSON.stringify([row.vertical, row.query]);
+    const group = groupByKey(cannibalizationGroups, key, () => blankMetric({ vertical: row.vertical, query: row.query, urls: [] }));
+    addMetric(group, row);
+    group.urls.push({ url: row.url, impressions: row.impressions });
+  }
+  const cannibalizationRows = sortMetrics([...cannibalizationGroups.values()]
+    .filter(row => row.urls.length > 1 && row.impressions >= minImpressions)
+    .map(row => ({
+      vertical: row.vertical,
+      query: row.query,
+      url_count: row.urls.length,
+      ...finishMetric(row),
+      top_urls: row.urls.sort((a, b) => b.impressions - a.impressions).slice(0, 5).map(item => item.url).join(' | ')
+    }))).slice(0, 500);
+
+  return { days, startDate, endDate: maxDate, summaryRows, queryRows, pageRows, cannibalizationRows };
+}
+
+function safeCsv(value) {
+  let text = value == null ? '' : String(value);
+  if (/^[=+\-@\t\r]/.test(text)) text = `'${text}`;
+  return `"${text.replaceAll('"', '""')}"`;
+}
+
+function csv(rows) {
+  if (!rows.length) return '';
+  const headers = Object.keys(rows[0]);
+  return `${headers.map(safeCsv).join(',')}\n${rows.map(row => headers.map(header => safeCsv(row[header])).join(',')).join('\n')}\n`;
+}
+
+async function writeReport(outputDir, window, availability) {
+  const windowDir = path.join(outputDir, `${window.days}d`);
+  await mkdir(windowDir, { recursive: true });
+  const reports = {
+    summary: window.summaryRows,
+    queries: window.queryRows,
+    pages: window.pageRows,
+    cannibalization: window.cannibalizationRows
+  };
+  for (const [name, rows] of Object.entries(reports)) {
+    await writeFile(path.join(windowDir, `vertical-${name}.json`), `${JSON.stringify(rows, null, 2)}\n`);
+    await writeFile(path.join(windowDir, `vertical-${name}.csv`), csv(rows));
+  }
+  await writeFile(path.join(windowDir, 'metadata.json'), `${JSON.stringify({
+    windowDays: window.days,
+    requestedRange: { startDate: window.startDate, endDate: window.endDate },
+    availableRange: availability
+  }, null, 2)}\n`);
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value == null) throw new Error(`Argumento inválido: ${key ?? ''}`);
+    values[key.slice(2)] = value;
+  }
+  return values;
+}
+
+export async function run(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const required = ['input', 'output', 'site', 'table', 'min-impressions', 'table-row-count'];
+  for (const name of required) if (!args[name]) throw new Error(`Falta --${name}`);
+  const minImpressions = number(args['min-impressions']);
+  if (!Number.isInteger(minImpressions) || minImpressions < 1) throw new Error('--min-impressions debe ser un entero positivo');
+
+  const rawRows = JSON.parse(await readFile(args.input, 'utf8'));
+  if (!Array.isArray(rawRows)) throw new Error('La lectura BigQuery no devolvió un array');
+  const rows = rawRows.map(normalizeRow).filter(row => row.siteUrl === args.site && row.searchType === 'web' && /^\d{4}-\d{2}-\d{2}$/.test(row.dataDate));
+  if (!rows.length) throw new Error(`No hay filas web para ${args.site}`);
+
+  const dates = [...new Set(rows.map(row => row.dataDate))].sort();
+  const availability = {
+    minDate: dates[0],
+    maxDate: dates.at(-1),
+    days: dates.length,
+    tableRows: number(args['table-row-count']),
+    usableWebRows: rows.length
+  };
+  await mkdir(args.output, { recursive: true });
+  await writeFile(path.join(args.output, 'availability.json'), `${JSON.stringify(availability, null, 2)}\n`);
+
+  const windows = [28, 90].map(days => analyzeWindow(rows, { days, maxDate: availability.maxDate, minImpressions }));
+  for (const window of windows) await writeReport(args.output, window, availability);
+
+  const lines = [
+    '# GSC BigQuery — Tarot y Biblias',
+    '',
+    `- Propiedad: \`${args.site}\``,
+    `- Tabla: \`${args.table}\``,
+    `- Datos disponibles: **${availability.minDate} a ${availability.maxDate}** (${availability.days} días; ${availability.usableWebRows} filas web de ${availability.tableRows} totales)`,
+    '- Ventanas solicitadas: 28 y 90 días, recortadas automáticamente a los datos realmente disponibles.',
+    `- Oportunidades: posición 4–20 y al menos ${minImpressions} impresiones.`,
+    '- Acceso BigQuery: metadatos + tabledata de sólo lectura; no crea query jobs.',
+    ''
+  ];
+  for (const window of windows) {
+    lines.push(`## Ventana ${window.days} días`, '');
+    if (!window.summaryRows.length) lines.push('- Sin filas clasificadas para Tarot o Biblias.');
+    for (const row of window.summaryRows) {
+      lines.push(`- ${row.vertical}: ${row.clicks} clics, ${row.impressions} impresiones, CTR ${(row.ctr * 100).toFixed(2)}%, posición media ${row.average_position.toFixed(1)}, ${row.urls} URLs, ${row.data_days} días con datos.`);
+    }
+    lines.push('', `- Queries accionables: ${window.queryRows.length}`, `- Posibles canibalizaciones: ${window.cannibalizationRows.length}`, '');
+  }
+  lines.push('> Informe de sólo lectura. No modifica Search Console, BigQuery, la web, Merchant ni producción.');
+  const summary = `${lines.join('\n')}\n`;
+  await writeFile(path.join(args.output, 'summary.md'), summary);
+  process.stdout.write(summary);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run().catch(error => {
+    process.stderr.write(`ERROR: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/seo/gsc-bigquery-vertical-report.sh
+++ b/scripts/seo/gsc-bigquery-vertical-report.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+PROJECT_ID="${GSC_BQ_PROJECT_ID:-amado-libros-analytics}"
+EXPECTED_PROJECT_NUMBER="${GSC_BQ_PROJECT_NUMBER:-667747565315}"
+DATASET_ID="${GSC_BQ_DATASET_ID:-searchconsole}"
+LOCATION="${GSC_BQ_LOCATION:-US}"
+SITE_URL="${GSC_BQ_SITE_URL:-sc-domain:amadolibros.com}"
+OUTPUT_DIR="${GSC_BQ_OUTPUT_DIR:-artifacts/gsc-bigquery-verticals}"
+MIN_IMPRESSIONS="${GSC_BQ_MIN_IMPRESSIONS:-3}"
+MAX_BYTES_BILLED="${GSC_BQ_MAX_BYTES_BILLED:-1000000000}"
+TABLE="${PROJECT_ID}.${DATASET_ID}.searchdata_url_impression"
+
+for command in gcloud bq jq date; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "ERROR: falta el comando requerido: $command" >&2
+    exit 2
+  fi
+done
+
+if ! [[ "$MIN_IMPRESSIONS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: GSC_BQ_MIN_IMPRESSIONS debe ser un entero positivo." >&2
+  exit 2
+fi
+if ! [[ "$MAX_BYTES_BILLED" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: GSC_BQ_MAX_BYTES_BILLED debe ser un entero positivo." >&2
+  exit 2
+fi
+
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+if [[ "$PROJECT_NUMBER" != "$EXPECTED_PROJECT_NUMBER" ]]; then
+  echo "ERROR: projectNumber inesperado para $PROJECT_ID: $PROJECT_NUMBER" >&2
+  exit 3
+fi
+
+mkdir -p "$OUTPUT_DIR/sql" "$OUTPUT_DIR/28d" "$OUTPUT_DIR/90d"
+
+bq_read() {
+  local format="$1"
+  local sql_file="$2"
+  bq --project_id="$PROJECT_ID" query \
+    --quiet \
+    --location="$LOCATION" \
+    --use_legacy_sql=false \
+    --maximum_bytes_billed="$MAX_BYTES_BILLED" \
+    --format="$format" < "$sql_file"
+}
+
+cat > "$OUTPUT_DIR/sql/availability.sql" <<SQL
+SELECT
+  CAST(MIN(data_date) AS STRING) AS min_data_date,
+  CAST(MAX(data_date) AS STRING) AS max_data_date,
+  COUNT(DISTINCT data_date) AS available_days,
+  COUNT(*) AS row_count
+FROM \`${TABLE}\`
+WHERE site_url = '${SITE_URL}'
+  AND search_type = 'web'
+SQL
+
+bq_read json "$OUTPUT_DIR/sql/availability.sql" > "$OUTPUT_DIR/availability.json"
+MIN_DATE="$(jq -r '.[0].min_data_date // empty' "$OUTPUT_DIR/availability.json")"
+MAX_DATE="$(jq -r '.[0].max_data_date // empty' "$OUTPUT_DIR/availability.json")"
+AVAILABLE_DAYS="$(jq -r '.[0].available_days // "0"' "$OUTPUT_DIR/availability.json")"
+ROW_COUNT="$(jq -r '.[0].row_count // "0"' "$OUTPUT_DIR/availability.json")"
+
+if [[ -z "$MIN_DATE" || -z "$MAX_DATE" ]]; then
+  echo "ERROR: no hay datos web para $SITE_URL en $TABLE." >&2
+  exit 4
+fi
+
+write_common_cte() {
+  local file="$1"
+  local start_date="$2"
+  cat > "$file" <<SQL
+WITH source AS (
+  SELECT
+    data_date,
+    url,
+    query,
+    is_anonymized_query,
+    country,
+    device,
+    clicks,
+    impressions,
+    sum_position,
+    LOWER(COALESCE(query, '')) AS query_normalized,
+    LOWER(COALESCE(url, '')) AS url_normalized
+  FROM \`${TABLE}\`
+  WHERE site_url = '${SITE_URL}'
+    AND search_type = 'web'
+    AND data_date BETWEEN DATE('${start_date}') AND DATE('${MAX_DATE}')
+), classified AS (
+  SELECT
+    *,
+    CASE
+      WHEN REGEXP_CONTAINS(query_normalized, r'(tarot|or[áa]culo|rider[ -]?waite|marsella|baraja adivinatoria|mazo de cartas)')
+        OR REGEXP_CONTAINS(url_normalized, r'(/libros/esoterismo-tarot|tarot|oraculo|oráculo|rider-waite|marsella)')
+        THEN 'tarot'
+      WHEN REGEXP_CONTAINS(query_normalized, r'(biblia|reina[ -]?valera|rvr[ -]?(1960|60)|rvc|nvi|ntv|dhh|jerusal[ée]n|latinoamericana|nuevo testamento)')
+        OR REGEXP_CONTAINS(url_normalized, r'(biblia|reina-valera|rvr-?(1960|60)|jerusalen|latinoamericana|nuevo-testamento)')
+        THEN 'biblias'
+      ELSE NULL
+    END AS vertical
+  FROM source
+)
+SQL
+}
+
+run_window() {
+  local window="$1"
+  local start_date
+  local window_dir="$OUTPUT_DIR/${window}d"
+  local prefix="$OUTPUT_DIR/sql/${window}d"
+  start_date="$(date -u -d "$MAX_DATE -$((window - 1)) days" +%F)"
+
+  write_common_cte "$prefix-summary.sql" "$start_date"
+  cat >> "$prefix-summary.sql" <<'SQL'
+SELECT
+  vertical,
+  SUM(clicks) AS clicks,
+  SUM(impressions) AS impressions,
+  SAFE_DIVIDE(SUM(clicks), SUM(impressions)) AS ctr,
+  SAFE_DIVIDE(SUM(sum_position), SUM(impressions)) + 1 AS average_position,
+  COUNT(DISTINCT url) AS urls,
+  COUNT(DISTINCT IF(is_anonymized_query, NULL, query)) AS queries,
+  COUNT(DISTINCT data_date) AS data_days
+FROM classified
+WHERE vertical IS NOT NULL
+GROUP BY vertical
+ORDER BY vertical
+SQL
+
+  write_common_cte "$prefix-queries.sql" "$start_date"
+  cat >> "$prefix-queries.sql" <<SQL
+SELECT
+  vertical,
+  query,
+  country,
+  device,
+  SUM(clicks) AS clicks,
+  SUM(impressions) AS impressions,
+  SAFE_DIVIDE(SUM(clicks), SUM(impressions)) AS ctr,
+  SAFE_DIVIDE(SUM(sum_position), SUM(impressions)) + 1 AS average_position
+FROM classified
+WHERE vertical IS NOT NULL
+  AND NOT is_anonymized_query
+  AND query IS NOT NULL
+  AND query != ''
+GROUP BY vertical, query, country, device
+HAVING SUM(impressions) >= ${MIN_IMPRESSIONS}
+  AND SAFE_DIVIDE(SUM(sum_position), SUM(impressions)) + 1 BETWEEN 4 AND 20
+ORDER BY impressions DESC, clicks DESC, average_position ASC
+LIMIT 1000
+SQL
+
+  write_common_cte "$prefix-pages.sql" "$start_date"
+  cat >> "$prefix-pages.sql" <<'SQL'
+SELECT
+  vertical,
+  url,
+  SUM(clicks) AS clicks,
+  SUM(impressions) AS impressions,
+  SAFE_DIVIDE(SUM(clicks), SUM(impressions)) AS ctr,
+  SAFE_DIVIDE(SUM(sum_position), SUM(impressions)) + 1 AS average_position,
+  COUNT(DISTINCT IF(is_anonymized_query, NULL, query)) AS queries
+FROM classified
+WHERE vertical IS NOT NULL
+  AND url IS NOT NULL
+  AND url != ''
+GROUP BY vertical, url
+ORDER BY impressions DESC, clicks DESC
+LIMIT 2000
+SQL
+
+  write_common_cte "$prefix-cannibalization.sql" "$start_date"
+  cat >> "$prefix-cannibalization.sql" <<SQL
+, query_page AS (
+  SELECT
+    vertical,
+    query,
+    url,
+    SUM(clicks) AS clicks,
+    SUM(impressions) AS impressions,
+    SUM(sum_position) AS sum_position
+  FROM classified
+  WHERE vertical IS NOT NULL
+    AND NOT is_anonymized_query
+    AND query IS NOT NULL
+    AND query != ''
+    AND url IS NOT NULL
+    AND url != ''
+  GROUP BY vertical, query, url
+)
+SELECT
+  vertical,
+  query,
+  COUNT(*) AS url_count,
+  SUM(clicks) AS clicks,
+  SUM(impressions) AS impressions,
+  SAFE_DIVIDE(SUM(sum_position), SUM(impressions)) + 1 AS average_position,
+  STRING_AGG(url, ' | ' ORDER BY impressions DESC LIMIT 5) AS top_urls
+FROM query_page
+GROUP BY vertical, query
+HAVING COUNT(*) > 1
+  AND SUM(impressions) >= ${MIN_IMPRESSIONS}
+ORDER BY impressions DESC, url_count DESC
+LIMIT 500
+SQL
+
+  for report in summary queries pages cannibalization; do
+    bq_read json "$prefix-${report}.sql" > "$window_dir/vertical-${report}.json"
+    bq_read csv "$prefix-${report}.sql" > "$window_dir/vertical-${report}.csv"
+  done
+
+  jq -n \
+    --arg window_days "$window" \
+    --arg start_date "$start_date" \
+    --arg end_date "$MAX_DATE" \
+    --arg available_min_date "$MIN_DATE" \
+    --arg available_max_date "$MAX_DATE" \
+    --arg available_days "$AVAILABLE_DAYS" \
+    '{
+      windowDays: ($window_days | tonumber),
+      requestedRange: {startDate: $start_date, endDate: $end_date},
+      availableRange: {minDate: $available_min_date, maxDate: $available_max_date, days: ($available_days | tonumber)}
+    }' > "$window_dir/metadata.json"
+}
+
+run_window 28
+run_window 90
+
+{
+  echo '# GSC BigQuery — Tarot y Biblias'
+  echo
+  echo "- Propiedad: \`$SITE_URL\`"
+  echo "- Tabla: \`$TABLE\`"
+  echo "- Datos disponibles: **$MIN_DATE a $MAX_DATE** ($AVAILABLE_DAYS días; $ROW_COUNT filas web)"
+  echo '- Ventanas solicitadas: 28 y 90 días, recortadas automáticamente a los datos realmente disponibles.'
+  echo "- Oportunidades: posición 4–20 y al menos $MIN_IMPRESSIONS impresiones."
+  echo "- Límite de costo por consulta: $MAX_BYTES_BILLED bytes."
+  echo
+  for window in 28 90; do
+    echo "## Ventana ${window} días"
+    echo
+    if [[ "$(jq 'length' "$OUTPUT_DIR/${window}d/vertical-summary.json")" -eq 0 ]]; then
+      echo '- Sin filas clasificadas para Tarot o Biblias.'
+    else
+      jq -r '.[] | "- \(.vertical): \(.clicks) clics, \(.impressions) impresiones, CTR \((.ctr * 10000 | round) / 100)%, posición media \((.average_position * 10 | round) / 10), \(.urls) URLs, \(.data_days) días con datos."' \
+        "$OUTPUT_DIR/${window}d/vertical-summary.json"
+    fi
+    echo
+    echo "- Queries accionables: $(jq 'length' "$OUTPUT_DIR/${window}d/vertical-queries.json")"
+    echo "- Posibles canibalizaciones: $(jq 'length' "$OUTPUT_DIR/${window}d/vertical-cannibalization.json")"
+    echo
+  done
+  echo '> Informe de sólo lectura. No modifica Search Console, BigQuery, la web, Merchant ni producción.'
+} > "$OUTPUT_DIR/summary.md"
+
+cat "$OUTPUT_DIR/summary.md"
+

--- a/scripts/seo/gsc-bigquery-vertical-report.sh
+++ b/scripts/seo/gsc-bigquery-vertical-report.sh
@@ -38,7 +38,10 @@ trap 'rm -f "$RAW_ROWS"' EXIT
 
 # `bq show` y `bq head` usan lectura de metadatos/tabledata. No crean jobs,
 # tablas ni vistas y permiten auditar el export sin bigquery.jobs.create.
-bq --project_id="$PROJECT_ID" show --format=json "$TABLE_REF" > "$OUTPUT_DIR/table-metadata.json"
+bq --project_id="$PROJECT_ID" show --format=json "$TABLE_REF" \
+  | sed -n '/^[[:space:]]*{/,$p' \
+  > "$OUTPUT_DIR/table-metadata.json"
+jq -e 'type == "object" and (.numRows != null)' "$OUTPUT_DIR/table-metadata.json" >/dev/null
 ROW_COUNT="$(jq -r '.numRows // "0"' "$OUTPUT_DIR/table-metadata.json")"
 
 if ! [[ "$ROW_COUNT" =~ ^[0-9]+$ ]] || [[ "$ROW_COUNT" -eq 0 ]]; then
@@ -53,7 +56,10 @@ fi
 bq --project_id="$PROJECT_ID" head \
   --max_rows="$ROW_COUNT" \
   --format=json \
-  "$TABLE_REF" > "$RAW_ROWS"
+  "$TABLE_REF" \
+  | sed -n '/^[[:space:]]*\[/,$p' \
+  > "$RAW_ROWS"
+jq -e 'type == "array"' "$RAW_ROWS" >/dev/null
 
 FETCHED_ROWS="$(jq 'length' "$RAW_ROWS")"
 if [[ "$FETCHED_ROWS" -ne "$ROW_COUNT" ]]; then

--- a/scripts/seo/gsc-bigquery-vertical-report.sh
+++ b/scripts/seo/gsc-bigquery-vertical-report.sh
@@ -4,28 +4,27 @@ set -Eeuo pipefail
 PROJECT_ID="${GSC_BQ_PROJECT_ID:-amado-libros-analytics}"
 EXPECTED_PROJECT_NUMBER="${GSC_BQ_PROJECT_NUMBER:-667747565315}"
 DATASET_ID="${GSC_BQ_DATASET_ID:-searchconsole}"
-LOCATION="${GSC_BQ_LOCATION:-US}"
 SITE_URL="${GSC_BQ_SITE_URL:-sc-domain:amadolibros.com}"
 OUTPUT_DIR="${GSC_BQ_OUTPUT_DIR:-artifacts/gsc-bigquery-verticals}"
 MIN_IMPRESSIONS="${GSC_BQ_MIN_IMPRESSIONS:-3}"
-MAX_BYTES_BILLED="${GSC_BQ_MAX_BYTES_BILLED:-1000000000}"
+MAX_ROWS="${GSC_BQ_MAX_ROWS:-250000}"
 TABLE="${PROJECT_ID}.${DATASET_ID}.searchdata_url_impression"
+TABLE_REF="${PROJECT_ID}:${DATASET_ID}.searchdata_url_impression"
 
-for command in gcloud bq jq date; do
+for command in gcloud bq jq node mktemp; do
   if ! command -v "$command" >/dev/null 2>&1; then
     echo "ERROR: falta el comando requerido: $command" >&2
     exit 2
   fi
 done
 
-if ! [[ "$MIN_IMPRESSIONS" =~ ^[1-9][0-9]*$ ]]; then
-  echo "ERROR: GSC_BQ_MIN_IMPRESSIONS debe ser un entero positivo." >&2
-  exit 2
-fi
-if ! [[ "$MAX_BYTES_BILLED" =~ ^[1-9][0-9]*$ ]]; then
-  echo "ERROR: GSC_BQ_MAX_BYTES_BILLED debe ser un entero positivo." >&2
-  exit 2
-fi
+for value_name in MIN_IMPRESSIONS MAX_ROWS; do
+  value="${!value_name}"
+  if ! [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: $value_name debe ser un entero positivo." >&2
+    exit 2
+  fi
+done
 
 PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
 if [[ "$PROJECT_NUMBER" != "$EXPECTED_PROJECT_NUMBER" ]]; then
@@ -33,228 +32,39 @@ if [[ "$PROJECT_NUMBER" != "$EXPECTED_PROJECT_NUMBER" ]]; then
   exit 3
 fi
 
-mkdir -p "$OUTPUT_DIR/sql" "$OUTPUT_DIR/28d" "$OUTPUT_DIR/90d"
+mkdir -p "$OUTPUT_DIR"
+RAW_ROWS="$(mktemp)"
+trap 'rm -f "$RAW_ROWS"' EXIT
 
-bq_read() {
-  local format="$1"
-  local sql_file="$2"
-  bq --project_id="$PROJECT_ID" query \
-    --quiet \
-    --location="$LOCATION" \
-    --use_legacy_sql=false \
-    --maximum_bytes_billed="$MAX_BYTES_BILLED" \
-    --format="$format" < "$sql_file"
-}
+# `bq show` y `bq head` usan lectura de metadatos/tabledata. No crean jobs,
+# tablas ni vistas y permiten auditar el export sin bigquery.jobs.create.
+bq --project_id="$PROJECT_ID" show --format=json "$TABLE_REF" > "$OUTPUT_DIR/table-metadata.json"
+ROW_COUNT="$(jq -r '.numRows // "0"' "$OUTPUT_DIR/table-metadata.json")"
 
-cat > "$OUTPUT_DIR/sql/availability.sql" <<SQL
-SELECT
-  CAST(MIN(data_date) AS STRING) AS min_data_date,
-  CAST(MAX(data_date) AS STRING) AS max_data_date,
-  COUNT(DISTINCT data_date) AS available_days,
-  COUNT(*) AS row_count
-FROM \`${TABLE}\`
-WHERE site_url = '${SITE_URL}'
-  AND search_type = 'web'
-SQL
-
-bq_read json "$OUTPUT_DIR/sql/availability.sql" > "$OUTPUT_DIR/availability.json"
-MIN_DATE="$(jq -r '.[0].min_data_date // empty' "$OUTPUT_DIR/availability.json")"
-MAX_DATE="$(jq -r '.[0].max_data_date // empty' "$OUTPUT_DIR/availability.json")"
-AVAILABLE_DAYS="$(jq -r '.[0].available_days // "0"' "$OUTPUT_DIR/availability.json")"
-ROW_COUNT="$(jq -r '.[0].row_count // "0"' "$OUTPUT_DIR/availability.json")"
-
-if [[ -z "$MIN_DATE" || -z "$MAX_DATE" ]]; then
-  echo "ERROR: no hay datos web para $SITE_URL en $TABLE." >&2
+if ! [[ "$ROW_COUNT" =~ ^[0-9]+$ ]] || [[ "$ROW_COUNT" -eq 0 ]]; then
+  echo "ERROR: $TABLE no tiene filas disponibles." >&2
   exit 4
 fi
+if [[ "$ROW_COUNT" -gt "$MAX_ROWS" ]]; then
+  echo "ERROR: $TABLE tiene $ROW_COUNT filas y supera el límite seguro de $MAX_ROWS; no se generará un informe parcial." >&2
+  exit 5
+fi
 
-write_common_cte() {
-  local file="$1"
-  local start_date="$2"
-  cat > "$file" <<SQL
-WITH source AS (
-  SELECT
-    data_date,
-    url,
-    query,
-    is_anonymized_query,
-    country,
-    device,
-    clicks,
-    impressions,
-    sum_position,
-    LOWER(COALESCE(query, '')) AS query_normalized,
-    LOWER(COALESCE(url, '')) AS url_normalized
-  FROM \`${TABLE}\`
-  WHERE site_url = '${SITE_URL}'
-    AND search_type = 'web'
-    AND data_date BETWEEN DATE('${start_date}') AND DATE('${MAX_DATE}')
-), classified AS (
-  SELECT
-    *,
-    CASE
-      WHEN REGEXP_CONTAINS(query_normalized, r'(tarot|or[áa]culo|rider[ -]?waite|marsella|baraja adivinatoria|mazo de cartas)')
-        OR REGEXP_CONTAINS(url_normalized, r'(/libros/esoterismo-tarot|tarot|oraculo|oráculo|rider-waite|marsella)')
-        THEN 'tarot'
-      WHEN REGEXP_CONTAINS(query_normalized, r'(biblia|reina[ -]?valera|rvr[ -]?(1960|60)|rvc|nvi|ntv|dhh|jerusal[ée]n|latinoamericana|nuevo testamento)')
-        OR REGEXP_CONTAINS(url_normalized, r'(biblia|reina-valera|rvr-?(1960|60)|jerusalen|latinoamericana|nuevo-testamento)')
-        THEN 'biblias'
-      ELSE NULL
-    END AS vertical
-  FROM source
-)
-SQL
-}
+bq --project_id="$PROJECT_ID" head \
+  --max_rows="$ROW_COUNT" \
+  --format=json \
+  "$TABLE_REF" > "$RAW_ROWS"
 
-run_window() {
-  local window="$1"
-  local start_date
-  local window_dir="$OUTPUT_DIR/${window}d"
-  local prefix="$OUTPUT_DIR/sql/${window}d"
-  start_date="$(date -u -d "$MAX_DATE -$((window - 1)) days" +%F)"
+FETCHED_ROWS="$(jq 'length' "$RAW_ROWS")"
+if [[ "$FETCHED_ROWS" -ne "$ROW_COUNT" ]]; then
+  echo "ERROR: lectura incompleta de $TABLE: esperadas=$ROW_COUNT, recibidas=$FETCHED_ROWS." >&2
+  exit 6
+fi
 
-  write_common_cte "$prefix-summary.sql" "$start_date"
-  cat >> "$prefix-summary.sql" <<'SQL'
-SELECT
-  vertical,
-  SUM(clicks) AS clicks,
-  SUM(impressions) AS impressions,
-  SAFE_DIVIDE(SUM(clicks), SUM(impressions)) AS ctr,
-  SAFE_DIVIDE(SUM(sum_position), SUM(impressions)) + 1 AS average_position,
-  COUNT(DISTINCT url) AS urls,
-  COUNT(DISTINCT IF(is_anonymized_query, NULL, query)) AS queries,
-  COUNT(DISTINCT data_date) AS data_days
-FROM classified
-WHERE vertical IS NOT NULL
-GROUP BY vertical
-ORDER BY vertical
-SQL
-
-  write_common_cte "$prefix-queries.sql" "$start_date"
-  cat >> "$prefix-queries.sql" <<SQL
-SELECT
-  vertical,
-  query,
-  country,
-  device,
-  SUM(clicks) AS clicks,
-  SUM(impressions) AS impressions,
-  SAFE_DIVIDE(SUM(clicks), SUM(impressions)) AS ctr,
-  SAFE_DIVIDE(SUM(sum_position), SUM(impressions)) + 1 AS average_position
-FROM classified
-WHERE vertical IS NOT NULL
-  AND NOT is_anonymized_query
-  AND query IS NOT NULL
-  AND query != ''
-GROUP BY vertical, query, country, device
-HAVING SUM(impressions) >= ${MIN_IMPRESSIONS}
-  AND SAFE_DIVIDE(SUM(sum_position), SUM(impressions)) + 1 BETWEEN 4 AND 20
-ORDER BY impressions DESC, clicks DESC, average_position ASC
-LIMIT 1000
-SQL
-
-  write_common_cte "$prefix-pages.sql" "$start_date"
-  cat >> "$prefix-pages.sql" <<'SQL'
-SELECT
-  vertical,
-  url,
-  SUM(clicks) AS clicks,
-  SUM(impressions) AS impressions,
-  SAFE_DIVIDE(SUM(clicks), SUM(impressions)) AS ctr,
-  SAFE_DIVIDE(SUM(sum_position), SUM(impressions)) + 1 AS average_position,
-  COUNT(DISTINCT IF(is_anonymized_query, NULL, query)) AS queries
-FROM classified
-WHERE vertical IS NOT NULL
-  AND url IS NOT NULL
-  AND url != ''
-GROUP BY vertical, url
-ORDER BY impressions DESC, clicks DESC
-LIMIT 2000
-SQL
-
-  write_common_cte "$prefix-cannibalization.sql" "$start_date"
-  cat >> "$prefix-cannibalization.sql" <<SQL
-, query_page AS (
-  SELECT
-    vertical,
-    query,
-    url,
-    SUM(clicks) AS clicks,
-    SUM(impressions) AS impressions,
-    SUM(sum_position) AS sum_position
-  FROM classified
-  WHERE vertical IS NOT NULL
-    AND NOT is_anonymized_query
-    AND query IS NOT NULL
-    AND query != ''
-    AND url IS NOT NULL
-    AND url != ''
-  GROUP BY vertical, query, url
-)
-SELECT
-  vertical,
-  query,
-  COUNT(*) AS url_count,
-  SUM(clicks) AS clicks,
-  SUM(impressions) AS impressions,
-  SAFE_DIVIDE(SUM(sum_position), SUM(impressions)) + 1 AS average_position,
-  STRING_AGG(url, ' | ' ORDER BY impressions DESC LIMIT 5) AS top_urls
-FROM query_page
-GROUP BY vertical, query
-HAVING COUNT(*) > 1
-  AND SUM(impressions) >= ${MIN_IMPRESSIONS}
-ORDER BY impressions DESC, url_count DESC
-LIMIT 500
-SQL
-
-  for report in summary queries pages cannibalization; do
-    bq_read json "$prefix-${report}.sql" > "$window_dir/vertical-${report}.json"
-    bq_read csv "$prefix-${report}.sql" > "$window_dir/vertical-${report}.csv"
-  done
-
-  jq -n \
-    --arg window_days "$window" \
-    --arg start_date "$start_date" \
-    --arg end_date "$MAX_DATE" \
-    --arg available_min_date "$MIN_DATE" \
-    --arg available_max_date "$MAX_DATE" \
-    --arg available_days "$AVAILABLE_DAYS" \
-    '{
-      windowDays: ($window_days | tonumber),
-      requestedRange: {startDate: $start_date, endDate: $end_date},
-      availableRange: {minDate: $available_min_date, maxDate: $available_max_date, days: ($available_days | tonumber)}
-    }' > "$window_dir/metadata.json"
-}
-
-run_window 28
-run_window 90
-
-{
-  echo '# GSC BigQuery — Tarot y Biblias'
-  echo
-  echo "- Propiedad: \`$SITE_URL\`"
-  echo "- Tabla: \`$TABLE\`"
-  echo "- Datos disponibles: **$MIN_DATE a $MAX_DATE** ($AVAILABLE_DAYS días; $ROW_COUNT filas web)"
-  echo '- Ventanas solicitadas: 28 y 90 días, recortadas automáticamente a los datos realmente disponibles.'
-  echo "- Oportunidades: posición 4–20 y al menos $MIN_IMPRESSIONS impresiones."
-  echo "- Límite de costo por consulta: $MAX_BYTES_BILLED bytes."
-  echo
-  for window in 28 90; do
-    echo "## Ventana ${window} días"
-    echo
-    if [[ "$(jq 'length' "$OUTPUT_DIR/${window}d/vertical-summary.json")" -eq 0 ]]; then
-      echo '- Sin filas clasificadas para Tarot o Biblias.'
-    else
-      jq -r '.[] | "- \(.vertical): \(.clicks) clics, \(.impressions) impresiones, CTR \((.ctr * 10000 | round) / 100)%, posición media \((.average_position * 10 | round) / 10), \(.urls) URLs, \(.data_days) días con datos."' \
-        "$OUTPUT_DIR/${window}d/vertical-summary.json"
-    fi
-    echo
-    echo "- Queries accionables: $(jq 'length' "$OUTPUT_DIR/${window}d/vertical-queries.json")"
-    echo "- Posibles canibalizaciones: $(jq 'length' "$OUTPUT_DIR/${window}d/vertical-cannibalization.json")"
-    echo
-  done
-  echo '> Informe de sólo lectura. No modifica Search Console, BigQuery, la web, Merchant ni producción.'
-} > "$OUTPUT_DIR/summary.md"
-
-cat "$OUTPUT_DIR/summary.md"
-
+node scripts/seo/gsc-bigquery-vertical-analysis.mjs \
+  --input "$RAW_ROWS" \
+  --output "$OUTPUT_DIR" \
+  --site "$SITE_URL" \
+  --table "$TABLE" \
+  --min-impressions "$MIN_IMPRESSIONS" \
+  --table-row-count "$ROW_COUNT"

--- a/scripts/seo/gsc-bigquery-vertical-report.sh
+++ b/scripts/seo/gsc-bigquery-vertical-report.sh
@@ -34,13 +34,17 @@ fi
 
 mkdir -p "$OUTPUT_DIR"
 RAW_ROWS="$(mktemp)"
-trap 'rm -f "$RAW_ROWS"' EXIT
+RAW_METADATA="$(mktemp)"
+trap 'rm -f "$RAW_ROWS" "$RAW_METADATA"' EXIT
 
 # `bq show` y `bq head` usan lectura de metadatos/tabledata. No crean jobs,
 # tablas ni vistas y permiten auditar el export sin bigquery.jobs.create.
-bq --project_id="$PROJECT_ID" show --format=json "$TABLE_REF" \
-  | sed -n '/^[[:space:]]*{/,$p' \
-  > "$OUTPUT_DIR/table-metadata.json"
+if ! bq --project_id="$PROJECT_ID" show --format=json "$TABLE_REF" > "$RAW_METADATA" 2>&1; then
+  echo "ERROR: no fue posible leer metadatos de $TABLE." >&2
+  sed -n '1,40p' "$RAW_METADATA" >&2
+  exit 7
+fi
+sed -n '/^[[:space:]]*{/,$p' "$RAW_METADATA" > "$OUTPUT_DIR/table-metadata.json"
 jq -e 'type == "object" and (.numRows != null)' "$OUTPUT_DIR/table-metadata.json" >/dev/null
 ROW_COUNT="$(jq -r '.numRows // "0"' "$OUTPUT_DIR/table-metadata.json")"
 
@@ -53,12 +57,15 @@ if [[ "$ROW_COUNT" -gt "$MAX_ROWS" ]]; then
   exit 5
 fi
 
-bq --project_id="$PROJECT_ID" head \
+if ! bq --project_id="$PROJECT_ID" head \
   --max_rows="$ROW_COUNT" \
   --format=json \
-  "$TABLE_REF" \
-  | sed -n '/^[[:space:]]*\[/,$p' \
-  > "$RAW_ROWS"
+  "$TABLE_REF" > "$RAW_METADATA" 2>&1; then
+  echo "ERROR: no fue posible leer filas de $TABLE; verificar bigquery.tables.getData." >&2
+  sed -n '1,40p' "$RAW_METADATA" >&2
+  exit 8
+fi
+sed -n '/^[[:space:]]*\[/,$p' "$RAW_METADATA" > "$RAW_ROWS"
 jq -e 'type == "array"' "$RAW_ROWS" >/dev/null
 
 FETCHED_ROWS="$(jq 'length' "$RAW_ROWS")"

--- a/scripts/seo/gsc-bigquery-vertical-report.sh
+++ b/scripts/seo/gsc-bigquery-vertical-report.sh
@@ -47,6 +47,7 @@ fi
 sed -n '/^[[:space:]]*{/,$p' "$RAW_METADATA" > "$OUTPUT_DIR/table-metadata.json"
 jq -e 'type == "object" and (.numRows != null)' "$OUTPUT_DIR/table-metadata.json" >/dev/null
 ROW_COUNT="$(jq -r '.numRows // "0"' "$OUTPUT_DIR/table-metadata.json")"
+PARTITION_EXPIRATION_MS="$(jq -r '.timePartitioning.expirationMs // "0"' "$OUTPUT_DIR/table-metadata.json")"
 
 if ! [[ "$ROW_COUNT" =~ ^[0-9]+$ ]] || [[ "$ROW_COUNT" -eq 0 ]]; then
   echo "ERROR: $TABLE no tiene filas disponibles." >&2
@@ -80,4 +81,5 @@ node scripts/seo/gsc-bigquery-vertical-analysis.mjs \
   --site "$SITE_URL" \
   --table "$TABLE" \
   --min-impressions "$MIN_IMPRESSIONS" \
-  --table-row-count "$ROW_COUNT"
+  --table-row-count "$ROW_COUNT" \
+  --partition-expiration-ms "$PARTITION_EXPIRATION_MS"


### PR DESCRIPTION
## Objetivo

Agregar un informe reproducible para priorizar oportunidades reales de Tarot/Oráculos y Biblias desde el export de Google Search Console en BigQuery.

## Alcance

- Lee únicamente `amado-libros-analytics.searchconsole.searchdata_url_impression`.
- Usa metadatos y `tabledata` de sólo lectura; no crea query jobs, tablas ni vistas.
- Segmenta Tarot y Biblias por señales de consulta y URL.
- Genera ventanas solicitadas de 28 y 90 días, resumen, oportunidades por consulta/país/dispositivo, páginas y señales de posible canibalización.
- Distingue ventana solicitada de cobertura efectiva; no presenta un histórico incompleto como si fueran 90 días reales.
- Informa la retención de particiones. La tabla observada tiene 60 días de retención, por lo que una ventana completa de 90 días no es sostenible con la política actual.
- Límite defensivo de 250.000 filas; falla antes de generar resultados parciales.
- No cambia frontend, Worker, catálogo, checkout, Merchant Center ni producción.

## Archivos

- `.github/workflows/gsc-bigquery-vertical-report.yml`
- `scripts/seo/gsc-bigquery-vertical-report.sh`
- `scripts/seo/gsc-bigquery-vertical-analysis.mjs`
- `functions/__tests__/gsc-bigquery-vertical-report.test.js`

## Validación

- `bash -n scripts/seo/gsc-bigquery-vertical-report.sh`
- `node --check scripts/seo/gsc-bigquery-vertical-analysis.mjs`
- `node --test functions/__tests__/gsc-bigquery-vertical-report.test.js`
- Resultado local: 8/8 pruebas pasan.
- CI requerido `Syntax & Build`: OK.
- Workflow `GSC BigQuery vertical opportunities` en PR: OK.
- Preview aislada: OK.
- Commit actual: `28b3dacca66d5186d47a2b67932eacca65ee0ddf`.

## Bloqueos de datos confirmados

1. `ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com` puede leer metadatos pero no filas: falta `bigquery.tables.getData`.
2. La retención actual de particiones es 60 días; una ventana de 90 días requiere una decisión separada sobre retención o una fuente histórica complementaria.

La ejecución real queda sólo bajo `workflow_dispatch`. Este PR no amplía IAM ni modifica retención.

## Condición de avance

PR en borrador. No fusionar ni desplegar a producción. Primero aprobar por separado el acceso mínimo de lectura, ejecutar manualmente el informe y revisar sus artefactos. La política de retención de 90 días se decide en otro lote.