### PR TITLE
GSC-BQ-IAM-1: Data Viewer sólo en dataset searchconsole

### DIFF
--- a/.github/workflows/gsc-bigquery-dataset-reader-grant.yml
+++ b/.github/workflows/gsc-bigquery-dataset-reader-grant.yml
@@ -8,6 +8,11 @@ on:
       - '.github/workflows/gsc-bigquery-dataset-reader-grant.yml'
       - 'scripts/seo/gsc-bigquery-dataset-reader-grant.sh'
       - 'functions/__tests__/gsc-bigquery-dataset-reader-grant.test.js'
+  pull_request:
+    paths:
+      - '.github/workflows/gsc-bigquery-dataset-reader-grant.yml'
+      - 'scripts/seo/gsc-bigquery-dataset-reader-grant.sh'
+      - 'functions/__tests__/gsc-bigquery-dataset-reader-grant.test.js'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/gsc-bigquery-dataset-reader-grant.yml
+++ b/.github/workflows/gsc-bigquery-dataset-reader-grant.yml
@@ -1,0 +1,83 @@
+name: GSC BigQuery dataset reader grant
+
+on:
+  push:
+    branches:
+      - agent/gsc-bq-data-viewer-iam-1
+    paths:
+      - '.github/workflows/gsc-bigquery-dataset-reader-grant.yml'
+      - 'scripts/seo/gsc-bigquery-dataset-reader-grant.sh'
+      - 'functions/__tests__/gsc-bigquery-dataset-reader-grant.test.js'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: gsc-bigquery-dataset-reader-grant
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate exact dataset grant
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+      - name: Validate implementation
+        run: |
+          bash -n scripts/seo/gsc-bigquery-dataset-reader-grant.sh
+          node --test functions/__tests__/gsc-bigquery-dataset-reader-grant.test.js
+
+  apply:
+    name: Grant and verify dataset reader
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Authenticate with Google
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: amado-libros-analytics
+          workload_identity_provider: projects/667747565315/locations/global/workloadIdentityPools/github-actions/providers/amadolibros-web
+          service_account: ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/cloud-platform
+          create_credentials_file: true
+          export_environment_variables: true
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          project_id: amado-libros-analytics
+      - name: Apply exact dataset binding
+        env:
+          GSC_BQ_PROJECT_ID: amado-libros-analytics
+          GSC_BQ_PROJECT_NUMBER: '667747565315'
+          GSC_BQ_DATASET_ID: searchconsole
+          GSC_BQ_OUTPUT_DIR: artifacts/gsc-bigquery-dataset-reader-grant
+        run: bash scripts/seo/gsc-bigquery-dataset-reader-grant.sh
+      - name: Write run summary
+        if: always()
+        run: |
+          if [ -s artifacts/gsc-bigquery-dataset-reader-grant/summary.md ]; then
+            cat artifacts/gsc-bigquery-dataset-reader-grant/summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## Dataset grant incompleto' >> "$GITHUB_STEP_SUMMARY"
+            echo 'No se confirmó el binding; revisar permisos del principal ejecutor.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload IAM evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gsc-bigquery-dataset-reader-grant-${{ github.run_id }}
+          path: artifacts/gsc-bigquery-dataset-reader-grant/
+          if-no-files-found: warn
+          retention-days: 30

--- a/functions/__tests__/gsc-bigquery-dataset-reader-grant.test.js
+++ b/functions/__tests__/gsc-bigquery-dataset-reader-grant.test.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const script = readFileSync(
+  new URL('../../scripts/seo/gsc-bigquery-dataset-reader-grant.sh', import.meta.url),
+  'utf8',
+);
+
+test('limita el binding al dataset searchconsole y al principal aprobado', () => {
+  assert.match(script, /DATASET_ID="\$\{GSC_BQ_DATASET_ID:-searchconsole\}"/);
+  assert.match(script, /serviceAccount:ga4-reporter@amado-libros-analytics\.iam\.gserviceaccount\.com/);
+  assert.match(script, /ROLE="roles\/bigquery\.dataViewer"/);
+  assert.match(script, /DATASET_REF="\$\{PROJECT_ID\}:\$\{DATASET_ID\}"/);
+});
+
+test('rechaza proyecto, número o dataset distintos', () => {
+  assert.match(script, /PROJECT_ID" != "amado-libros-analytics"/);
+  assert.match(script, /PROJECT_NUMBER" != "\$EXPECTED_PROJECT_NUMBER"/);
+  assert.match(script, /DATASET_ID" != "searchconsole"/);
+});
+
+test('usa IAM de dataset y no agrega roles a nivel proyecto', () => {
+  assert.match(script, /get-iam-policy/);
+  assert.match(script, /add-iam-policy-binding/);
+  assert.doesNotMatch(script, /gcloud projects add-iam-policy-binding/);
+});
+
+test('verifica el binding exacto después de aplicar', () => {
+  assert.match(script, /policy-after\.json/);
+  assert.match(script, /if ! binding_exists "\$OUTPUT_DIR\/policy-after\.json"/);
+});

--- a/functions/__tests__/gsc-bigquery-dataset-reader-grant.test.js
+++ b/functions/__tests__/gsc-bigquery-dataset-reader-grant.test.js
@@ -20,13 +20,17 @@ test('rechaza proyecto, número o dataset distintos', () => {
   assert.match(script, /DATASET_ID" != "searchconsole"/);
 });
 
-test('usa IAM de dataset y no agrega roles a nivel proyecto', () => {
-  assert.match(script, /get-iam-policy/);
-  assert.match(script, /add-iam-policy-binding/);
+test('usa la API IAM del dataset y no agrega roles a nivel proyecto', () => {
+  assert.match(script, /datasets\/\$\{DATASET_ID\}/);
+  assert.match(script, /:getIamPolicy/);
+  assert.match(script, /:setIamPolicy/);
   assert.doesNotMatch(script, /gcloud projects add-iam-policy-binding/);
+  assert.doesNotMatch(script, /bq .*add-iam-policy-binding/);
 });
 
-test('verifica el binding exacto después de aplicar', () => {
+test('conserva la política y verifica el binding exacto después de aplicar', () => {
+  assert.match(script, /\{policy: \.\}/);
+  assert.match(script, /set-policy-request\.json/);
   assert.match(script, /policy-after\.json/);
   assert.match(script, /if ! binding_exists "\$OUTPUT_DIR\/policy-after\.json"/);
 });

--- a/functions/__tests__/gsc-bigquery-dataset-reader-grant.test.js
+++ b/functions/__tests__/gsc-bigquery-dataset-reader-grant.test.js
@@ -37,3 +37,8 @@ test('conserva el ACL, usa etag y verifica el binding exacto después de aplicar
   assert.match(script, /dataset-after\.json/);
   assert.match(script, /if ! binding_exists "\$OUTPUT_DIR\/dataset-after\.json"/);
 });
+
+test('descarta advertencias anteriores al JSON de bq show', () => {
+  assert.match(script, /sed -n '\/\^\[\[:space:\]\]\*\{\/\,\$p'/);
+  assert.match(script, /\.datasetReference\.datasetId == \$dataset/);
+});

--- a/functions/__tests__/gsc-bigquery-dataset-reader-grant.test.js
+++ b/functions/__tests__/gsc-bigquery-dataset-reader-grant.test.js
@@ -9,7 +9,8 @@ const script = readFileSync(
 
 test('limita el binding al dataset searchconsole y al principal aprobado', () => {
   assert.match(script, /DATASET_ID="\$\{GSC_BQ_DATASET_ID:-searchconsole\}"/);
-  assert.match(script, /serviceAccount:ga4-reporter@amado-libros-analytics\.iam\.gserviceaccount\.com/);
+  assert.match(script, /REPORTER_EMAIL="ga4-reporter@amado-libros-analytics\.iam\.gserviceaccount\.com"/);
+  assert.match(script, /MEMBER="serviceAccount:\$\{REPORTER_EMAIL\}"/);
   assert.match(script, /ROLE="roles\/bigquery\.dataViewer"/);
   assert.match(script, /DATASET_REF="\$\{PROJECT_ID\}:\$\{DATASET_ID\}"/);
 });
@@ -20,17 +21,19 @@ test('rechaza proyecto, número o dataset distintos', () => {
   assert.match(script, /DATASET_ID" != "searchconsole"/);
 });
 
-test('usa la API IAM del dataset y no agrega roles a nivel proyecto', () => {
+test('usa el ACL READER equivalente a Data Viewer y no agrega roles a nivel proyecto', () => {
   assert.match(script, /datasets\/\$\{DATASET_ID\}/);
-  assert.match(script, /:getIamPolicy/);
-  assert.match(script, /:setIamPolicy/);
+  assert.match(script, /role: "READER"/);
+  assert.match(script, /userByEmail: \$email/);
+  assert.match(script, /updateMode=UPDATE_ACL/);
   assert.doesNotMatch(script, /gcloud projects add-iam-policy-binding/);
   assert.doesNotMatch(script, /bq .*add-iam-policy-binding/);
 });
 
-test('conserva la política y verifica el binding exacto después de aplicar', () => {
-  assert.match(script, /\{policy: \.\}/);
-  assert.match(script, /set-policy-request\.json/);
-  assert.match(script, /policy-after\.json/);
-  assert.match(script, /if ! binding_exists "\$OUTPUT_DIR\/policy-after\.json"/);
+test('conserva el ACL, usa etag y verifica el binding exacto después de aplicar', () => {
+  assert.match(script, /\(\.access \/\/ \[\]\) \+ \[/);
+  assert.match(script, /If-Match: \$ETAG/);
+  assert.match(script, /dataset-patch-request\.json/);
+  assert.match(script, /dataset-after\.json/);
+  assert.match(script, /if ! binding_exists "\$OUTPUT_DIR\/dataset-after\.json"/);
 });

--- a/scripts/seo/gsc-bigquery-dataset-reader-grant.sh
+++ b/scripts/seo/gsc-bigquery-dataset-reader-grant.sh
@@ -9,7 +9,7 @@ ROLE="roles/bigquery.dataViewer"
 OUTPUT_DIR="${GSC_BQ_OUTPUT_DIR:-artifacts/gsc-bigquery-dataset-reader-grant}"
 DATASET_REF="${PROJECT_ID}:${DATASET_ID}"
 
-for command in gcloud bq jq; do
+for command in gcloud bq curl jq; do
   if ! command -v "$command" >/dev/null 2>&1; then
     echo "ERROR: falta el comando requerido: $command" >&2
     exit 2
@@ -29,7 +29,15 @@ fi
 mkdir -p "$OUTPUT_DIR"
 gcloud config list --format=yaml > "$OUTPUT_DIR/gcloud-context.yaml"
 bq --project_id="$PROJECT_ID" show --format=prettyjson "$DATASET_REF" > "$OUTPUT_DIR/dataset.json"
-bq --project_id="$PROJECT_ID" get-iam-policy --format=prettyjson "$DATASET_REF" > "$OUTPUT_DIR/policy-before.json"
+ACCESS_TOKEN="$(gcloud auth print-access-token)"
+POLICY_URL="https://bigquery.googleapis.com/bigquery/v2/projects/${PROJECT_ID}/datasets/${DATASET_ID}"
+
+get_policy() {
+  local output_file="$1"
+  curl --fail-with-body --silent --show-error --request POST --header "Authorization: Bearer $ACCESS_TOKEN" --header 'Content-Type: application/json' --data '{"options":{"requestedPolicyVersion":3}}' "${POLICY_URL}:getIamPolicy" > "$output_file"
+}
+
+get_policy "$OUTPUT_DIR/policy-before.json"
 
 binding_exists() {
   local file="$1"
@@ -41,27 +49,38 @@ binding_exists() {
 if binding_exists "$OUTPUT_DIR/policy-before.json"; then
   echo "El binding exacto ya existe; ejecución idempotente."
 else
-  bq --project_id="$PROJECT_ID" add-iam-policy-binding     --member="$MEMBER"     --role="$ROLE"     "$DATASET_REF" >/dev/null
+  jq --arg role "$ROLE" --arg member "$MEMBER" '
+    .bindings = (
+      [(.bindings // [])[] | select(.role != $role)] +
+      [{
+        role: $role,
+        members: (([(.bindings // [])[] | select(.role == $role) | .members[]?] + [$member]) | unique)
+      }]
+    )
+    | {policy: .}
+  ' "$OUTPUT_DIR/policy-before.json" > "$OUTPUT_DIR/set-policy-request.json"
+
+  curl --fail-with-body --silent --show-error --request POST --header "Authorization: Bearer $ACCESS_TOKEN" --header 'Content-Type: application/json' --data-binary "@$OUTPUT_DIR/set-policy-request.json" "${POLICY_URL}:setIamPolicy" > "$OUTPUT_DIR/set-policy-response.json"
 fi
 
-bq --project_id="$PROJECT_ID" get-iam-policy --format=prettyjson "$DATASET_REF" > "$OUTPUT_DIR/policy-after.json"
+get_policy "$OUTPUT_DIR/policy-after.json"
 if ! binding_exists "$OUTPUT_DIR/policy-after.json"; then
   echo "ERROR: no se confirmó el binding exacto en el dataset." >&2
   exit 5
 fi
 
-cat > "$OUTPUT_DIR/summary.md" <<EOF
-# GSC BigQuery dataset reader grant
-
-- Project: `$PROJECT_ID` (`$PROJECT_NUMBER`)
-- Dataset: `$DATASET_ID`
-- Member: `$MEMBER`
-- Role: `$ROLE`
-- Scope: dataset only
-- Web/Worker deploy: no
-- Production code change: no
-
-El binding exacto quedó confirmado en la política IAM del dataset.
-EOF
+{
+  echo "# GSC BigQuery dataset reader grant"
+  echo
+  echo "- Project: $PROJECT_ID ($PROJECT_NUMBER)"
+  echo "- Dataset: $DATASET_ID"
+  echo "- Member: $MEMBER"
+  echo "- Role: $ROLE"
+  echo "- Scope: dataset only"
+  echo "- Web/Worker deploy: no"
+  echo "- Production code change: no"
+  echo
+  echo "El binding exacto quedó confirmado en la política IAM del dataset."
+} > "$OUTPUT_DIR/summary.md"
 
 cat "$OUTPUT_DIR/summary.md"

--- a/scripts/seo/gsc-bigquery-dataset-reader-grant.sh
+++ b/scripts/seo/gsc-bigquery-dataset-reader-grant.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+PROJECT_ID="${GSC_BQ_PROJECT_ID:-amado-libros-analytics}"
+EXPECTED_PROJECT_NUMBER="${GSC_BQ_PROJECT_NUMBER:-667747565315}"
+DATASET_ID="${GSC_BQ_DATASET_ID:-searchconsole}"
+MEMBER="serviceAccount:ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com"
+ROLE="roles/bigquery.dataViewer"
+OUTPUT_DIR="${GSC_BQ_OUTPUT_DIR:-artifacts/gsc-bigquery-dataset-reader-grant}"
+DATASET_REF="${PROJECT_ID}:${DATASET_ID}"
+
+for command in gcloud bq jq; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "ERROR: falta el comando requerido: $command" >&2
+    exit 2
+  fi
+done
+
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+if [[ "$PROJECT_ID" != "amado-libros-analytics" || "$PROJECT_NUMBER" != "$EXPECTED_PROJECT_NUMBER" ]]; then
+  echo "ERROR: proyecto inesperado: $PROJECT_ID ($PROJECT_NUMBER)." >&2
+  exit 3
+fi
+if [[ "$DATASET_ID" != "searchconsole" ]]; then
+  echo "ERROR: dataset inesperado: $DATASET_ID." >&2
+  exit 4
+fi
+
+mkdir -p "$OUTPUT_DIR"
+gcloud config list --format=yaml > "$OUTPUT_DIR/gcloud-context.yaml"
+bq --project_id="$PROJECT_ID" show --format=prettyjson "$DATASET_REF" > "$OUTPUT_DIR/dataset.json"
+bq --project_id="$PROJECT_ID" get-iam-policy --format=prettyjson "$DATASET_REF" > "$OUTPUT_DIR/policy-before.json"
+
+binding_exists() {
+  local file="$1"
+  jq -e --arg role "$ROLE" --arg member "$MEMBER" '
+    any(.bindings[]?; .role == $role and ((.members // []) | index($member) != null))
+  ' "$file" >/dev/null
+}
+
+if binding_exists "$OUTPUT_DIR/policy-before.json"; then
+  echo "El binding exacto ya existe; ejecución idempotente."
+else
+  bq --project_id="$PROJECT_ID" add-iam-policy-binding     --member="$MEMBER"     --role="$ROLE"     "$DATASET_REF" >/dev/null
+fi
+
+bq --project_id="$PROJECT_ID" get-iam-policy --format=prettyjson "$DATASET_REF" > "$OUTPUT_DIR/policy-after.json"
+if ! binding_exists "$OUTPUT_DIR/policy-after.json"; then
+  echo "ERROR: no se confirmó el binding exacto en el dataset." >&2
+  exit 5
+fi
+
+cat > "$OUTPUT_DIR/summary.md" <<EOF
+# GSC BigQuery dataset reader grant
+
+- Project: `$PROJECT_ID` (`$PROJECT_NUMBER`)
+- Dataset: `$DATASET_ID`
+- Member: `$MEMBER`
+- Role: `$ROLE`
+- Scope: dataset only
+- Web/Worker deploy: no
+- Production code change: no
+
+El binding exacto quedó confirmado en la política IAM del dataset.
+EOF
+
+cat "$OUTPUT_DIR/summary.md"

--- a/scripts/seo/gsc-bigquery-dataset-reader-grant.sh
+++ b/scripts/seo/gsc-bigquery-dataset-reader-grant.sh
@@ -4,7 +4,8 @@ set -Eeuo pipefail
 PROJECT_ID="${GSC_BQ_PROJECT_ID:-amado-libros-analytics}"
 EXPECTED_PROJECT_NUMBER="${GSC_BQ_PROJECT_NUMBER:-667747565315}"
 DATASET_ID="${GSC_BQ_DATASET_ID:-searchconsole}"
-MEMBER="serviceAccount:ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com"
+REPORTER_EMAIL="ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com"
+MEMBER="serviceAccount:${REPORTER_EMAIL}"
 ROLE="roles/bigquery.dataViewer"
 OUTPUT_DIR="${GSC_BQ_OUTPUT_DIR:-artifacts/gsc-bigquery-dataset-reader-grant}"
 DATASET_REF="${PROJECT_ID}:${DATASET_ID}"
@@ -28,45 +29,37 @@ fi
 
 mkdir -p "$OUTPUT_DIR"
 gcloud config list --format=yaml > "$OUTPUT_DIR/gcloud-context.yaml"
-bq --project_id="$PROJECT_ID" show --format=prettyjson "$DATASET_REF" > "$OUTPUT_DIR/dataset.json"
+bq --project_id="$PROJECT_ID" show --format=prettyjson "$DATASET_REF" > "$OUTPUT_DIR/dataset-before.json"
 ACCESS_TOKEN="$(gcloud auth print-access-token)"
-POLICY_URL="https://bigquery.googleapis.com/bigquery/v2/projects/${PROJECT_ID}/datasets/${DATASET_ID}"
-
-get_policy() {
-  local output_file="$1"
-  curl --fail-with-body --silent --show-error --request POST --header "Authorization: Bearer $ACCESS_TOKEN" --header 'Content-Type: application/json' --data '{"options":{"requestedPolicyVersion":3}}' "${POLICY_URL}:getIamPolicy" > "$output_file"
-}
-
-get_policy "$OUTPUT_DIR/policy-before.json"
+DATASET_URL="https://bigquery.googleapis.com/bigquery/v2/projects/${PROJECT_ID}/datasets/${DATASET_ID}"
 
 binding_exists() {
   local file="$1"
-  jq -e --arg role "$ROLE" --arg member "$MEMBER" '
-    any(.bindings[]?; .role == $role and ((.members // []) | index($member) != null))
+  jq -e --arg email "$REPORTER_EMAIL" '
+    any(.access[]?; .role == "READER" and .userByEmail == $email)
   ' "$file" >/dev/null
 }
 
-if binding_exists "$OUTPUT_DIR/policy-before.json"; then
+if binding_exists "$OUTPUT_DIR/dataset-before.json"; then
   echo "El binding exacto ya existe; ejecución idempotente."
 else
-  jq --arg role "$ROLE" --arg member "$MEMBER" '
-    .bindings = (
-      [(.bindings // [])[] | select(.role != $role)] +
-      [{
-        role: $role,
-        members: (([(.bindings // [])[] | select(.role == $role) | .members[]?] + [$member]) | unique)
-      }]
-    )
-    | {policy: .}
-  ' "$OUTPUT_DIR/policy-before.json" > "$OUTPUT_DIR/set-policy-request.json"
+  ETAG="$(jq -r '.etag // empty' "$OUTPUT_DIR/dataset-before.json")"
+  if [[ -z "$ETAG" ]]; then
+    echo "ERROR: el dataset no devolvió etag; no se modifica el ACL." >&2
+    exit 5
+  fi
 
-  curl --fail-with-body --silent --show-error --request POST --header "Authorization: Bearer $ACCESS_TOKEN" --header 'Content-Type: application/json' --data-binary "@$OUTPUT_DIR/set-policy-request.json" "${POLICY_URL}:setIamPolicy" > "$OUTPUT_DIR/set-policy-response.json"
+  jq --arg email "$REPORTER_EMAIL" '
+    {access: ((.access // []) + [{role: "READER", userByEmail: $email}])}
+  ' "$OUTPUT_DIR/dataset-before.json" > "$OUTPUT_DIR/dataset-patch-request.json"
+
+  curl --fail-with-body --silent --show-error --request PATCH --header "Authorization: Bearer $ACCESS_TOKEN" --header 'Content-Type: application/json' --header "If-Match: $ETAG" --data-binary "@$OUTPUT_DIR/dataset-patch-request.json" "${DATASET_URL}?updateMode=UPDATE_ACL" > "$OUTPUT_DIR/dataset-patch-response.json"
 fi
 
-get_policy "$OUTPUT_DIR/policy-after.json"
-if ! binding_exists "$OUTPUT_DIR/policy-after.json"; then
+bq --project_id="$PROJECT_ID" show --format=prettyjson "$DATASET_REF" > "$OUTPUT_DIR/dataset-after.json"
+if ! binding_exists "$OUTPUT_DIR/dataset-after.json"; then
   echo "ERROR: no se confirmó el binding exacto en el dataset." >&2
-  exit 5
+  exit 6
 fi
 
 {
@@ -75,12 +68,12 @@ fi
   echo "- Project: $PROJECT_ID ($PROJECT_NUMBER)"
   echo "- Dataset: $DATASET_ID"
   echo "- Member: $MEMBER"
-  echo "- Role: $ROLE"
+  echo "- Effective role: $ROLE (BigQuery dataset ACL READER)"
   echo "- Scope: dataset only"
   echo "- Web/Worker deploy: no"
   echo "- Production code change: no"
   echo
-  echo "El binding exacto quedó confirmado en la política IAM del dataset."
+  echo "El binding exacto quedó confirmado en el ACL del dataset."
 } > "$OUTPUT_DIR/summary.md"
 
 cat "$OUTPUT_DIR/summary.md"

--- a/scripts/seo/gsc-bigquery-dataset-reader-grant.sh
+++ b/scripts/seo/gsc-bigquery-dataset-reader-grant.sh
@@ -29,7 +29,24 @@ fi
 
 mkdir -p "$OUTPUT_DIR"
 gcloud config list --format=yaml > "$OUTPUT_DIR/gcloud-context.yaml"
-bq --project_id="$PROJECT_ID" show --format=prettyjson "$DATASET_REF" > "$OUTPUT_DIR/dataset-before.json"
+
+show_dataset() {
+  local output_file="$1"
+  local raw_file
+  raw_file="$(mktemp)"
+  if ! bq --project_id="$PROJECT_ID" show --format=prettyjson "$DATASET_REF" > "$raw_file" 2>&1; then
+    cat "$raw_file" >&2
+    rm -f "$raw_file"
+    return 1
+  fi
+  sed -n '/^[[:space:]]*{/,$p' "$raw_file" > "$output_file"
+  rm -f "$raw_file"
+  jq -e --arg dataset "$DATASET_ID" '
+    type == "object" and .datasetReference.datasetId == $dataset
+  ' "$output_file" >/dev/null
+}
+
+show_dataset "$OUTPUT_DIR/dataset-before.json"
 ACCESS_TOKEN="$(gcloud auth print-access-token)"
 DATASET_URL="https://bigquery.googleapis.com/bigquery/v2/projects/${PROJECT_ID}/datasets/${DATASET_ID}"
 
@@ -56,7 +73,7 @@ else
   curl --fail-with-body --silent --show-error --request PATCH --header "Authorization: Bearer $ACCESS_TOKEN" --header 'Content-Type: application/json' --header "If-Match: $ETAG" --data-binary "@$OUTPUT_DIR/dataset-patch-request.json" "${DATASET_URL}?updateMode=UPDATE_ACL" > "$OUTPUT_DIR/dataset-patch-response.json"
 fi
 
-bq --project_id="$PROJECT_ID" show --format=prettyjson "$DATASET_REF" > "$OUTPUT_DIR/dataset-after.json"
+show_dataset "$OUTPUT_DIR/dataset-after.json"
 if ! binding_exists "$OUTPUT_DIR/dataset-after.json"; then
   echo "ERROR: no se confirmó el binding exacto en el dataset." >&2
   exit 6


### PR DESCRIPTION
## Alcance
Concede y verifica el binding exacto aprobado:

- Principal: `serviceAccount:ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com`
- Rol efectivo: `roles/bigquery.dataViewer` (ACL de dataset `READER`)
- Recurso único: dataset `amado-libros-analytics:searchconsole`

## Guardrails
- Rechaza cualquier project ID, project number o dataset distinto.
- No agrega roles a nivel proyecto.
- Conserva el ACL existente, usa el `etag` y verifica el binding exacto.
- Sin deploy web/Worker, sin cambio de Producción y sin merge automático.

## Validación
- `bash -n scripts/seo/gsc-bigquery-dataset-reader-grant.sh`: OK.
- `node --test functions/__tests__/gsc-bigquery-dataset-reader-grant.test.js`: 5/5 OK.
- Job `Validate exact dataset grant`: success.

## Resultado de ejecución
La aplicación **no se realizó**. El principal que ejecuta el workflow es el propio `ga4-reporter` y no tiene `bigquery.datasets.update` sobre `searchconsole`.

Evidencia del run [32644489334](https://github.com/trexxeseba/amadolibros-web/actions/runs/32644489334):

```
Access Denied: Dataset amado-libros-analytics:searchconsole:
Permission bigquery.datasets.update denied
```

Antes del intento, el ACL no contenía a `ga4-reporter`. La llamada de actualización fue rechazada; no hubo mutación.

También se comprobó que `bq get-iam-policy` y `datasets.getIamPolicy` devuelven `This feature requires allowlisting` en este dataset, por lo que el script usa el ACL de dataset, equivalente documentado a Data Viewer.

## Siguiente paso
Un administrador del dataset debe agregar manualmente a `ga4-reporter@amado-libros-analytics.iam.gserviceaccount.com` como **BigQuery Data Viewer**, sólo en `searchconsole`. Luego se reejecuta este workflow para verificar el estado y recién después se ejecuta el informe GSC del PR #232.

Este PR queda Draft. No fusionar.