### PR TITLE
CATALOG-IMAGE-QUALITY-1: corregir portada incorrecta de MLU717791364

### DIFF
--- a/functions/__tests__/catalog-image-overrides.test.js
+++ b/functions/__tests__/catalog-image-overrides.test.js
@@ -1,0 +1,143 @@
+// CATALOG-IMAGE-QUALITY-1 — correcciones explícitas y verificadas para dos
+// imágenes puntuales del catálogo. Estos tests prueban el contrato exacto
+// pedido: sólo los IDs listados reciben override, MLU717791364 deja de
+// mostrar el logo de "El Yelmo de Mambrino", el resto de los datos del
+// producto (isbn, título, precio, stock, galería) queda intacto, un
+// producto no listado conserva su imagen original, y nunca se inventa una
+// imagen para un candidato que no pudo validarse (CASO 2).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CATALOG_IMAGE_OVERRIDES,
+  overrideImageForProduct,
+  applyCatalogImageOverride,
+} from '../_shared/catalog-image-overrides.js';
+import { coverSource, primaryCoverSource } from '../book-cover/[[path]].js';
+
+const YELMO_LOGO_URL = 'https://http2.mlstatic.com/D_YELMO_LOGO-O.jpg';
+const VERIFIED_REPLACEMENT_URL = 'https://http2.mlstatic.com/D_821791-MLU83069485320_032025-O.jpg';
+
+const santaBiblia = Object.freeze({
+  id: 'MLU717791364',
+  title: 'Santa Biblia',
+  author: 'Martín Nieto, Evaristo',
+  isbn: '9788428543231',
+  price: 15000,
+  status: 'active',
+  available_quantity: 2,
+  thumbnail: YELMO_LOGO_URL.replace('-O.', '-I.'),
+  pictures: [YELMO_LOGO_URL, 'https://http2.mlstatic.com/D_OTRA-O.jpg'],
+  permalink: 'https://articulo.mercadolibre.com.uy/MLU717791364',
+});
+
+// CASO 2 — imagen de baja calidad, explícitamente NO implementado: no hay
+// evidencia de comparación visual/bytes real disponible (ver PR), así que
+// este producto nunca debe recibir un override inventado.
+const evangelioEsenios = Object.freeze({
+  id: 'MLU683276890',
+  title: 'El Evangelio de los Esenios 1',
+  author: 'Edmon Bordeaux Szekely',
+  isbn: '9789995471234',
+  price: 8000,
+  status: 'active',
+  available_quantity: 5,
+  thumbnail: 'https://http2.mlstatic.com/D_890906-MLA49286758306_032022-I.jpg',
+  pictures: ['https://http2.mlstatic.com/D_890906-MLA49286758306_032022-O.jpg'],
+  permalink: 'https://articulo.mercadolibre.com.uy/MLU683276890',
+});
+
+// ── 1. Sólo los IDs listados explícitamente pueden recibir un override ─────
+
+test('1. sólo MLU717791364 tiene override explícito; ningún otro ID lo tiene, ni siquiera MLU683276890 (CASO 2)', () => {
+  assert.deepEqual(Object.keys(CATALOG_IMAGE_OVERRIDES), ['MLU717791364']);
+  assert.ok(overrideImageForProduct('MLU717791364'));
+  assert.equal(overrideImageForProduct('MLU683276890'), null);
+  assert.equal(overrideImageForProduct('MLU000000000'), null);
+  assert.equal(overrideImageForProduct(''), null);
+  assert.equal(overrideImageForProduct(undefined), null);
+});
+
+test('1b. overrideImageForProduct es insensible a mayúsculas/minúsculas pero no matchea por título ni similitud', () => {
+  assert.ok(overrideImageForProduct('mlu717791364'));
+  // Un producto con título parecido pero id distinto nunca recibe override.
+  assert.equal(overrideImageForProduct('MLU717791365'), null);
+});
+
+// ── 2. MLU717791364 deja de mostrar la imagen del Yelmo de Mambrino ────────
+
+test('2. applyCatalogImageOverride reemplaza pictures[0] de MLU717791364 por la portada verificada, no por el logo del Yelmo', () => {
+  const result = applyCatalogImageOverride(santaBiblia);
+  assert.notEqual(result.pictures[0], YELMO_LOGO_URL);
+  assert.equal(result.pictures[0], VERIFIED_REPLACEMENT_URL);
+});
+
+test('2b. coverSource()/primaryCoverSource() (capa compartida real de tarjetas y ficha) tampoco sirven el logo del Yelmo para MLU717791364', () => {
+  const source = primaryCoverSource(santaBiblia);
+  assert.notEqual(source, YELMO_LOGO_URL);
+  assert.equal(source, VERIFIED_REPLACEMENT_URL);
+  assert.equal(coverSource(santaBiblia, 0), VERIFIED_REPLACEMENT_URL);
+});
+
+// ── 3. El ISBN y los demás datos permanecen intactos ────────────────────────
+
+test('3. applyCatalogImageOverride no toca título, isbn, slug-source, precio, stock, id ni permalink', () => {
+  const result = applyCatalogImageOverride(santaBiblia);
+  assert.equal(result.id, santaBiblia.id);
+  assert.equal(result.title, santaBiblia.title);
+  assert.equal(result.isbn, santaBiblia.isbn);
+  assert.equal(result.price, santaBiblia.price);
+  assert.equal(result.available_quantity, santaBiblia.available_quantity);
+  assert.equal(result.status, santaBiblia.status);
+  assert.equal(result.permalink, santaBiblia.permalink);
+});
+
+test('3b. sólo pictures[0] cambia; el resto de la galería original queda igual', () => {
+  const result = applyCatalogImageOverride(santaBiblia);
+  assert.equal(result.pictures.length, santaBiblia.pictures.length);
+  assert.equal(result.pictures[1], santaBiblia.pictures[1]);
+});
+
+test('3c. el objeto original pasado a applyCatalogImageOverride no se muta', () => {
+  const before = JSON.stringify(santaBiblia);
+  applyCatalogImageOverride(santaBiblia);
+  assert.equal(JSON.stringify(santaBiblia), before);
+});
+
+test('3d. coverSource() para posiciones distintas de 0 nunca aplica el override (sólo la portada)', () => {
+  assert.equal(coverSource(santaBiblia, 1), 'https://http2.mlstatic.com/D_OTRA-O.jpg');
+});
+
+// ── 4. Un producto no listado conserva su imagen original ──────────────────
+
+test('4. un producto sin override (MLU683276890, CASO 2) conserva su imagen y objeto originales sin cambios', () => {
+  const result = applyCatalogImageOverride(evangelioEsenios);
+  assert.equal(result, evangelioEsenios); // misma referencia: no se copia si no hay override
+  assert.equal(result.pictures[0], evangelioEsenios.pictures[0]);
+});
+
+test('4b. coverSource()/primaryCoverSource() para un producto no listado resuelven la imagen original sin tocarla', () => {
+  assert.equal(
+    primaryCoverSource(evangelioEsenios),
+    'https://http2.mlstatic.com/D_890906-MLA49286758306_032022-O.jpg',
+  );
+});
+
+// ── 5. No se inventa una imagen si la candidata no pudo validarse (CASO 2) ─
+
+test('5. CASO 2 (MLU683276890) no tiene override: la falta de verificación visual/de bytes nunca se completa con una imagen inventada', () => {
+  assert.equal(overrideImageForProduct('MLU683276890'), null);
+  assert.equal(Object.prototype.hasOwnProperty.call(CATALOG_IMAGE_OVERRIDES, 'MLU683276890'), false);
+});
+
+test('5b. applyCatalogImageOverride es idempotente: aplicarla dos veces da el mismo resultado que una vez', () => {
+  const once = applyCatalogImageOverride(santaBiblia);
+  const twice = applyCatalogImageOverride(once);
+  assert.deepEqual(once, twice);
+});
+
+test('5c. applyCatalogImageOverride tolera entradas no válidas sin inventar nada (null, undefined, objeto sin id)', () => {
+  assert.equal(applyCatalogImageOverride(null), null);
+  assert.equal(applyCatalogImageOverride(undefined), undefined);
+  const noId = { title: 'sin id' };
+  assert.equal(applyCatalogImageOverride(noId), noId);
+});

--- a/functions/_shared/catalog-image-overrides.js
+++ b/functions/_shared/catalog-image-overrides.js
@@ -1,0 +1,86 @@
+// functions/_shared/catalog-image-overrides.js
+//
+// CATALOG-IMAGE-QUALITY-1 — overrides explícitos, verificados uno por uno,
+// para la imagen PRINCIPAL (posición 0) de productos puntuales del
+// catálogo. Nunca es una heurística: no compara títulos, no adivina
+// duplicados por similitud. Cada entrada requiere evidencia verificada a
+// mano (ej. ISBN compartido con el duplicado limpio) antes de agregarse
+// acá — agregar una entrada sin esa evidencia es un error de uso de este
+// archivo, no algo que el código pueda detectar por sí solo.
+//
+// Sólo reemplaza pictures[0]. El resto de la galería original del
+// producto (pictures[1..]) nunca se toca. La imagen de reemplazo siempre
+// debe ser una URL mlstatic.com que ya exista en pictures[] de OTRO
+// producto verificado de nuestro propio catálogo — nunca una imagen de una
+// librería externa.
+
+const MLSTATIC_HOST_RE = /(^|\.)mlstatic\.com$/i;
+
+function isMlstaticImageUrl(value) {
+  if (typeof value !== 'string' || !value.trim()) return false;
+  try {
+    const url = new URL(value.trim());
+    return ['http:', 'https:'].includes(url.protocol) && MLSTATIC_HOST_RE.test(url.hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+// CASO 1 — CATALOG-IMAGE-QUALITY-1: MLU717791364 ("Santa Biblia", Martín
+// Nieto / Evaristo, Editorial San Pablo, ISBN 9788428543231) muestra como
+// portada el logo de la librería "El Yelmo de Mambrino", que nunca debería
+// aparecer ahí. El duplicado verificado MLU717869050 comparte exactamente
+// el mismo ISBN y tiene una portada limpia real de Mercado Libre.
+export const CATALOG_IMAGE_OVERRIDES = Object.freeze({
+  MLU717791364: Object.freeze({
+    imageUrl: 'https://http2.mlstatic.com/D_821791-MLU83069485320_032025-O.jpg',
+    reason: 'La imagen principal original muestra el logo de la librería "El Yelmo de Mambrino" en vez de la portada del libro.',
+    verifiedIsbn: '9788428543231',
+    sourceProductId: 'MLU717869050',
+  }),
+});
+
+// Falla rápido en tiempo de carga si alguna entrada no apunta a una imagen
+// mlstatic válida — mejor un error temprano en tests/build que servir un
+// override roto en producción.
+for (const [productId, override] of Object.entries(CATALOG_IMAGE_OVERRIDES)) {
+  if (!isMlstaticImageUrl(override.imageUrl)) {
+    throw new Error(`catalog-image-overrides: URL de imagen inválida para ${productId}`);
+  }
+}
+
+/**
+ * Devuelve el override verificado para un product id, o null si ese id no
+ * tiene ninguno. Sólo los IDs listados explícitamente en
+ * CATALOG_IMAGE_OVERRIDES pueden recibir un override — no hay heurística,
+ * no hay matching por título ni por similitud.
+ * @param {unknown} productId
+ */
+export function overrideImageForProduct(productId) {
+  const id = String(productId || '').trim().toUpperCase();
+  return Object.prototype.hasOwnProperty.call(CATALOG_IMAGE_OVERRIDES, id)
+    ? CATALOG_IMAGE_OVERRIDES[id]
+    : null;
+}
+
+/**
+ * Devuelve una copia superficial de `item` con `pictures[0]` reemplazada
+ * por la imagen verificada, sólo si `item.id` tiene un override explícito
+ * en CATALOG_IMAGE_OVERRIDES. Cualquier otro producto se devuelve tal cual
+ * (mismo objeto, sin copiar). No toca título, isbn, slug, precio, stock,
+ * disponibilidad, ni el resto de la galería.
+ *
+ * Idempotente: aplicarla dos veces da el mismo resultado que aplicarla una
+ * vez, porque la decisión depende únicamente de item.id y siempre escribe
+ * el mismo valor verificado en la posición 0.
+ * @param {object} item
+ */
+export function applyCatalogImageOverride(item) {
+  if (!item || typeof item !== 'object') return item;
+  const override = overrideImageForProduct(item.id);
+  if (!override) return item;
+  const pictures = Array.isArray(item.pictures) ? [...item.pictures] : [];
+  if (pictures.length > 0) pictures[0] = override.imageUrl;
+  else pictures.unshift(override.imageUrl);
+  return { ...item, pictures };
+}

--- a/functions/book-cover/[[path]].js
+++ b/functions/book-cover/[[path]].js
@@ -1,5 +1,6 @@
 import { fetchCatalog, fetchPausedItem } from '../_shared/catalog.js';
 import { findPreviewCover } from '../_shared/preview-cover.js';
+import { overrideImageForProduct } from '../_shared/catalog-image-overrides.js';
 
 const PRODUCT_ID_RE = /^MLU\d+$/;
 const COVER_FILE_RE = /^cover(?:-([2-9]|1[0-6]))?\.jpg$/;
@@ -27,6 +28,14 @@ export function primaryCoverSource(item) {
 
 export function coverSource(item, position = 0) {
   if (!Number.isInteger(position) || position < 0 || position >= MAX_GALLERY_IMAGES) return '';
+  // CATALOG-IMAGE-QUALITY-1: sólo la posición 0 (portada) puede tener un
+  // override explícito y verificado — nunca el resto de la galería. Sólo
+  // los IDs listados en catalog-image-overrides.js reciben esto; cualquier
+  // otro producto sigue su resolución normal por pictures[]/thumbnail.
+  if (position === 0) {
+    const override = overrideImageForProduct(item?.id);
+    if (override) return largeMlImage(override.imageUrl);
+  }
   const pictures = Array.isArray(item?.pictures)
     ? item.pictures.filter(value => typeof value === 'string')
     : [];

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -37,6 +37,7 @@
  */
 
 import { slugify } from './_shared/slug.js';
+import { applyCatalogImageOverride } from './_shared/catalog-image-overrides.js';
 // GLOBAL-SHELL-1: mismo favicon que el resto del sitio.
 import { faviconHeadHtml } from './_shared/brand.js';
 import {
@@ -729,7 +730,12 @@ export async function onRequest(ctx) {
 
     const page      = pageParam.page;
     const offset    = (page - 1) * MAX_RESULTS;
-    const limited   = filtered.slice(offset, offset + MAX_RESULTS);
+    // CATALOG-IMAGE-QUALITY-1: sólo afecta pictures[0] de los IDs listados
+    // explícitamente en catalog-image-overrides.js. En producción la imagen
+    // real sale de bookCoverUrl()/coverSource() (mismo override aplicado
+    // ahí); esto cubre además la vista Preview de estas tarjetas, que usa
+    // pictures[] directamente.
+    const limited   = filtered.slice(offset, offset + MAX_RESULTS).map(applyCatalogImageOverride);
     const rangeFrom = totalResults === 0 ? 0 : offset + 1;
     const rangeTo   = offset + limited.length;
 

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -18,6 +18,7 @@ import { BASE, fetchCatalog, fetchPausedItem } from '../_shared/catalog.js';
 import { previewCoverUrl as resolvePreviewCoverUrl } from '../_shared/preview-cover.js';
 import { authorPathForName } from '../_shared/seo-authors.js';
 import { PRODUCT_ID_REDIRECTS, PRODUCT_SEO_OVERRIDES } from '../_shared/seo-products.js';
+import { applyCatalogImageOverride } from '../_shared/catalog-image-overrides.js';
 import {
     bookCoverUrl,
     cloudflareImageUrl,
@@ -1070,6 +1071,15 @@ export async function onRequest(context) {
         });
     }
     if (!item) return notFound();
+
+    // CATALOG-IMAGE-QUALITY-1: sólo afecta pictures[0] de los IDs listados
+    // explícitamente en catalog-image-overrides.js. No toca título, isbn,
+    // slug (se calcula igual, de item.title, sin cambios) ni el resto de la
+    // galería. En producción las imágenes reales salen de /book-cover/
+    // (ver coverSource() en functions/book-cover/[[path]].js, que aplica el
+    // mismo override); esto cubre además la vista Preview, que muestra
+    // pictures[] directamente sin pasar por ese endpoint.
+    item = applyCatalogImageOverride(item);
 
     const slug = slugify(item.title);
     const isPreview = context.env?.APP_ENV === 'preview';


### PR DESCRIPTION
## Objetivo

Corregir dos imágenes puntuales y verificadas del catálogo, en un frente separado de portada/SEO/categorías/Merchant/mojibake (PRs #237/#238/#239 no se tocan ni se reutilizan).

## CASO 1 — imagen incorrecta (implementado)

- Producto `MLU717791364` — "Santa Biblia", Martín Nieto/Evaristo, Editorial San Pablo, ISBN `9788428543231`.
- La imagen principal mostraba el logo de la librería "El Yelmo de Mambrino" en vez de la portada.
- Duplicado verificado `MLU717869050` comparte exactamente el mismo ISBN y tiene una portada limpia real de Mercado Libre: `https://http2.mlstatic.com/D_821791-MLU83069485320_032025-O.jpg`.
- Corrección **explícita y limitada** a `MLU717791364` — sin heurística global, sin matching por título.

## CASO 2 — imagen de baja calidad (NO implementado, documentado)

- Producto `MLU683276890` — "El Evangelio de los Esenios 1".
- No fue posible comparar visualmente las candidatas ni sus dimensiones/bytes reales: este entorno de ejecución bloquea el egress hacia `http2.mlstatic.com` (proxy de red del sandbox).
- Siguiendo la instrucción explícita de la tarea ("si no podés demostrarlo, no cambies este caso"), **no se agregó override para este producto**. Queda pendiente de una verificación manual/con acceso de red antes de decidir un cambio.

## Qué cambia y dónde

- **`functions/_shared/catalog-image-overrides.js`** (nuevo): allowlist explícito y data-driven (`CATALOG_IMAGE_OVERRIDES`), con `overrideImageForProduct()` y `applyCatalogImageOverride()`. Sólo reemplaza `pictures[0]`; valida en tiempo de carga que cada URL sea `mlstatic.com`.
- **`functions/book-cover/[[path]].js`**: `coverSource()` aplica el override en la posición 0 antes de resolver la imagen normal. Esta es la capa compartida real que sirve los bytes de imagen en producción para `bookCoverUrl()` (ficha, tarjetas de catálogo, categorías, especialidades, etc.).
- **`functions/libro/[[path]].js`** y **`functions/catalogo.js`**: aplican `applyCatalogImageOverride(item)` sobre el/los ítems antes de renderizar, para cubrir el modo Preview (que muestra `pictures[]` directamente, sin pasar por `/book-cover/`).

## Guardrails respetados

- Sólo imágenes oficiales ya presentes en nuestro catálogo/Mercado Libre — ninguna imagen de librería externa.
- Override aplicado en la capa compartida de resolución de imagen (no duplicado por página).
- Título, ISBN, slug, precio, stock y galería original (`pictures[1..]`) intactos — verificado en tests.
- Feed de Merchant Center (`functions/feed.xml.js`) no se toca: resuelve imágenes de forma independiente, no importa ninguno de los módulos modificados.
- Solución data-driven, explícita e idempotente (depende sólo de `item.id`, resultado estable al aplicarse más de una vez).

## Límite documentado (no bloqueante)

`functions/libros/[[path]].js` (tarjetas de categoría) no se modificó para no mezclar el frente de categorías. En producción esa superficie ya queda cubierta por el fix de `coverSource()`; en modo Preview esas tarjetas seguirían mostrando la imagen original de `MLU717791364` hasta un cambio futuro acotado a ese archivo.

## Tests

Nuevo `functions/__tests__/catalog-image-overrides.test.js` (13 casos), probando explícitamente los 5 puntos pedidos:
1. Sólo `MLU717791364` tiene override — ningún otro ID, incluido `MLU683276890`.
2. `MLU717791364` deja de mostrar la imagen del Yelmo (`coverSource`/`primaryCoverSource`/`applyCatalogImageOverride`).
3. ISBN, título, precio, stock, id, permalink y resto de la galería quedan intactos; el objeto original no se muta.
4. Un producto no listado (`MLU683276890`, CASO 2) conserva su imagen y objeto original sin copiar.
5. No se inventa una imagen para un candidato no validado (CASO 2 sigue sin override).

Regresión y suite completa (todo en verde):
- `cover-preview-ui-config.test.js` + `social-cover-global-autocomplete.test.js`: 10/10.
- Suite ficha/catálogo/dedupe/paginación/schema (11 archivos): 169/169.
- `scripts/validate-ci.sh` (suite completa + Astro build checkout ON y OFF): OK.

## Antes / después (CASO 1)

| | Antes | Después |
|---|---|---|
| `pictures[0]` de MLU717791364 | logo "El Yelmo de Mambrino" | `https://http2.mlstatic.com/D_821791-MLU83069485320_032025-O.jpg` |
| ISBN | `9788428543231` | `9788428543231` (sin cambios) |
| Resto de galería, título, precio, stock | — | sin cambios |
| Producto no listado (ej. MLU683276890) | imagen original | imagen original (sin cambios) |

Draft PR — no mergear. Voy a monitorear CI/Preview y verificar visualmente la ficha de MLU717791364 en escritorio y móvil apenas el deploy de Preview esté disponible.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp2uS5z3ac9dPNHpSqdqv1)_