### PR TITLE
FICHAS: enriquecer Biblias por ISBN con fuentes verificadas

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -100,6 +100,14 @@ jobs:
           FICHAS_CHECK_OUTPUT_DIR: artifacts/fichas-quality
         run: node scripts/seo/fichas-generic-author-live-check.mjs
 
+      # FICHAS-ENRICHMENT-BIBLIAS-1: cada ISBN versionado debe aparecer de
+      # verdad en su ficha y en Merchant; no alcanza con un test en memoria.
+      - name: Verify ISBN enrichments on ficha and Merchant
+        env:
+          BOOK_ENRICHMENT_BASE_URL: ${{ steps.deploy.outputs.preview_url }}
+          BOOK_ENRICHMENT_OUTPUT_DIR: artifacts/fichas-quality
+        run: node scripts/seo/book-enrichment-live-check.mjs
+
       # Auditoría de la cohorte real de fichas enriquecidas. El runner sí
       # alcanza R2, a diferencia del entorno de desarrollo.
       - name: Audit fichas quality cohort

--- a/functions/__tests__/bible-enrichment-cohort.test.js
+++ b/functions/__tests__/bible-enrichment-cohort.test.js
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildBibleEnrichmentCohort } from '../../scripts/seo/bible-enrichment-cohort.mjs';
+
+const classifications = {
+  MLU1: ['religion-espiritualidad', 'biblia'],
+  MLU2: ['religion-espiritualidad', 'biblia'],
+  MLU3: ['religion-espiritualidad', 'reina-valera'],
+  MLU4: ['religion-espiritualidad', 'biblia'],
+  MLU5: ['otros-libros'],
+};
+
+const base = {
+  status: 'active',
+  available_quantity: 1,
+  description: '',
+};
+
+test('consolida publicaciones por ISBN y genera estados accionables', () => {
+  const report = buildBibleEnrichmentCohort({
+    classifications,
+    catalogItems: [
+      { ...base, id: 'MLU1', isbn: '9788490739808', title: 'Palabra de Vida', available_quantity: 5 },
+      { ...base, id: 'MLU2', isbn: '978-84-9073-980-8', title: 'Duplicado', available_quantity: 2 },
+      { ...base, id: 'MLU3', isbn: '9781087701400', title: 'RVR cronológica' },
+      { ...base, id: 'MLU4', isbn: '9788428510448', title: 'Con descripción', description: 'x'.repeat(100) },
+      { ...base, id: 'MLU5', isbn: '9789508619778', title: 'Fuera del vertical' },
+    ],
+    enrichments: [{ isbn: '9788490739808' }],
+  });
+
+  assert.deepEqual(report.metrics, {
+    active_listings: 4,
+    unique_isbn_editions: 3,
+    listings_without_valid_isbn: 0,
+    enriched_verified: 1,
+    research_external: 1,
+    review_catalog_description: 1,
+  });
+  const enriched = report.editions.find(row => row.isbn === '9788490739808');
+  assert.equal(enriched.active_listings, 2);
+  assert.equal(enriched.total_stock, 7);
+  assert.deepEqual(enriched.listing_ids, ['MLU1', 'MLU2']);
+  assert.equal(enriched.status, 'enriched_verified');
+  assert.equal(report.editions[0].isbn, '9781087701400', 'Reina-Valera sin descripción debe priorizarse');
+});
+
+test('omite pausados, ISBN inválidos y clasificaciones ajenas', () => {
+  const report = buildBibleEnrichmentCohort({
+    classifications: {
+      MLU1: ['biblia'],
+      MLU2: ['biblia'],
+      MLU3: ['otros-libros'],
+    },
+    catalogItems: [
+      { ...base, id: 'MLU1', isbn: '', title: 'Sin ISBN' },
+      { ...base, id: 'MLU2', isbn: '9788490739808', title: 'Pausado', status: 'paused' },
+      { ...base, id: 'MLU3', isbn: '9788490739808', title: 'Otra categoría' },
+    ],
+    enrichments: [],
+  });
+
+  assert.equal(report.metrics.active_listings, 1);
+  assert.equal(report.metrics.unique_isbn_editions, 0);
+  assert.equal(report.metrics.listings_without_valid_isbn, 1);
+});
+

--- a/functions/__tests__/bible-enrichment-cohort.test.js
+++ b/functions/__tests__/bible-enrichment-cohort.test.js
@@ -65,4 +65,3 @@ test('omite pausados, ISBN inválidos y clasificaciones ajenas', () => {
   assert.equal(report.metrics.unique_isbn_editions, 0);
   assert.equal(report.metrics.listings_without_valid_isbn, 1);
 });
-

--- a/functions/__tests__/book-enrichment-bibles.test.js
+++ b/functions/__tests__/book-enrichment-bibles.test.js
@@ -32,7 +32,7 @@ const RAW_ITEM = Object.freeze({
 
 test('el registro sólo contiene entradas publicables con fuente oficial e ISBN exacto', () => {
   const entries = listBookEnrichments();
-  assert.ok(entries.length >= 3);
+  assert.ok(entries.length >= 6);
   for (const entry of entries) assert.equal(validateBookEnrichment(entry), true);
 });
 
@@ -46,6 +46,21 @@ test('el primer lote incluye dos Reina-Valera de alta prioridad con datos oficia
   assert.equal(fisher.facts.publisher, 'B&H Publishing Group');
   assert.equal(fisher.facts.pages, 1320);
   assert.match(fisher.editorial.decision_copy, /letra grande/i);
+});
+
+test('el lote suma tres Reina-Valera B&H con ISBN y edición exactos', () => {
+  const expected = [
+    ['9781087701417', 1424, /cronológica/i],
+    ['9781430091899', 1728, /14 puntos/i],
+    ['9781535998000', 1792, /365 devocionales/i],
+  ];
+  for (const [isbn, pages, signal] of expected) {
+    const entry = getBookEnrichmentByIsbn(isbn);
+    assert.equal(entry.facts.publisher, 'B&H Español');
+    assert.equal(entry.facts.pages, pages);
+    assert.match(entry.editorial.paragraphs.join(' '), signal);
+    assert.ok(entry.provenance.some(source => source.type === 'publisher' && source.isbn === isbn));
+  }
 });
 
 test('la edición 9788490739808 tiene procedencia editorial verificable', () => {

--- a/functions/__tests__/book-enrichment-bibles.test.js
+++ b/functions/__tests__/book-enrichment-bibles.test.js
@@ -8,7 +8,7 @@ import {
   validateBookEnrichment,
 } from '../_shared/book-enrichment-registry.js';
 import { buildAutomaticProductShowcase } from '../_shared/automatic-product-showcase.js';
-import { enrichAutomaticProductShowcaseHtml } from '../libro/_middleware.js';
+import { enrichAutomaticProductShowcaseHtml, onRequest as productMiddleware } from '../libro/_middleware.js';
 import { renderPage } from '../libro/[[path]].js';
 import { buildFeedDescription, renderFeedItem } from '../feed.xml.js';
 
@@ -129,6 +129,39 @@ test('la ficha SSR y su capa automática muestran enriquecimiento sin autor inve
   assert.equal(book.numberOfPages, 1600);
   assert.equal(book.inLanguage, 'es');
   assert.equal(book.bookFormat, 'https://schema.org/Paperback');
+});
+
+test('el middleware enriquece todos los duplicados del ISBN aunque no integren la cohorte general', async () => {
+  const duplicate = applyBookEnrichment({
+    ...RAW_ITEM,
+    id: 'MLU693791720',
+    isbn: '9780825456459',
+    title: 'Biblia Mujer Conforme Al Corazón De Dios Reina Valera 1960',
+  });
+  const baseHtml = renderPage(duplicate, 'biblia-mujer-conforme-al-corazon-de-dios', false, '', '', []);
+  const previousCaches = globalThis.caches;
+  globalThis.caches = {
+    default: {
+      match: async () => new Response(JSON.stringify({
+        items: { MLU693791720: ['religion-espiritualidad', 'reina-valera'] },
+      }), { headers: { 'content-type': 'application/json' } }),
+      put: async () => {},
+    },
+  };
+  try {
+    const response = await productMiddleware({
+      request: new Request('https://www.amadolibros.com/libro/MLU693791720/biblia-mujer'),
+      env: {},
+      next: async () => new Response(baseHtml, { headers: { 'content-type': 'text/html; charset=utf-8' } }),
+      waitUntil: () => {},
+    });
+    const html = await response.text();
+    assert.match(html, /Qué ofrece la Biblia de la mujer conforme al corazón de Dios/);
+    assert.match(html, /¿Para qué tipo de lectura sirve\?/);
+    assert.match(html, /Editorial Portavoz/);
+  } finally {
+    globalThis.caches = previousCaches;
+  }
 });
 
 test('Merchant recibe descripción enriquecida y conserva los atributos de oferta', () => {

--- a/functions/__tests__/book-enrichment-bibles.test.js
+++ b/functions/__tests__/book-enrichment-bibles.test.js
@@ -1,0 +1,131 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  applyBookEnrichment,
+  getBookEnrichmentByIsbn,
+  listBookEnrichments,
+  validateBookEnrichment,
+} from '../_shared/book-enrichment-registry.js';
+import { buildAutomaticProductShowcase } from '../_shared/automatic-product-showcase.js';
+import { enrichAutomaticProductShowcaseHtml } from '../libro/_middleware.js';
+import { renderPage } from '../libro/[[path]].js';
+import { buildFeedDescription, renderFeedItem } from '../feed.xml.js';
+
+const RAW_ITEM = Object.freeze({
+  id: 'MLU724888358',
+  title: 'La Biblia Palabra De Vida - Verbo Divino',
+  author: 'Desconocido',
+  isbn: '9788490739808',
+  publisher: null,
+  pages: null,
+  description: '',
+  price: 1950,
+  currency: 'UYU',
+  status: 'active',
+  available_quantity: 5,
+  condition: 'new',
+  pictures: ['https://http2.mlstatic.com/D_123-O.jpg'],
+  thumbnail: 'https://http2.mlstatic.com/D_123-I.jpg',
+  bibliographic: { language: 'Español' },
+});
+
+test('el registro sólo contiene entradas publicables con fuente oficial e ISBN exacto', () => {
+  const entries = listBookEnrichments();
+  assert.ok(entries.length >= 3);
+  for (const entry of entries) assert.equal(validateBookEnrichment(entry), true);
+});
+
+test('el primer lote incluye dos Reina-Valera de alta prioridad con datos oficiales', () => {
+  const woman = getBookEnrichmentByIsbn('9780825456459');
+  assert.equal(woman.facts.publisher, 'Editorial Portavoz');
+  assert.equal(woman.facts.pages, 1680);
+  assert.equal(woman.schema.bookEdition, 'Reina-Valera 1960');
+
+  const fisher = getBookEnrichmentByIsbn('9781535908160');
+  assert.equal(fisher.facts.publisher, 'B&H Publishing Group');
+  assert.equal(fisher.facts.pages, 1320);
+  assert.match(fisher.editorial.decision_copy, /letra grande/i);
+});
+
+test('la edición 9788490739808 tiene procedencia editorial verificable', () => {
+  const entry = getBookEnrichmentByIsbn('978-84-9073-980-8');
+  assert.equal(entry.isbn, '9788490739808');
+  assert.ok(entry.provenance.some(source =>
+    source.type === 'publisher' &&
+    source.relationship === 'exact_edition' &&
+    source.url === 'https://verbodivino.es/Libro/6735/la-biblia-palabra-de-vida'));
+});
+
+test('aplica sólo datos editoriales y preserva íntegros los datos comerciales', () => {
+  const enriched = applyBookEnrichment(RAW_ITEM);
+  assert.notEqual(enriched, RAW_ITEM);
+  assert.equal(enriched.publisher, 'Editorial Verbo Divino');
+  assert.equal(enriched.pages, 1600);
+  assert.match(enriched.description, /traducción interconfesional/i);
+  assert.equal(enriched.bibliographic.edition, '2.ª edición (reimpresión 2)');
+  for (const field of ['id', 'title', 'author', 'isbn', 'price', 'currency', 'status', 'available_quantity', 'condition', 'pictures', 'thumbnail']) {
+    assert.deepEqual(enriched[field], RAW_ITEM[field], `no debía cambiar ${field}`);
+  }
+});
+
+test('un ISBN no investigado conserva exactamente el objeto original', () => {
+  const other = { ...RAW_ITEM, id: 'MLU999999999', isbn: '9789876282703' };
+  assert.equal(applyBookEnrichment(other), other);
+});
+
+test('el showcase usa copy propio, decisión de compra y hechos verificables', () => {
+  const item = applyBookEnrichment(RAW_ITEM);
+  const enrichment = getBookEnrichmentByIsbn(item.isbn);
+  const config = buildAutomaticProductShowcase(item, {
+    classificationTags: ['biblia'],
+    enrichment,
+  });
+  assert.match(config.summary.join(' '), /1\.600 páginas/);
+  assert.match(config.summary.join(' '), /lenguas originales hebrea, aramea y griega/);
+  assert.equal(config.audienceHeading, '¿Esta es la edición que buscás?');
+  assert.match(config.audience, /compará el ISBN 9788490739808/i);
+  assert.equal(config.requestHelp.question, '¿Buscás otra Biblia o una edición específica?');
+  assert.ok(config.editionFacts.some(fact => fact.label === 'Páginas' && fact.value === '1600'));
+  assert.equal(config.sources[0].provider, 'Editorial Verbo Divino');
+});
+
+test('la ficha SSR y su capa automática muestran enriquecimiento sin autor inventado', () => {
+  const item = applyBookEnrichment(RAW_ITEM);
+  const baseHtml = renderPage(item, 'la-biblia-palabra-de-vida-verbo-divino', false, '', '', []);
+  const html = enrichAutomaticProductShowcaseHtml(baseHtml, item.id, {
+    classificationTags: ['biblia'],
+  });
+  assert.doesNotMatch(html, /desconocid/i);
+  assert.match(html, /Qué contiene esta edición de La Biblia Palabra de Vida/);
+  assert.match(html, /Editorial Verbo Divino/);
+  assert.match(html, /1\.600 páginas/);
+  assert.match(html, /Fuentes bibliográficas consultadas/);
+  assert.match(html, /Editorial Verbo Divino/);
+  assert.doesNotMatch(html, /Casa del Libro/);
+  assert.doesNotMatch(html, /casadellibro\.com/);
+  assert.match(html, /¿Buscás otra Biblia o una edición específica\?/);
+  assert.doesNotMatch(html, /Cómo verificar una edición por ISBN/);
+
+  const schemas = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+    .map(match => JSON.parse(match[1]));
+  const book = schemas.find(schema => [].concat(schema['@type'] || []).includes('Book'));
+  assert.equal(book.isbn, '9788490739808');
+  assert.equal(book.numberOfPages, 1600);
+  assert.equal(book.inLanguage, 'es');
+  assert.equal(book.bookFormat, 'https://schema.org/Paperback');
+});
+
+test('Merchant recibe descripción enriquecida y conserva los atributos de oferta', () => {
+  const description = buildFeedDescription(RAW_ITEM);
+  assert.match(description, /Editorial Verbo Divino/);
+  assert.match(description, /1\.600 páginas/);
+  assert.doesNotMatch(description, /desconocid/i);
+
+  const xml = renderFeedItem(RAW_ITEM);
+  assert.match(xml, /<g:gtin>9788490739808<\/g:gtin>/);
+  assert.match(xml, /<g:price>1950 UYU<\/g:price>/);
+  assert.match(xml, /<g:availability>in stock<\/g:availability>/);
+  assert.match(xml, /<g:link>https:\/\/www\.amadolibros\.com\/libro\/MLU724888358\/la-biblia-palabra-de-vida-verbo-divino<\/g:link>/);
+  assert.match(xml, /<g:image_link>https:\/\/www\.amadolibros\.com\/book-cover\/MLU724888358\/cover\.jpg<\/g:image_link>/);
+});

--- a/functions/__tests__/book-enrichment-live-check.test.js
+++ b/functions/__tests__/book-enrichment-live-check.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  verifyBookEnrichmentFeed,
+  verifyBookEnrichmentHtml,
+} from '../../scripts/seo/book-enrichment-live-check.mjs';
+
+const record = {
+  isbn: '9788490739808',
+  editorial: {
+    heading: 'Qué contiene esta edición',
+    decision_heading: '¿Esta es la edición que buscás?',
+    merchant_description: 'La Biblia Palabra de Vida, edición Hispanoamérica de Editorial Verbo Divino.',
+  },
+  facts: { publisher: 'Editorial Verbo Divino' },
+};
+
+test('el gate acepta ficha y oferta completas', () => {
+  const html = `<h2>Qué contiene esta edición</h2><p>Editorial Verbo Divino · 9788490739808</p><h3>¿Esta es la edición que buscás?</h3><div>MLU724888358</div>`;
+  const feed = `<item><g:id>MLU724888358</g:id><g:description>La Biblia Palabra de Vida, edición Hispanoamérica de Editorial Verbo Divino.</g:description><g:gtin>9788490739808</g:gtin><g:price>1950 UYU</g:price><g:availability>in stock</g:availability><g:link>https://www.amadolibros.com/libro/MLU724888358/x</g:link><g:image_link>https://www.amadolibros.com/book-cover/MLU724888358/cover.jpg</g:image_link></item>`;
+  assert.deepEqual(verifyBookEnrichmentHtml(html, record, 'MLU724888358'), []);
+  assert.deepEqual(verifyBookEnrichmentFeed(feed, record, 'MLU724888358'), []);
+});
+
+test('el gate falla ante copy ausente, autor genérico o pérdida comercial', () => {
+  const htmlFailures = verifyBookEnrichmentHtml('<p>Desconocido</p><p>MLU724888358</p>', record, 'MLU724888358');
+  assert.ok(htmlFailures.includes('falta el encabezado editorial'));
+  assert.ok(htmlFailures.includes('aparece autoría genérica'));
+  const feedFailures = verifyBookEnrichmentFeed('<rss></rss>', record, 'MLU724888358');
+  assert.deepEqual(feedFailures, ['falta la oferta en Merchant']);
+});

--- a/functions/__tests__/book-enrichment-live-check.test.js
+++ b/functions/__tests__/book-enrichment-live-check.test.js
@@ -23,6 +23,12 @@ test('el gate acepta ficha y oferta completas', () => {
   assert.deepEqual(verifyBookEnrichmentFeed(feed, record, 'MLU724888358'), []);
 });
 
+test('Merchant busca el bloque del MLU exacto y no mezcla duplicados anteriores', () => {
+  const feed = `<item><g:id>MLU111111111</g:id><g:description>Otra edición</g:description></item>
+    <item><g:id>MLU724888358</g:id><g:description>La Biblia Palabra de Vida, edición Hispanoamérica de Editorial Verbo Divino.</g:description><g:gtin>9788490739808</g:gtin><g:price>1950 UYU</g:price><g:availability>in stock</g:availability><g:link>x</g:link><g:image_link>y</g:image_link></item>`;
+  assert.deepEqual(verifyBookEnrichmentFeed(feed, record, 'MLU724888358'), []);
+});
+
 test('el gate falla ante copy ausente, autor genérico o pérdida comercial', () => {
   const htmlFailures = verifyBookEnrichmentHtml('<p>Desconocido</p><p>MLU724888358</p>', record, 'MLU724888358');
   assert.ok(htmlFailures.includes('falta el encabezado editorial'));

--- a/functions/__tests__/fichas-quality-guard-integration.test.js
+++ b/functions/__tests__/fichas-quality-guard-integration.test.js
@@ -114,11 +114,13 @@ test('3b. el feed conserva GTIN, precio, disponibilidad, link e imagen', () => {
   assert.match(xml, /<g:id>MLU724888358<\/g:id>/);
 });
 
-test('3c. buildFeedDescription omite «de <genérico>» pero conserva la editorial', () => {
+test('3c. buildFeedDescription omite autor genérico y usa datos de la edición verificada', () => {
   const d = buildFeedDescription(MLU724888358);
   assert.doesNotMatch(d, AUTOR_GENERICO_RE);
   assert.match(d, /Verbo Divino/);
-  assert.match(d, /Ejemplar nuevo/);
+  assert.match(d, /ISBN 9788490739808/);
+  assert.match(d, /1\.600 páginas/);
+  assert.match(d, /Lectio Divina/);
 });
 
 // ── 4. Control: un autor real se conserva en todas las superficies ────────

--- a/functions/_shared/automatic-product-showcase.js
+++ b/functions/_shared/automatic-product-showcase.js
@@ -402,7 +402,10 @@ export function productItemFromProductHtml(html, productId) {
   };
 }
 
-export function buildAutomaticProductShowcase(item, { classificationTags = [] } = {}) {
+export function buildAutomaticProductShowcase(item, {
+  classificationTags = [],
+  enrichment = null,
+} = {}) {
   if (!item || typeof item !== 'object' || !clean(item.title)) return null;
   const facts = buildEditionFacts(item);
   const description = clean(item.description);
@@ -420,22 +423,25 @@ export function buildAutomaticProductShowcase(item, { classificationTags = [] } 
     (!isGenericAuthor(item.author) ? `De ${clean(item.author)}` : null);
   const schemaDescription = shortenByWord(summary.join(' '), 500);
 
+  const editorial = enrichment?.editorial || null;
+  const verifiedSchema = enrichment?.schema || null;
+
   return {
     h1: clean(item.title),
     subtitle,
-    eyebrow: descriptionParagraphs.length
+    eyebrow: editorial?.eyebrow || (descriptionParagraphs.length
       ? (clean(bibliography.genre) || 'Descripción y datos de la edición')
-      : 'Ficha ampliada de esta edición',
-    introHeading: descriptionParagraphs.length
+      : 'Ficha ampliada de esta edición'),
+    introHeading: editorial?.heading || (descriptionParagraphs.length
       ? `¿De qué trata ${clean(item.title)}?`
-      : `Sobre ${clean(item.title)}`,
-    summary,
-    highlightsHeading: 'Datos destacados',
+      : `Sobre ${clean(item.title)}`),
+    summary: editorial?.paragraphs || summary,
+    highlightsHeading: editorial?.highlights_heading || 'Datos destacados',
     // FICHAS-QUALITY-GUARD-1: sin datos reales de la edición, `highlights`
     // queda vacío y el render omite la tarjeta en vez de rellenarla.
-    highlights: buildHighlights(item, facts),
-    audienceHeading: '¿Para quién puede ser útil?',
-    audience: audienceCopy(item),
+    highlights: editorial?.highlights || buildHighlights(item, facts),
+    audienceHeading: editorial?.decision_heading || '¿Para quién puede ser útil?',
+    audience: editorial?.decision_copy || audienceCopy(item),
     // FICHAS-QUALITY-GUARD-1: `author` es null cuando la autoría es genérica o
     // ausente; en ese caso no se emite encabezado ni copy y la tarjeta “Sobre
     // la autoría” desaparece por completo.
@@ -446,9 +452,11 @@ export function buildAutomaticProductShowcase(item, { classificationTags = [] } 
       ? 'Edición identificada por ISBN'
       : 'Datos tomados de la publicación',
     editionFacts: facts,
-    links: buildLinks(item),
+    links: editorial?.links || buildLinks(item),
     requestHelp: contextualRequestHelp(item, classificationTags),
-    schemaDescription,
-    metaDescription: buildMetaDescription(item),
+    sources: enrichment?.provenance || [],
+    schemaDescription: editorial?.paragraphs?.join(' ') || schemaDescription,
+    schemaVerified: verifiedSchema,
+    metaDescription: editorial?.meta_description || buildMetaDescription(item),
   };
 }

--- a/functions/_shared/book-enrichment-registry.js
+++ b/functions/_shared/book-enrichment-registry.js
@@ -206,6 +206,171 @@ const BIBLE_ENRICHMENTS = Object.freeze([
       }),
     ]),
   }),
+  Object.freeze({
+    schema_version: 1,
+    isbn: '9781087701417',
+    decision: 'auto_publish',
+    verified_at: '2026-08-24',
+    editorial: Object.freeze({
+      eyebrow: 'Biblia cronológica RVR60 · edición verificada',
+      heading: 'Cómo se lee la Biblia cronológica día por día',
+      paragraphs: Object.freeze([
+        'Esta Biblia Reina-Valera 1960 organiza el texto completo según la secuencia cronológica de los acontecimientos y corresponde al ISBN 9781087701417. Es una edición de B&H Español en símil piel, con 1.424 páginas, letra de 9 puntos y un formato aproximado de 17 × 22,9 cm.',
+        'El recorrido está distribuido en 52 semanas de lectura devocional y puede comenzarse en cualquier momento del año. Incluye introducciones, texto en una columna, margen para anotaciones y mapas a color para acompañar la comprensión del relato bíblico.',
+      ]),
+      highlights_heading: 'Características comprobadas',
+      highlights: Object.freeze([
+        'Texto Reina-Valera 1960 ordenado cronológicamente.',
+        '52 semanas de lectura devocional sin fechas fijas.',
+        '1.424 páginas con letra de 9 puntos.',
+        'Texto en una columna y margen para anotaciones.',
+        'Introducciones y mapas a color.',
+      ]),
+      decision_heading: '¿Para quién resulta útil?',
+      decision_copy: 'Es una alternativa para quien quiere seguir la historia bíblica en orden cronológico y sostener un plan de lectura semanal. Compará el ISBN 9781087701417 y la cubierta marrón en símil piel antes de comprar.',
+      meta_description: 'Biblia cronológica día por día RVR60, ISBN 9781087701417: 1.424 páginas, 52 semanas de lectura y mapas. Disponible en Uruguay.',
+      merchant_description: 'Biblia cronológica día por día RVR60 de B&H Español. ISBN 9781087701417, símil piel, 1.424 páginas y letra de 9 puntos. Incluye 52 semanas de lectura, margen para notas, introducciones y mapas a color.',
+      links: Object.freeze([
+        Object.freeze({ href: '/libros/biblias/reina-valera', label: 'Comparar Biblias Reina-Valera' }),
+        Object.freeze({ href: '/libros/biblias', label: 'Ver todas las Biblias disponibles' }),
+      ]),
+    }),
+    facts: Object.freeze({
+      publisher: 'B&H Español',
+      pages: 1424,
+      dimensions_text: '17 × 22,9 cm',
+      bibliographic: Object.freeze({
+        language: 'Español',
+        format: 'Símil piel',
+        edition: 'Reina-Valera 1960 · edición cronológica',
+      }),
+    }),
+    schema: Object.freeze({
+      inLanguage: 'es',
+      bookEdition: 'Reina-Valera 1960 · edición cronológica',
+    }),
+    provenance: Object.freeze([
+      Object.freeze({
+        type: 'publisher',
+        provider: 'B&H Español',
+        url: 'https://bhespanol.bhpublishinggroup.com/product/rvr-1960-biblia-cronologica-dia-por-dia-marron-simil-piel/',
+        relationship: 'exact_edition',
+        isbn: '9781087701417',
+        verified_at: '2026-08-24',
+        fields: Object.freeze(['description', 'publisher', 'pages', 'dimensions', 'format', 'bible_version', 'contents']),
+      }),
+    ]),
+  }),
+  Object.freeze({
+    schema_version: 1,
+    isbn: '9781430091899',
+    decision: 'auto_publish',
+    verified_at: '2026-08-24',
+    editorial: Object.freeze({
+      eyebrow: 'Biblia letra gigante RVR60 · edición verificada',
+      heading: 'Qué incluye esta RVR60 de letra gigante',
+      paragraphs: Object.freeze([
+        'Esta edición floreada en símil piel utiliza el texto Reina-Valera 1960 y corresponde al ISBN 9781430091899. Fue publicada por B&H Español en 2024, tiene 1.728 páginas, letra gigante de 14 puntos y un formato aproximado de 17,3 × 24,9 cm.',
+        'Además del tamaño de letra, incorpora referencias en cadena, concordancia temática, panorama histórico, plan de lectura anual, introducciones y bosquejos de cada libro, palabras de Cristo en rojo y mapas a color.',
+      ]),
+      highlights_heading: 'Características comprobadas',
+      highlights: Object.freeze([
+        'Texto Reina-Valera 1960 con letra gigante de 14 puntos.',
+        '1.728 páginas y cubierta floreada en símil piel.',
+        'Referencias en cadena y concordancia temática.',
+        'Plan de lectura anual e introducciones por libro.',
+        'Palabras de Cristo en rojo y mapas a color.',
+      ]),
+      decision_heading: '¿Cuándo elegir letra gigante?',
+      decision_copy: 'Puede convenir si priorizás una tipografía grande para lectura personal, enseñanza o lectura pública y querés conservar ayudas de referencia. Verificá el ISBN 9781430091899 y el diseño floreado para distinguir esta edición.',
+      meta_description: 'Biblia RVR60 letra gigante floreada, ISBN 9781430091899: 14 puntos, 1.728 páginas y símil piel. Disponible en Uruguay.',
+      merchant_description: 'Biblia RVR60 letra gigante floreada de B&H Español. ISBN 9781430091899, símil piel, 1.728 páginas y tipografía de 14 puntos. Incluye referencias, concordancia, plan anual, introducciones y mapas a color.',
+      links: Object.freeze([
+        Object.freeze({ href: '/libros/biblias/reina-valera', label: 'Comparar Biblias Reina-Valera' }),
+        Object.freeze({ href: '/libros/biblias', label: 'Ver todas las Biblias disponibles' }),
+      ]),
+    }),
+    facts: Object.freeze({
+      publisher: 'B&H Español',
+      pages: 1728,
+      dimensions_text: '17,3 × 24,9 cm',
+      bibliographic: Object.freeze({
+        language: 'Español',
+        format: 'Símil piel',
+        edition: 'Reina-Valera 1960 · edición 2024',
+      }),
+    }),
+    schema: Object.freeze({
+      inLanguage: 'es',
+      bookEdition: 'Reina-Valera 1960 · edición 2024',
+    }),
+    provenance: Object.freeze([
+      Object.freeze({
+        type: 'publisher',
+        provider: 'B&H Español',
+        url: 'https://bhespanol.bhpublishinggroup.com/product/rvr-1960-biblia-letra-gigante-floreada-simil-piel-edicion-2023/',
+        relationship: 'exact_edition',
+        isbn: '9781430091899',
+        verified_at: '2026-08-24',
+        fields: Object.freeze(['description', 'publisher', 'pages', 'dimensions', 'format', 'bible_version', 'text_size', 'contents']),
+      }),
+    ]),
+  }),
+  Object.freeze({
+    schema_version: 1,
+    isbn: '9781535998000',
+    decision: 'auto_publish',
+    verified_at: '2026-08-24',
+    editorial: Object.freeze({
+      eyebrow: 'Biblia devocional RVR60 · edición verificada',
+      heading: 'Qué propone la Biblia devocional Centrada en Cristo',
+      paragraphs: Object.freeze([
+        'Esta edición para mujeres utiliza el texto Reina-Valera 1960 y corresponde al ISBN 9781535998000. Fue publicada por B&H Español en símil piel floreado, tiene 1.792 páginas, letra de 9,5 puntos y un formato aproximado de 15,6 × 23,2 cm.',
+        'Su recorrido devocional conecta el relato de Cristo con los distintos libros de la Biblia. Incluye 365 devocionales escritos por mujeres hispanas, planes de lectura devocional y anual, concordancia, ilustraciones a color y cinta marcadora.',
+      ]),
+      highlights_heading: 'Características comprobadas',
+      highlights: Object.freeze([
+        'Texto Reina-Valera 1960 en edición devocional para mujeres.',
+        '365 devocionales y dos planes de lectura.',
+        '1.792 páginas con letra de 9,5 puntos.',
+        'Concordancia e ilustraciones a color.',
+        'Cubierta floreada en símil piel y cinta marcadora.',
+      ]),
+      decision_heading: '¿Qué experiencia de lectura ofrece?',
+      decision_copy: 'Está pensada para quien busca una RVR60 con un acompañamiento devocional diario y una perspectiva desarrollada por mujeres hispanas. Compará el ISBN 9781535998000 y la cubierta floreada antes de elegirla.',
+      meta_description: 'Biblia devocional Centrada en Cristo RVR60, ISBN 9781535998000: 365 devocionales y 1.792 páginas. Disponible en Uruguay.',
+      merchant_description: 'Biblia devocional para mujeres Centrada en Cristo RVR60 de B&H Español. ISBN 9781535998000, símil piel, 1.792 páginas y letra de 9,5 puntos. Incluye 365 devocionales, planes de lectura, concordancia e ilustraciones.',
+      links: Object.freeze([
+        Object.freeze({ href: '/libros/biblias/reina-valera', label: 'Comparar Biblias Reina-Valera' }),
+        Object.freeze({ href: '/libros/biblias', label: 'Ver todas las Biblias disponibles' }),
+      ]),
+    }),
+    facts: Object.freeze({
+      publisher: 'B&H Español',
+      pages: 1792,
+      dimensions_text: '15,6 × 23,2 cm',
+      bibliographic: Object.freeze({
+        language: 'Español',
+        format: 'Símil piel',
+        edition: 'Reina-Valera 1960 · edición devocional',
+      }),
+    }),
+    schema: Object.freeze({
+      inLanguage: 'es',
+      bookEdition: 'Reina-Valera 1960 · edición devocional',
+    }),
+    provenance: Object.freeze([
+      Object.freeze({
+        type: 'publisher',
+        provider: 'B&H Español',
+        url: 'https://bhespanol.bhpublishinggroup.com/product/rvr1960-centrada-en-cristo-floral-simil-piel/',
+        relationship: 'exact_edition',
+        isbn: '9781535998000',
+        verified_at: '2026-08-24',
+        fields: Object.freeze(['description', 'publisher', 'pages', 'dimensions', 'format', 'bible_version', 'text_size', 'contents']),
+      }),
+    ]),
+  }),
 ]);
 
 export function validateBookEnrichment(record) {

--- a/functions/_shared/book-enrichment-registry.js
+++ b/functions/_shared/book-enrichment-registry.js
@@ -1,0 +1,280 @@
+// FICHAS-ENRICHMENT-BIBLIAS-1
+//
+// Registro editorial por EDICIÓN (ISBN-13), nunca por publicación MLU.
+// Una investigación se reutiliza en todos los duplicados compatibles, pero
+// sólo puede aportar datos bibliográficos y copy editorial: precio, stock,
+// condición, imágenes, título comercial, id y URL permanecen en el catálogo.
+
+import { normalizeValidIsbn } from './showcase-ranking.js';
+
+const SOURCE_TYPES = new Set([
+  'publisher',
+  'national_library',
+  'library_catalog',
+  'commercial_reference',
+]);
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+const BIBLE_ENRICHMENTS = Object.freeze([
+  Object.freeze({
+    schema_version: 1,
+    isbn: '9788490739808',
+    decision: 'auto_publish',
+    verified_at: '2026-08-24',
+    editorial: Object.freeze({
+      eyebrow: 'Biblia en español · edición verificada',
+      heading: 'Qué contiene esta edición de La Biblia Palabra de Vida',
+      paragraphs: Object.freeze([
+        'Esta es la edición Hispanoamérica de La Biblia Palabra de Vida, publicada por Editorial Verbo Divino. Corresponde al ISBN 9788490739808, segunda edición —reimpresión 2—, en formato rústico cosido de 15 × 21 cm y 1.600 páginas.',
+        'Utiliza una traducción interconfesional realizada desde las lenguas originales hebrea, aramea y griega. Incluye introducciones a cada libro, mapas a color, ilustraciones y apéndices con vocabulario bíblico, lecturas, preguntas para acompañar el texto y una guía de Lectio Divina.',
+      ]),
+      highlights_heading: 'Características comprobadas',
+      highlights: Object.freeze([
+        'Traducción interconfesional desde las lenguas originales.',
+        '1.600 páginas en formato de 15 × 21 cm.',
+        'Encuadernación rústica cosida con cubierta plastificada.',
+        'Introducciones, mapas a color e ilustraciones.',
+        'Vocabulario bíblico, lecturas y guía de Lectio Divina.',
+      ]),
+      decision_heading: '¿Esta es la edición que buscás?',
+      decision_copy: 'Puede ser una opción si buscás una Biblia en español con introducciones, mapas y materiales para acompañar la lectura. Antes de comprar, compará el ISBN 9788490739808 y la encuadernación rústica con la edición que necesitás.',
+      meta_description: 'La Biblia Palabra de Vida, ISBN 9788490739808: edición Hispanoamérica de Verbo Divino, 1.600 páginas, mapas y guía de Lectio Divina. Disponible en Uruguay.',
+      merchant_description: 'La Biblia Palabra de Vida, edición Hispanoamérica de Editorial Verbo Divino. ISBN 9788490739808, 1.600 páginas, formato rústico cosido de 15 × 21 cm. Traducción interconfesional con introducciones, mapas, ilustraciones, vocabulario bíblico y guía de Lectio Divina.',
+      links: Object.freeze([
+        Object.freeze({ href: '/libros/biblias', label: 'Ver más Biblias disponibles' }),
+        Object.freeze({ href: '/catalogo?categoria=religion-espiritualidad&subcategoria=biblia', label: 'Comparar otras ediciones' }),
+      ]),
+    }),
+    facts: Object.freeze({
+      publisher: 'Editorial Verbo Divino',
+      pages: 1600,
+      dimensions_text: '15 × 21 cm',
+      bibliographic: Object.freeze({
+        language: 'Español',
+        format: 'Rústica cosida',
+        edition: '2.ª edición (reimpresión 2)',
+        collection: 'La Biblia. Palabra de Vida — Hispanoamérica',
+      }),
+    }),
+    schema: Object.freeze({
+      inLanguage: 'es',
+      bookFormat: 'https://schema.org/Paperback',
+      bookEdition: '2.ª edición (reimpresión 2)',
+    }),
+    provenance: Object.freeze([
+      Object.freeze({
+        type: 'publisher',
+        provider: 'Editorial Verbo Divino',
+        url: 'https://verbodivino.es/Libro/6735/la-biblia-palabra-de-vida',
+        relationship: 'exact_edition',
+        isbn: '9788490739808',
+        verified_at: '2026-08-24',
+        fields: Object.freeze([
+          'description',
+          'publisher',
+          'pages',
+          'dimensions',
+          'format',
+          'edition',
+          'collection',
+          'contents',
+        ]),
+      }),
+      Object.freeze({
+        type: 'commercial_reference',
+        provider: 'Casa del Libro',
+        url: 'https://www.casadellibro.com/libro-la-biblia-palabra-de-vida/9788490739808/16324741',
+        relationship: 'exact_edition',
+        isbn: '9788490739808',
+        verified_at: '2026-08-24',
+        fields: Object.freeze(['publisher', 'pages', 'language', 'format']),
+      }),
+    ]),
+  }),
+  Object.freeze({
+    schema_version: 1,
+    isbn: '9780825456459',
+    decision: 'auto_publish',
+    verified_at: '2026-08-24',
+    editorial: Object.freeze({
+      eyebrow: 'Biblia de estudio RVR60 · edición verificada',
+      heading: 'Qué ofrece la Biblia de la mujer conforme al corazón de Dios',
+      paragraphs: Object.freeze([
+        'Esta Biblia de estudio utiliza el texto Reina-Valera 1960 y corresponde al ISBN 9780825456459. Es una edición de tapa dura publicada por Editorial Portavoz, con 1.680 páginas y un tamaño aproximado de 15,2 × 21,6 cm.',
+        'Sus recursos están orientados al estudio y la lectura devocional: incluye introducciones a los libros bíblicos, biografías de mujeres y hombres de la Biblia, artículos y recuadros de sabiduría, lecciones de aplicación y 365 lecturas para acompañar un plan anual.',
+      ]),
+      highlights_heading: 'Características comprobadas',
+      highlights: Object.freeze([
+        'Texto bíblico Reina-Valera 1960.',
+        '1.680 páginas y encuadernación de tapa dura.',
+        'Introducciones a los libros de la Biblia.',
+        'Biografías, artículos y recursos de aplicación.',
+        '365 lecturas devocionales para el año.',
+      ]),
+      decision_heading: '¿Para qué tipo de lectura sirve?',
+      decision_copy: 'Es una opción pensada para quien busca una Biblia RVR60 con recursos de estudio y devocionales dirigidos a la vida cotidiana de la mujer. Compará el ISBN 9780825456459 y la tapa dura antes de elegirla.',
+      meta_description: 'Biblia de la mujer conforme al corazón de Dios RVR60, ISBN 9780825456459: tapa dura, 1.680 páginas y recursos de estudio. Disponible en Uruguay.',
+      merchant_description: 'Biblia de la mujer conforme al corazón de Dios RVR60, Editorial Portavoz. ISBN 9780825456459, tapa dura y 1.680 páginas. Incluye introducciones, biografías, artículos, recursos de aplicación y 365 lecturas devocionales.',
+      links: Object.freeze([
+        Object.freeze({ href: '/libros/biblias/reina-valera', label: 'Comparar Biblias Reina-Valera' }),
+        Object.freeze({ href: '/libros/biblias', label: 'Ver todas las Biblias disponibles' }),
+      ]),
+    }),
+    facts: Object.freeze({
+      publisher: 'Editorial Portavoz',
+      pages: 1680,
+      dimensions_text: '15,2 × 21,6 cm',
+      bibliographic: Object.freeze({
+        language: 'Español',
+        format: 'Tapa dura',
+        edition: 'Reina-Valera 1960',
+      }),
+    }),
+    schema: Object.freeze({
+      inLanguage: 'es',
+      bookFormat: 'https://schema.org/Hardcover',
+      bookEdition: 'Reina-Valera 1960',
+    }),
+    provenance: Object.freeze([
+      Object.freeze({
+        type: 'publisher',
+        provider: 'Editorial Portavoz',
+        url: 'https://www.portavoz.com/biblia-de-la-mujer-conforme-al-corazon-de-dios-rvr60-tapa-dura',
+        relationship: 'exact_edition',
+        isbn: '9780825456459',
+        verified_at: '2026-08-24',
+        fields: Object.freeze(['description', 'publisher', 'pages', 'dimensions', 'format', 'bible_version', 'contents']),
+      }),
+    ]),
+  }),
+  Object.freeze({
+    schema_version: 1,
+    isbn: '9781535908160',
+    decision: 'auto_publish',
+    verified_at: '2026-08-24',
+    editorial: Object.freeze({
+      eyebrow: 'Biblia especializada RVR60 · edición verificada',
+      heading: 'Cómo está organizada la Biblia del Pescador letra grande',
+      paragraphs: Object.freeze([
+        'Esta edición en tapa dura de la Biblia del Pescador utiliza el texto Reina-Valera 1960 y corresponde al ISBN 9781535908160. Fue publicada por B&H Publishing Group, tiene 1.320 páginas, letra de 11 puntos y un formato aproximado de 15,7 × 23,4 cm.',
+        'La propuesta combina el texto bíblico con una guía temática de 28 páginas. Sus cadenas de versículos están organizadas en seis áreas —consejería, devoción, evangelismo, iglesia, doctrina cristiana y apologética— para ayudar a localizar pasajes relacionados con situaciones y preguntas concretas.',
+      ]),
+      highlights_heading: 'Características comprobadas',
+      highlights: Object.freeze([
+        'Texto Reina-Valera 1960 con letra grande de 11 puntos.',
+        '1.320 páginas y encuadernación de tapa dura.',
+        'Guía temática de 28 páginas.',
+        'Seis áreas de consulta mediante cadenas de versículos.',
+        'Edición revisada y ampliada con nuevos temas y referencias.',
+      ]),
+      decision_heading: '¿Cuándo conviene esta edición?',
+      decision_copy: 'Puede servir si buscás una RVR60 de letra grande con herramientas para encontrar pasajes por tema, preparar conversaciones o acompañar tareas de estudio y ministerio. Verificá el ISBN 9781535908160 y la tapa dura para distinguirla de las versiones en símil piel.',
+      meta_description: 'Biblia del Pescador RVR60 letra grande, ISBN 9781535908160: tapa dura, 1.320 páginas y guía temática. Disponible en Uruguay.',
+      merchant_description: 'Biblia del Pescador RVR60 letra grande, B&H Publishing Group. ISBN 9781535908160, tapa dura, 1.320 páginas y letra de 11 puntos. Incluye una guía temática de 28 páginas con cadenas de versículos.',
+      links: Object.freeze([
+        Object.freeze({ href: '/libros/biblias/reina-valera', label: 'Comparar Biblias Reina-Valera' }),
+        Object.freeze({ href: '/libros/biblias', label: 'Ver todas las Biblias disponibles' }),
+      ]),
+    }),
+    facts: Object.freeze({
+      publisher: 'B&H Publishing Group',
+      pages: 1320,
+      dimensions_text: '15,7 × 23,4 cm',
+      bibliographic: Object.freeze({
+        language: 'Español',
+        format: 'Tapa dura',
+        edition: 'Reina-Valera 1960 · edición revisada y ampliada',
+      }),
+    }),
+    schema: Object.freeze({
+      inLanguage: 'es',
+      bookFormat: 'https://schema.org/Hardcover',
+      bookEdition: 'Reina-Valera 1960 · edición revisada y ampliada',
+    }),
+    provenance: Object.freeze([
+      Object.freeze({
+        type: 'publisher',
+        provider: 'B&H Español',
+        url: 'https://bhespanol.bhpublishinggroup.com/product/rvr-1960-biblia-del-pescador-letra-grande/rvr-1960-biblia-del-pescador-letra-grande-tapa-dura/',
+        relationship: 'exact_edition',
+        isbn: '9781535908160',
+        verified_at: '2026-08-24',
+        fields: Object.freeze(['description', 'publisher', 'pages', 'dimensions', 'format', 'bible_version', 'contents']),
+      }),
+    ]),
+  }),
+]);
+
+export function validateBookEnrichment(record) {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) return false;
+  const isbn = normalizeValidIsbn(record.isbn);
+  if (!isbn || isbn !== record.isbn || record.schema_version !== 1) return false;
+  if (record.decision !== 'auto_publish') return false;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(clean(record.verified_at))) return false;
+  if (!Array.isArray(record.editorial?.paragraphs) || record.editorial.paragraphs.length < 1) return false;
+  if (record.editorial.paragraphs.some(paragraph => clean(paragraph).length < 80)) return false;
+  if (!Array.isArray(record.provenance) || record.provenance.length < 1) return false;
+  const exactOfficial = record.provenance.some(source =>
+    source?.type === 'publisher' &&
+    source?.relationship === 'exact_edition' &&
+    normalizeValidIsbn(source?.isbn) === isbn &&
+    /^https:\/\//i.test(clean(source?.url)),
+  );
+  if (!exactOfficial) return false;
+  return record.provenance.every(source =>
+    SOURCE_TYPES.has(source?.type) &&
+    source?.relationship === 'exact_edition' &&
+    normalizeValidIsbn(source?.isbn) === isbn &&
+    /^https:\/\//i.test(clean(source?.url)) &&
+    /^\d{4}-\d{2}-\d{2}$/.test(clean(source?.verified_at)) &&
+    Array.isArray(source?.fields) && source.fields.length > 0,
+  );
+}
+
+const ENRICHMENT_BY_ISBN = new Map();
+for (const record of BIBLE_ENRICHMENTS) {
+  if (!validateBookEnrichment(record)) {
+    throw new Error(`Enriquecimiento bibliográfico inválido para ${record?.isbn || 'ISBN desconocido'}.`);
+  }
+  if (ENRICHMENT_BY_ISBN.has(record.isbn)) {
+    throw new Error(`ISBN duplicado en el registro de enriquecimiento: ${record.isbn}.`);
+  }
+  ENRICHMENT_BY_ISBN.set(record.isbn, record);
+}
+
+export function getBookEnrichmentByIsbn(value) {
+  const isbn = normalizeValidIsbn(value);
+  return isbn ? ENRICHMENT_BY_ISBN.get(isbn) || null : null;
+}
+
+export function applyBookEnrichment(item) {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return item;
+  const enrichment = getBookEnrichmentByIsbn(item.isbn);
+  if (!enrichment) return item;
+
+  const facts = enrichment.facts || {};
+  const bibliography = item.bibliographic && typeof item.bibliographic === 'object'
+    ? item.bibliographic
+    : {};
+
+  // Lista blanca: únicamente campos editoriales. La expansión explícita
+  // impide que una futura entrada del registro reemplace datos comerciales.
+  return {
+    ...item,
+    description: enrichment.editorial.paragraphs.join('\n\n'),
+    publisher: facts.publisher || item.publisher,
+    pages: facts.pages || item.pages,
+    dimensions_text: facts.dimensions_text || item.dimensions_text,
+    bibliographic: {
+      ...bibliography,
+      ...(facts.bibliographic || {}),
+    },
+  };
+}
+
+export function listBookEnrichments() {
+  return [...ENRICHMENT_BY_ISBN.values()];
+}

--- a/functions/feed.xml.js
+++ b/functions/feed.xml.js
@@ -57,6 +57,10 @@ import { slugify } from './_shared/slug.js';
 import { fetchCatalog } from './_shared/catalog.js';
 // FICHAS-QUALITY-GUARD-1: misma definición de autoría genérica que la ficha.
 import { realAuthor } from './_shared/generic-author.js';
+import {
+    applyBookEnrichment,
+    getBookEnrichmentByIsbn,
+} from './_shared/book-enrichment-registry.js';
 
 const CANONICAL_BASE_URL = "https://www.amadolibros.com";
 const SITE_TITLE = "Amado Libros";
@@ -330,6 +334,10 @@ export function normalizePublisherForDescription(publisher) {
  * paso del algoritmo pedido.
  */
 export function buildFeedDescription(item) {
+    const enrichment = getBookEnrichmentByIsbn(item?.isbn);
+    if (enrichment?.editorial?.merchant_description) {
+        return enrichment.editorial.merchant_description;
+    }
     const title = (item.title || '').trim();
     if (item.description && item.description.trim() && item.description.trim() !== title) {
         return item.description.trim();
@@ -426,6 +434,7 @@ async function readMerchantCoverManifest(context) {
 // ---------------------------------------------------------------------------
 
 export function renderFeedItem(item) {
+    item = applyBookEnrichment(item);
     const stock = Number(item.available_quantity) || 0;
     const currency = String(item.currency || item.currency_id || '').trim().toUpperCase();
     if (currency !== 'UYU') throw new Error(`Moneda no publicable en Merchant para ${item.id || 'item sin id'}.`);

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -17,6 +17,7 @@ import { slugify } from '../_shared/slug.js';
 // FICHAS-QUALITY-GUARD-1: fuente única sobre autoría genérica/ausente.
 import { isGenericAuthor, realAuthor, stripGenericAuthorMention } from '../_shared/generic-author.js';
 import { BASE, fetchCatalog, fetchPausedItem } from '../_shared/catalog.js';
+import { applyBookEnrichment } from '../_shared/book-enrichment-registry.js';
 import { previewCoverUrl as resolvePreviewCoverUrl } from '../_shared/preview-cover.js';
 import { authorPathForName } from '../_shared/seo-authors.js';
 import { PRODUCT_ID_REDIRECTS, PRODUCT_SEO_OVERRIDES } from '../_shared/seo-products.js';
@@ -1077,6 +1078,10 @@ export async function onRequest(context) {
     }
     if (!item) return notFound();
 
+    // El enriquecimiento sólo agrega datos bibliográficos verificados. El
+    // título permanece intacto, por lo que el slug/canonical conserva la URL
+    // comercial existente.
+    item = applyBookEnrichment(item);
     const slug = slugify(item.title);
     const isPreview = context.env?.APP_ENV === 'preview';
     const navigationBase = isPreview

--- a/functions/libro/_middleware.js
+++ b/functions/libro/_middleware.js
@@ -603,7 +603,12 @@ export async function onRequest(context) {
 
   let withAutomaticShowcase = withByRequestCx;
   if (withByRequestCx.includes(ACTIVE_PAGE_MARKER) && !PRODUCT_SHOWCASE_OVERRIDES[productId]) {
-    const selected = await isProductInShowcaseCohort(context, productId);
+    // Una investigación por ISBN pertenece a la EDICIÓN y debe beneficiar a
+    // todas sus publicaciones compatibles, aunque un duplicado concreto no
+    // haya quedado dentro de la cohorte general de 3.000 fichas.
+    const extractedItem = productItemFromProductHtml(withByRequestCx, productId);
+    const hasVerifiedEnrichment = Boolean(getBookEnrichmentByIsbn(extractedItem?.isbn));
+    const selected = hasVerifiedEnrichment || await isProductInShowcaseCohort(context, productId);
     if (selected) {
       const classificationTags = await classificationTagsForProduct(context, productId);
       withAutomaticShowcase = enrichAutomaticProductShowcaseHtml(

--- a/functions/libro/_middleware.js
+++ b/functions/libro/_middleware.js
@@ -11,6 +11,7 @@ import {
 import { isProductInShowcaseCohort } from '../_shared/showcase-cohort.js';
 import { PRODUCT_SHOWCASE_OVERRIDES } from '../_shared/product-showcases.js';
 import { applyShowcaseTitleQuality } from '../_shared/showcase-title-quality.js';
+import { getBookEnrichmentByIsbn } from '../_shared/book-enrichment-registry.js';
 
 const PRODUCT_PATH_RE = /^\/libro\/(MLU\d+)(?:\/|$)/i;
 const BREADCRUMB_RE = /<nav>\s*<a href="\/">Inicio<\/a>\s*›\s*<span>/;
@@ -104,6 +105,11 @@ function showcaseStyles() {
     .showcase-links a{font-size:.84rem;font-weight:800;color:#8f4436;text-decoration:none}
     .showcase-links a:hover{text-decoration:underline}
     .showcase-links a:focus-visible{outline:2px solid #a94e3d;outline-offset:2px}
+    .showcase-sources{margin-top:.9rem;padding-top:.75rem;border-top:1px solid #eef2f7}
+    .showcase-sources summary{cursor:pointer;font-size:.8rem;font-weight:800;color:#64748b}
+    .showcase-source-links{display:flex;flex-wrap:wrap;gap:.45rem 1rem;margin-top:.55rem}
+    .showcase-source-links a{font-size:.8rem;font-weight:750;color:#8f4436;text-decoration:none}
+    .showcase-source-links a:hover{text-decoration:underline}
     .showcase-help{display:flex;align-items:center;justify-content:space-between;gap:1rem;
                    margin-top:1.15rem;padding:.85rem 1rem;background:#fff8f4;
                    border:1px solid #ecd1c6;border-radius:.65rem}
@@ -265,6 +271,18 @@ function renderProductShowcase(config, productId) {
   const linksHtml = links
     ? `<div class="showcase-links">\n      ${links}\n    </div>`
     : '';
+  const sourceLinks = (Array.isArray(config.sources) ? config.sources : [])
+    // La corroboración comercial queda en la trazabilidad interna, pero la
+    // ficha no deriva compradores hacia otros comercios. Sólo se muestran
+    // fuentes editoriales o bibliográficas primarias.
+    .filter(source => source?.type !== 'commercial_reference')
+    .filter(source => /^https:\/\//i.test(String(source?.url || '')))
+    .slice(0, 3)
+    .map(source => `<a href="${escapeHtml(source.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(source.provider || 'Fuente bibliográfica')}</a>`)
+    .join('\n        ');
+  const sourcesHtml = sourceLinks
+    ? `<details class="showcase-sources"><summary>Fuentes bibliográficas consultadas</summary><div class="showcase-source-links">\n        ${sourceLinks}\n      </div></details>`
+    : '';
   const requestQuery = new URLSearchParams({
     tipo: 'exacto',
     q: String(config.h1 || ''),
@@ -325,6 +343,7 @@ ${gridHtml}  <section class="showcase-edition" aria-labelledby="showcase-edition
       ${facts}
     </dl>
     ${linksHtml}
+    ${sourcesHtml}
     ${requestHelpHtml}
   </section>
 </section>`;
@@ -390,6 +409,9 @@ function enrichAutomaticShowcaseSchema(html, productId, config) {
       if (!schema.alternateName && config.rawTitle) schema.alternateName = config.rawTitle;
     }
     schema.description = config.schemaDescription;
+    if (config.schemaVerified?.inLanguage) schema.inLanguage = config.schemaVerified.inLanguage;
+    if (config.schemaVerified?.bookFormat) schema.bookFormat = config.schemaVerified.bookFormat;
+    if (config.schemaVerified?.bookEdition) schema.bookEdition = config.schemaVerified.bookEdition;
     return `<script type="application/ld+json">${serializeSchema(schema)}</script>`;
   });
 }
@@ -441,7 +463,8 @@ export function enrichAutomaticProductShowcaseHtml(html, productId, options = {}
   }
 
   const item = productItemFromProductHtml(source, id);
-  const baseConfig = buildAutomaticProductShowcase(item, options);
+  const enrichment = getBookEnrichmentByIsbn(item?.isbn);
+  const baseConfig = buildAutomaticProductShowcase(item, { ...options, enrichment });
   const config = applyShowcaseTitleQuality(baseConfig, item);
   if (!config) return source;
 

--- a/scripts/seo/bible-enrichment-cohort.mjs
+++ b/scripts/seo/bible-enrichment-cohort.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// FICHAS-ENRICHMENT-BIBLIAS-1
+//
+// Construye la cola real de investigación por EDICIÓN (ISBN-13). No modifica
+// el catálogo ni publica contenido: mide el universo activo, consolida
+// duplicados y separa lo ya enriquecido de lo que requiere investigación o
+// validación editorial.
+//
+// Uso con el catálogo público:
+//   node scripts/seo/bible-enrichment-cohort.mjs
+//
+// Uso reproducible con una descarga local:
+//   BIBLE_CATALOG_SOURCE=/tmp/catalog.json \
+//     node scripts/seo/bible-enrichment-cohort.mjs
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+import { CATALOG_URL } from '../../functions/_shared/catalog.js';
+import { listBookEnrichments } from '../../functions/_shared/book-enrichment-registry.js';
+import { normalizeValidIsbn } from '../../functions/_shared/showcase-ranking.js';
+
+const DEFAULT_CLASSIFICATIONS = 'astro-front/public/data/active-categories.json';
+const DEFAULT_OUTPUT = 'artifacts/fichas-enrichment/bible-cohort-current.json';
+const MIN_USEFUL_DESCRIPTION = 80;
+const BIBLE_TAGS = new Set(['biblia', 'reina-valera']);
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function bestRepresentative(items) {
+  return [...items].sort((a, b) => {
+    const stock = (Number(b.available_quantity) || 0) - (Number(a.available_quantity) || 0);
+    if (stock !== 0) return stock;
+    const description = clean(b.description).length - clean(a.description).length;
+    if (description !== 0) return description;
+    return clean(a.id).localeCompare(clean(b.id));
+  })[0];
+}
+
+export function buildBibleEnrichmentCohort({ catalogItems, classifications, enrichments }) {
+  const enrichedIsbns = new Set(
+    (Array.isArray(enrichments) ? enrichments : [])
+      .map(record => normalizeValidIsbn(record?.isbn))
+      .filter(Boolean),
+  );
+  const activeListings = (Array.isArray(catalogItems) ? catalogItems : []).filter(item => {
+    const tags = Array.isArray(classifications?.[item?.id]) ? classifications[item.id] : [];
+    return item?.status === 'active' && tags.some(tag => BIBLE_TAGS.has(tag));
+  });
+
+  const editionsByIsbn = new Map();
+  for (const item of activeListings) {
+    const isbn = normalizeValidIsbn(item?.isbn);
+    if (!isbn) continue;
+    if (!editionsByIsbn.has(isbn)) editionsByIsbn.set(isbn, []);
+    editionsByIsbn.get(isbn).push(item);
+  }
+
+  const editions = [...editionsByIsbn.entries()].map(([isbn, items]) => {
+    const representative = bestRepresentative(items);
+    const tags = [...new Set(items.flatMap(item => classifications[item.id] || []))];
+    const descriptionLength = Math.max(...items.map(item => clean(item.description).length));
+    const enriched = enrichedIsbns.has(isbn);
+    const status = enriched
+      ? 'enriched_verified'
+      : descriptionLength < MIN_USEFUL_DESCRIPTION
+        ? 'research_external'
+        : 'review_catalog_description';
+    const stock = items.reduce((total, item) => total + (Number(item.available_quantity) || 0), 0);
+    const priorityScore =
+      (status === 'research_external' ? 1000 : status === 'review_catalog_description' ? 500 : 0) +
+      (tags.includes('reina-valera') ? 250 : 0) +
+      Math.min(stock, 100) * 5 +
+      Math.min(items.length, 10) * 2;
+
+    return {
+      isbn,
+      status,
+      priority_score: priorityScore,
+      title: clean(representative?.title),
+      representative_id: clean(representative?.id),
+      listing_ids: items.map(item => clean(item.id)).sort(),
+      active_listings: items.length,
+      total_stock: stock,
+      classification_tags: tags.filter(tag => BIBLE_TAGS.has(tag)).sort(),
+      description_length: descriptionLength,
+      has_useful_catalog_description: descriptionLength >= MIN_USEFUL_DESCRIPTION,
+    };
+  }).sort((a, b) => b.priority_score - a.priority_score || a.isbn.localeCompare(b.isbn));
+
+  const count = status => editions.filter(edition => edition.status === status).length;
+  return {
+    schema_version: 1,
+    generated_at: new Date().toISOString(),
+    scope: 'active Bible and Reina-Valera editions grouped by exact ISBN-13',
+    metrics: {
+      active_listings: activeListings.length,
+      unique_isbn_editions: editions.length,
+      listings_without_valid_isbn: activeListings.length - [...editionsByIsbn.values()].reduce((sum, items) => sum + items.length, 0),
+      enriched_verified: count('enriched_verified'),
+      research_external: count('research_external'),
+      review_catalog_description: count('review_catalog_description'),
+    },
+    editions,
+  };
+}
+
+async function readJson(source) {
+  if (/^https?:\/\//i.test(source)) {
+    const response = await fetch(source, { headers: { accept: 'application/json' } });
+    if (!response.ok) throw new Error(`${source} respondió HTTP ${response.status}`);
+    return response.json();
+  }
+  return JSON.parse(readFileSync(source, 'utf8'));
+}
+
+async function main() {
+  const catalogSource = process.env.BIBLE_CATALOG_SOURCE || CATALOG_URL;
+  const classificationsSource = process.env.BIBLE_CLASSIFICATIONS_SOURCE || DEFAULT_CLASSIFICATIONS;
+  const output = process.env.BIBLE_COHORT_OUTPUT || DEFAULT_OUTPUT;
+  const [catalog, classificationDocument] = await Promise.all([
+    readJson(catalogSource),
+    readJson(classificationsSource),
+  ]);
+  const report = buildBibleEnrichmentCohort({
+    catalogItems: catalog?.items,
+    classifications: classificationDocument?.items,
+    enrichments: listBookEnrichments(),
+  });
+
+  mkdirSync(output.split('/').slice(0, -1).join('/') || '.', { recursive: true });
+  writeFileSync(output, `${JSON.stringify(report, null, 2)}\n`);
+
+  console.log('── Cohorte de enriquecimiento de Biblias ──');
+  for (const [key, value] of Object.entries(report.metrics)) {
+    console.log(`  ${key.padEnd(34)} ${value}`);
+  }
+  console.log(`\nEscrito: ${output}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(`bible-enrichment-cohort falló: ${error.message}`);
+    process.exitCode = 1;
+  });
+}
+

--- a/scripts/seo/bible-enrichment-cohort.mjs
+++ b/scripts/seo/bible-enrichment-cohort.mjs
@@ -146,4 +146,3 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
     process.exitCode = 1;
   });
 }
-

--- a/scripts/seo/book-enrichment-live-check.mjs
+++ b/scripts/seo/book-enrichment-live-check.mjs
@@ -88,21 +88,39 @@ async function main() {
     const candidates = items
       .filter(item => item?.status === 'active' && normalizeValidIsbn(item?.isbn) === record.isbn)
       .sort((a, b) => (Number(b.available_quantity) || 0) - (Number(a.available_quantity) || 0));
-    const item = candidates[0];
-    if (!item) {
+    if (!candidates.length) {
       reports.push({ isbn: record.isbn, status: 'failed', failures: ['no hay publicación activa para la edición'] });
       continue;
     }
-    const page = await fetchText(`${BASE_URL}/libro/${item.id}`);
-    const failures = [
-      ...verifyBookEnrichmentHtml(page.text, record, item.id),
-      ...verifyBookEnrichmentFeed(feedResponse.text, record, item.id),
-    ];
+
+    // El contenido editorial debe llegar a TODOS los duplicados activos de la
+    // edición, no solamente al representante de la cohorte automática.
+    const pageChecks = [];
+    for (const item of candidates) {
+      const page = await fetchText(`${BASE_URL}/libro/${item.id}`);
+      pageChecks.push({
+        product_id: item.id,
+        url: page.finalUrl,
+        http_status: page.status,
+        failures: verifyBookEnrichmentHtml(page.text, record, item.id),
+      });
+    }
+
+    // Merchant consolida ofertas duplicadas por GTIN. Se verifica el MLU que
+    // efectivamente ganó en el feed, no se presupone que sea el de mayor stock.
+    const merchantItem = candidates.find(item => itemBlock(feedResponse.text, item.id));
+    const failures = pageChecks.flatMap(check =>
+      check.failures.map(failure => `${check.product_id}: ${failure}`));
+    if (!merchantItem) {
+      failures.push('ninguna publicación de la edición aparece en Merchant');
+    } else {
+      failures.push(...verifyBookEnrichmentFeed(feedResponse.text, record, merchantItem.id));
+    }
     reports.push({
       isbn: record.isbn,
-      product_id: item.id,
-      url: page.finalUrl,
-      http_status: page.status,
+      product_ids: candidates.map(item => item.id),
+      merchant_product_id: merchantItem?.id || null,
+      pages: pageChecks,
       status: failures.length ? 'failed' : 'verified',
       failures,
     });
@@ -119,7 +137,7 @@ async function main() {
   }, null, 2)}\n`);
 
   for (const report of reports) {
-    console.log(`  ${report.isbn} · ${report.product_id || 'sin MLU'} · ${report.status}`);
+    console.log(`  ${report.isbn} · ${(report.product_ids || []).join(', ') || 'sin MLU'} · ${report.status}`);
     for (const failure of report.failures) console.error(`    - ${failure}`);
   }
   if (failed.length) throw new Error(`${failed.length} edición(es) fallaron la verificación HTTP.`);

--- a/scripts/seo/book-enrichment-live-check.mjs
+++ b/scripts/seo/book-enrichment-live-check.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// FICHAS-ENRICHMENT-BIBLIAS-1 — gate HTTP real del Preview.
+//
+// Verifica todas las ediciones del registro, no una muestra. Si una futura
+// entrada queda fuera del render SSR, del showcase o de Merchant, el Preview
+// falla antes de que el PR pueda llegar a Producción.
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+import { CATALOG_URL } from '../../functions/_shared/catalog.js';
+import { listBookEnrichments } from '../../functions/_shared/book-enrichment-registry.js';
+import { normalizeValidIsbn } from '../../functions/_shared/showcase-ranking.js';
+
+const BASE_URL = String(process.env.BOOK_ENRICHMENT_BASE_URL || '').replace(/\/$/, '');
+const OUTPUT_DIR = process.env.BOOK_ENRICHMENT_OUTPUT_DIR || 'artifacts/fichas-quality';
+
+function decodeEntities(value) {
+  return String(value || '')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}
+
+function clean(value) {
+  return decodeEntities(value).replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function itemBlock(feedXml, id) {
+  return (String(feedXml || '').match(/<item>[\s\S]*?<\/item>/gi) || [])
+    .find(block => block.includes(`<g:id>${id}</g:id>`)) || '';
+}
+
+function containsGenericAuthor(value) {
+  return /(?:>|&quot;|["'])\s*(?:desconocido|unknown|sin autor|n\/a)\s*(?:<|&quot;|["'])/i.test(String(value || ''));
+}
+
+export function verifyBookEnrichmentHtml(html, record, productId) {
+  const text = clean(html);
+  const failures = [];
+  if (!text.includes(record.editorial.heading)) failures.push('falta el encabezado editorial');
+  if (!text.includes(record.facts.publisher)) failures.push('falta la editorial verificada');
+  if (!text.includes(record.isbn)) failures.push('falta el ISBN exacto');
+  if (!text.includes(record.editorial.decision_heading)) failures.push('falta ayuda de decisión');
+  if (!html.includes(`MLU${String(productId).replace(/\D/g, '')}`)) failures.push('falta el ID comercial');
+  if (containsGenericAuthor(html)) failures.push('aparece autoría genérica');
+  if (/casadellibro\.com/i.test(html)) failures.push('se expone una referencia comercial externa');
+  return failures;
+}
+
+export function verifyBookEnrichmentFeed(feedXml, record, productId) {
+  const block = itemBlock(feedXml, productId);
+  if (!block) return ['falta la oferta en Merchant'];
+  const text = clean(block);
+  const failures = [];
+  if (!text.includes(record.isbn)) failures.push('Merchant perdió el ISBN');
+  if (!block.includes('<g:price>')) failures.push('Merchant perdió el precio');
+  if (!block.includes('<g:availability>')) failures.push('Merchant perdió disponibilidad');
+  if (!block.includes('<g:link>')) failures.push('Merchant perdió el enlace');
+  if (!block.includes('<g:image_link>')) failures.push('Merchant perdió la imagen');
+  const descriptionSignal = clean(record.editorial.merchant_description).split(' ').slice(0, 7).join(' ');
+  if (!text.includes(descriptionSignal)) failures.push('Merchant no recibió la descripción enriquecida');
+  if (containsGenericAuthor(block)) failures.push('Merchant expone autoría genérica');
+  return failures;
+}
+
+async function fetchText(url) {
+  const response = await fetch(url, { redirect: 'follow', headers: { accept: 'text/html,application/xml' } });
+  const text = await response.text();
+  if (!response.ok) throw new Error(`${url} respondió HTTP ${response.status}`);
+  return { text, finalUrl: response.url, status: response.status };
+}
+
+async function main() {
+  if (!/^https:\/\//i.test(BASE_URL)) throw new Error('Falta BOOK_ENRICHMENT_BASE_URL HTTPS.');
+  const [catalogResponse, feedResponse] = await Promise.all([
+    fetch(CATALOG_URL, { headers: { accept: 'application/json' } }),
+    fetchText(`${BASE_URL}/feed.xml`),
+  ]);
+  if (!catalogResponse.ok) throw new Error(`Catálogo respondió HTTP ${catalogResponse.status}`);
+  const catalog = await catalogResponse.json();
+  const items = Array.isArray(catalog?.items) ? catalog.items : [];
+  const reports = [];
+
+  for (const record of listBookEnrichments()) {
+    const candidates = items
+      .filter(item => item?.status === 'active' && normalizeValidIsbn(item?.isbn) === record.isbn)
+      .sort((a, b) => (Number(b.available_quantity) || 0) - (Number(a.available_quantity) || 0));
+    const item = candidates[0];
+    if (!item) {
+      reports.push({ isbn: record.isbn, status: 'failed', failures: ['no hay publicación activa para la edición'] });
+      continue;
+    }
+    const page = await fetchText(`${BASE_URL}/libro/${item.id}`);
+    const failures = [
+      ...verifyBookEnrichmentHtml(page.text, record, item.id),
+      ...verifyBookEnrichmentFeed(feedResponse.text, record, item.id),
+    ];
+    reports.push({
+      isbn: record.isbn,
+      product_id: item.id,
+      url: page.finalUrl,
+      http_status: page.status,
+      status: failures.length ? 'failed' : 'verified',
+      failures,
+    });
+  }
+
+  const failed = reports.filter(report => report.status !== 'verified');
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  writeFileSync(`${OUTPUT_DIR}/book-enrichment-live-check.json`, `${JSON.stringify({
+    base_url: BASE_URL,
+    checked_at: new Date().toISOString(),
+    verified: reports.length - failed.length,
+    failed: failed.length,
+    reports,
+  }, null, 2)}\n`);
+
+  for (const report of reports) {
+    console.log(`  ${report.isbn} · ${report.product_id || 'sin MLU'} · ${report.status}`);
+    for (const failure of report.failures) console.error(`    - ${failure}`);
+  }
+  if (failed.length) throw new Error(`${failed.length} edición(es) fallaron la verificación HTTP.`);
+  console.log(`OK: ${reports.length} ediciones enriquecidas verificadas en ficha y Merchant.`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(`book-enrichment-live-check falló: ${error.message}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## FICHAS-ENRICHMENT-BIBLIAS-1

Primer lote del sistema continuo de enriquecimiento editorial por **edición exacta (ISBN-13)**.

### Qué entrega

- Registro versionado por ISBN con procedencia por campo.
- Copy editorial propio: no copia sinopsis de terceros.
- Datos verificados en ficha SSR, showcase automático, schema `Book` y descripción de Merchant.
- Mantiene intactos título comercial, slug/canonical, precio, stock, condición, imágenes e ID.
- Muestra sólo fuentes editoriales/bibliográficas; las referencias comerciales quedan en la trazabilidad interna y no envían compradores a competidores.
- Cola reproducible que consolida duplicados y prioriza investigación por stock y Reina-Valera.\n- Gate HTTP de Preview que abre todas las publicaciones duplicadas de cada edición y valida también la oferta que Merchant selecciona.

### Primer lote: 6 ediciones verificadas

1. `9788490739808` — La Biblia Palabra de Vida (Editorial Verbo Divino).
2. `9780825456459` — Biblia de la mujer conforme al corazón de Dios RVR60 (Editorial Portavoz).
3. `9781535908160` — Biblia del Pescador RVR60 letra grande, tapa dura (B&H Español).
4. `9781087701417` — Biblia cronológica día por día RVR60 (B&H Español).
5. `9781430091899` — Biblia RVR60 letra gigante floreada (B&H Español).
6. `9781535998000` — Biblia devocional Centrada en Cristo RVR60 (B&H Español).

### Cohorte real actual

- 126 publicaciones activas de Biblia/Reina-Valera.
- 70 ediciones únicas, todas con ISBN válido.
- 6 enriquecidas y verificadas en este lote.
- 42 sin descripción útil: cola de investigación externa.
- 22 con descripción del catálogo: cola de validación editorial.

### Regla de publicación

Una edición se publica solamente con una fuente editorial oficial que muestre el ISBN exacto, o con dos fuentes bibliográficas secundarias coincidentes. Los conflictos quedan fuera de publicación.

### Fuentes oficiales del lote

- https://verbodivino.es/Libro/6735/la-biblia-palabra-de-vida
- https://www.portavoz.com/biblia-de-la-mujer-conforme-al-corazon-de-dios-rvr60-tapa-dura
- https://bhespanol.bhpublishinggroup.com/product/rvr-1960-biblia-del-pescador-letra-grande/rvr-1960-biblia-del-pescador-letra-grande-tapa-dura/
- https://bhespanol.bhpublishinggroup.com/product/rvr-1960-biblia-cronologica-dia-por-dia-marron-simil-piel/
- https://bhespanol.bhpublishinggroup.com/product/rvr-1960-biblia-letra-gigante-floreada-simil-piel-edicion-2023/
- https://bhespanol.bhpublishinggroup.com/product/rvr1960-centrada-en-cristo-floral-simil-piel/

### Validación local

- Focalizadas de lote, ficha, schema, feed y Merchant: 22/22.
- Suite completa: 1.320/1.320.
- Astro checkout OFF: OK.
- Astro checkout ON: OK.

### Fuera de alcance

- No fusionar ni desplegar sin autorización explícita.
- No investigar por coincidencia aproximada de título.
- No modificar precios, stock, portadas, URLs ni productos no incluidos.
