### PR TITLE
MERCHANT-LOCAL-DELIVERY-1: declarar entrega en el día en Montevideo

### DIFF
--- a/functions/__tests__/merchant-local-delivery.test.js
+++ b/functions/__tests__/merchant-local-delivery.test.js
@@ -1,0 +1,101 @@
+// MERCHANT-LOCAL-DELIVERY-1 — el feed debe declarar la entrega en el día en
+// Montevideo con EXACTAMENTE los mismos importes que cobra el checkout real.
+// Un feed que promete un envío más barato que el checkout es causa de
+// desaprobación en Merchant, y antes que eso es una promesa falsa al
+// comprador.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  itemShippingCostUyu,
+  shippingTags,
+  MONTEVIDEO_REGION,
+  MONTEVIDEO_SERVICE,
+  SHIPPING_COUNTRY,
+} from '../_shared/merchant-delivery.js';
+import { FREE_SHIPPING_THRESHOLD, SHIPPING_COST } from '../api/_orders_logic.js';
+import { renderFeedItem } from '../feed.xml.js';
+
+const baseItem = {
+  id: 'MLU123456789',
+  title: 'Tarot de Marsella con guía',
+  price: 990,
+  currency: 'UYU',
+  available_quantity: 2,
+  condition: 'new',
+  isbn: '9788428543231',
+  thumbnail: 'https://http2.mlstatic.com/D_ABC-O.jpg',
+  pictures: ['https://http2.mlstatic.com/D_ABC-O.jpg'],
+};
+
+// ── 1. El costo declarado es el que cobra el checkout ──────────────────────
+
+test('1. bajo el umbral se declara el costo real de envío del checkout', () => {
+  assert.equal(itemShippingCostUyu(FREE_SHIPPING_THRESHOLD - 1), SHIPPING_COST);
+  assert.equal(itemShippingCostUyu(990), SHIPPING_COST);
+});
+
+test('1b. desde el umbral inclusive el envío es gratis, igual que en el checkout', () => {
+  assert.equal(itemShippingCostUyu(FREE_SHIPPING_THRESHOLD), 0);
+  assert.equal(itemShippingCostUyu(FREE_SHIPPING_THRESHOLD + 500), 0);
+});
+
+test('1c. un precio inválido nunca promete envío gratis (falla del lado seguro)', () => {
+  assert.equal(itemShippingCostUyu(undefined), SHIPPING_COST);
+  assert.equal(itemShippingCostUyu(null), SHIPPING_COST);
+  assert.equal(itemShippingCostUyu('no-es-un-precio'), SHIPPING_COST);
+  assert.equal(itemShippingCostUyu(-100), SHIPPING_COST);
+});
+
+// ── 2. Montevideo queda declarado como entrega en el día ───────────────────
+
+test('2. se emite una entrada de Montevideo con handling y tránsito en 0 (mismo día)', () => {
+  const xml = shippingTags({ price: 990 });
+  assert.match(xml, new RegExp(`<g:region>${MONTEVIDEO_REGION}</g:region>`));
+  assert.match(xml, new RegExp(`<g:service>${MONTEVIDEO_SERVICE}</g:service>`));
+  assert.match(xml, /<g:max_handling_time>0<\/g:max_handling_time>/);
+  assert.match(xml, /<g:max_transit_time>0<\/g:max_transit_time>/);
+});
+
+test('2b. el país declarado es Uruguay', () => {
+  assert.match(shippingTags({ price: 990 }), new RegExp(`<g:country>${SHIPPING_COUNTRY}</g:country>`));
+});
+
+// ── 3. El resto del país no declara plazos que no podemos garantizar ───────
+
+test('3. se emiten dos entradas: Montevideo con tiempos y nacional sin tiempos', () => {
+  const xml = shippingTags({ price: 990 });
+  const bloques = xml.match(/<g:shipping>/g) || [];
+  assert.equal(bloques.length, 2, 'debe haber exactamente dos bloques de envío');
+  // Sólo el bloque de Montevideo declara tiempos.
+  assert.equal((xml.match(/<g:max_transit_time>/g) || []).length, 1);
+  assert.equal((xml.match(/<g:region>/g) || []).length, 1);
+});
+
+// ── 4. Integración real con el feed ────────────────────────────────────────
+
+test('4. renderFeedItem incluye los bloques de envío con el precio correcto', () => {
+  const xml = renderFeedItem(baseItem);
+  assert.match(xml, /<g:shipping>/);
+  assert.match(xml, new RegExp(`<g:price>${SHIPPING_COST} UYU</g:price>`));
+  assert.match(xml, new RegExp(`<g:region>${MONTEVIDEO_REGION}</g:region>`));
+});
+
+test('4b. un ítem caro declara envío gratis en el feed', () => {
+  const xml = renderFeedItem({ ...baseItem, price: FREE_SHIPPING_THRESHOLD + 100 });
+  assert.match(xml, /<g:price>0 UYU<\/g:price>/);
+});
+
+test('4c. el feed sigue emitiendo los atributos que ya tenía (sin regresión)', () => {
+  const xml = renderFeedItem(baseItem);
+  for (const tag of ['g:id', 'g:title', 'g:description', 'g:link', 'g:availability', 'g:condition']) {
+    assert.match(xml, new RegExp(`<${tag}>`), `falta ${tag}`);
+  }
+  // El precio del producto sigue intacto y no se confunde con el del envío.
+  assert.match(xml, /<g:price>990 UYU<\/g:price>/);
+});
+
+// ── 5. Idempotencia ────────────────────────────────────────────────────────
+
+test('5. shippingTags es puro: mismo ítem, misma salida', () => {
+  assert.equal(shippingTags({ price: 990 }), shippingTags({ price: 990 }));
+});

--- a/functions/_shared/merchant-delivery.js
+++ b/functions/_shared/merchant-delivery.js
@@ -1,0 +1,89 @@
+// functions/_shared/merchant-delivery.js
+//
+// MERCHANT-LOCAL-DELIVERY-1 — expone en el feed de Merchant Center la
+// capacidad de entrega que hoy es invisible para Google: entrega en el día
+// en Montevideo.
+//
+// Por qué importa: Amado Libros es una tienda en línea que entrega en el
+// mismo día en Montevideo. Ningún competidor grande del vertical
+// (marketplaces cross-border, tiendas regionales) puede igualar eso. Hasta
+// ahora el feed no emitía NINGÚN atributo de envío, así que Google no tenía
+// forma de saberlo y no podía mostrarlo en Shopping.
+//
+// Fuente única de verdad de los importes: functions/api/_orders_logic.js —
+// los mismos valores que cobra el checkout real. Nunca se declara acá un
+// precio de envío distinto del que el comprador va a pagar; un feed que
+// promete un envío más barato que el checkout es causa de desaprobación en
+// Merchant y, antes que eso, de una mala experiencia real.
+
+import { FREE_SHIPPING_THRESHOLD, SHIPPING_COST } from '../api/_orders_logic.js';
+
+export const SHIPPING_COUNTRY = 'UY';
+
+// La entrega en el día está confirmada para Montevideo. Para el resto del
+// país NO tenemos un plazo verificado, así que la entrada nacional se emite
+// sin tiempos de tránsito: declarar un plazo que no podemos garantizar es
+// peor que no declarar ninguno.
+export const MONTEVIDEO_REGION = 'Montevideo';
+export const MONTEVIDEO_SERVICE = 'Entrega en el día';
+
+/**
+ * Costo de envío que corresponde a ESTE ítem comprado solo.
+ *
+ * El umbral de envío gratis es por total de carrito, pero `g:shipping` es
+ * por producto: Google espera el costo aplicable a ese ítem. Se usa el
+ * mismo criterio por-ítem que ya muestra la ficha pública
+ * (`hasFreeShipping` en functions/libro/[[path]].js), para que feed, ficha
+ * y checkout digan exactamente lo mismo.
+ *
+ * @param {number} priceUyu precio del ítem en UYU
+ * @returns {number} costo de envío en UYU (0 si califica para envío gratis)
+ */
+export function itemShippingCostUyu(priceUyu) {
+    const price = Number(priceUyu);
+    if (!Number.isFinite(price) || price < 0) return SHIPPING_COST;
+    return price >= FREE_SHIPPING_THRESHOLD ? 0 : SHIPPING_COST;
+}
+
+function shippingBlock({ region, service, priceUyu, sameDay }) {
+    const timing = sameDay
+        ? `
+            <g:min_handling_time>0</g:min_handling_time>
+            <g:max_handling_time>0</g:max_handling_time>
+            <g:min_transit_time>0</g:min_transit_time>
+            <g:max_transit_time>0</g:max_transit_time>`
+        : '';
+    return `
+        <g:shipping>
+            <g:country>${SHIPPING_COUNTRY}</g:country>${region ? `
+            <g:region>${region}</g:region>` : ''}${service ? `
+            <g:service>${service}</g:service>` : ''}
+            <g:price>${priceUyu} UYU</g:price>${timing}
+        </g:shipping>`;
+}
+
+/**
+ * Devuelve los bloques `<g:shipping>` para un ítem.
+ *
+ * Emite dos entradas:
+ *  1. Montevideo, entrega en el día (handling 0, tránsito 0) — el
+ *     diferencial real del negocio.
+ *  2. Nacional, mismo precio, SIN tiempos declarados — porque no tenemos un
+ *     plazo verificado para el interior.
+ *
+ * Idempotente y puro: depende sólo del precio del ítem.
+ *
+ * @param {{price?: number|string}} item
+ */
+export function shippingTags(item) {
+    const priceUyu = itemShippingCostUyu(item?.price);
+    return [
+        shippingBlock({
+            region: MONTEVIDEO_REGION,
+            service: MONTEVIDEO_SERVICE,
+            priceUyu,
+            sameDay: true,
+        }),
+        shippingBlock({ region: '', service: '', priceUyu, sameDay: false }),
+    ].join('');
+}

--- a/functions/feed.xml.js
+++ b/functions/feed.xml.js
@@ -55,6 +55,9 @@
 
 import { slugify } from './_shared/slug.js';
 import { fetchCatalog } from './_shared/catalog.js';
+// MERCHANT-LOCAL-DELIVERY-1: entrega en el día en Montevideo, declarada con
+// los mismos importes que cobra el checkout real.
+import { shippingTags } from './_shared/merchant-delivery.js';
 
 const CANONICAL_BASE_URL = "https://www.amadolibros.com";
 const SITE_TITLE = "Amado Libros";
@@ -455,7 +458,7 @@ export function renderFeedItem(item) {
         ${imageLink ? `<g:image_link>${escapeXml(imageLink)}</g:image_link>` : ''}
         <g:availability>${availability}</g:availability>
         <g:price>${escapeXml(price)}</g:price>
-        <g:condition>${escapeXml(cond)}</g:condition>${gtinTag}${identifierExistsTag}
+        <g:condition>${escapeXml(cond)}</g:condition>${gtinTag}${identifierExistsTag}${shippingTags(item)}
     </item>`;
 }
 


### PR DESCRIPTION
## El problema

Amado Libros entrega **en el mismo día en Montevideo**. Ningún competidor grande del vertical (marketplaces cross-border, tiendas regionales) puede igualar ese plazo.

Hasta ahora el feed de Merchant Center emitía sólo estos atributos:

```
g:id  g:title  g:description  g:link  g:image_link
g:price  g:availability  g:condition  g:gtin  g:identifier_exists
```

**Ningún atributo de envío.** Google no tenía forma de saber el plazo de entrega y no podía mostrarlo en Shopping — el diferencial comercial más fuerte del negocio era invisible en el canal donde más pesa.

## Qué cambia

`functions/_shared/merchant-delivery.js` (nuevo) emite dos bloques `<g:shipping>` por ítem:

1. **Montevideo**, servicio `Entrega en el día`, con `min/max_handling_time` y `min/max_transit_time` en `0`.
2. **Nacional**, mismo precio, **sin tiempos declarados** — no tenemos un plazo verificado para el interior, y declarar uno que no podemos garantizar es peor que no declarar ninguno.

## Paridad con el checkout real

Los importes salen de `functions/api/_orders_logic.js` (`SHIPPING_COST = 250`, `FREE_SHIPPING_THRESHOLD = 1500`) — la misma fuente que cobra el checkout. No se declara acá ningún precio propio.

El umbral de envío gratis es **por carrito**, pero `g:shipping` es **por producto**. Se aplica el mismo criterio por-ítem que ya muestra la ficha pública (`hasFreeShipping` en `functions/libro/[[path]].js`), de modo que feed, ficha y checkout digan exactamente lo mismo. Un feed que promete un envío más barato que el checkout es causa de desaprobación en Merchant y, antes que eso, una promesa falsa al comprador.

Ante un precio inválido la función **falla del lado seguro**: cobra envío, nunca lo regala.

## Alcance y no-colisión

Deliberadamente acotado a `functions/feed.xml.js` y su módulo nuevo. **Ninguno de los PR abiertos toca ese archivo**, así que este frente no colisiona con el tren de integración en curso (#236, #240, #237, #235, #241). No cambia el sitio, ni precios, ni fichas, ni categorías.

## Fuera de alcance — próximo paso documentado

No incluidos acá, a propósito:

- **`g:google_product_category`** — hoy los **249 mazos** del universo tarot (de 527 ítems; 119 activos vendibles) se envían sin categoría propia y Google los infiere como libros. Están compitiendo en la vertical equivocada. El ID numérico exacto de la taxonomía de Google hay que confirmarlo contra el archivo vigente, no adivinarlo.
- **`g:product_type`** — taxonomía propia desde `active-categories.json`.
- **Atributos de pickup** (`pickup_method`, `pickup_sla`) — requieren confirmar si aplican sin un feed de inventario local configurado.

## Tests

`functions/__tests__/merchant-local-delivery.test.js` — 10 casos:
paridad de importes con el checkout, el umbral en ambos bordes (`1499` / `1500`), falla segura ante precio inválido (`undefined`, `null`, string, negativo), declaración de mismo día para Montevideo, ausencia de plazos en la entrada nacional, integración real con `renderFeedItem`, y ausencia de regresión en los atributos previos.

- Focalizados: **10/10**
- Regresión Merchant (`feed-gtin-and-coverage`, `merchant-readonly-audit`, `merchant-trust-pages`): **46/46**
- `scripts/validate-ci.sh` — suite completa **1273/1273**, builds Astro checkout OFF y ON: **OK**

## Antes de mergear

Esto toca **Merchant Center, que es producción comercial**. Draft a propósito — conviene revisar el XML resultante en el Preview antes de autorizar, y confirmar que el servicio "Entrega en el día" refleja la política que querés declararle a Google.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp2uS5z3ac9dPNHpSqdqv1)_