### PR TITLE
FICHAS-QUALITY-GUARD-1: eliminar copy automático vacío en fichas enriquecidas

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -92,6 +92,22 @@ jobs:
           SHOWCASE_CONCURRENCY: '5'
         run: node scripts/seo/showcase-live-audit.mjs
 
+      # FICHAS-QUALITY-GUARD-1: comprobación HTTP real contra el Preview.
+      # Los tests corren en memoria; esto mira lo que el servidor devuelve.
+      - name: Check generic author on ficha and feed
+        env:
+          FICHAS_CHECK_BASE_URL: ${{ steps.deploy.outputs.preview_url }}
+          FICHAS_CHECK_OUTPUT_DIR: artifacts/fichas-quality
+        run: node scripts/seo/fichas-generic-author-live-check.mjs
+
+      # Auditoría de la cohorte real de fichas enriquecidas. El runner sí
+      # alcanza R2, a diferencia del entorno de desarrollo.
+      - name: Audit fichas quality cohort
+        env:
+          FICHAS_AUDIT_OUTPUT_DIR: artifacts/fichas-quality
+          FICHAS_AUDIT_SAMPLE: '30'
+        run: node scripts/seo/fichas-quality-audit.mjs
+
       - name: Audit by-request hub link graph
         env:
           SEO_BASE_URL: ${{ steps.deploy.outputs.preview_url }}
@@ -99,6 +115,15 @@ jobs:
           SEO_OUTPUT_DIR: artifacts/seo-order-hub-preview
           SEO_CONCURRENCY: '8'
         run: node scripts/seo/order-hub-live-audit.mjs
+
+      - name: Upload fichas quality report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fichas-quality-pr-${{ github.event.pull_request.number }}
+          path: artifacts/fichas-quality/
+          if-no-files-found: warn
+          retention-days: 30
 
       - name: Upload Preview report
         if: always()

--- a/functions/__tests__/automatic-product-showcase.test.js
+++ b/functions/__tests__/automatic-product-showcase.test.js
@@ -180,11 +180,14 @@ test('sin descripción no inventa una sinopsis y lo declara con hechos', () => {
   assert.doesNotMatch(showcase.summary.join(' '), /presenta un recorrido sistemático/);
 });
 
-test('sin autor confiable no inventa biografía', () => {
+// FICHAS-QUALITY-GUARD-1: antes se emitía una sección "Sobre la autoría" con
+// un párrafo de disculpa. Ocupaba espacio comercial sin informar nada, así que
+// ahora la sección se omite por completo.
+test('sin autor confiable no inventa biografía ni emite sección de autoría', () => {
   const showcase = buildAutomaticProductShowcase(book({ author: 'Varios autores' }));
 
-  assert.equal(showcase.authorHeading, 'Sobre la autoría');
-  assert.match(showcase.authorBio, /No completamos ese dato por inferencia/);
+  assert.equal(showcase.authorHeading, null);
+  assert.equal(showcase.authorBio, null);
   assert.ok(!showcase.links.some(link => link.label.includes('Varios autores')));
 });
 
@@ -203,7 +206,9 @@ test('convierte una ficha activa en vidriera sin tocar precio, stock ni acciones
   assert.match(html, /class="product-showcase"/);
   assert.match(html, /¿De qué trata Manual de prueba clínica\?/);
   assert.match(html, /Datos destacados/);
-  assert.match(html, /¿Para quién puede ser útil\?/);
+  // FICHAS-QUALITY-GUARD-1: el bloque de audiencia sólo recombinaba autor y
+  // categoría, sin aportar ningún hecho verificable — ya no se emite.
+  assert.doesNotMatch(html, /¿Para quién puede ser útil\?/);
   assert.match(html, /Más sobre Ana Pérez/);
   assert.match(html, /Ficha de esta edición/);
   assert.match(html, /class="showcase-help"/);

--- a/functions/__tests__/fichas-quality-guard-integration.test.js
+++ b/functions/__tests__/fichas-quality-guard-integration.test.js
@@ -1,0 +1,188 @@
+// FICHAS-QUALITY-GUARD-1 — pruebas de INTEGRACIÓN sobre el HTML SSR completo
+// y el feed XML completo.
+//
+// Por qué existe este archivo aparte: la primera versión de esta corrección
+// sólo probó buildAutomaticProductShowcase() y dio un falso verde. El
+// generador del showcase estaba limpio, pero la página real seguía emitiendo
+// "Desconocido" en el JSON-LD, la tabla de datos, el mensaje de WhatsApp, los
+// relacionados y <g:description> del feed. Estas pruebas miran la salida
+// completa, que es lo que ve el cliente y lo que indexa Google.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { renderPage, selectRelatedBooks } from '../libro/[[path]].js';
+import { renderFeedItem, buildFeedDescription } from '../feed.xml.js';
+import { buildAutomaticProductShowcase } from '../_shared/automatic-product-showcase.js';
+import { buildBookWhatsAppMessage } from '../../shared/whatsapp-messages.js';
+
+// Patrón único que debe estar ausente de TODA superficie visible.
+const AUTOR_GENERICO_RE = /desconocid|unknown author|autor no especificado|sin especificar|varios autores|vv\.?\s*aa\.?/i;
+
+// Caso obligatorio de regresión, con los datos reales del producto.
+const MLU724888358 = Object.freeze({
+  id: 'MLU724888358',
+  title: 'La Biblia Palabra De Vida - Verbo Divino',
+  author: 'Desconocido',
+  isbn: '9788490739808',
+  publisher: 'Verbo Divino',
+  price: 1490,
+  currency: 'UYU',
+  status: 'active',
+  available_quantity: 3,
+  condition: 'new',
+  permalink: 'https://articulo.mercadolibre.com.uy/MLU-724888358',
+  thumbnail: 'https://http2.mlstatic.com/D_BIBLIA-I.jpg',
+  pictures: ['https://http2.mlstatic.com/D_BIBLIA-O.jpg'],
+  description: '',
+  bibliographic: {},
+});
+
+// Relacionados que arrastran «De Desconocido» en el título mostrado.
+const RELACIONADOS_GENERICOS = [
+  { id: 'MLU900000001', title: 'Biblia de bolsillo — De Desconocido', author: 'Desconocido', status: 'active', available_quantity: 2 },
+  { id: 'MLU900000002', title: 'Nuevo Testamento, de Desconocido', author: 'Desconocido', status: 'active', available_quantity: 1 },
+];
+
+const AUTOR_REAL = Object.freeze({
+  ...MLU724888358,
+  id: 'MLU111111111',
+  title: 'Cien años de soledad',
+  author: 'Gabriel García Márquez',
+  isbn: '9780307474728',
+  permalink: 'https://articulo.mercadolibre.com.uy/MLU-111111111',
+});
+
+// ── 1 y 2. Render SSR completo: HTML + JSON-LD + WhatsApp + relacionados ──
+
+test('1. el HTML SSR completo de MLU724888358 no contiene ninguna autoría genérica', () => {
+  // Pipeline real: selectRelatedBooks() decide qué relacionados existen. Con
+  // autoría genérica devuelve [], así que el bloque no se renderiza. Inyectar
+  // relacionados a mano saltearía esa lógica y probaría un escenario que en
+  // producción no ocurre.
+  const relacionados = selectRelatedBooks(RELACIONADOS_GENERICOS, MLU724888358, 4);
+  assert.equal(relacionados.length, 0, 'una autoría genérica no debe agrupar relacionados');
+
+  const html = renderPage(MLU724888358, 'la-biblia-palabra-de-vida-verbo-divino', false, '', '', relacionados);
+  assert.doesNotMatch(html, AUTOR_GENERICO_RE);
+});
+
+test('2. la ausencia se verifica superficie por superficie', () => {
+  const html = renderPage(MLU724888358, 'la-biblia-palabra-de-vida-verbo-divino', false, '', '',
+    selectRelatedBooks(RELACIONADOS_GENERICOS, MLU724888358, 4));
+
+  // JSON-LD: sin nodo author
+  const bloques = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+    .map(m => JSON.parse(m[1]));
+  const producto = bloques.find(s => [].concat(s['@type'] || []).includes('Book'));
+  assert.ok(producto, 'debe existir el JSON-LD del libro');
+  assert.equal('author' in producto, false, 'el JSON-LD no debe declarar author');
+  assert.doesNotMatch(JSON.stringify(producto), AUTOR_GENERICO_RE);
+
+  // Tabla de datos: sin fila Autor
+  assert.doesNotMatch(html, /<dt>Autor<\/dt>/);
+
+  // Relacionados: con autoría genérica el bloque no existe.
+  assert.doesNotMatch(html, /Otros libros de/);
+  assert.doesNotMatch(html, /class="related-books"/);
+  assert.doesNotMatch(html, /De Desconocido/i);
+});
+
+test('2b. el mensaje de WhatsApp omite la línea Autor cuando la autoría es genérica', () => {
+  for (const generico of ['Desconocido', 'Unknown', 'Varios autores', 'VV. AA.', 'N/A']) {
+    const msg = buildBookWhatsAppMessage({ title: 'La Biblia', author: generico, page: '/libro/MLU724888358' });
+    assert.doesNotMatch(msg, /Autor:/, `no debía haber línea Autor para ${generico}`);
+    assert.doesNotMatch(msg, AUTOR_GENERICO_RE);
+  }
+});
+
+// ── 3. Feed completo ──────────────────────────────────────────────────────
+
+test('3. el bloque de feed de MLU724888358 no contiene autoría genérica', () => {
+  const xml = renderFeedItem(MLU724888358);
+  assert.doesNotMatch(xml, AUTOR_GENERICO_RE);
+  assert.doesNotMatch(xml, /de Desconocido/i);
+});
+
+test('3b. el feed conserva GTIN, precio, disponibilidad, link e imagen', () => {
+  const xml = renderFeedItem(MLU724888358);
+  assert.match(xml, /<g:gtin>9788490739808<\/g:gtin>/);
+  assert.match(xml, /<g:price>1490 UYU<\/g:price>/);
+  assert.match(xml, /<g:availability>in stock<\/g:availability>/);
+  assert.match(xml, /<g:link>https:\/\/www\.amadolibros\.com\/libro\/MLU724888358\//);
+  assert.match(xml, /<g:image_link>/);
+  assert.match(xml, /<g:id>MLU724888358<\/g:id>/);
+});
+
+test('3c. buildFeedDescription omite «de <genérico>» pero conserva la editorial', () => {
+  const d = buildFeedDescription(MLU724888358);
+  assert.doesNotMatch(d, AUTOR_GENERICO_RE);
+  assert.match(d, /Verbo Divino/);
+  assert.match(d, /Ejemplar nuevo/);
+});
+
+// ── 4. Control: un autor real se conserva en todas las superficies ────────
+
+test('4. un autor real sigue apareciendo en HTML, JSON-LD, WhatsApp y feed', () => {
+  const html = renderPage(AUTOR_REAL, 'cien-anos-de-soledad', false, '', '', []);
+  assert.match(html, /Gabriel García Márquez/);
+  assert.match(html, /<dt>Autor<\/dt>/);
+
+  const bloques = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+    .map(m => JSON.parse(m[1]));
+  const producto = bloques.find(s => [].concat(s['@type'] || []).includes('Book'));
+  assert.equal(producto.author.name, 'Gabriel García Márquez');
+
+  const msg = buildBookWhatsAppMessage({ title: AUTOR_REAL.title, author: AUTOR_REAL.author, page: '/x' });
+  assert.match(msg, /Autor: Gabriel García Márquez/);
+
+  assert.match(buildFeedDescription(AUTOR_REAL), /de Gabriel García Márquez/);
+});
+
+test('4b. con autor real los relacionados conservan "Otros libros de"', () => {
+  const html = renderPage(AUTOR_REAL, 'cien-anos-de-soledad', false, '', '', [
+    { id: 'MLU900000003', title: 'El amor en los tiempos del cólera', author: 'Gabriel García Márquez', status: 'active', available_quantity: 1 },
+  ]);
+  assert.match(html, /Otros libros de/);
+  assert.doesNotMatch(html, /Libros relacionados/);
+});
+
+// ── 5. El feed sigue siendo XML válido ───────────────────────────────────
+
+test('5. el bloque del feed es XML bien formado y sin etiquetas rotas', () => {
+  const xml = renderFeedItem(MLU724888358);
+  assert.match(xml.trim(), /^<item>/);
+  assert.match(xml.trim(), /<\/item>$/);
+  // Cada etiqueta g: abierta se cierra.
+  const abiertas = [...xml.matchAll(/<(g:[a-z_]+)>/g)].map(m => m[1]);
+  for (const tag of new Set(abiertas)) {
+    const a = (xml.match(new RegExp(`<${tag}>`, 'g')) || []).length;
+    const c = (xml.match(new RegExp(`</${tag}>`, 'g')) || []).length;
+    assert.equal(a, c, `${tag}: ${a} aperturas vs ${c} cierres`);
+  }
+  assert.doesNotMatch(xml, /undefined|\[object Object\]|null<\//);
+});
+
+// ── Preservación exigida ─────────────────────────────────────────────────
+
+test('6. se preservan ISBN, precio, stock, imagen, slug/canonical, título y CTA', () => {
+  const html = renderPage(MLU724888358, 'la-biblia-palabra-de-vida-verbo-divino', false, '', '',
+    selectRelatedBooks(RELACIONADOS_GENERICOS, MLU724888358, 4));
+  assert.match(html, /9788490739808/);
+  assert.match(html, /1[.,]?490/);
+  assert.match(html, /La Biblia Palabra De Vida - Verbo Divino/);
+  assert.match(html, /la-biblia-palabra-de-vida-verbo-divino/);
+  assert.match(html, /<link rel="canonical"/);
+  // En producción la portada se sirve por el proxy propio, no por mlstatic.
+  assert.match(html, /\/book-cover\/MLU724888358\/cover\.jpg/);
+});
+
+// El CTA contextual (#240) lo genera la capa del showcase, no renderPage: se
+// verifica donde realmente se produce.
+test('6b. el CTA contextual de Biblias se preserva intacto', () => {
+  const s = buildAutomaticProductShowcase(MLU724888358, { classificationTags: ['biblia'] });
+  assert.equal(s.requestHelp.question, '¿Buscás otra Biblia o una edición específica?');
+  assert.equal(s.requestHelp.label, 'Contanos qué buscás');
+  assert.match(s.requestHelp.href, /^\/pedir-libro\?/);
+  assert.match(s.requestHelp.href, /libro=MLU724888358/);
+});

--- a/functions/__tests__/fichas-quality-guard.test.js
+++ b/functions/__tests__/fichas-quality-guard.test.js
@@ -1,0 +1,208 @@
+// FICHAS-QUALITY-GUARD-1 — el generador automático de las fichas enriquecidas
+// no debe producir copy vacío, relleno ni autoría inventada.
+//
+// Causa raíz corregida: 'Desconocido' y 'Unknown' NO estaban en GENERIC_AUTHORS,
+// así que pasaban como autoría real y generaban "Más sobre Desconocido",
+// "Ver otros libros de Desconocido" y "lectores de Desconocido".
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isGenericAuthor } from '../_shared/showcase-ranking.js';
+import { buildAutomaticProductShowcase } from '../_shared/automatic-product-showcase.js';
+
+const GENERICOS = [
+  'Desconocido', 'desconocido', 'DESCONOCIDO', '  Desconocido  ',
+  'Unknown', 'unknown', 'Unknown Author',
+  'Sin autor', 'sin autor',
+  'Autor no especificado', 'Autor desconocido', 'Autoría desconocida',
+  'No aplica', 'N/A', 'n/a', 'NA', 'S/A', 'S/D',
+  'Varios', 'Varios autores',
+  'VV. AA.', 'VV AA', 'VVAA', 'AA. VV.', 'AAVV',
+  'No especificado', 'Sin especificar', 'Sin datos',
+  'Anónimo', 'anonimo',
+];
+
+// Ficha real de la cohorte, usada como caso obligatorio de regresión.
+const MLU724888358 = Object.freeze({
+  id: 'MLU724888358',
+  title: 'La Biblia Palabra de Vida — Verbo Divino',
+  author: 'Desconocido',
+  isbn: '9788490739808',
+  publisher: 'Verbo Divino',
+  price: 1490,
+  available_quantity: 3,
+  status: 'active',
+  pictures: ['https://http2.mlstatic.com/D_BIBLIA-O.jpg'],
+  thumbnail: 'https://http2.mlstatic.com/D_BIBLIA-I.jpg',
+  description: '',
+  bibliographic: {},
+});
+
+const AUTOR_REAL = Object.freeze({
+  id: 'MLU111111111',
+  title: 'Cien años de soledad',
+  author: 'Gabriel García Márquez',
+  isbn: '9780307474728',
+  publisher: 'Vintage',
+  pages: 417,
+  description: 'La historia de la familia Buendía a lo largo de siete generaciones en el pueblo de Macondo, fundado por José Arcadio Buendía. Una obra central del realismo mágico latinoamericano que recorre guerras, amores y la soledad como herencia familiar.',
+  bibliographic: { genre: 'Novela', language: 'Español', format: 'Tapa blanda' },
+});
+
+const SIN_DATOS = Object.freeze({
+  id: 'MLU222222222',
+  title: 'Cuaderno de trabajo',
+  author: 'Varios autores',
+  isbn: null,
+  publisher: null,
+  description: '',
+  bibliographic: {},
+});
+
+const texto = showcase => JSON.stringify(showcase);
+
+// ── 1. Todos los autores genéricos se convierten en ausencia de autor ──────
+
+test('1. cada variante de autoría genérica se reconoce como ausencia de autor', () => {
+  for (const valor of GENERICOS) {
+    assert.equal(isGenericAuthor(valor), true, `debía ser genérico: ${JSON.stringify(valor)}`);
+  }
+  assert.equal(isGenericAuthor(''), true);
+  assert.equal(isGenericAuthor(null), true);
+  assert.equal(isGenericAuthor(undefined), true);
+});
+
+test('1b. un autor real NO se marca como genérico', () => {
+  for (const valor of ['Gabriel García Márquez', 'Meg Meeker', 'Martín Nieto', 'Anne Rice']) {
+    assert.equal(isGenericAuthor(valor), false, `no debía ser genérico: ${valor}`);
+  }
+});
+
+// ── 2. Ningún autor genérico genera copy, subtítulo ni enlace interno ──────
+
+test('2. una autoría genérica no produce copy, encabezado, subtítulo ni enlace de autor', () => {
+  for (const valor of GENERICOS) {
+    const s = buildAutomaticProductShowcase({ ...MLU724888358, author: valor });
+    assert.equal(s.authorBio, null, `authorBio debía omitirse para ${valor}`);
+    assert.equal(s.authorHeading, null, `authorHeading debía omitirse para ${valor}`);
+    assert.equal(s.subtitle, null, `subtitle no debe repetir la autoría genérica ${valor}`);
+    for (const link of s.links) {
+      assert.doesNotMatch(link.label, /Ver otros libros de/i, `enlace de autor para ${valor}`);
+      assert.doesNotMatch(link.href, /q=.*desconocid/i);
+    }
+    assert.doesNotMatch(texto(s), new RegExp(`Más sobre ${valor}`, 'i'));
+  }
+});
+
+test('2b. no se sustituye la autoría ausente por una inventada', () => {
+  const s = buildAutomaticProductShowcase(MLU724888358);
+  assert.doesNotMatch(texto(s), /Equipo editorial|Varios autores|Autor an[óo]nimo/i);
+});
+
+// ── 3. Un autor real sigue funcionando ────────────────────────────────────
+
+test('3. un autor real conserva encabezado, copy y enlace interno', () => {
+  const s = buildAutomaticProductShowcase(AUTOR_REAL);
+  assert.equal(s.authorHeading, 'Más sobre Gabriel García Márquez');
+  assert.match(s.authorBio, /Gabriel García Márquez/);
+  assert.ok(s.links.some(l => l.label === 'Ver otros libros de Gabriel García Márquez'));
+});
+
+// ── 4. Una ficha sin información suficiente omite las secciones débiles ───
+
+test('4. sin datos de edición no se rellenan "Datos destacados" con frases genéricas', () => {
+  const s = buildAutomaticProductShowcase(SIN_DATOS);
+  assert.doesNotMatch(texto(s), /Disponible para compra inmediata/i);
+  assert.doesNotMatch(texto(s), /La ficha reúne los datos aportados por la publicación/i);
+  assert.doesNotMatch(texto(s), /Información comercial verificada al momento/i);
+  assert.doesNotMatch(texto(s), /Podés consultar cualquier dato de edición antes de comprar\./i);
+});
+
+test('4b. el bloque de audiencia (sólo autor + categoría) se omite siempre en la ficha automática', () => {
+  for (const item of [MLU724888358, AUTOR_REAL, SIN_DATOS]) {
+    const s = buildAutomaticProductShowcase(item);
+    assert.equal(s.audience, null, `audience debía omitirse para ${item.id}`);
+  }
+  const s = buildAutomaticProductShowcase(AUTOR_REAL);
+  assert.doesNotMatch(texto(s), /Puede interesar a lectores de/i);
+  assert.doesNotMatch(texto(s), /Pensado para lectores de/i);
+});
+
+// ── 5. MLU724888358 queda limpia ──────────────────────────────────────────
+
+test('5. MLU724888358 no muestra "Desconocido" en ninguna forma', () => {
+  const s = buildAutomaticProductShowcase(MLU724888358);
+  const t = texto(s);
+  assert.doesNotMatch(t, /Desconocido/i, 'ninguna aparición de "Desconocido"');
+  assert.doesNotMatch(t, /Más sobre Desconocido/i);
+  assert.doesNotMatch(t, /Ver otros libros de Desconocido/i);
+  assert.doesNotMatch(t, /lectores de Desconocido/i);
+  // Tampoco debe quedar una fila "Autoría" en los datos de la edición.
+  assert.equal(s.editionFacts.some(f => f.label === 'Autoría'), false);
+});
+
+test('5b. MLU724888358 conserva los datos concretos que sí tiene', () => {
+  const s = buildAutomaticProductShowcase(MLU724888358);
+  assert.ok(s.editionFacts.some(f => f.label === 'ISBN' && f.value === '9788490739808'));
+  assert.ok(s.editionFacts.some(f => f.label === 'Editorial' && f.value === 'Verbo Divino'));
+  assert.equal(s.h1, 'La Biblia Palabra de Vida — Verbo Divino');
+  assert.equal(s.verifiedLabel, 'Edición identificada por ISBN');
+});
+
+// ── 6. No cambian ISBN, slug, canonical, precio, stock ni imágenes ────────
+
+test('6. el generador no toca ISBN, precio, stock, imágenes ni el id del producto', () => {
+  const original = JSON.parse(JSON.stringify(MLU724888358));
+  buildAutomaticProductShowcase(MLU724888358);
+  assert.deepEqual(JSON.parse(JSON.stringify(MLU724888358)), original, 'el item no debe mutarse');
+});
+
+test('6b. el showcase no emite slug ni canonical: no puede alterarlos', () => {
+  const s = buildAutomaticProductShowcase(MLU724888358);
+  assert.equal('slug' in s, false);
+  assert.equal('canonical' in s, false);
+  assert.equal('price' in s, false);
+  assert.equal('available_quantity' in s, false);
+});
+
+// ── 7. Las fichas con descripción real no pierden contenido válido ────────
+
+test('7. una descripción real se conserva íntegra como resumen', () => {
+  const s = buildAutomaticProductShowcase(AUTOR_REAL);
+  assert.ok(s.summary.length >= 1);
+  assert.match(s.summary.join(' '), /Macondo/);
+  assert.match(s.summary.join(' '), /realismo mágico/);
+  assert.equal(s.introHeading, '¿De qué trata Cien años de soledad?');
+});
+
+test('7b. con descripción real los datos destacados siguen presentes', () => {
+  const s = buildAutomaticProductShowcase(AUTOR_REAL);
+  assert.ok(s.highlights.length >= 3, 'un libro con datos completos conserva sus destacados');
+  assert.ok(s.highlights.some(h => /417 páginas/.test(h)));
+});
+
+// ── 8. No aparecen frases automáticas de relleno ──────────────────────────
+
+const FRASES_DE_RELLENO = [
+  /Disponible para compra inmediata en Amado Libros/i,
+  /La ficha reúne los datos aportados por la publicación/i,
+  /Información comercial verificada al momento de la consulta/i,
+  /Puede interesar a lectores de/i,
+  /Puede interesar a quienes buscan lecturas de/i,
+  /Pensado para lectores de/i,
+  /Para quienes buscan esta obra y necesitan comprobar/i,
+  /La publicación no aporta una autoría suficientemente clara/i,
+];
+
+test('8. ninguna frase de relleno aparece en la muestra auditada', () => {
+  const muestra = [MLU724888358, AUTOR_REAL, SIN_DATOS,
+    { ...MLU724888358, author: 'VV. AA.' },
+    { ...SIN_DATOS, author: 'Unknown', bibliographic: { genre: 'Religión' } },
+  ];
+  for (const item of muestra) {
+    const t = texto(buildAutomaticProductShowcase(item));
+    for (const frase of FRASES_DE_RELLENO) {
+      assert.doesNotMatch(t, frase, `frase de relleno en ${item.id}: ${frase}`);
+    }
+  }
+});

--- a/functions/__tests__/fichas-quality-guard.test.js
+++ b/functions/__tests__/fichas-quality-guard.test.js
@@ -206,3 +206,25 @@ test('8. ninguna frase de relleno aparece en la muestra auditada', () => {
     }
   }
 });
+
+// ── 9. El audit debe leer el formato REAL de la cohorte ───────────────────
+// Bug detectado en CI: fichas-quality-audit.mjs asumía `cohorte.items` y la
+// cohorte publica `ids`. Falló con "ninguna ficha analizable". Este test fija
+// el contrato para que el script no vuelva a desincronizarse del formato.
+
+test('9. la cohorte publica `ids` (no `items`) y normalizeShowcaseCohort la acepta', async () => {
+  const { normalizeShowcaseCohort } = await import('../_shared/showcase-cohort.js');
+  const payload = {
+    schema_version: 2,
+    total: 2,
+    ids: ['MLU724888358', 'MLU111111111'],
+    generated_at: '2026-08-24T00:00:00Z',
+  };
+  const normalizada = normalizeShowcaseCohort(payload);
+  assert.ok(normalizada, 'el formato real de la cohorte debe normalizar');
+  assert.equal(normalizada.total, 2);
+  assert.ok(normalizada.ids.has('MLU724888358'));
+  // Un payload con `items` en vez de `ids` NO es válido: es exactamente el
+  // formato que el script asumía por error.
+  assert.equal(normalizeShowcaseCohort({ schema_version: 2, total: 2, items: payload.ids }), null);
+});

--- a/functions/_shared/automatic-product-showcase.js
+++ b/functions/_shared/automatic-product-showcase.js
@@ -197,46 +197,33 @@ function buildHighlights(item, facts) {
       highlights.push(candidate);
     }
   }
-  while (highlights.length < 3) {
-    const fallback = [
-      'Disponible para compra inmediata en Amado Libros.',
-      'La ficha reúne los datos aportados por la publicación.',
-      'Podés consultar cualquier dato de edición antes de comprar.',
-    ][highlights.length] || 'Información comercial verificada al momento de la consulta.';
-    highlights.push(fallback);
-  }
+  // FICHAS-QUALITY-GUARD-1: antes se rellenaba hasta un mínimo de 3 con frases
+  // genéricas ("Disponible para compra inmediata…") que no son datos de la
+  // edición. Ese relleno se elimina: se devuelve sólo lo que la publicación
+  // realmente aporta, aunque sean menos de tres puntos o ninguno. Una lista
+  // vacía hace que la sección entera se omita.
   return highlights.slice(0, 5);
 }
 
-function audienceCopy(item) {
-  const bibliography = item?.bibliographic && typeof item.bibliographic === 'object'
-    ? item.bibliographic
-    : {};
-  const genre = clean(bibliography.genre);
-  const author = !isGenericAuthor(item?.author) ? clean(item.author) : null;
-  if (genre && author) {
-    return `Puede interesar a lectores de ${author} y a quienes buscan obras registradas dentro de ${genre}. La ficha permite verificar la edición concreta antes de comprar.`;
-  }
-  if (genre) {
-    return `Puede interesar a quienes buscan lecturas de ${genre}. La ficha reúne los datos disponibles para comprobar que se trata de la edición correcta.`;
-  }
-  if (author) {
-    return `Pensado para lectores de ${author} y para quienes buscan esta obra o una edición específica. Revisá ISBN, editorial y formato antes de confirmar la compra.`;
-  }
-  return 'Para quienes buscan esta obra y necesitan comprobar edición, ISBN, editorial, formato o condición antes de comprar.';
+// FICHAS-QUALITY-GUARD-1: el bloque de audiencia sólo puede construirse
+// recombinando autor y categoría — no aporta ningún hecho verificable sobre la
+// edición. Devolver null hace que la sección se omita por completo en la ficha
+// automática. Las fichas curadas a mano (functions/_shared/product-showcases.js)
+// siguen pudiendo declarar su propio `audience` real, que sí se renderiza.
+function audienceCopy() {
+  return null;
 }
 
+// FICHAS-QUALITY-GUARD-1: sin autoría verificable no hay nada honesto que
+// contar sobre el autor. Antes se emitía una sección con el nombre repetido
+// ("Más sobre Desconocido") o un párrafo de disculpa; ambas ocupaban espacio
+// comercial sin informar. Ahora la sección simplemente no existe.
 function authorCopy(item) {
   const author = !isGenericAuthor(item?.author) ? clean(item.author) : null;
-  if (author) {
-    return {
-      heading: `Más sobre ${author}`,
-      copy: `La autoría de esta publicación figura como ${author}. Desde esta ficha podés consultar otros títulos disponibles de la misma autoría y comparar ediciones en el catálogo de Amado Libros.`,
-    };
-  }
+  if (!author) return null;
   return {
-    heading: 'Sobre la autoría',
-    copy: 'La publicación no aporta una autoría suficientemente clara. No completamos ese dato por inferencia: podés consultarnos para verificarlo antes de comprar.',
+    heading: `Más sobre ${author}`,
+    copy: `La autoría de esta publicación figura como ${author}. Desde esta ficha podés consultar otros títulos disponibles de la misma autoría y comparar ediciones en el catálogo de Amado Libros.`,
   };
 }
 
@@ -444,11 +431,16 @@ export function buildAutomaticProductShowcase(item, { classificationTags = [] } 
       : `Sobre ${clean(item.title)}`,
     summary,
     highlightsHeading: 'Datos destacados',
+    // FICHAS-QUALITY-GUARD-1: sin datos reales de la edición, `highlights`
+    // queda vacío y el render omite la tarjeta en vez de rellenarla.
     highlights: buildHighlights(item, facts),
     audienceHeading: '¿Para quién puede ser útil?',
     audience: audienceCopy(item),
-    authorHeading: author.heading,
-    authorBio: author.copy,
+    // FICHAS-QUALITY-GUARD-1: `author` es null cuando la autoría es genérica o
+    // ausente; en ese caso no se emite encabezado ni copy y la tarjeta “Sobre
+    // la autoría” desaparece por completo.
+    authorHeading: author?.heading ?? null,
+    authorBio: author?.copy ?? null,
     editionHeading: 'Ficha de esta edición',
     verifiedLabel: normalizeValidIsbn(item.isbn)
       ? 'Edición identificada por ISBN'

--- a/functions/_shared/generic-author.js
+++ b/functions/_shared/generic-author.js
@@ -1,0 +1,116 @@
+// functions/_shared/generic-author.js
+//
+// FICHAS-QUALITY-GUARD-1 — fuente única de verdad sobre qué valores de
+// "autor" NO son una autoría, sino la ausencia de autoría escrita de
+// distintas maneras por el origen de datos ('Desconocido', 'Unknown',
+// 'Varios autores', 'N/A'…).
+//
+// Por qué vive acá y no en showcase-ranking.js: la autoría se muestra en
+// varias superficies independientes — el JSON-LD de la ficha, la tabla de
+// datos, el mensaje de WhatsApp, el bloque de relacionados y la descripción
+// del feed de Merchant. Cada una tenía su propio criterio (o ninguno), así
+// que "Desconocido" desaparecía de una y seguía apareciendo en las otras.
+// Con un único módulo compartido, arreglar la lista arregla todas a la vez.
+//
+// REGLA: un valor genérico se OMITE. Nunca se sustituye por "Varios
+// autores", "Equipo editorial" ni ninguna otra autoría inventada. El dato
+// queda ausente hasta que exista una fuente verificable.
+
+const GENERIC_AUTHORS = new Set([
+  'anónimo',
+  'anonimo',
+  'autor',
+  'autores',
+  'autor desconocido',
+  'autor no especificado',
+  'autoria desconocida',
+  'autoría desconocida',
+  'desconocida',
+  'desconocido',
+  'no aplica',
+  'no especificado',
+  'no especificada',
+  'n/a',
+  'na',
+  's/a',
+  's/d',
+  'sin autor',
+  'sin datos',
+  'sin especificar',
+  'unknown',
+  'unknown author',
+  'varios',
+  'varios autores',
+  'vv aa',
+  'vv. aa.',
+  'vvaa',
+  'aa vv',
+  'aa. vv.',
+  'aavv',
+]);
+
+function normalizeAuthorKey(value) {
+  return String(value ?? '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLocaleLowerCase('es');
+}
+
+/**
+ * true cuando el valor no identifica a una persona u organización real:
+ * vacío, nulo, o una de las formas conocidas de "no sabemos quién es".
+ * @param {unknown} value
+ */
+export function isGenericAuthor(value) {
+  const key = normalizeAuthorKey(value);
+  if (!key) return true;
+  if (GENERIC_AUTHORS.has(key)) return true;
+  // Variantes acentuadas normalizadas ('anónimo' -> 'anonimo') y con puntos
+  // sueltos ('vv.aa.') caen acá sin necesidad de enumerarlas todas.
+  return GENERIC_AUTHORS.has(key.replace(/[.\s]/g, ''));
+}
+
+/**
+ * Devuelve la autoría real ya limpia, o null si es genérica/ausente.
+ * Usar esto en vez de `item.author` en cualquier superficie visible.
+ * @param {unknown} value
+ */
+export function realAuthor(value) {
+  if (isGenericAuthor(value)) return null;
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+
+// Fragmentos explícitos "De <autor genérico>" que algunos títulos mostrados
+// y textos alt arrastran desde el origen. Se limpian SÓLO en el texto
+// visible; el título comercial original nunca se modifica.
+const GENERIC_AUTHOR_ALTERNATION = [...GENERIC_AUTHORS]
+  .sort((a, b) => b.length - a.length)
+  .map(value => value.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&').replace(/\s+/g, '\\s+'))
+  .join('|');
+
+const DE_GENERIC_AUTHOR_RE = new RegExp(
+  `[,\\u2014\\-–—]?\\s*\\bde\\s+(?:${GENERIC_AUTHOR_ALTERNATION})\\b\\.?`,
+  'giu',
+);
+
+/**
+ * Quita fragmentos como «De Desconocido» / «, de Varios autores» de un texto
+ * visible (título mostrado en una tarjeta, atributo alt). No toca el título
+ * comercial almacenado: se aplica sólo al string que se va a pintar.
+ *
+ * Es conservador a propósito: sólo elimina la construcción "de <genérico>",
+ * nunca palabras sueltas, para no mutilar títulos legítimos.
+ * @param {unknown} value
+ */
+export function stripGenericAuthorMention(value) {
+  const text = String(value ?? '');
+  if (!text) return text;
+  return text
+    .replace(DE_GENERIC_AUTHOR_RE, '')
+    .replace(/\s{2,}/g, ' ')
+    .replace(/\s+([,.;:])/g, '$1')
+    .replace(/[\s,—\-–—]+$/u, '')
+    .trim();
+}

--- a/functions/_shared/showcase-ranking.js
+++ b/functions/_shared/showcase-ranking.js
@@ -6,20 +6,43 @@ import { deriveBookDisplayTitle } from './book-display-title.js';
 export const LEGACY_SHOWCASE_LIMIT = 1000;
 export const DEFAULT_SHOWCASE_LIMIT = 3000;
 
+// FICHAS-QUALITY-GUARD-1: un valor de esta lista NO es una autoría — es la
+// ausencia de autoría escrita de distintas maneras por el origen de datos.
+// Tratarlos como autor real producía copy sin sentido comercial en las fichas
+// enriquecidas ("Más sobre Desconocido", "Ver otros libros de Desconocido").
+// Nunca se sustituyen por una autoría inventada: el dato queda omitido hasta
+// que exista una fuente verificable.
 const GENERIC_AUTHORS = new Set([
   'anónimo',
   'anonimo',
   'autor',
   'autores',
+  'autor desconocido',
   'autor no especificado',
+  'autoria desconocida',
+  'autoría desconocida',
+  'desconocida',
+  'desconocido',
   'no aplica',
+  'no especificado',
+  'no especificada',
   'n/a',
+  'na',
   's/a',
+  's/d',
   'sin autor',
+  'sin datos',
+  'sin especificar',
+  'unknown',
+  'unknown author',
   'varios',
   'varios autores',
   'vv aa',
   'vv. aa.',
+  'vvaa',
+  'aa vv',
+  'aa. vv.',
+  'aavv',
 ]);
 
 const PLACEHOLDER_PUBLISHERS = new Set([

--- a/functions/_shared/showcase-ranking.js
+++ b/functions/_shared/showcase-ranking.js
@@ -3,47 +3,17 @@
 
 import { deriveBookDisplayTitle } from './book-display-title.js';
 
+// FICHAS-QUALITY-GUARD-1: qué valores NO son una autoría se define en un solo
+// lugar. Antes esta lista vivía duplicada aquí, en functions/libro/[[path]].js
+// y en ningún lado para el feed y WhatsApp; las copias divergieron y por eso
+// 'Desconocido' llegó a producción. Se re-exporta para no romper a quienes ya
+// importaban isGenericAuthor desde este módulo.
+export { isGenericAuthor } from './generic-author.js';
+import { isGenericAuthor } from './generic-author.js';
+
 export const LEGACY_SHOWCASE_LIMIT = 1000;
 export const DEFAULT_SHOWCASE_LIMIT = 3000;
 
-// FICHAS-QUALITY-GUARD-1: un valor de esta lista NO es una autoría — es la
-// ausencia de autoría escrita de distintas maneras por el origen de datos.
-// Tratarlos como autor real producía copy sin sentido comercial en las fichas
-// enriquecidas ("Más sobre Desconocido", "Ver otros libros de Desconocido").
-// Nunca se sustituyen por una autoría inventada: el dato queda omitido hasta
-// que exista una fuente verificable.
-const GENERIC_AUTHORS = new Set([
-  'anónimo',
-  'anonimo',
-  'autor',
-  'autores',
-  'autor desconocido',
-  'autor no especificado',
-  'autoria desconocida',
-  'autoría desconocida',
-  'desconocida',
-  'desconocido',
-  'no aplica',
-  'no especificado',
-  'no especificada',
-  'n/a',
-  'na',
-  's/a',
-  's/d',
-  'sin autor',
-  'sin datos',
-  'sin especificar',
-  'unknown',
-  'unknown author',
-  'varios',
-  'varios autores',
-  'vv aa',
-  'vv. aa.',
-  'vvaa',
-  'aa vv',
-  'aa. vv.',
-  'aavv',
-]);
 
 const PLACEHOLDER_PUBLISHERS = new Set([
   'amado libros',
@@ -97,10 +67,6 @@ export function normalizeValidIsbn(value) {
   return `${base}${(10 - (sum % 10)) % 10}`;
 }
 
-export function isGenericAuthor(value) {
-  const key = normalizedText(value);
-  return !key || GENERIC_AUTHORS.has(key);
-}
 
 function realPublisher(value) {
   const key = normalizedText(value);

--- a/functions/feed.xml.js
+++ b/functions/feed.xml.js
@@ -55,6 +55,8 @@
 
 import { slugify } from './_shared/slug.js';
 import { fetchCatalog } from './_shared/catalog.js';
+// FICHAS-QUALITY-GUARD-1: misma definición de autoría genérica que la ficha.
+import { realAuthor } from './_shared/generic-author.js';
 
 const CANONICAL_BASE_URL = "https://www.amadolibros.com";
 const SITE_TITLE = "Amado Libros";
@@ -334,7 +336,9 @@ export function buildFeedDescription(item) {
     }
 
     const parts = [title ? `Libro "${title}"` : 'Libro'];
-    if (item.author) parts.push(`de ${item.author}`);
+    // FICHAS-QUALITY-GUARD-1: nunca 'de Desconocido' en g:description.
+    const feedAuthor = realAuthor(item.author);
+    if (feedAuthor) parts.push(`de ${feedAuthor}`);
     const publisher = normalizePublisherForDescription(item.publisher);
     if (publisher) parts.push(`publicado por ${publisher}`);
 

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -14,6 +14,8 @@
  */
 
 import { slugify } from '../_shared/slug.js';
+// FICHAS-QUALITY-GUARD-1: fuente única sobre autoría genérica/ausente.
+import { isGenericAuthor, realAuthor, stripGenericAuthorMention } from '../_shared/generic-author.js';
 import { BASE, fetchCatalog, fetchPausedItem } from '../_shared/catalog.js';
 import { previewCoverUrl as resolvePreviewCoverUrl } from '../_shared/preview-cover.js';
 import { authorPathForName } from '../_shared/seo-authors.js';
@@ -256,21 +258,9 @@ ${displayImages.map((image, i) => `    <button type="button" class="thumb-btn" d
 })();<\/script>`;
 }
 
-const GENERIC_AUTHOR_KEYS = new Set([
-    'anónimo',
-    'anonimo',
-    'autor',
-    'autores',
-    'autor no especificado',
-    'no aplica',
-    'n/a',
-    's/a',
-    'sin autor',
-    'varios',
-    'varios autores',
-    'vv aa',
-    'vv. aa.',
-]);
+// FICHAS-QUALITY-GUARD-1: la lista local de autores genéricos se eliminó.
+// Ahora se usa isGenericAuthor() de _shared/generic-author.js — una sola lista
+// para ficha, relacionados, WhatsApp, JSON-LD y feed.
 
 function authorKey(author) {
     return String(author || '').trim().toLocaleLowerCase('es').replace(/\s+/g, ' ');
@@ -286,7 +276,7 @@ export function selectRelatedBooks(catalogItems, item, limit = 4) {
 
     const currentAuthor = authorKey(item.author);
     const requestedLimit = Math.min(4, Math.max(0, Number(limit) || 0));
-    if (!currentAuthor || GENERIC_AUTHOR_KEYS.has(currentAuthor) || requestedLimit === 0) return [];
+    if (!currentAuthor || isGenericAuthor(currentAuthor) || requestedLimit === 0) return [];
 
     const seen = new Set([String(item.id || '')]);
     const related = [];
@@ -295,6 +285,7 @@ export function selectRelatedBooks(catalogItems, item, limit = 4) {
         if (!candidateId || seen.has(candidateId)) continue;
         if (!candidate?.title || candidate.status !== 'active') continue;
         if ((Number(candidate.available_quantity) || 0) <= 0) continue;
+        if (isGenericAuthor(candidate.author)) continue;
         if (authorKey(candidate.author) !== currentAuthor) continue;
 
         seen.add(candidateId);
@@ -308,7 +299,10 @@ function renderRelatedBooks(relatedBooks, author, useCloudflareImages = true) {
     if (!Array.isArray(relatedBooks) || relatedBooks.length === 0) return '';
 
     const cards = relatedBooks.map((book) => {
-        const title = escapeHtml(book.title);
+        // FICHAS-QUALITY-GUARD-1: se limpia sólo el fragmento explícito
+        // «de <autor genérico>» del texto VISIBLE (título de tarjeta y alt).
+        // El título comercial almacenado no se modifica.
+        const title = escapeHtml(stripGenericAuthorMention(book.title) || book.title);
         const href = `/libro/${encodeURIComponent(book.id)}/${slugify(book.title)}`;
         const source = useCloudflareImages
             ? bookCoverUrl(book.id)
@@ -329,10 +323,15 @@ function renderRelatedBooks(relatedBooks, author, useCloudflareImages = true) {
     </li>`;
     }).join('\n');
 
-    const authorPath = authorPathForName(author);
-    const heading = authorPath
-        ? `Otros libros de <a href="${escapeHtml(authorPath)}">${escapeHtml(author)}</a>`
-        : `Otros libros de ${escapeHtml(author)}`;
+    // FICHAS-QUALITY-GUARD-1: sin autoría real no se puede decir "Otros libros
+    // de X". El bloque conserva su valor de navegación con un heading neutro.
+    const realName = realAuthor(author);
+    const authorPath = realName ? authorPathForName(realName) : null;
+    const heading = !realName
+        ? 'Libros relacionados'
+        : authorPath
+            ? `Otros libros de <a href="${escapeHtml(authorPath)}">${escapeHtml(realName)}</a>`
+            : `Otros libros de ${escapeHtml(realName)}`;
     return `<section class="related-books" aria-labelledby="related-books-title">
     <h2 id="related-books-title">${heading}</h2>
     <ul class="related-books-grid">${cards}</ul>
@@ -379,7 +378,12 @@ function notFound() {
 export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverSrc = '', relatedBooks = []) {
     const canonicalUrl = `${BASE}/libro/${item.id}/${slug}`;
     const safeTitle    = escapeHtml(item.title);
-    const safeAuthor   = item.author ? escapeHtml(item.author) : null;
+    // FICHAS-QUALITY-GUARD-1: 'Desconocido', 'Unknown', 'Varios autores'… no
+    // son autoría. displayAuthor queda null y TODA superficie que dependa de
+    // él (fila Autor, JSON-LD, WhatsApp, relacionados, meta description) omite
+    // el dato en vez de imprimir un nombre falso. Nunca se sustituye.
+    const displayAuthor = realAuthor(item.author);
+    const safeAuthor   = displayAuthor ? escapeHtml(displayAuthor) : null;
     const seoOverride  = PRODUCT_SEO_OVERRIDES[item.id] || null;
     const documentTitle = escapeHtml(seoOverride?.title || item.title);
     const indexWhenPaused = seoOverride?.indexWhenPaused === true ||
@@ -421,13 +425,13 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
         : '';
     const waMessage = buildBookWhatsAppMessage({
         title: item.title,
-        author: item.author,
+        author: displayAuthor,
         page: canonicalUrl,
         available: inStock,
         unsupportedCurrency: inStock && !checkoutCurrencySupported,
     });
     const waLink = whatsappHref(waMessage);
-    const relatedBooksHtml = renderRelatedBooks(relatedBooks, item.author, !isPreview);
+    const relatedBooksHtml = renderRelatedBooks(relatedBooks, displayAuthor, !isPreview);
     const viewItemAnalytics = {
         dedupeKey: `view_item_${item.id}`,
         ...(sellableInCheckout ? { value: price } : {}),
@@ -440,7 +444,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     };
 
     const detailRows = [
-        safeAuthor ? detailRow('Autor', item.author) : '',
+        displayAuthor ? detailRow('Autor', displayAuthor) : '',
         detailRow('ISBN', item.isbn),
         detailRow('Editorial', normalizePublisher(item.publisher)),
         item.pages ? detailRow('Páginas', `${item.pages}`) : '',
@@ -499,7 +503,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
         '@type':    ['Product', 'Book'],
         'name':     item.title,
         'image':    images.length ? images : img,
-        'description': description || (item.author ? `${item.title} — ${item.author}` : item.title),
+        'description': description || (displayAuthor ? `${item.title} — ${displayAuthor}` : item.title),
         'sku':      item.id,
     };
     if (sellableInCheckout) {
@@ -526,8 +530,10 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
             },
         };
     }
-    if (item.author) {
-        schemaProduct.author = { '@type': 'Person', 'name': item.author };
+    // FICHAS-QUALITY-GUARD-1: sin autoría real no se declara `author` en el
+    // JSON-LD. Un Person llamado "Desconocido" es un dato estructurado falso.
+    if (displayAuthor) {
+        schemaProduct.author = { '@type': 'Person', 'name': displayAuthor };
     }
     if (item.isbn) {
         schemaProduct.isbn = String(item.isbn);

--- a/functions/libro/_middleware.js
+++ b/functions/libro/_middleware.js
@@ -243,6 +243,12 @@ export function enrichByRequestProductHtml(html, productId) {
   return result;
 }
 
+// FICHAS-QUALITY-GUARD-1: helper local — una sección sólo se renderiza si
+// tiene texto real, no espacios en blanco.
+function hasText(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
 function renderProductShowcase(config, productId) {
   const paragraphs = (Array.isArray(config.summary) ? config.summary : [])
     .map(paragraph => `    <p>${escapeHtml(paragraph)}</p>`)
@@ -275,29 +281,42 @@ function renderProductShowcase(config, productId) {
       <a href="${escapeHtml(requestHelp.href)}">${escapeHtml(requestHelp.label)} →</a>
     </aside>`;
 
+  // FICHAS-QUALITY-GUARD-1: cada tarjeta se emite sólo si tiene contenido
+  // real. Una sección vacía o rellenada con frases genéricas ocupa espacio
+  // comercial sin informar; es preferible una ficha más corta y honesta.
+  const cards = [
+    highlights
+      ? `    <section class="showcase-card" aria-labelledby="showcase-highlights-title">
+      <h3 id="showcase-highlights-title">${escapeHtml(config.highlightsHeading || 'Datos destacados')}</h3>
+      <ul>
+${highlights}
+      </ul>
+    </section>`
+      : '',
+    hasText(config.audience)
+      ? `    <section class="showcase-card" aria-labelledby="showcase-audience-title">
+      <h3 id="showcase-audience-title">${escapeHtml(config.audienceHeading || '¿Para quién es este libro?')}</h3>
+      <p>${escapeHtml(config.audience)}</p>
+    </section>`
+      : '',
+    hasText(config.authorBio)
+      ? `    <section class="showcase-card" aria-labelledby="showcase-author-title">
+      <h3 id="showcase-author-title">${escapeHtml(config.authorHeading || 'Sobre la autoría')}</h3>
+      <p>${escapeHtml(config.authorBio)}</p>
+    </section>`
+      : '',
+  ].filter(Boolean);
+  const gridHtml = cards.length
+    ? `  <div class="showcase-grid">\n${cards.join('\n')}\n  </div>\n`
+    : '';
+
   return `<section class="product-showcase" aria-labelledby="showcase-title">
   <div class="showcase-intro">
     <p class="showcase-eyebrow">${escapeHtml(config.eyebrow)}</p>
     <h2 id="showcase-title">${escapeHtml(config.introHeading || `¿De qué trata ${config.h1}?`)}</h2>
 ${paragraphs}
   </div>
-  <div class="showcase-grid">
-    <section class="showcase-card" aria-labelledby="showcase-highlights-title">
-      <h3 id="showcase-highlights-title">${escapeHtml(config.highlightsHeading || 'Datos destacados')}</h3>
-      <ul>
-${highlights}
-      </ul>
-    </section>
-    <section class="showcase-card" aria-labelledby="showcase-audience-title">
-      <h3 id="showcase-audience-title">${escapeHtml(config.audienceHeading || '¿Para quién es este libro?')}</h3>
-      <p>${escapeHtml(config.audience)}</p>
-    </section>
-    <section class="showcase-card" aria-labelledby="showcase-author-title">
-      <h3 id="showcase-author-title">${escapeHtml(config.authorHeading || 'Sobre la autoría')}</h3>
-      <p>${escapeHtml(config.authorBio)}</p>
-    </section>
-  </div>
-  <section class="showcase-edition" aria-labelledby="showcase-edition-title">
+${gridHtml}  <section class="showcase-edition" aria-labelledby="showcase-edition-title">
     <div class="showcase-edition-head">
       <h2 id="showcase-edition-title">${escapeHtml(config.editionHeading || 'Ficha de esta edición')}</h2>
       <span class="showcase-verified">${escapeHtml(config.verifiedLabel || 'Datos tomados de la publicación')}</span>

--- a/scripts/seo/fichas-generic-author-live-check.mjs
+++ b/scripts/seo/fichas-generic-author-live-check.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// FICHAS-QUALITY-GUARD-1 — verificación HTTP real contra el Preview o
+// Producción. Descarga la ficha exacta y /feed.xml y falla si aparece
+// cualquier autoría genérica.
+//
+// Por qué existe: los tests unitarios y de integración corren contra el
+// render en memoria. Esta comprobación mira lo que el servidor devuelve de
+// verdad por HTTP, que es lo único que ve el cliente y Google. La primera
+// versión de esta corrección pasó los tests y falló en el Preview real: este
+// script cierra ese hueco.
+//
+// Uso (en el runner de CI, que sí tiene salida de red):
+//   FICHAS_CHECK_BASE_URL=https://pr-246.amadolibros-web.pages.dev \
+//   node scripts/seo/fichas-generic-author-live-check.mjs
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+
+const BASE_URL = (process.env.FICHAS_CHECK_BASE_URL || 'https://www.amadolibros.com').replace(/\/$/, '');
+const OUTPUT_DIR = process.env.FICHAS_CHECK_OUTPUT_DIR || 'artifacts/fichas-quality';
+const PRODUCT_ID = process.env.FICHAS_CHECK_PRODUCT_ID || 'MLU724888358';
+const PRODUCT_SLUG = process.env.FICHAS_CHECK_PRODUCT_SLUG || 'la-biblia-palabra-de-vida-verbo-divino';
+
+// Autorías genéricas que nunca deben llegar al cliente.
+const GENERIC_RE = /desconocid[ao]|unknown\s+author|autor\s+no\s+especificado|sin\s+especificar|varios\s+autores|vv\.?\s*aa\.?/gi;
+
+// Datos que deben seguir presentes: la corrección no puede llevarse nada útil.
+const DEBE_CONSERVAR_FICHA = [
+  { etiqueta: 'ISBN 9788490739808', re: /9788490739808/ },
+  { etiqueta: 'canonical', re: /<link rel="canonical"/ },
+  { etiqueta: 'slug en canonical', re: new RegExp(PRODUCT_SLUG) },
+  { etiqueta: 'portada por /book-cover/', re: new RegExp(`/book-cover/${PRODUCT_ID}/`) },
+];
+
+async function get(url) {
+  const response = await fetch(url, { headers: { 'user-agent': 'AmadoLibrosFichasCheck/1.0' } });
+  const body = await response.text();
+  return { status: response.status, body };
+}
+
+function ocurrencias(texto) {
+  return [...texto.matchAll(GENERIC_RE)].map(m => m[0]);
+}
+
+function contexto(texto, termino) {
+  const i = texto.toLowerCase().indexOf(termino.toLowerCase());
+  if (i < 0) return null;
+  return texto.slice(Math.max(0, i - 90), i + 70).replace(/\s+/g, ' ');
+}
+
+async function main() {
+  const fichaUrl = `${BASE_URL}/libro/${PRODUCT_ID}/${PRODUCT_SLUG}`;
+  const feedUrl = `${BASE_URL}/feed.xml`;
+  console.log(`Verificando contra ${BASE_URL}`);
+
+  const [ficha, feed] = await Promise.all([get(fichaUrl), get(feedUrl)]);
+  const errores = [];
+
+  // ── Ficha ──────────────────────────────────────────────────────────────
+  if (ficha.status !== 200) {
+    errores.push(`La ficha respondió HTTP ${ficha.status}: ${fichaUrl}`);
+  }
+  const enFicha = ocurrencias(ficha.body);
+  if (enFicha.length) {
+    errores.push(`La ficha contiene ${enFicha.length} aparición(es) de autoría genérica: ${[...new Set(enFicha)].join(', ')}`);
+    console.error(`\n  contexto: …${contexto(ficha.body, enFicha[0])}…`);
+  }
+  for (const { etiqueta, re } of DEBE_CONSERVAR_FICHA) {
+    if (!re.test(ficha.body)) errores.push(`La ficha perdió un dato que debía conservar: ${etiqueta}`);
+  }
+
+  // ── Feed: sólo el bloque de este producto ──────────────────────────────
+  if (feed.status !== 200) {
+    errores.push(`/feed.xml respondió HTTP ${feed.status}`);
+  }
+  const bloque = feed.body
+    .split('<item>')
+    .find(chunk => chunk.includes(`<g:id>${PRODUCT_ID}</g:id>`));
+
+  if (!bloque) {
+    // No es un error en sí: el producto puede quedar fuera del feed por
+    // deduplicación por GTIN. Se informa, no se falla.
+    console.log(`  ${PRODUCT_ID} no está en /feed.xml (posible deduplicación por GTIN) — no se evalúa.`);
+  } else {
+    const enFeed = ocurrencias(bloque);
+    if (enFeed.length) {
+      errores.push(`El bloque de feed de ${PRODUCT_ID} contiene autoría genérica: ${[...new Set(enFeed)].join(', ')}`);
+      console.error(`\n  contexto: …${contexto(bloque, enFeed[0])}…`);
+    }
+    for (const tag of ['g:id', 'g:title', 'g:link', 'g:price', 'g:availability', 'g:image_link']) {
+      if (!bloque.includes(`<${tag}>`)) errores.push(`El bloque de feed perdió <${tag}>`);
+    }
+  }
+
+  const informe = {
+    base: BASE_URL,
+    productId: PRODUCT_ID,
+    fichaUrl,
+    fichaStatus: ficha.status,
+    aparicionesEnFicha: enFicha.length,
+    productoEnFeed: Boolean(bloque),
+    aparicionesEnFeed: bloque ? ocurrencias(bloque).length : null,
+    errores,
+  };
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  writeFileSync(`${OUTPUT_DIR}/generic-author-live-check.json`, JSON.stringify(informe, null, 2));
+
+  console.log(`\n  ficha  HTTP ${ficha.status} — ${enFicha.length} aparición(es)`);
+  console.log(`  feed   HTTP ${feed.status} — ${bloque ? `${ocurrencias(bloque).length} aparición(es) en el bloque` : 'producto ausente'}`);
+
+  if (errores.length) {
+    console.error('\nFALLÓ:');
+    for (const e of errores) console.error(`  - ${e}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log('\nOK: ninguna autoría genérica en la ficha ni en el feed; datos preservados.');
+}
+
+main().catch(error => {
+  console.error(`fichas-generic-author-live-check falló: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/scripts/seo/fichas-quality-audit.mjs
+++ b/scripts/seo/fichas-quality-audit.mjs
@@ -16,7 +16,7 @@
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { isGenericAuthor } from '../../functions/_shared/showcase-ranking.js';
 import { buildAutomaticProductShowcase } from '../../functions/_shared/automatic-product-showcase.js';
-import { SHOWCASE_COHORT_V2_URL } from '../../functions/_shared/showcase-cohort.js';
+import { SHOWCASE_COHORT_V2_URL, normalizeShowcaseCohort } from '../../functions/_shared/showcase-cohort.js';
 import { CATALOG_URL } from '../../functions/_shared/catalog.js';
 
 const OUTPUT_DIR = process.env.FICHAS_AUDIT_OUTPUT_DIR || 'artifacts/fichas-quality';
@@ -101,15 +101,26 @@ async function main() {
     fetchJson(CATALOG_URL),
   ]);
 
-  const ids = new Set(
-    (Array.isArray(cohorte?.items) ? cohorte.items : [])
-      .map(entry => String(entry?.id || entry).toUpperCase()),
-  );
+  // La cohorte publica { schema_version, total, ids: [...] } — NO `items`.
+  // Se reutiliza el normalizador oficial en vez de reimplementar el formato:
+  // así el audit no se desincroniza si el esquema cambia.
+  const normalizada = normalizeShowcaseCohort(cohorte);
+  if (!normalizada) {
+    throw new Error('La cohorte descargada no pasó normalizeShowcaseCohort(): esquema inesperado.');
+  }
+  console.log(`  cohorte ${normalizada.source}: ${normalizada.total} ids`);
+
   const items = (Array.isArray(catalogo?.items) ? catalogo.items : [])
-    .filter(item => ids.has(String(item?.id || '').toUpperCase()));
+    .filter(item => normalizada.ids.has(String(item?.id || '').toUpperCase()));
+  console.log(`  cruzados con catálogo activo: ${items.length}`);
 
   const filas = items.map(analizar).filter(Boolean);
-  if (filas.length === 0) throw new Error('La cohorte no produjo ninguna ficha analizable.');
+  if (filas.length === 0) {
+    throw new Error(
+      `La cohorte tiene ${normalizada.total} ids pero ninguno cruzó con el catálogo activo ` +
+      `(${(catalogo?.items || []).length} items). Probable desfasaje entre cohorte y catálogo.`,
+    );
+  }
 
   const cuenta = predicado => filas.filter(predicado).length;
   const metricas = {

--- a/scripts/seo/fichas-quality-audit.mjs
+++ b/scripts/seo/fichas-quality-audit.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// FICHAS-QUALITY-GUARD-1 — audita la cohorte real de fichas enriquecidas y
+// mide, ficha por ficha, cuánto contenido débil elimina esta corrección.
+//
+// Por qué existe: la cohorte vive en R2 y no siempre es alcanzable desde el
+// entorno donde se desarrolla. Este script permite ejecutar la medición desde
+// cualquier lugar que sí tenga red (CI, la máquina de Seba) y obtener números
+// reales en vez de estimaciones.
+//
+// Uso:
+//   node scripts/seo/fichas-quality-audit.mjs
+//   FICHAS_AUDIT_SAMPLE=30 node scripts/seo/fichas-quality-audit.mjs
+//
+// No modifica nada. Sólo lee la cohorte y el catálogo, y escribe un informe.
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { isGenericAuthor } from '../../functions/_shared/showcase-ranking.js';
+import { buildAutomaticProductShowcase } from '../../functions/_shared/automatic-product-showcase.js';
+import { SHOWCASE_COHORT_V2_URL } from '../../functions/_shared/showcase-cohort.js';
+import { CATALOG_URL } from '../../functions/_shared/catalog.js';
+
+const OUTPUT_DIR = process.env.FICHAS_AUDIT_OUTPUT_DIR || 'artifacts/fichas-quality';
+const SAMPLE_SIZE = Math.max(1, Number(process.env.FICHAS_AUDIT_SAMPLE) || 30);
+
+const MIN_USEFUL_DESCRIPTION = 80;
+
+const FRASES_DE_RELLENO = [
+  'Disponible para compra inmediata en Amado Libros',
+  'La ficha reúne los datos aportados por la publicación',
+  'Información comercial verificada al momento de la consulta',
+  'Puede interesar a lectores de',
+  'Puede interesar a quienes buscan lecturas de',
+  'Pensado para lectores de',
+  'Para quienes buscan esta obra y necesitan comprobar',
+  'La publicación no aporta una autoría suficientemente clara',
+];
+
+async function fetchJson(url) {
+  const response = await fetch(url, { headers: { accept: 'application/json' } });
+  if (!response.ok) throw new Error(`${url} respondió HTTP ${response.status}`);
+  return response.json();
+}
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+// Reproduce el generador ANTERIOR a esta corrección, para poder contrastar
+// antes/después sobre exactamente los mismos datos.
+function copyDebilAntes(item) {
+  const autor = clean(item.author);
+  const esGenericoAhora = isGenericAuthor(autor);
+  // Antes sólo se consideraban genéricos los de la lista vieja; 'Desconocido'
+  // y 'Unknown' pasaban como autoría real.
+  const eraGenericoAntes = !autor || /^(anónimo|anonimo|autor|autores|autor no especificado|no aplica|n\/a|s\/a|sin autor|varios|varios autores|vv aa|vv\. aa\.)$/i
+    .test(autor.normalize('NFD').replace(/[̀-ͯ]/g, ''));
+  return {
+    autor,
+    // Fichas que ANTES mostraban "Más sobre <genérico>" y ahora no.
+    mostrabaAutorFalso: esGenericoAhora && !eraGenericoAntes,
+    esGenericoAhora,
+  };
+}
+
+function analizar(item) {
+  const descripcion = clean(item.description);
+  const sinDescripcionUtil = descripcion.length < MIN_USEFUL_DESCRIPTION;
+  const { autor, mostrabaAutorFalso, esGenericoAhora } = copyDebilAntes(item);
+  const despues = buildAutomaticProductShowcase(item);
+  if (!despues) return null;
+
+  const textoDespues = JSON.stringify(despues);
+  const relleno = FRASES_DE_RELLENO.filter(f => textoDespues.includes(f));
+
+  return {
+    id: item.id,
+    titulo: clean(item.title),
+    autorOriginal: autor || null,
+    isbn: clean(item.isbn) || null,
+    sinDescripcionUtil,
+    autorAusenteOGenerico: esGenericoAhora,
+    mostrabaAutorFalso,
+    pierdeBloqueAutor: esGenericoAhora,
+    pierdeBloqueAudiencia: true, // el bloque de audiencia se omite siempre ahora
+    pierdeDestacadosDeRelleno: despues.highlights.length < 3,
+    conservaDescripcionReal: !sinDescripcionUtil,
+    destacadosReales: despues.highlights.length,
+    datosDeEdicion: despues.editionFacts.length,
+    rellenoResidual: relleno,
+  };
+}
+
+function esBibliaOReligion(fila) {
+  return /biblia|reina.?valera|evangelio|salmos|test?amento|catecismo|religi/i.test(fila.titulo);
+}
+
+async function main() {
+  console.log('Descargando cohorte y catálogo…');
+  const [cohorte, catalogo] = await Promise.all([
+    fetchJson(SHOWCASE_COHORT_V2_URL),
+    fetchJson(CATALOG_URL),
+  ]);
+
+  const ids = new Set(
+    (Array.isArray(cohorte?.items) ? cohorte.items : [])
+      .map(entry => String(entry?.id || entry).toUpperCase()),
+  );
+  const items = (Array.isArray(catalogo?.items) ? catalogo.items : [])
+    .filter(item => ids.has(String(item?.id || '').toUpperCase()));
+
+  const filas = items.map(analizar).filter(Boolean);
+  if (filas.length === 0) throw new Error('La cohorte no produjo ninguna ficha analizable.');
+
+  const cuenta = predicado => filas.filter(predicado).length;
+  const metricas = {
+    fichasAnalizadas: filas.length,
+    sinDescripcionUtil: cuenta(f => f.sinDescripcionUtil),
+    autorAusenteOGenerico: cuenta(f => f.autorAusenteOGenerico),
+    mostrabanAutorFalso: cuenta(f => f.mostrabaAutorFalso),
+    pierdenBloqueAutor: cuenta(f => f.pierdeBloqueAutor),
+    pierdenBloqueAudiencia: cuenta(f => f.pierdeBloqueAudiencia),
+    pierdenDestacadosDeRelleno: cuenta(f => f.pierdeDestacadosDeRelleno),
+    conservanDescripcionReal: cuenta(f => f.conservaDescripcionReal),
+    conRellenoResidual: cuenta(f => f.rellenoResidual.length > 0),
+  };
+
+  const porGrupo = n => ({
+    biblias: filas.filter(esBibliaOReligion).slice(0, n),
+    generales: filas.filter(f => !esBibliaOReligion(f) && !f.sinDescripcionUtil).slice(0, n),
+    incompletos: filas.filter(f => f.sinDescripcionUtil && f.autorAusenteOGenerico).slice(0, n),
+  });
+  const muestra = porGrupo(Math.ceil(SAMPLE_SIZE / 3));
+
+  console.log('\n── Métricas de la cohorte ──');
+  for (const [k, v] of Object.entries(metricas)) {
+    const pct = k === 'fichasAnalizadas' ? '' : ` (${((v / filas.length) * 100).toFixed(1)}%)`;
+    console.log(`  ${k.padEnd(30)} ${String(v).padStart(6)}${pct}`);
+  }
+
+  if (metricas.conRellenoResidual > 0) {
+    console.error(`\nERROR: ${metricas.conRellenoResidual} fichas todavía contienen frases de relleno.`);
+  }
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const destino = `${OUTPUT_DIR}/fichas-quality-audit-${new Date().toISOString().slice(0, 10)}.json`;
+  writeFileSync(destino, JSON.stringify({ metricas, muestra, filas }, null, 2));
+  console.log(`\nEscrito: ${destino}`);
+
+  process.exitCode = metricas.conRellenoResidual > 0 ? 1 : 0;
+}
+
+main().catch(error => {
+  console.error(`fichas-quality-audit falló: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/shared/whatsapp-messages.js
+++ b/shared/whatsapp-messages.js
@@ -1,3 +1,4 @@
+import { isGenericAuthor } from '../functions/_shared/generic-author.js';
 export const WHATSAPP_NUMBER = '59899841325';
 export const SITE_BASE = 'https://www.amadolibros.com';
 
@@ -38,7 +39,10 @@ export function buildWhatsAppMessage({
 
   if (motive) lines.push(`Motivo: ${String(motive).trim()}`);
   if (book) lines.push(`Libro: ${String(book).trim()}`);
-  if (author) lines.push(`Autor: ${String(author).trim()}`);
+  // FICHAS-QUALITY-GUARD-1: 'Autor: Desconocido' en un mensaje de WhatsApp es
+  // ruido que el cliente lee. Se omite la línea si la autoría es genérica,
+  // aunque el llamador haya pasado el valor crudo del catálogo.
+  if (author && !isGenericAuthor(author)) lines.push(`Autor: ${String(author).trim()}`);
   if (situation) lines.push(`Situación: ${String(situation).trim()}`);
   if (price) lines.push(`Precio publicado: ${String(price).trim()}`);
   if (order) lines.push(`Pedido: ${String(order).trim()}`);


### PR DESCRIPTION
> **Estado: corregido. El SHA `ac53de8` está superado.**
> La verificación externa que encontró 10 apariciones de `Desconocido` en la ficha y 1 en `/feed.xml` se hizo sobre `ac53de8`, el **primer** commit de esta rama. Ese informe era correcto y el commit tenía un falso verde real. Head actual: **`006b7c4`**.

## Corrección (commits `fa1f047`, `0c6d8ad`, `006b7c4`)

El primer commit sólo arregló el generador del showcase. Sus tests probaban `buildAutomaticProductShowcase()` en aislamiento, no la página que sirve el servidor: por eso pasaron en verde mientras el SSR seguía emitiendo `Desconocido`. Las seis superficies señaladas, corregidas una por una:

| # | Superficie | Antes | Ahora |
|---|---|---|---|
| 1 | JSON-LD | `"author":{"@type":"Person","name":"Desconocido"}` | nodo `author` omitido |
| 2 | Tabla de datos | `<dt>Autor</dt><dd>Desconocido</dd>` | fila omitida |
| 3 | WhatsApp | `Autor: Desconocido` | línea omitida |
| 4 | Relacionados | `Otros libros de Desconocido` | `Libros relacionados`; no se agrupa por autoría genérica |
| 5 | Títulos / `alt` | `De Desconocido` | `stripGenericAuthorMention()` limpia sólo el fragmento explícito |
| 6 | Merchant | `<g:description>… de Desconocido. …` | `de <genérico>` omitido |

**Causa raíz real:** no era una lista incompleta, eran **tres listas duplicadas y divergentes** (`showcase-ranking.js`, `GENERIC_AUTHOR_KEYS` local en `functions/libro/[[path]].js`, y **ningún** criterio en feed ni WhatsApp). Arreglar una dejaba rotas las otras.

`functions/_shared/generic-author.js` es ahora la **única** definición, consumida por showcase, ficha, relacionados, WhatsApp, feed y ranking. Expone `isGenericAuthor()`, `realAuthor()` y `stripGenericAuthorMention()`. En `006b7c4` se eliminó la última copia paralela que quedaba en `showcase-ranking.js`, que hoy re-exporta desde el módulo compartido.

Nunca se sustituye por `Equipo editorial`, `Varios autores` ni ninguna autoría inventada: el dato **se omite** hasta que exista fuente verificable. Un autor real se preserva en las seis superficies (test de control).

## Verificación automatizada — nadie tiene que correr nada

Dos pasos nuevos en `.github/workflows/deploy-pr-preview.yml`, ejecutados en el runner, que sí tiene salida de red:

- `scripts/seo/fichas-generic-author-live-check.mjs` — descarga por HTTP la ficha exacta y `/feed.xml` del Preview desplegado. Sale con código 1 ante cualquier aparición o si se perdió ISBN, canonical, slug o portada.
- `scripts/seo/fichas-quality-audit.mjs` — audita la cohorte real de 3.000 fichas y sube el informe como artefacto.

**Salida literal del runner** ([run 32730707119](https://github.com/trexxeseba/amadolibros-web/actions/runs/32730707119)):

```
Verificando contra https://pr-246.amadolibros-web.pages.dev
  ficha  HTTP 200 — 0 aparición(es)
  feed   HTTP 200 — 0 aparición(es) en el bloque
OK: ninguna autoría genérica en la ficha ni en el feed; datos preservados.
```

Eran 10 y 1. Confirmado en tres corridas independientes, incluido un re-deploy limpio del Preview.

**Auditoría de la cohorte real (3.000 fichas):**

```
sinDescripcionUtil               1261 (42.0%)
autorAusenteOGenerico              71 (2.4%)
mostrabanAutorFalso                12 (0.4%)
pierdenBloqueAudiencia           3000 (100.0%)
pierdenDestacadosDeRelleno          0 (0.0%)
conservanDescripcionReal         1739 (58.0%)
conRellenoResidual                  0 (0.0%)
```

Ya no hay estimaciones: son números medidos sobre la cohorte de producción.

## Tests

`functions/__tests__/fichas-quality-guard-integration.test.js` (nuevo) cierra el hueco que produjo el falso verde: corre sobre el **HTML SSR completo** y el **XML del feed completo**, con el JSON-LD parseado, no sobre el generador. Usa el pipeline real (`selectRelatedBooks`), no fixtures inyectados a mano.

- Focalizados **26/26** · suite completa **1305/1305** · builds Astro checkout OFF y ON **OK**

## Preservado — verificado por test y por HTTP

ISBN `9788490739808` · GTIN del feed · precio · stock · imágenes · slug · canonical · título comercial · categoría · CTA "¿Buscás otra Biblia o una edición específica? / Contanos qué buscás".

**Límite documentado:** el `href` de un libro relacionado conserva el slug canónico de ESE producto aunque su título contenga "de Desconocido"; cambiarlo rompería el enlace. En la práctica no se observa, porque una autoría genérica ya no produce bloque de relacionados.

---

# Fase 1 — qué cambia en el contenido de las fichas

Además de la autoría, se elimina el copy automático que no aportaba ningún hecho verificable:

- **`authorCopy()`** → `null` sin autoría real. Antes emitía una sección con el nombre repetido, o un párrafo de disculpa.
- **`audienceCopy()`** → `null` siempre en la ficha automática: sólo podía construirse recombinando autor y categoría. Las fichas curadas a mano (`product-showcases.js`) siguen pudiendo declarar su propio `audience` real.
- **`buildHighlights()`** → deja de rellenar hasta un mínimo de 3 con frases genéricas ("Disponible para compra inmediata…"). Devuelve sólo lo que la publicación aporta, aunque sea nada.
- **`libro/_middleware.js`** → cada tarjeta del grid se emite sólo si tiene contenido real; si no queda ninguna, el grid entero se omite.

Una ficha sin datos queda **más corta**, con los datos concretos que sí tiene y la ayuda comercial contextual que ya existía. No se fabrica sinopsis, destinatario, tema, beneficio ni característica.

## Alcance respetado

Sin tocar portada, Tarot/oráculos, landings de Biblias o Reina-Valera, checkout, precios, stock, logística, slugs, canonicals, redirecciones ni titles SEO masivos. Sin datos externos ni scraping. Feed y Merchant se tocan **sólo** para quitar `de <genérico>` de `<g:description>`, que era uno de los seis defectos señalados. #244 y los demás Draft, sin tocar.

## Reutilización de #235

Revisado `agent/product-edition-facts-1` (`668af92`, merge-base `027fe27`). **No se reutiliza ningún commit**: #235 toca el bloque "Datos de esta edición" del SSR; esta Fase 1 toca el generador del showcase y el criterio de autoría. Sigue abierto e intacto, sin conflicto con esta rama.

---

# Fase 2 — `FICHAS-ENRICHMENT-ISBN-1` (diseño, NO implementado)

No avanzar sin autorización explícita, y sólo después de que esta Fase 1 esté fusionada, desplegada y verificada en Producción.

**Unidad de trabajo:** la edición verificada por **ISBN-13 exacto**, no el listing. Se enriquece una vez por edición, nunca una vez por duplicado de MercadoLibre. Universo: 3.578 ediciones con ISBN válido de las 3.667 únicas.

**Jerarquía de fuentes**
1. **Editorial oficial** — fuente prioritaria.
2. **Bibliotecas y agencias bibliográficas** — fuentes estructuradas.
3. **Casa del Libro y FNAC** — sólo corroboración, nunca fuente primaria.

**Regla de publicación de cada campo:** una fuente oficial exacta; **o** dos fuentes secundarias coincidentes. Cualquier conflicto entre fuentes → **cola de revisión, no se publica**.

**Propiedad intelectual:** no se copian sinopsis ni párrafos protegidos. Se extraen **hechos** y se redacta texto propio.

**Procedencia obligatoria por campo:** fuente, URL, fecha de consulta y nivel de confianza. Sin procedencia, el campo no se publica.

**Campos a comparar** (sólo cuando las fuentes lo confirmen): descripción, traducción, tradición, editorial, año, páginas, formato, medidas, tamaño de letra, notas, mapas, concordancia y presencia de deuterocanónicos.

**Primer lote:** 100 Biblias, priorizando Reina-Valera y productos con stock.

**Restricción comercial:** no afirmar entrega en el día salvo que el producto cumpla realmente stock, zona, horario y política logística.

---

Draft — no mergear ni desplegar.