### PR TITLE
PRODUCT-EDITION-FACTS-1: fichas claras para Google y asistentes

### DIFF
--- a/functions/__tests__/ficha-pricing-cta-order.test.js
+++ b/functions/__tests__/ficha-pricing-cta-order.test.js
@@ -174,8 +174,8 @@ test('12. Datos de esta edición muestra sólo atributos bibliográficos disponi
         },
     }), 'un-libro', false, '');
 
-    assert.match(html, /<details class="book-more">/);
-    assert.match(html, /<summary>Ver más sobre este libro<\/summary>/);
+    assert.match(html, /<section class="book-edition" aria-labelledby="edition-heading">/);
+    assert.match(html, /<h2 id="edition-heading">Datos de esta edición<\/h2>/);
     assert.match(html, /<dt>Editorial<\/dt><dd>Editorial Sur<\/dd>/);
     assert.match(html, /<dt>Páginas<\/dt><dd>312<\/dd>/);
     assert.match(html, /<dt>Idioma<\/dt><dd>Español<\/dd>/);
@@ -206,7 +206,7 @@ test('14. La descripción real de ML queda visible, preserva párrafos y se esca
         author: null,
         description: 'Primera línea.\n\nSegunda <línea> & detalle.',
     }), 'un-libro', false, '');
-    assert.match(html, /<h2>Descripción<\/h2>/);
+    assert.match(html, /<h2>Descripción de esta edición<\/h2>/);
     assert.match(html, /Primera línea\.\n\nSegunda &lt;línea&gt; &amp; detalle\./);
     assert.match(html, /\.book-description p\{white-space:pre-line/);
     assert.match(html, /"description":"Primera línea\.\\n\\nSegunda \\u003clínea> & detalle\."/);

--- a/functions/__tests__/ficha-pricing-cta-order.test.js
+++ b/functions/__tests__/ficha-pricing-cta-order.test.js
@@ -160,7 +160,7 @@ test('11. Responsive: no hay reglas que oculten o reordenen los CTA por media qu
     assert.doesNotMatch(html, /@media[^{]*\{[^}]*\.btn-(ml|wa|cart)/s);
 });
 
-test('12. Ver más muestra sólo atributos bibliográficos disponibles traídos de ML', () => {
+test('12. Datos de esta edición muestra sólo atributos bibliográficos disponibles traídos de ML', () => {
     const html = renderPage(book({
         publisher: 'Editorial Sur',
         pages: 312,
@@ -187,7 +187,7 @@ test('12. Ver más muestra sólo atributos bibliográficos disponibles traídos 
     assert.doesNotMatch(html, /<dt>Colección<\/dt>/);
 });
 
-test('13. Ver más no aparece cuando ML no aporta ningún detalle útil', () => {
+test('13. Datos de esta edición no aparece cuando ML no aporta ningún detalle útil', () => {
     const html = renderPage(book({
         author: null,
         isbn: null,
@@ -198,10 +198,10 @@ test('13. Ver más no aparece cuando ML no aporta ningún detalle útil', () => 
         bibliographic: null,
         available_quantity: 0,
     }), 'un-libro', false, '');
-    assert.doesNotMatch(html, /Ver más sobre este libro/);
+    assert.doesNotMatch(html, /Datos de esta edición/);
 });
 
-test('14. La descripción real de ML aparece en Ver más, preserva párrafos y se escapa', () => {
+test('14. La descripción real de ML queda visible, preserva párrafos y se escapa', () => {
     const html = renderPage(book({
         author: null,
         description: 'Primera línea.\n\nSegunda <línea> & detalle.',

--- a/functions/__tests__/ficha-pricing-cta-order.test.js
+++ b/functions/__tests__/ficha-pricing-cta-order.test.js
@@ -174,8 +174,8 @@ test('12. Datos de esta edición muestra sólo atributos bibliográficos disponi
         },
     }), 'un-libro', false, '');
 
-    assert.match(html, /<section class="book-edition" aria-labelledby="edition-heading">/);
-    assert.match(html, /<h2 id="edition-heading">Datos de esta edición<\/h2>/);
+    assert.match(html, /<section class="edition-facts" aria-labelledby="edition-facts-title">/);
+    assert.match(html, /<h2 id="edition-facts-title">Datos de esta edición<\/h2>/);
     assert.match(html, /<dt>Editorial<\/dt><dd>Editorial Sur<\/dd>/);
     assert.match(html, /<dt>Páginas<\/dt><dd>312<\/dd>/);
     assert.match(html, /<dt>Idioma<\/dt><dd>Español<\/dd>/);
@@ -206,7 +206,7 @@ test('14. La descripción real de ML queda visible, preserva párrafos y se esca
         author: null,
         description: 'Primera línea.\n\nSegunda <línea> & detalle.',
     }), 'un-libro', false, '');
-    assert.match(html, /<h2>Descripción de esta edición<\/h2>/);
+    assert.match(html, /<h2 id="book-description-title">Descripción de esta edición<\/h2>/);
     assert.match(html, /Primera línea\.\n\nSegunda &lt;línea&gt; &amp; detalle\./);
     assert.match(html, /\.book-description p\{white-space:pre-line/);
     assert.match(html, /"description":"Primera línea\.\\n\\nSegunda \\u003clínea> & detalle\."/);

--- a/functions/__tests__/product-edition-facts.test.js
+++ b/functions/__tests__/product-edition-facts.test.js
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  meaningfulDescription,
+  renderPage,
+} from '../libro/[[path]].js';
+
+function book(overrides = {}) {
+  return {
+    id: 'MLU123456789',
+    title: 'Biblia Reina-Valera 1960 letra grande',
+    author: 'Sociedades Bíblicas Unidas',
+    isbn: '9780000000002',
+    publisher: 'Editorial de prueba',
+    pages: 1280,
+    price: 2490,
+    currency: 'UYU',
+    status: 'active',
+    available_quantity: 2,
+    condition: 'new',
+    pictures: ['https://http2.mlstatic.com/D_TEST-O.jpg'],
+    thumbnail: '',
+    permalink: 'https://articulo.mercadolibre.com.uy/MLU123456789',
+    description: 'Edición de prueba con referencias y mapas. Revisá los datos físicos antes de comprar.',
+    bibliographic: {
+      language: 'Español',
+      format: 'Tapa dura',
+      edition: 'Reina-Valera 1960',
+      publication_year: '2024',
+    },
+    ...overrides,
+  };
+}
+
+function jsonLd(html) {
+  return [...html.matchAll(/<script type="application\/ld\+json">([^<]+)<\/script>/g)]
+    .map(match => JSON.parse(match[1]));
+}
+
+test('muestra autor y datos verificables de la edición en HTML visible, no en details', () => {
+  const html = renderPage(book(), 'biblia-reina-valera-1960-letra-grande', true, '');
+
+  assert.match(html, /class="product-byline">de [\s\S]*Sociedades Bíblicas Unidas/);
+  assert.match(html, /<section class="edition-facts"[^>]*>/);
+  assert.match(html, /<h2 id="edition-facts-title">Datos de esta edición<\/h2>/);
+  assert.match(html, /<dt>ISBN<\/dt><dd>9780000000002<\/dd>/);
+  assert.match(html, /<dt>Editorial<\/dt><dd>Editorial de prueba<\/dd>/);
+  assert.match(html, /<dt>Idioma<\/dt><dd>Español<\/dd>/);
+  assert.match(html, /<dt>Formato<\/dt><dd>Tapa dura<\/dd>/);
+  assert.match(html, /<dt>Edición<\/dt><dd>Reina-Valera 1960<\/dd>/);
+  assert.doesNotMatch(html, /<details class="book-more"/);
+  assert.ok(html.indexOf('Agregar al carrito') < html.indexOf('Datos de esta edición'));
+});
+
+test('suprime una descripción que sólo repite el título y conserva una descripción real', () => {
+  assert.equal(
+    meaningfulDescription('Biblia RVR 1960', '  Biblia RVR 1960  '),
+    '',
+  );
+  assert.equal(
+    meaningfulDescription('Biblia RVR 1960', 'Edición con letra grande y mapas.'),
+    'Edición con letra grande y mapas.',
+  );
+
+  const duplicated = renderPage(book({
+    description: 'Biblia Reina-Valera 1960 letra grande',
+  }), 'biblia-reina-valera-1960-letra-grande', true, '');
+  assert.doesNotMatch(duplicated, /class="book-description"/);
+
+  const useful = renderPage(book(), 'biblia-reina-valera-1960-letra-grande', true, '');
+  assert.match(useful, /Descripción de esta edición/);
+  assert.match(useful, /Edición de prueba con referencias y mapas/);
+});
+
+test('la promesa logística visible queda condicionada y no promete dos horas a todo el stock', () => {
+  const html = renderPage(book(), 'biblia-reina-valera-1960-letra-grande', true, '');
+
+  assert.match(html, /Entregas rápidas en Montevideo, según zona, horario y disponibilidad/);
+  assert.doesNotMatch(html, /Entrega en 2 horas en Montevideo/);
+});
+
+test('Product\/Book identifica URL canónica y breadcrumb completo', () => {
+  const html = renderPage(book(), 'biblia-reina-valera-1960-letra-grande', true, '');
+  const schemas = jsonLd(html);
+  const product = schemas.find(schema => Array.isArray(schema['@type']));
+  const breadcrumb = schemas.find(schema => schema['@type'] === 'BreadcrumbList');
+
+  assert.ok(product);
+  assert.deepEqual(product['@type'], ['Product', 'Book']);
+  assert.equal(
+    product.url,
+    'https://www.amadolibros.com/libro/MLU123456789/biblia-reina-valera-1960-letra-grande',
+  );
+  assert.equal(product.isbn, '9780000000002');
+  assert.equal(product.offers.url, product.url);
+
+  assert.ok(breadcrumb);
+  assert.deepEqual(
+    breadcrumb.itemListElement.map(row => [row.position, row.name]),
+    [
+      [1, 'Inicio'],
+      [2, 'Catálogo'],
+      [3, 'Biblia Reina-Valera 1960 letra grande'],
+    ],
+  );
+  assert.match(html, /<a href="\/catalogo">Catálogo<\/a>/);
+});

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -121,6 +121,21 @@ function normalizePublisher(publisher) {
     return s;
 }
 
+function comparableText(value) {
+    return String(value || '')
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLocaleLowerCase('es')
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim();
+}
+
+export function meaningfulDescription(title, description) {
+    const text = String(description || '').trim();
+    if (!text) return '';
+    return comparableText(text) === comparableText(title) ? '' : text;
+}
+
 function formatDimensions(dimensions) {
     if (!dimensions || typeof dimensions !== 'object') return null;
 
@@ -415,9 +430,12 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     const bibliographic = item.bibliographic && typeof item.bibliographic === 'object'
         ? item.bibliographic
         : {};
-    const description = item.description ? String(item.description).trim() : '';
+    const description = meaningfulDescription(item.title, item.description);
     const descriptionHtml = description
-        ? `<div class="book-description"><h2>Descripción</h2><p>${escapeHtml(description)}</p></div>`
+        ? `<section class="book-description" aria-labelledby="book-description-title">
+      <h2 id="book-description-title">Descripción de esta edición</h2>
+      <p>${escapeHtml(description)}</p>
+    </section>`
         : '';
     const waMessage = buildBookWhatsAppMessage({
         title: item.title,
@@ -428,6 +446,12 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     });
     const waLink = whatsappHref(waMessage);
     const relatedBooksHtml = renderRelatedBooks(relatedBooks, item.author, !isPreview);
+    const authorPagePath = item.author ? authorPathForName(item.author) : null;
+    const authorBylineHtml = item.author
+        ? `<p class="product-byline">de ${authorPagePath
+            ? `<a href="${escapeHtml(authorPagePath)}">${safeAuthor}</a>`
+            : safeAuthor}</p>`
+        : '';
     const viewItemAnalytics = {
         dedupeKey: `view_item_${item.id}`,
         ...(sellableInCheckout ? { value: price } : {}),
@@ -463,12 +487,12 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
             ? detailRow('Disponibilidad', `${stockQty} disponible${stockQty === 1 ? '' : 's'}`)
             : '',
     ].filter(Boolean).join('\n');
-    const moreDetailsHtml = detailRows || descriptionHtml
-        ? `<details class="book-more">
-      <summary>Ver más sobre este libro</summary>
-      ${descriptionHtml}
-      ${detailRows ? `<dl class="details">${detailRows}</dl>` : ''}
-    </details>`
+    const editionFactsHtml = detailRows
+        ? `<section class="edition-facts" aria-labelledby="edition-facts-title">
+      <h2 id="edition-facts-title">Datos de esta edición</h2>
+      <dl class="details">${detailRows}</dl>
+      <p class="edition-facts-note">Mostramos solamente los datos identificados para esta edición. Si necesitás confirmar otra característica, consultanos antes de comprar.</p>
+    </section>`
         : '';
 
     const defaultMetaDesc = sellableInCheckout
@@ -500,6 +524,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
         'name':     item.title,
         'image':    images.length ? images : img,
         'description': description || (item.author ? `${item.title} — ${item.author}` : item.title),
+        'url':      canonicalUrl,
         'sku':      item.id,
     };
     if (sellableInCheckout) {
@@ -639,7 +664,8 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
         '@type':    'BreadcrumbList',
         'itemListElement': [
             { '@type': 'ListItem', 'position': 1, 'name': 'Inicio', 'item': `${BASE}/` },
-            { '@type': 'ListItem', 'position': 2, 'name': item.title.substring(0, 80) },
+            { '@type': 'ListItem', 'position': 2, 'name': 'Catálogo', 'item': `${BASE}/catalogo` },
+            { '@type': 'ListItem', 'position': 3, 'name': item.title.substring(0, 80), 'item': canonicalUrl },
         ],
     };
 
@@ -756,7 +782,9 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     .lb-close:focus-visible{outline:2px solid white;outline-offset:2px}
     @media(max-width:480px){.lb-img{max-height:60vh}}
     .info h1{font-size:1.25rem;font-weight:700;line-height:1.35;
-             margin-bottom:.75rem;color:#0f172a}
+             margin-bottom:.3rem;color:#0f172a}
+    .product-byline{font-size:.92rem;color:#475569;margin:0 0 .75rem}
+    .product-byline a{color:#334155;font-weight:700;text-decoration-thickness:1px;text-underline-offset:2px}
     .meta{font-size:.875rem;color:#475569;margin-bottom:.4rem}
     .meta strong{color:#1e293b}
     .badge{display:inline-block;padding:.2rem .7rem;border-radius:2rem;
@@ -769,6 +797,13 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     .detail-row:last-child{border-bottom:0}
     .detail-row dt{font-weight:700;color:#334155}
     .detail-row dd{color:#475569}
+    .edition-facts{margin:1rem 0;background:#fff;border:1px solid #d8d1c7;
+                   border-radius:.65rem;overflow:hidden}
+    .edition-facts h2{font-size:1rem;line-height:1.35;padding:.8rem .85rem;
+                      color:#1e293b;border-bottom:1px solid #e2e8f0}
+    .edition-facts .details{border:0;border-radius:0;margin:0}
+    .edition-facts-note{padding:.7rem .85rem;font-size:.76rem;color:#64748b;
+                        background:#f8fafc;border-top:1px solid #e2e8f0}
     .book-more{margin:.25rem 0 .875rem;background:#fff;border:1px solid #e2e8f0;
                border-radius:.5rem;overflow:hidden}
     .book-more summary{cursor:pointer;min-height:44px;display:flex;align-items:center;
@@ -885,6 +920,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
 
 <nav>
   <a href="/">Inicio</a> ›
+  <a href="/catalogo">Catálogo</a> ›
   <span>${safeTitle.substring(0, 70)}${item.title.length > 70 ? '…' : ''}</span>
 </nav>
 
@@ -892,16 +928,17 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
   ${renderGallery(images, safeTitle)}
   <div class="info">
     <h1>${safeTitle}</h1>
+    ${authorBylineHtml}
     ${inStock ? `<span class="badge in-stock">✓ En stock</span>` : ''}
-    ${inStock ? moreDetailsHtml : ''}
     ${priceHtml}
     <div class="cta">
       ${actionHtml}
     </div>
-    ${!inStock ? moreDetailsHtml : ''}
+    ${editionFactsHtml}
+    ${descriptionHtml}
     ${seoOpportunityHtml}
     <p class="shipping">${inStock
-      ? '🚚 Entrega en 2 horas en Montevideo · Envíos a todo Uruguay · Envío gratis desde $1.500.'
+      ? '🚚 Entregas rápidas en Montevideo, según zona, horario y disponibilidad · Envíos a todo Uruguay · Envío gratis desde $1.500.'
       : '🌎 Si preferís no esperar, también podemos buscarlo por encargo en el exterior.'
     } <a href="/politicas#envios">Ver política de envíos</a>.</p>
   </div>

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -804,16 +804,9 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     .edition-facts .details{border:0;border-radius:0;margin:0}
     .edition-facts-note{padding:.7rem .85rem;font-size:.76rem;color:#64748b;
                         background:#f8fafc;border-top:1px solid #e2e8f0}
-    .book-more{margin:.25rem 0 .875rem;background:#fff;border:1px solid #e2e8f0;
-               border-radius:.5rem;overflow:hidden}
-    .book-more summary{cursor:pointer;min-height:44px;display:flex;align-items:center;
-                       padding:.65rem .8rem;font-size:.86rem;font-weight:750;color:#334155}
-    .book-more summary:hover{background:#f8fafc}
-    .book-more summary:focus-visible{outline:2px solid #3b82f6;outline-offset:-2px}
-    .book-more[open] summary{border-bottom:1px solid #e2e8f0}
-    .book-more .details{border:0;border-radius:0;margin:0}
-    .book-description{padding:.8rem;border-bottom:1px solid #e2e8f0}
-    .book-description h2{font-size:.9rem;margin:0 0 .35rem;color:#334155}
+    .book-description{margin:1rem 0;padding:.85rem;background:#fff;
+                      border:1px solid #d8d1c7;border-radius:.65rem}
+    .book-description h2{font-size:1rem;line-height:1.35;margin:0 0 .45rem;color:#1e293b}
     .book-description p{white-space:pre-line;font-size:.84rem;color:#475569;line-height:1.55}
     .price-box{background:#fff;border:1px solid #d8d1c7;border-radius:.65rem;
                padding:1rem 1.25rem;margin:.875rem 0}


### PR DESCRIPTION
## Objetivo

Mejora las fichas de producto para personas, Google y asistentes, usando sólo datos ya presentes y verificados en el catálogo.

## Cambios

- Muestra el autor inmediatamente debajo del H1, enlazado a su página cuando existe una URL de autor válida.
- Reemplaza el bloque colapsado “Ver más” por una sección HTML visible y semántica **Datos de esta edición**.
- Expone ISBN, editorial, páginas, idioma, formato, edición, año y demás atributos sólo cuando existen.
- Suprime descripciones que son únicamente una repetición exacta del título.
- Mantiene la descripción útil en una sección separada **Descripción de esta edición**.
- Agrega la URL canónica al JSON-LD Product/Book.
- Completa breadcrumb visible y estructurado: Inicio → Catálogo → ficha.
- Corrige la promesa logística global: elimina “Entrega en 2 horas” para todo el stock y comunica entregas rápidas condicionadas a zona, horario y disponibilidad.

## Guardrails

- No inventa ISBN, editorial, formato, stock ni logística.
- No cambia catálogo, precios, checkout, Merchant ni GA4.
- No crea URLs nuevas.
- No modifica Producción ni fusiona automáticamente.

## Validación

Nuevo test focalizado:
`node --test functions/__tests__/product-edition-facts.test.js`

El PR queda Draft para validar CI y Preview antes de cualquier decisión de merge.