### PR TITLE
MOJIBAKE-FIX-1: reparar UTF-8 mal interpretado en título/autor/descripción

### DIFF
--- a/functions/__tests__/mojibake-integration.test.js
+++ b/functions/__tests__/mojibake-integration.test.js
@@ -1,0 +1,175 @@
+// MOJIBAKE-FIX-1 — pruebas de integración: confirman que la reparación se
+// aplica de forma coherente en la ficha de producto y en los resultados
+// del buscador, y que nunca cambia el slug/URL canónica (que sigue
+// derivando del título original, sin reparar).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { renderPage } from '../libro/[[path]].js';
+import { onRequest as catalogRequest } from '../catalogo.js';
+import { CATALOG_URL } from '../_shared/catalog.js';
+
+const MOJIBAKE_TITLE = 'Soy Una SuperniÃ±a';
+const CORRECT_TITLE = 'Soy Una Superniña';
+const MOJIBAKE_TITLE_2 = 'Del CÃ­rculo Que Se CayÃ³ De Una Camiseta De Lunares';
+const CORRECT_TITLE_2 = 'Del Círculo Que Se Cayó De Una Camiseta De Lunares';
+
+function mojibakeBook(overrides = {}) {
+  return {
+    id: 'MLU900000001',
+    title: MOJIBAKE_TITLE,
+    author: 'MarÃ­a JosÃ© PÃ©rez',
+    isbn: '9780000000099',
+    price: 990,
+    currency: 'UYU',
+    status: 'active',
+    available_quantity: 3,
+    condition: 'new',
+    pictures: ['https://http2.mlstatic.com/D_TEST-O.jpg'],
+    thumbnail: '',
+    permalink: 'https://articulo.mercadolibre.com.uy/MLU900000001',
+    description: 'Una ediciÃ³n especial, con ilustraciones a color.',
+    publisher: 'Editorial NiÃ±ez',
+    bibliographic: { language: 'EspaÃ±ol', edition: 'Primera ediciÃ³n' },
+    ...overrides,
+  };
+}
+
+function jsonLdBlocks(html) {
+  return [...html.matchAll(/<script type="application\/ld\+json">([^<]+)<\/script>/g)]
+    .map(match => JSON.parse(match[1]));
+}
+
+// ── Ficha de producto ────────────────────────────────────────────────────
+
+test('la ficha muestra el título reparado en H1, <title>, meta description, JSON-LD y alt, sin cambiar el slug', () => {
+  const rawTitleSlug = 'soy-una-supernia-a'; // el mismo slug que produce hoy el título corrupto — no debe cambiar
+  const html = renderPage(mojibakeBook(), rawTitleSlug, false, '');
+
+  // Texto visible reparado
+  assert.match(html, /<h1>Soy Una Superniña<\/h1>/);
+  assert.match(html, /<title>Soy Una Superniña \| Amado Libros<\/title>/);
+  assert.doesNotMatch(html, /Ã±|Ã­|Ã³|Ã©/); // ningún resto de mojibake en el HTML
+
+  // Meta description y og/twitter usan el texto reparado
+  assert.match(html, /<meta name="description" content="[^"]*Superniña[^"]*"/);
+  assert.match(html, /<meta property="og:title"\s+content="Soy Una Superniña \| Amado Libros">/);
+
+  // JSON-LD Product/Book usa el nombre reparado
+  const schemas = jsonLdBlocks(html);
+  const product = schemas.find(schema => Array.isArray(schema['@type']));
+  assert.ok(product);
+  assert.equal(product.name, CORRECT_TITLE);
+  assert.match(product.description, /especial/);
+  assert.doesNotMatch(JSON.stringify(product), /Ã±|Ã­|Ã³/);
+
+  // Alt de imagen reparado
+  assert.match(html, /alt="Soy Una Superniña"/);
+
+  // La URL canónica sigue siendo la misma que ya existe hoy (deriva del
+  // slug pasado por el caller, calculado con el título SIN reparar).
+  assert.match(html, new RegExp(`<link rel="canonical" href="https://www\\.amadolibros\\.com/libro/MLU900000001/${rawTitleSlug}">`));
+});
+
+test('la ficha repara autor, editorial y campos bibliográficos, sin tocar id/isbn/precio/stock', () => {
+  const html = renderPage(mojibakeBook(), 'slug-fijo', false, '');
+  assert.match(html, /Editorial Niñez/);
+  assert.match(html, /Español/);
+  assert.match(html, /Primera edición/);
+  // Campos no textuales, intactos
+  assert.match(html, /MLU900000001/);
+  assert.match(html, /9780000000099/);
+  assert.match(html, /990/);
+});
+
+test('un texto ya correcto en la ficha no se altera', () => {
+  const html = renderPage(mojibakeBook({
+    title: 'Cien años de soledad',
+    author: 'Gabriel García Márquez',
+    description: 'Una historia de la familia Buendía en Macondo.',
+    bibliographic: {},
+  }), 'cien-anos-de-soledad', false, '');
+  assert.match(html, /<h1>Cien años de soledad<\/h1>/);
+  assert.match(html, /Gabriel García Márquez/);
+});
+
+// ── Resultados del buscador (/catalogo) ─────────────────────────────────
+
+function context(url, appEnv = 'test') {
+  return {
+    request: new Request(url),
+    params: {},
+    env: { APP_ENV: appEnv },
+    waitUntil() {},
+  };
+}
+
+function installCatalogCache(catalog) {
+  globalThis.caches = {
+    default: {
+      async match(request) {
+        return request.url === CATALOG_URL ? Response.json(catalog) : null;
+      },
+      async put() {},
+    },
+  };
+}
+
+test.afterEach(() => {
+  delete globalThis.fetch;
+  delete globalThis.caches;
+});
+
+test('el resultado de búsqueda muestra el título reparado, con el mismo href que ya existe hoy', async () => {
+  installCatalogCache({
+    total: 2,
+    items: [
+      mojibakeBook(),
+      {
+        id: 'MLU900000002', title: MOJIBAKE_TITLE_2, author: null,
+        isbn: '9780000000100', price: 1200, status: 'active', available_quantity: 1,
+        thumbnail: '', pictures: [], permalink: 'https://x/MLU900000002',
+      },
+    ],
+  });
+  const response = await catalogRequest(context('https://www.amadolibros.com/catalogo?q=super'));
+  const html = await response.text();
+
+  assert.match(html, new RegExp(`class="rc-title">${CORRECT_TITLE}</p>`));
+  assert.doesNotMatch(html, /Ã±|Ã­|Ã³/);
+  // El href sigue siendo el que ya generaba el título corrupto — no cambia
+  // la URL canónica de la ficha para este producto.
+  assert.match(html, /href="[^"]*\/libro\/MLU900000001\/soy-una-supernia-a"/);
+});
+
+test('el resultado de búsqueda repara también el segundo título reportado', async () => {
+  installCatalogCache({
+    total: 1,
+    items: [{
+      id: 'MLU900000003', title: MOJIBAKE_TITLE_2, author: 'Autora Tres',
+      isbn: '9780000000101', price: 800, status: 'active', available_quantity: 1,
+      thumbnail: '', pictures: [], permalink: 'https://x/MLU900000003',
+    }],
+  });
+  // "camiseta" no forma parte de los tramos con mojibake del título, así
+  // que ya matchea hoy contra el título sin reparar — esta prueba valida
+  // sólo el TEXTO MOSTRADO reparado, no el matching de búsqueda (que sigue
+  // comparando contra el título original; ver limitaciones en el informe).
+  const response = await catalogRequest(context('https://www.amadolibros.com/catalogo?q=camiseta'));
+  const html = await response.text();
+  assert.match(html, new RegExp(`class="rc-title">${CORRECT_TITLE_2}</p>`));
+});
+
+test('resultados con título ya correcto no cambian', async () => {
+  installCatalogCache({
+    total: 1,
+    items: [{
+      id: 'MLU900000004', title: 'Cien años de soledad', author: 'Gabriel García Márquez',
+      isbn: '9780000000102', price: 1500, status: 'active', available_quantity: 4,
+      thumbnail: '', pictures: [], permalink: 'https://x/MLU900000004',
+    }],
+  });
+  const response = await catalogRequest(context('https://www.amadolibros.com/catalogo?q=soledad'));
+  const html = await response.text();
+  assert.match(html, /class="rc-title">Cien años de soledad<\/p>/);
+});

--- a/functions/__tests__/mojibake.test.js
+++ b/functions/__tests__/mojibake.test.js
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  fixMojibake,
+  hasIrreversibleDataLoss,
+  hasMojibakeSignal,
+} from '../_shared/mojibake.js';
+
+// ── Casos obligatorios del reporte ──────────────────────────────────────
+
+test('repara SuperniÃ±a -> Superniña', () => {
+  assert.equal(fixMojibake('SuperniÃ±a'), 'Superniña');
+});
+
+test('repara CÃ­rculo -> Círculo dentro de un título completo', () => {
+  assert.equal(
+    fixMojibake('Del CÃ­rculo Que Se CayÃ³ De Una Camiseta De Lunares'),
+    'Del Círculo Que Se Cayó De Una Camiseta De Lunares',
+  );
+});
+
+test('repara CayÃ³ -> Cayó', () => {
+  assert.equal(fixMojibake('CayÃ³'), 'Cayó');
+});
+
+test('repara JesÃºs -> Jesús', () => {
+  assert.equal(fixMojibake('JesÃºs'), 'Jesús');
+});
+
+test('repara ediciÃ³n -> edición', () => {
+  assert.equal(fixMojibake('ediciÃ³n'), 'edición');
+});
+
+// ── Controles negativos: texto Unicode correcto queda intacto ──────────
+
+test('no toca palabras con acentos ya correctos', () => {
+  for (const text of [
+    'niña',
+    'Círculo',
+    'Jesús',
+    'Cien años de soledad',
+    'José María Ñúñez',
+    'edición',
+    'último',
+    'público',
+  ]) {
+    assert.equal(fixMojibake(text), text, `no debería cambiar: ${text}`);
+  }
+});
+
+test('no toca títulos con caracteres extranjeros legítimos', () => {
+  for (const text of [
+    'Über todo: relatos',
+    'Café con leche',
+    'François y el mar',
+    'Naïve: una historia',
+    '¡Hola! ¿Qué tal?',
+    'Ella dijo "hola" y ‘hola’ de nuevo',
+  ]) {
+    assert.equal(fixMojibake(text), text, `no debería cambiar: ${text}`);
+  }
+});
+
+test('no toca texto vacío, nulo o no-string', () => {
+  assert.equal(fixMojibake(''), '');
+  assert.equal(fixMojibake(null), '');
+  assert.equal(fixMojibake(undefined), '');
+  assert.equal(fixMojibake(123), '123');
+});
+
+// ── Idempotencia ─────────────────────────────────────────────────────────
+
+test('es idempotente: aplicarla dos veces da el mismo resultado', () => {
+  const cases = [
+    'SuperniÃ±a',
+    'Del CÃ­rculo Que Se CayÃ³ De Una Camiseta De Lunares',
+    'niña',
+    'Cien años de soledad',
+    'texto sin ningún problema',
+  ];
+  for (const text of cases) {
+    const once = fixMojibake(text);
+    const twice = fixMojibake(once);
+    assert.equal(twice, once, `no idempotente para: ${text}`);
+  }
+});
+
+// ── Nunca introduce el carácter de reemplazo ────────────────────────────
+
+test('nunca introduce el carácter de reemplazo Unicode', () => {
+  const cases = [
+    'SuperniÃ±a',
+    'texto normal',
+    'Ã©Ã¨Ã Ã¹Ã¬Ã²', // corrida larga de vocales mal codificadas
+    '￿￾', // codepoints fuera de rango, no deberían romper nada
+  ];
+  for (const text of cases) {
+    assert.equal(fixMojibake(text).includes('�'), false, `introdujo \\uFFFD para: ${text}`);
+  }
+});
+
+test('si el texto ya perdió datos (contiene el carácter de reemplazo), lo deja intacto', () => {
+  const lossy = 'Historia � incompleta';
+  assert.equal(fixMojibake(lossy), lossy);
+});
+
+// ── Múltiples corridas en un mismo texto ────────────────────────────────
+
+test('repara varias corridas de mojibake en el mismo texto', () => {
+  assert.equal(fixMojibake('SuperniÃ±a y JesÃºs, ediciÃ³n especial'), 'Superniña y Jesús, edición especial');
+});
+
+// ── Emoji / secuencias UTF-8 de más de 2 bytes ──────────────────────────
+
+test('repara mojibake de emoji (secuencias UTF-8 de 4 bytes)', () => {
+  // "🎉" (U+1F389) re-interpretado byte a byte como Windows-1252 produce "ðŸŽ‰".
+  assert.equal(fixMojibake('Novedad ðŸŽ‰ de la semana'), 'Novedad 🎉 de la semana');
+});
+
+// ── hasMojibakeSignal / hasIrreversibleDataLoss (medición y reportes) ──
+
+test('hasMojibakeSignal detecta los patrones típicos, no falsos positivos en texto sano', () => {
+  assert.equal(hasMojibakeSignal('SuperniÃ±a'), true);
+  assert.equal(hasMojibakeSignal('Novedad ðŸŽ‰'), true);
+  assert.equal(hasMojibakeSignal('Historia � incompleta'), true);
+  assert.equal(hasMojibakeSignal('niña'), false);
+  assert.equal(hasMojibakeSignal('Cien años de soledad'), false);
+});
+
+test('hasIrreversibleDataLoss sólo detecta el carácter de reemplazo Unicode', () => {
+  assert.equal(hasIrreversibleDataLoss('Historia � incompleta'), true);
+  assert.equal(hasIrreversibleDataLoss('SuperniÃ±a'), false);
+  assert.equal(hasIrreversibleDataLoss('niña'), false);
+});

--- a/functions/_shared/mojibake.js
+++ b/functions/_shared/mojibake.js
@@ -1,0 +1,140 @@
+// functions/_shared/mojibake.js
+//
+// Repara texto UTF-8 que fue mal interpretado una vez como Latin-1/
+// Windows-1252 en algun punto del pipeline (sync, import legado, etc.) --
+// el patron clasico "SuperniA?a" en vez de "Supernina" (con la enie real).
+// No es un diccionario de reemplazos por producto: revierte la
+// transformacion de bytes que produjo el mojibake, asi que corrige
+// cualquier texto afectado por la misma causa, sin listar casos
+// particulares.
+//
+// Como funciona:
+// 1. Busca corridas contiguas de caracteres "altos" (codepoint >= 0x80)
+//    que tengan un byte Windows-1252 valido -- es decir, exactamente los
+//    caracteres que aparecen cuando bytes UTF-8 reales se re-interpretan
+//    de a uno como Windows-1252.
+// 2. Convierte esa corrida de vuelta a sus bytes originales y los
+//    decodifica como UTF-8 en modo estricto (`fatal: true`).
+// 3. Solo reemplaza la corrida si la decodificacion UTF-8 tiene exito. Una
+//    corrida de caracteres Latin-1 "sanos" (por ejemplo, una unica vocal
+//    acentuada) casi nunca forma una secuencia UTF-8 valida al
+//    reinterpretarse como bytes, asi que el modo estricto la deja intacta
+//    -- de ahi que la funcion nunca "arregle" texto que ya esta bien,
+//    nunca introduzca el caracter de reemplazo Unicode, y sea idempotente
+//    (aplicarla sobre texto ya reparado no vuelve a encontrar corridas
+//    reparables).
+
+// Windows-1252 solo difiere de Latin-1 (ISO-8859-1) en el rango 0x80-0x9F.
+// Los bytes sin entrada en esta tabla (0x81, 0x8D, 0x8F, 0x90, 0x9D) no
+// estan definidos en Windows-1252 y por lo tanto nunca se usan revertidos.
+const CP1252_HIGH_TO_CODEPOINT = Object.freeze({
+  0x80: 0x20ac, 0x82: 0x201a, 0x83: 0x0192, 0x84: 0x201e, 0x85: 0x2026,
+  0x86: 0x2020, 0x87: 0x2021, 0x88: 0x02c6, 0x89: 0x2030, 0x8a: 0x0160,
+  0x8b: 0x2039, 0x8c: 0x0152, 0x8e: 0x017d, 0x91: 0x2018, 0x92: 0x2019,
+  0x93: 0x201c, 0x94: 0x201d, 0x95: 0x2022, 0x96: 0x2013, 0x97: 0x2014,
+  0x98: 0x02dc, 0x99: 0x2122, 0x9a: 0x0161, 0x9b: 0x203a, 0x9c: 0x0153,
+  0x9e: 0x017e, 0x9f: 0x0178,
+});
+
+// Codepoint Unicode -> byte Windows-1252 (inversa de la tabla anterior, mas
+// el rango Latin-1 0xA0-0xFF donde Windows-1252 y Unicode coinciden 1:1).
+const CODEPOINT_TO_CP1252_BYTE = new Map();
+for (let byte = 0xa0; byte <= 0xff; byte += 1) CODEPOINT_TO_CP1252_BYTE.set(byte, byte);
+for (const [byteText, codepoint] of Object.entries(CP1252_HIGH_TO_CODEPOINT)) {
+  CODEPOINT_TO_CP1252_BYTE.set(codepoint, Number(byteText));
+}
+
+// Corrida de caracteres "altos" (codepoint >= 0x0080): candidatos a ser
+// bytes UTF-8 reinterpretados como Windows-1252. repairRun() decide si la
+// corrida es realmente reparable; este regex solo la recorta del resto del
+// texto. Escrito con \u explicito para no depender de glifos no-ASCII
+// literales en el codigo fuente.
+const HIGH_RUN_RE = /[-￿]+/gu;
+const REPLACEMENT_CHAR = '�';
+
+let cachedDecoder = null;
+function utf8StrictDecoder() {
+  // TextDecoder es global en Cloudflare Workers y en Node -- no depende de
+  // Buffer, asi que la misma funcion corre igual en functions/ (Workers) y
+  // si algun script de mantenimiento la reutiliza en Node.
+  if (!cachedDecoder) cachedDecoder = new TextDecoder('utf-8', { fatal: true });
+  return cachedDecoder;
+}
+
+// Intenta reinterpretar una corrida de caracteres "altos" como bytes
+// Windows-1252 y decodificarlos como UTF-8. Devuelve el texto reparado, o
+// null si la corrida no es mojibake reparable (deja el original intacto).
+function repairRun(run) {
+  const bytes = [];
+  for (const char of run) {
+    const codepoint = char.codePointAt(0);
+    const byte = CODEPOINT_TO_CP1252_BYTE.get(codepoint);
+    if (byte == null) return null; // caracter fuera de Windows-1252: no es este tipo de mojibake
+    bytes.push(byte);
+  }
+  try {
+    const decoded = utf8StrictDecoder().decode(Uint8Array.from(bytes));
+    if (!decoded || decoded.includes(REPLACEMENT_CHAR)) return null;
+    return decoded;
+  } catch {
+    return null; // secuencia UTF-8 invalida => la corrida no era mojibake
+  }
+}
+
+/**
+ * Repara texto UTF-8 mal interpretado como Latin-1/Windows-1252, solo
+ * cuando encuentra una corrida de bytes que decodifica limpiamente como
+ * UTF-8 valido. Texto ya correcto (incluyendo vocales acentuadas sueltas,
+ * espanol, u otros idiomas) queda intacto porque una corrida "sana" casi
+ * nunca decodifica como UTF-8 valido en modo estricto.
+ *
+ * Idempotente: aplicarla dos veces da el mismo resultado que aplicarla una
+ * vez, porque el texto ya reparado no contiene mas corridas reparables.
+ *
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function fixMojibake(value) {
+  const text = value == null ? '' : String(value);
+  if (!text) return text;
+  return text.replace(HIGH_RUN_RE, run => repairRun(run) ?? run);
+}
+
+// Senales de que un texto probablemente contiene mojibake, para medicion y
+// reportes (no se usan para decidir si reparar -- eso lo decide
+// fixMojibake por si sola, de forma deterministica). Cubre los patrones
+// mencionados en el reporte: "A" + diacritico suelto (UTF-8 de 2 bytes mal
+// interpretado), "A-circunfleja" seguido de moneda/comillas (secuencias de
+// 3 bytes), y el caracter de reemplazo Unicode, que senala una perdida de
+// datos ya irreversible (no reparable por esta funcion).
+const MOJIBAKE_SIGNAL_RE = new RegExp(
+  'Ã[-¿]' + // Ã + byte de continuación típico (ej. Ã±, Ã­, Ã³, Ã º)
+  '|Â[-¿]' + // Â + byte de continuación típico
+  '|â€' + // â€ (comillas/rayas de 3 bytes mal interpretadas)
+  '|ðŸ' + // ðŸ (emoji de 4 bytes mal interpretado)
+  '|' + REPLACEMENT_CHAR,
+  'u',
+);
+
+/**
+ * true si el texto tiene una senal reconocible de mojibake o de perdida de
+ * datos ya irreversible (caracter de reemplazo). Uso exclusivo de medicion
+ * y reportes -- fixMojibake no depende de esta funcion para decidir si
+ * reparar un texto.
+ * @param {unknown} value
+ */
+export function hasMojibakeSignal(value) {
+  const text = value == null ? '' : String(value);
+  return MOJIBAKE_SIGNAL_RE.test(text);
+}
+
+/**
+ * true si el texto contiene el caracter de reemplazo Unicode, senal de que
+ * los bytes originales ya se perdieron en algun punto anterior y no se
+ * pueden reconstruir a partir del texto solo.
+ * @param {unknown} value
+ */
+export function hasIrreversibleDataLoss(value) {
+  const text = value == null ? '' : String(value);
+  return text.includes(REPLACEMENT_CHAR);
+}

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -37,6 +37,7 @@
  */
 
 import { slugify } from './_shared/slug.js';
+import { fixMojibake } from './_shared/mojibake.js';
 // GLOBAL-SHELL-1: mismo favicon que el resto del sitio.
 import { faviconHeadHtml } from './_shared/brand.js';
 import {
@@ -398,8 +399,8 @@ const CAT_SELECT_STYLES = `
 // texto visible.
 function buildOrderWaMessage(book, href) {
     return buildBookWhatsAppMessage({
-        title: book.title,
-        author: book.author,
+        title: fixMojibake(book.title),
+        author: book.author ? fixMojibake(book.author) : book.author,
         page: href,
         available: false,
     });
@@ -747,6 +748,10 @@ export async function onRequest(ctx) {
         : Array(limited.length).fill(null);
 
     const cards = limited.map((b, idx) => {
+        // El slug/href sigue derivando del título original (sin reparar):
+        // esta es la misma URL canónica que /libro/[[path]].js calcula con
+        // slugify(item.title), así que no cambia aunque el título tenga
+        // mojibake.
         const slug  = slugify(b.title);
         const rawHref = `${previewBase}/libro/${b.id}/${slug}`;
         const href  = escapeHtml(rawHref);
@@ -759,9 +764,9 @@ export async function onRequest(ctx) {
             sizes: CARD_IMAGE_SIZES,
         });
         const img = escapeHtml(image.src);
-        const title = escapeHtml(b.title);
+        const title = escapeHtml(fixMojibake(b.title));
         const author = b.author
-            ? `<p class="rc-author">${escapeHtml(b.author)}</p>`
+            ? `<p class="rc-author">${escapeHtml(fixMojibake(b.author))}</p>`
             : '';
         const available = b.status === 'active' && Number(b.available_quantity) > 0;
         // Tratamiento "Disponible por encargo"/"Pedir este libro"

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -15,6 +15,7 @@
 
 import { slugify } from '../_shared/slug.js';
 import { BASE, fetchCatalog, fetchPausedItem } from '../_shared/catalog.js';
+import { fixMojibake } from '../_shared/mojibake.js';
 import { previewCoverUrl as resolvePreviewCoverUrl } from '../_shared/preview-cover.js';
 import { authorPathForName } from '../_shared/seo-authors.js';
 import { PRODUCT_ID_REDIRECTS, PRODUCT_SEO_OVERRIDES } from '../_shared/seo-products.js';
@@ -136,6 +137,28 @@ function formatDimensions(dimensions) {
 function detailRow(label, value) {
     if (value == null || value === '') return '';
     return `<div class="detail-row"><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`;
+}
+
+// MOJIBAKE-FIX-1: repara texto UTF-8 mal interpretado como Latin-1 (ej.
+// "SuperniÃ±a" -> "Superniña") sólo en los campos de texto visibles/SEO.
+// Nunca toca id, isbn, precio, stock ni disponibilidad, y se aplica sobre
+// una copia — el slug canónico (calculado por el caller con slugify(item.
+// title) ANTES de esta reparación) sigue derivando del título original,
+// así que la URL no cambia.
+function withDisplayTextRepaired(item) {
+    const bibliographic = item.bibliographic && typeof item.bibliographic === 'object' && !Array.isArray(item.bibliographic)
+        ? Object.fromEntries(Object.entries(item.bibliographic).map(
+            ([key, value]) => [key, typeof value === 'string' ? fixMojibake(value) : value],
+        ))
+        : item.bibliographic;
+    return {
+        ...item,
+        title: fixMojibake(item.title),
+        author: typeof item.author === 'string' ? fixMojibake(item.author) : item.author,
+        description: typeof item.description === 'string' ? fixMojibake(item.description) : item.description,
+        publisher: typeof item.publisher === 'string' ? fixMojibake(item.publisher) : item.publisher,
+        bibliographic,
+    };
 }
 
 function renderGallery(images, safeTitle) {
@@ -308,7 +331,9 @@ function renderRelatedBooks(relatedBooks, author, useCloudflareImages = true) {
     if (!Array.isArray(relatedBooks) || relatedBooks.length === 0) return '';
 
     const cards = relatedBooks.map((book) => {
-        const title = escapeHtml(book.title);
+        const title = escapeHtml(fixMojibake(book.title));
+        // El slug sigue derivando del título original (sin reparar) para no
+        // cambiar la URL canónica de los libros relacionados.
         const href = `/libro/${encodeURIComponent(book.id)}/${slugify(book.title)}`;
         const source = useCloudflareImages
             ? bookCoverUrl(book.id)
@@ -377,6 +402,10 @@ function notFound() {
 // ---------------------------------------------------------------------------
 
 export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverSrc = '', relatedBooks = []) {
+    // `slug` ya fue calculado por el caller con el título original (sin
+    // reparar) — se preserva así para no cambiar la URL canónica. A partir
+    // de acá, `item` es una copia con el texto visible reparado.
+    item = withDisplayTextRepaired(item);
     const canonicalUrl = `${BASE}/libro/${item.id}/${slug}`;
     const safeTitle    = escapeHtml(item.title);
     const safeAuthor   = item.author ? escapeHtml(item.author) : null;


### PR DESCRIPTION
## Objetivo

Corregir de forma general y comprobable el mojibake reportado en producción (`SuperniÃ±a` → `Superniña`, `CÃrculo`/`CayÃ³` → `Círculo`/`Cayó`), sin hardcodear reemplazos por producto — se corrige la causa compartida (texto UTF-8 re-interpretado alguna vez como Latin-1/Windows-1252), no los dos títulos puntuales.

## Causa raíz

En algún punto del pipeline (sync desde Mercado Libre / import legado) el texto quedó guardado tal como se ve al re-interpretar UTF-8 una vez como Windows-1252. No hay un lugar seguro para re-codificar el catálogo en origen sin riesgo de romper otros campos, así que la corrección se aplica en la capa de presentación (texto visible/SEO/JSON-LD), de forma genérica y reversible.

## Qué se agregó

- **`functions/_shared/mojibake.js` (nuevo)** — `fixMojibake(text)`: busca corridas de caracteres "altos" que, reinterpretados como bytes Windows-1252, decodifican limpiamente como UTF-8 válido (`TextDecoder('utf-8', {fatal:true})`). Sólo reemplaza cuando la decodificación tiene éxito — texto ya sano (una vocal acentuada suelta, idiomas extranjeros legítimos) casi nunca forma una secuencia UTF-8 válida al reinterpretarse, así que queda intacto. Nunca introduce el carácter de reemplazo `�`, es idempotente. `hasMojibakeSignal()`/`hasIrreversibleDataLoss()` son sólo para medición/reportes, no deciden la reparación.

## Dónde se aplica (y dónde no)

| Superficie | Cambiado | Detalle |
|---|---|---|
| Ficha de producto (`functions/libro/[[path]].js`) | ✅ | H1, `<title>`, meta description, og/twitter, JSON-LD `Product`/`Book`, breadcrumb, alt de imágenes, libros relacionados |
| Buscador (`functions/catalogo.js`) | ✅ | Título/autor de cada card, alt de imagen, mensaje de WhatsApp "pedir este libro" |
| Landings de categoría (`functions/libros/[[path]].js`) | ❌ | Explícitamente reservado a otro frente (landings/Tarot/Biblias) |
| Portada (`public/index.html`, `astro-front/`) | ❌ | Ya verifiqué cuál portada alimenta producción realmente (`public/index.html`, vía `pages_build_output_dir` en `wrangler.toml` — `astro-front` sólo se despliega a un preview `noindex`) — de cualquier modo, portada quedó fuera de alcance a propósito |
| Merchant/feed (`functions/feed.xml.js`) | ❌ | Fuera de alcance a propósito |

**El slug/URL canónica nunca cambia.** En los tres puntos donde se toca texto, el `slug`/`href` de cada producto sigue derivando del **título original sin reparar** (ya calculado por el caller antes de aplicar `fixMojibake`), exactamente igual que hoy — no se generan redirecciones ni se rompen URLs indexadas.

## Guardrails respetados

- No cambia IDs, MLUs, ISBN, precios, stock ni disponibilidad (copia superficial sólo sobre campos de texto: `title`, `author`, `description`, `publisher`, `bibliographic.*`).
- No cambia URLs canónicas ni genera redirecciones (ver arriba).
- No toca categorías, taxonomía, landings, navegación, portada, imágenes ni Merchant Center.
- No hardcodea los dos títulos del reporte — son sólo casos de test.

## Tests

- `functions/__tests__/mojibake.test.js` (15 casos): los 5 patrones obligatorios del reporte, controles negativos (acentos correctos, idiomas extranjeros legítimos, vacío/nulo), idempotencia, nunca introduce `�`, corridas múltiples en un mismo texto, mojibake de emoji (secuencias UTF-8 de 4 bytes), y las funciones de medición.
- `functions/__tests__/mojibake-integration.test.js` (6 casos end-to-end): `renderPage()` real de la ficha y el `onRequest` real de `/catalogo`, verificando que título visible + meta + JSON-LD coinciden, y que la URL canónica/slug no cambia.
- Suite completa: `bash scripts/validate-ci.sh` → **270/270 tests** + build de `astro-front` (checkout ON/OFF) exitoso.

## Validación de cuántos productos están afectados

Intenté contar productos activos afectados fetcheando el `catalog.json` público, pero el proxy de esta sesión bloquea el dominio de R2 (`pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev`, 403 de política). En vez de escribir un contador duplicado, usé el detector ya existente en el repo — `looksLikeMojibake()` en `scripts/seo/catalog-quality-audit.mjs` — y revisé el run más reciente de CI contra el catálogo real (run [`32644489247`](https://github.com/trexxeseba/amadolibros-web/actions/runs/32644489247), snapshot `catalogUpdatedAt: 2026-08-23T07:19:52Z`, mismo día):

```
"issues": { "mojibakeTitles": [], "mojibakeTitleCount": 0, "mojibakeTitlePercent": 0 }
```

**0 de 7108 títulos activos** matchean el patrón hoy. No pude confirmarlo con un fetch propio por el bloqueo de red — ver "Riesgos" abajo.

## Riesgos / casos que decidí no corregir automáticamente

1. **El conteo real de productos afectados no está confirmado por mí.** El detector existente da 0 en el catálogo activo de hoy; no verifiqué el catálogo **pausado** (sin stock) ni campos fuera de `title` con ese detector — es posible que los dos títulos del reporte ya se hayan corregido en origen, estén pausados, o vivan en otro campo. Recomiendo correr `node scripts/seo/catalog-quality-audit.mjs` (o revisar el catálogo pausado) antes de dar el bug por cerrado.
2. **El buscador no encuentra por acento un título con mojibake.** `functions/catalogo.js` sigue comparando (`tokenize`/`itemMatchesQuery`) contra el título **original sin reparar** — sólo el texto mostrado se repara. Si alguien busca "niña" (bien escrito), no encuentra hoy un producto guardado como "niÃ±a" (sí lo encuentra buscando "super" u otra porción no afectada). Corregir esto requeriría tocar la lógica de matching/ranking, que dejé fuera a propósito por ser más riesgoso y no pedido explícitamente en las pruebas obligatorias.
3. **Landings de categoría y portada quedan con el problema sin corregir**, por decisión explícita de alcance (frentes de otro workstream).
4. **Pérdida de datos irreversible** (texto que ya contiene el carácter de reemplazo `�`) no se intenta reparar — no hay forma de reconstruir bytes ya perdidos a partir del texto solo. `hasIrreversibleDataLoss()` queda disponible para detectarlo en auditorías futuras.

## Verificación pendiente en Preview

No pude desplegar ni verificar en Preview desde esta sesión (sin acceso a Cloudflare/Wrangler aquí). Falta, antes de sacar de Draft:
- Confirmar en Preview los dos títulos reportados (si siguen existiendo con mojibake).
- Una búsqueda que los encuentre (por una porción del título no afectada por el mojibake, ver riesgo 2).
- Una ficha individual mostrando H1/meta/JSON-LD coincidentes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp2uS5z3ac9dPNHpSqdqv1)_