### PR TITLE
HOME: priorizar Tarot, Biblias y accesos visuales

### DIFF
--- a/astro-front/src/components/BestsellerSection.astro
+++ b/astro-front/src/components/BestsellerSection.astro
@@ -43,7 +43,7 @@ try {
 {missing
   ? <Fragment set:html="<!-- novedades: home.json no encontrado en build — sección omitida -->" />
   : (books.length > 0 && (
-      <section class="bs-section">
+      <section id="incorporaciones-recientes" class="bs-section">
         <div class="bs-inner">
           <h2 class="bs-heading">Incorporaciones recientes</h2>
           <div class="bs-grid">
@@ -57,6 +57,7 @@ try {
 
 <style>
   .bs-section {
+    scroll-margin-top: 5rem;
     background: var(--bg);
     border-top: 1px solid var(--border);
   }

--- a/astro-front/src/components/CategoryAccess.astro
+++ b/astro-front/src/components/CategoryAccess.astro
@@ -1,40 +1,35 @@
 ---
-// HOME — ACCESO A CATEGORÍAS
-// Acceso visual compacto a las categorías principales, conectado con el
-// filtro ?categoria= de /catalogo. Mismo patrón de BestsellerSection: lee
-// un JSON estático en build time (fs), sin JS cliente, sin llamada nueva
-// en runtime. No toca checkout, Mercado Pago ni fichas individuales.
-//
-// Fuente: astro-front/public/data/active-categories.json — el mismo
-// artefacto que consume functions/catalogo.js (scripts/categorize/
-// export-active-categories.js). No se regenera en cada deploy: se
-// actualiza cuando se vuelve a correr el pipeline de clasificación y se
-// commitea, igual que en el catálogo.
+// Accesos editoriales prioritarios de la portada. Los conteos salen del
+// mismo artefacto versionado que usa el catálogo. Se renderiza en build:
+// no agrega JavaScript ni solicitudes en el cliente.
 import fs from 'node:fs';
 import path from 'node:path';
 
 const CATEGORIES_JSON = path.resolve(process.cwd(), 'public/data/active-categories.json');
 
-interface Category {
+interface Subcategory {
   id: string;
   name: string;
   count: number;
 }
 
-// Allowlist SEO: solo estas categorías tienen una landing limpia e
-// indexable. Mantener cerrada evita enlazar automáticamente categorías
-// débiles o catch-all a páginas que Google no debería indexar.
+interface Category {
+  id: string;
+  name: string;
+  count: number;
+  subcategories?: Subcategory[];
+}
+
 const SEO_CATEGORY_IDS = [
-  'infantil-juvenil',
   'esoterismo-tarot',
+  'religion-espiritualidad',
+  'infantil-juvenil',
   'medicina-salud',
   'literatura-ficcion',
   'idiomas-aprendizaje',
   'psicologia',
   'desarrollo-personal',
-  'religion-espiritualidad',
 ];
-const seoOrder = new Map(SEO_CATEGORY_IDS.map((id, index) => [id, index]));
 
 let categories: Category[] = [];
 let missing = false;
@@ -42,188 +37,343 @@ let missing = false;
 try {
   const raw = fs.readFileSync(CATEGORIES_JSON, 'utf-8');
   const data = JSON.parse(raw) as { categories: Category[] };
-  categories = (data.categories || [])
-    .filter(c => seoOrder.has(c.id))
-    .sort((a, b) => seoOrder.get(a.id)! - seoOrder.get(b.id)!);
-} catch (e: unknown) {
+  categories = data.categories || [];
+} catch (error: unknown) {
   missing = true;
-  const msg = e instanceof Error ? e.message : String(e);
-  console.warn('[CategoryAccess] active-categories.json no disponible en build:', msg);
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn('[CategoryAccess] active-categories.json no disponible en build:', message);
 }
+
+const category = (id: string) => categories.find(entry => entry.id === id);
+const subcategoryCount = (categoryId: string, subcategoryId: string) =>
+  category(categoryId)?.subcategories?.find(entry => entry.id === subcategoryId)?.count || 0;
+
+const priorityAccesses = [
+  {
+    id: 'tarot',
+    eyebrow: 'Elegí tu mazo',
+    name: 'Tarot y oráculos',
+    description: 'Mazos, oráculos y libros para comparar.',
+    href: '/libros/esoterismo-tarot',
+    count: subcategoryCount('esoterismo-tarot', 'tarot-oraculos'),
+    icon: '✦',
+    tone: 'night',
+  },
+  {
+    id: 'biblias',
+    eyebrow: 'Ediciones y formatos',
+    name: 'Biblias',
+    description: 'Católicas y otras ediciones: letra, tamaño y encuadernación.',
+    href: '/libros/biblias',
+    count: subcategoryCount('religion-espiritualidad', 'biblia'),
+    icon: 'B',
+    tone: 'clay',
+  },
+  {
+    id: 'reina-valera',
+    eyebrow: 'Acceso directo',
+    name: 'Reina-Valera',
+    description: 'RVR 1960 y otras ediciones identificadas.',
+    href: '/libros/biblias/reina-valera',
+    count: subcategoryCount('religion-espiritualidad', 'reina-valera'),
+    icon: 'RV',
+    tone: 'gold',
+  },
+  {
+    id: 'psicologia',
+    eyebrow: 'Personas y vínculos',
+    name: 'Psicología',
+    description: 'Clínica, crianza, neurociencias y bienestar.',
+    href: '/libros/psicologia',
+    count: category('psicologia')?.count || 0,
+    icon: 'Ψ',
+    tone: 'sage',
+  },
+  {
+    id: 'infantil',
+    eyebrow: 'Para crecer leyendo',
+    name: 'Infantil y juvenil',
+    description: 'Historias, aprendizaje y libros para regalar.',
+    href: '/libros/infantil-juvenil',
+    count: category('infantil-juvenil')?.count || 0,
+    icon: 'A',
+    tone: 'sky',
+  },
+  {
+    id: 'recientes',
+    eyebrow: 'Lo que acaba de llegar',
+    name: 'Incorporaciones recientes',
+    description: 'Nuevos ingresos con stock publicados por fecha.',
+    href: '#incorporaciones-recientes',
+    count: 0,
+    icon: '+',
+    tone: 'rose',
+  },
+];
+
+const secondaryAccesses = [
+  {
+    name: 'Cábala y Kabbalah',
+    href: '/catalogo?categoria=esoterismo-tarot&subcategoria=cabala-kabbalah',
+    count: subcategoryCount('esoterismo-tarot', 'cabala-kabbalah'),
+  },
+  {
+    name: 'Sufismo',
+    href: '/catalogo?categoria=esoterismo-tarot&subcategoria=sufismo',
+    count: subcategoryCount('esoterismo-tarot', 'sufismo'),
+  },
+];
+
+const seoCategories = categories
+  .filter(entry => SEO_CATEGORY_IDS.includes(entry.id))
+  .filter(entry => !['esoterismo-tarot', 'infantil-juvenil', 'psicologia'].includes(entry.id));
+
+const number = new Intl.NumberFormat('es-UY');
 ---
 
 {missing
-  ? <Fragment set:html="<!-- acceso a categorías: active-categories.json no encontrado en build — sección omitida -->" />
-  : (categories.length > 0 && (
-      <section class="ca-section" aria-label="Categorías del catálogo">
-        <div class="ca-inner">
-          <h2 class="ca-heading">Explorá por categoría</h2>
-          <div class="ca-row" role="list">
-            <a class="ca-chip ca-chip-priority" href="/libros/biblias" role="listitem">
-              <span class="ca-chip-name">Biblias</span>
-              <span class="ca-chip-count">Ediciones para comparar</span>
-              <span class="ca-chip-scope">Disponibles y por encargo</span>
-            </a>
-            <a class="ca-chip ca-chip-priority" href="/libros/biblias/reina-valera" role="listitem">
-              <span class="ca-chip-name">Biblias Reina-Valera</span>
-              <span class="ca-chip-count">Revisiones y formatos</span>
-              <span class="ca-chip-scope">Disponibles y por encargo</span>
-            </a>
-            {categories.map(cat => (
-              <a
-                class="ca-chip"
-                href={`/libros/${encodeURIComponent(cat.id)}`}
-                role="listitem"
-              >
-                <span class="ca-chip-name">{cat.name}</span>
-                <span class="ca-chip-count">{cat.count} títulos</span>
-                <span class="ca-chip-scope">Disponibles y por encargo</span>
-              </a>
-            ))}
-            <a class="ca-chip ca-chip-all" href="/catalogo">
-              Ver todo el catálogo →
-            </a>
-          </div>
+  ? <Fragment set:html="<!-- accesos editoriales: active-categories.json no encontrado en build -->" />
+  : (
+    <section class="ca-panel" aria-labelledby="ca-heading">
+      <div class="ca-heading-row">
+        <div>
+          <span class="ca-kicker">Entrá por lo que estás buscando</span>
+          <h2 id="ca-heading">Encontrá más rápido tu próxima lectura</h2>
         </div>
-      </section>
-    ))
+        <a class="ca-all ca-all-desktop" href="/catalogo">Ver catálogo completo →</a>
+      </div>
+
+      <div class="ca-grid" role="list">
+        {priorityAccesses.map(entry => (
+          <a
+            class={`ca-card ca-card-${entry.tone}`}
+            href={entry.href}
+            data-home-access={entry.id}
+            role="listitem"
+          >
+            <span class="ca-icon" aria-hidden="true">{entry.icon}</span>
+            <span class="ca-card-copy">
+              <span class="ca-eyebrow">{entry.eyebrow}</span>
+              <strong>{entry.name}</strong>
+              <span class="ca-description">{entry.description}</span>
+              {entry.count > 0 && <small>{number.format(entry.count)} títulos disponibles y por encargo</small>}
+            </span>
+            <span class="ca-arrow" aria-hidden="true">→</span>
+          </a>
+        ))}
+      </div>
+
+      <div class="ca-secondary" aria-label="Más accesos del catálogo">
+        <span class="ca-secondary-label">También podés explorar:</span>
+        {secondaryAccesses.map(entry => (
+          <a href={entry.href}>
+            {entry.name}{entry.count > 0 ? ` · ${number.format(entry.count)}` : ''}
+          </a>
+        ))}
+        {seoCategories.map(cat => (
+          <a href={`/libros/${encodeURIComponent(cat.id)}`}>
+            {cat.name} · {number.format(cat.count)}
+          </a>
+        ))}
+      </div>
+
+      <a class="ca-all ca-all-mobile" href="/catalogo">Ver catálogo completo →</a>
+    </section>
+  )
 }
 
 <style>
-  .ca-section {
-    background: var(--surface);
-    border-top: 1px solid var(--border);
+  .ca-panel {
+    padding: 1.1rem;
+    background: rgba(255, 255, 255, 0.78);
+    border: 1px solid rgba(58, 43, 34, 0.14);
+    border-radius: 1.25rem;
+    box-shadow: 0 18px 50px rgba(45, 32, 24, 0.09);
   }
 
-  .ca-inner {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 1.75rem 1.5rem;
+  .ca-heading-row {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.85rem;
   }
 
-  @media (min-width: 768px) {
-    .ca-inner { padding: 2.25rem 2rem; }
+  .ca-kicker {
+    display: block;
+    margin-bottom: 0.25rem;
+    color: var(--salmon-hover);
+    font-size: 0.64rem;
+    font-weight: 850;
+    letter-spacing: 0.085em;
+    text-transform: uppercase;
   }
 
-  .ca-heading {
-    font-family: var(--font-display);
-    font-weight: 700;
-    font-size: clamp(1.125rem, 2.4vw, 1.375rem);
+  .ca-heading-row h2 {
+    max-width: 20ch;
     color: var(--ink);
-    letter-spacing: -0.01em;
-    margin-bottom: 1rem;
+    font-family: var(--font-display);
+    font-size: clamp(1.3rem, 2.6vw, 1.75rem);
+    line-height: 1.08;
   }
 
-  /* Mobile (HOME-UX-MOBILE-1 punto 2): grilla compacta de 2 columnas
-     iguales, sin scroll horizontal — antes era una fila con scroll que
-     escondía categorías sin que fuera evidente que había que arrastrar.
-     Nombre arriba (puede ocupar 2 líneas), cantidad debajo y
-     visualmente secundaria. */
-  .ca-row {
+  .ca-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.6rem;
+    gap: 0.55rem;
   }
 
-  .ca-chip {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.2rem;
-    min-height: 3.25rem;
-    padding: 0.75rem 0.9rem;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: var(--r);
+  .ca-card {
+    position: relative;
+    display: grid;
+    grid-template-columns: 2rem minmax(0, 1fr);
+    gap: 0.55rem;
+    min-width: 0;
+    padding: 0.85rem 0.7rem;
+    overflow: hidden;
+    border: 1px solid rgba(51, 42, 35, 0.12);
+    border-radius: 0.85rem;
     color: var(--ink);
-    font-family: var(--font-ui);
-    font-size: 0.85rem;
-    font-weight: 600;
     text-decoration: none;
-    white-space: normal;
-    overflow-wrap: break-word;
-    transition: background 0.15s, border-color 0.15s, transform 0.15s;
+    transition: transform 0.16s, border-color 0.16s, box-shadow 0.16s;
   }
 
-  .ca-chip:hover {
-    background: rgba(228, 153, 130, 0.12);
+  .ca-card:hover {
+    transform: translateY(-2px);
     border-color: var(--salmon);
-    transform: translateY(-1px);
+    box-shadow: 0 8px 20px rgba(45, 32, 24, 0.1);
   }
 
-  .ca-chip-priority {
-    background: rgba(228, 153, 130, 0.14);
-    border-color: var(--salmon);
-  }
+  .ca-card-night { background: linear-gradient(145deg, #282034, #463650); color: #fff; }
+  .ca-card-clay { background: linear-gradient(145deg, #f8e2d8, #f2caba); }
+  .ca-card-gold { background: linear-gradient(145deg, #f5e9c9, #ead49d); }
+  .ca-card-sage { background: linear-gradient(145deg, #e1eee3, #c8decf); }
+  .ca-card-sky { background: linear-gradient(145deg, #e1edf0, #c9dfe5); }
+  .ca-card-rose { background: linear-gradient(145deg, #f5dfe2, #edc7ce); }
 
-  .ca-chip-name {
-    line-height: 1.3;
-  }
-
-  .ca-chip-count {
-    color: var(--ink-2);
-    font-weight: 500;
-    font-size: 0.75rem;
-  }
-
-  .ca-chip-scope {
-    color: var(--ink-2);
-    font-weight: 500;
-    font-size: 0.68rem;
-    line-height: 1.2;
-  }
-
-  .ca-chip-all {
-    grid-column: 1 / -1;
+  .ca-icon {
+    display: inline-flex;
     align-items: center;
     justify-content: center;
-    text-align: center;
-    background: var(--ink);
-    border-color: var(--ink);
-    color: #fff;
+    width: 2rem;
+    height: 2rem;
+    border: 1px solid currentColor;
+    border-radius: 999px;
+    font-family: var(--font-display);
+    font-size: 0.78rem;
+    font-weight: 800;
+    opacity: 0.82;
   }
 
-  .ca-chip-all:hover {
-    background: var(--salmon-hover);
-    border-color: var(--salmon-hover);
+  .ca-card-copy,
+  .ca-card-copy > span,
+  .ca-card-copy strong,
+  .ca-card-copy small {
+    display: block;
   }
 
-  /* Desktop (>=700px): presentación anterior — pill de una línea, nombre
-     y cantidad lado a lado, grid de 3 columnas. Queda igual que antes de
-     este lote. */
+  .ca-eyebrow {
+    margin-bottom: 0.15rem;
+    font-size: 0.58rem;
+    font-weight: 800;
+    letter-spacing: 0.045em;
+    text-transform: uppercase;
+    opacity: 0.68;
+  }
+
+  .ca-card strong {
+    font-size: 0.88rem;
+    line-height: 1.16;
+  }
+
+  .ca-description,
+  .ca-card small,
+  .ca-arrow {
+    display: none;
+  }
+
+  .ca-secondary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.45rem;
+    margin-top: 0.8rem;
+  }
+
+  .ca-secondary-label {
+    width: 100%;
+    color: var(--ink-2);
+    font-size: 0.68rem;
+    font-weight: 700;
+  }
+
+  .ca-secondary a {
+    padding: 0.38rem 0.58rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--ink);
+    font-size: 0.67rem;
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  .ca-secondary a:hover { border-color: var(--salmon); }
+
+  .ca-all {
+    color: var(--ink);
+    font-size: 0.74rem;
+    font-weight: 800;
+    text-decoration: none;
+  }
+
+  .ca-all-desktop { display: none; }
+
+  .ca-all-mobile {
+    display: inline-flex;
+    margin-top: 0.85rem;
+    padding-bottom: 0.12rem;
+    border-bottom: 1.5px solid var(--salmon);
+  }
+
   @media (min-width: 700px) {
-    .ca-row {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+    .ca-panel { padding: 1.35rem; }
+    .ca-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .ca-all-desktop { display: inline-flex; flex: 0 0 auto; }
+    .ca-all-mobile { display: none; }
+  }
+
+  @media (min-width: 1000px) {
+    .ca-card {
+      grid-template-columns: 2.25rem minmax(0, 1fr) auto;
+      min-height: 7.2rem;
+      padding: 0.85rem;
     }
 
-    .ca-chip {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) auto;
-      align-items: center;
-      gap: 0.4rem;
-      min-height: 0;
-      padding: 0.6rem 1rem;
-      border-radius: 999px;
+    .ca-icon { width: 2.25rem; height: 2.25rem; }
+    .ca-card strong { font-size: 0.94rem; }
+
+    .ca-description {
+      display: block;
+      margin-top: 0.25rem;
+      font-size: 0.68rem;
+      line-height: 1.3;
+      opacity: 0.78;
     }
 
-    .ca-chip-name {
-      grid-row: 1 / 3;
+    .ca-card small {
+      display: block;
+      margin-top: 0.35rem;
+      font-size: 0.58rem;
+      line-height: 1.25;
+      opacity: 0.62;
     }
 
-    .ca-chip-count,
-    .ca-chip-scope {
-      text-align: right;
-      white-space: nowrap;
-    }
-
-    .ca-chip-scope {
-      font-size: 0.62rem;
-    }
-
-    .ca-chip-all {
-      display: flex;
-      max-width: 260px;
-      margin: 0 auto;
+    .ca-arrow {
+      display: block;
+      align-self: end;
+      font-size: 1rem;
+      opacity: 0.65;
     }
   }
 </style>

--- a/astro-front/src/components/CommercialBenefits.astro
+++ b/astro-front/src/components/CommercialBenefits.astro
@@ -1,0 +1,231 @@
+<section class="commercial-section" aria-labelledby="commercial-heading">
+  <div class="commercial-panel">
+    <div class="commercial-heading">
+      <span>Comprar en Amado Libros</span>
+      <h2 id="commercial-heading">Claro, rápido y con atención personal.</h2>
+      <p>Te ayudamos a encontrar la edición correcta y coordinamos cada pedido con vos.</p>
+    </div>
+
+    <ul class="benefit-grid" role="list">
+      <li>
+        <span class="benefit-icon" aria-hidden="true">2h</span>
+        <span>
+          <strong>Biblias seleccionadas en aprox. 2 horas*</strong>
+          <small>En Montevideo, cuando hay stock apto para express.</small>
+        </span>
+      </li>
+      <li>
+        <span class="benefit-icon" aria-hidden="true">12</span>
+        <span>
+          <strong>Hasta 12 cuotas</strong>
+          <small>Con Mercado Pago.</small>
+        </span>
+      </li>
+      <li>
+        <span class="benefit-icon" aria-hidden="true">%</span>
+        <span>
+          <strong>12% menos por transferencia</strong>
+          <small>Cuando corresponda para ese producto.</small>
+        </span>
+      </li>
+      <li>
+        <span class="benefit-icon" aria-hidden="true">UY</span>
+        <span>
+          <strong>Envíos a todo Uruguay</strong>
+          <small>Envío gratis desde el importe vigente.</small>
+        </span>
+      </li>
+      <li>
+        <span class="benefit-icon" aria-hidden="true">+</span>
+        <span>
+          <strong>Libros por encargo</strong>
+          <small>Buscamos agotados, importados y ediciones difíciles.</small>
+        </span>
+      </li>
+      <li>
+        <span class="benefit-icon" aria-hidden="true">IG</span>
+        <span>
+          <strong>Pedidos para iglesias</strong>
+          <small>Lotes, presentación y personalización provista por la congregación.</small>
+        </span>
+      </li>
+    </ul>
+
+    <p class="delivery-disclaimer">
+      *La entrega express depende del título, stock, zona, horario y disponibilidad del servicio. La confirmamos antes de enviarlo.
+    </p>
+
+    <div class="request-box">
+      <div>
+        <strong>¿No encontrás el libro?</strong>
+        <span>Una persona de Amado Libros revisa tu pedido.</span>
+        <a class="request-guide" href="/libros-agotados-importados-uruguay">
+          Cómo funciona nuestro servicio de encargos →
+        </a>
+      </div>
+      <a class="request-button" href="/pedir-libro?tipo=exacto">
+        Contanos qué libro buscás
+      </a>
+    </div>
+  </div>
+</section>
+
+<style>
+  .commercial-section {
+    padding: 2.5rem 1.25rem;
+    background: var(--bg);
+  }
+
+  .commercial-panel {
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 1.5rem;
+    border-radius: 1.15rem;
+    background: var(--ink);
+    color: #fff;
+    box-shadow: 0 18px 48px rgba(24, 18, 14, 0.16);
+  }
+
+  .commercial-heading > span {
+    color: var(--salmon);
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .commercial-heading h2 {
+    max-width: 22ch;
+    margin-top: 0.35rem;
+    color: #fff;
+    font-family: var(--font-display);
+    font-size: clamp(1.55rem, 4.5vw, 2.15rem);
+    line-height: 1.12;
+  }
+
+  .commercial-heading p {
+    max-width: 54ch;
+    margin-top: 0.55rem;
+    color: rgba(255, 255, 255, 0.72);
+    font-size: 0.82rem;
+    line-height: 1.5;
+  }
+
+  .benefit-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.65rem;
+    margin-top: 1.2rem;
+    padding: 0;
+    list-style: none;
+  }
+
+  .benefit-grid li {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    min-width: 0;
+    padding: 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 0.75rem;
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .benefit-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 2rem;
+    height: 2rem;
+    border: 1px solid currentColor;
+    border-radius: 999px;
+    color: var(--salmon);
+    font-size: 0.65rem;
+    font-weight: 850;
+  }
+
+  .benefit-grid strong,
+  .benefit-grid small {
+    display: block;
+  }
+
+  .benefit-grid strong {
+    color: #fff;
+    font-size: 0.78rem;
+    line-height: 1.25;
+  }
+
+  .benefit-grid small {
+    margin-top: 0.18rem;
+    color: rgba(255, 255, 255, 0.67);
+    font-size: 0.66rem;
+    line-height: 1.3;
+  }
+
+  .delivery-disclaimer {
+    margin-top: 0.75rem;
+    color: rgba(255, 255, 255, 0.52);
+    font-size: 0.66rem;
+    line-height: 1.45;
+  }
+
+  .request-box {
+    display: grid;
+    gap: 0.9rem;
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.16);
+  }
+
+  .request-box strong,
+  .request-box span {
+    display: block;
+  }
+
+  .request-box strong { color: #fff; font-size: 0.95rem; }
+
+  .request-box span {
+    margin-top: 0.2rem;
+    color: rgba(255, 255, 255, 0.72);
+    font-size: 0.78rem;
+  }
+
+  .request-guide {
+    display: inline-block;
+    margin-top: 0.45rem;
+    color: #fff;
+    font-size: 0.73rem;
+    font-weight: 700;
+    text-underline-offset: 0.18em;
+  }
+
+  .request-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 46px;
+    padding: 0.75rem 1rem;
+    border-radius: 0.65rem;
+    background: var(--salmon);
+    color: #fff;
+    font-size: 0.82rem;
+    font-weight: 800;
+    line-height: 1.15;
+    text-align: center;
+    text-decoration: none;
+  }
+
+  .request-button:hover { background: var(--salmon-hover); }
+
+  @media (min-width: 700px) {
+    .commercial-section { padding: 3.5rem 2rem; }
+    .commercial-panel { padding: 2rem; }
+    .benefit-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .request-box { grid-template-columns: minmax(0, 1fr) auto; align-items: center; }
+  }
+
+  @media (max-width: 390px) {
+    .benefit-grid { grid-template-columns: 1fr; }
+  }
+</style>

--- a/astro-front/src/components/Hero.astro
+++ b/astro-front/src/components/Hero.astro
@@ -1,15 +1,16 @@
 ---
+import CategoryAccess from './CategoryAccess.astro';
 ---
 
 <section class="hero-shell">
   <div class="hero">
     <div class="hero-content">
-      <span class="hero-badge">Librería uruguaya</span>
+      <span class="hero-badge">Librería uruguaya · compra online</span>
 
-      <h1 class="hero-h1">Especialistas en libros difíciles de conseguir.</h1>
+      <h1 class="hero-h1">Tarot, Biblias y libros difíciles de conseguir en Uruguay.</h1>
 
       <p class="hero-lead">
-        Buscá entre nuestros libros disponibles o pedinos ediciones agotadas e importadas de Europa y otros mercados.
+        Buscá por título, autor o ISBN. También conseguimos ediciones agotadas e importadas de Europa y otros mercados.
       </p>
 
       <form class="hero-search" action="/catalogo" method="get" role="search">
@@ -30,95 +31,22 @@
         >
         <button type="submit">Buscar</button>
       </form>
+
+      <div class="hero-help">
+        <span>¿No aparece en el catálogo?</span>
+        <a href="/pedir-libro?tipo=exacto">Pedinos una búsqueda manual →</a>
+      </div>
     </div>
 
-    <aside class="hero-commercial" aria-label="Ventajas de comprar en Amado Libros">
-      <div class="commercial-heading">
-        <span>Comprar en Amado Libros</span>
-        <h2>Claro, rápido y con atención personal.</h2>
-      </div>
-
-      <ul class="benefit-grid" role="list">
-        <li>
-          <span class="benefit-icon" aria-hidden="true">
-            <svg viewBox="0 0 32 32" fill="none">
-              <path d="M3 19h17V9H3v10Zm17-7h5l4 5v2h-9v-7Z" stroke="currentColor" stroke-width="1.8"/>
-              <circle cx="8" cy="22" r="2.5" stroke="currentColor" stroke-width="1.8"/>
-              <circle cx="24" cy="22" r="2.5" stroke="currentColor" stroke-width="1.8"/>
-            </svg>
-          </span>
-          <span>
-            <strong>Entrega en 2 horas*</strong>
-            <small>En Montevideo</small>
-          </span>
-        </li>
-
-        <li>
-          <span class="benefit-icon" aria-hidden="true">
-            <svg viewBox="0 0 32 32" fill="none">
-              <rect x="3.5" y="7" width="25" height="18" rx="3" stroke="currentColor" stroke-width="1.8"/>
-              <path d="M4 12h24M8 20h7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
-            </svg>
-          </span>
-          <span>
-            <strong>Hasta 12 cuotas</strong>
-            <small>Con Mercado Pago</small>
-          </span>
-        </li>
-
-        <li>
-          <span class="benefit-icon" aria-hidden="true">
-            <svg viewBox="0 0 32 32" fill="none">
-              <path d="M6 10.5A4.5 4.5 0 1 0 15 10.5a4.5 4.5 0 0 0-9 0ZM17 21.5a4.5 4.5 0 1 0 9 0 4.5 4.5 0 0 0-9 0Z" stroke="currentColor" stroke-width="1.8"/>
-              <path d="m8 26 16-20" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-          </span>
-          <span>
-            <strong>12% menos</strong>
-            <small>Pagando por transferencia</small>
-          </span>
-        </li>
-
-        <li>
-          <span class="benefit-icon" aria-hidden="true">
-            <svg viewBox="0 0 32 32" fill="none">
-              <circle cx="14.5" cy="15.5" r="9.5" stroke="currentColor" stroke-width="1.8"/>
-              <path d="M5 15.5h19M14.5 6c3.4 3.3 4.5 6.5 4.5 9.5S17.9 21.7 14.5 25M14.5 6C11.1 9.3 10 12.5 10 15.5s1.1 6.2 4.5 9.5" stroke="currentColor" stroke-width="1.6"/>
-              <path d="m22 22 6 6M23.5 18.5v7M20 22h7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
-            </svg>
-          </span>
-          <span>
-            <strong>Libros por encargo</strong>
-            <small>Europa y otros mercados</small>
-          </span>
-        </li>
-      </ul>
-
-      <p class="delivery-disclaimer">*El plazo depende de la zona y del horario del pedido. Coordinamos la entrega con vos.</p>
-
-      <div class="request-box">
-        <div>
-          <strong>¿No encontrás el libro?</strong>
-          <span>Buscamos agotados, importados y ediciones difíciles.</span>
-          <a class="request-guide" href="/libros-agotados-importados-uruguay">
-            Cómo funciona nuestro servicio de encargos →
-          </a>
-        </div>
-        <a
-          href="/pedir-libro?tipo=exacto"
-          aria-label="Contar qué libro buscás"
-        >
-          Contanos qué libro buscás
-        </a>
-      </div>
-    </aside>
+    <CategoryAccess />
   </div>
 </section>
 
 <style>
   .hero-shell {
     background:
-      radial-gradient(circle at 18% 30%, rgba(228, 153, 130, 0.1), transparent 34%),
+      radial-gradient(circle at 12% 18%, rgba(228, 153, 130, 0.16), transparent 34%),
+      radial-gradient(circle at 90% 0%, rgba(218, 193, 135, 0.14), transparent 30%),
       var(--bg);
     border-bottom: 1px solid var(--border);
   }
@@ -127,41 +55,43 @@
     max-width: 1200px;
     margin: 0 auto;
     display: grid;
+    gap: 1rem;
+    padding: 1.6rem 1rem 1.4rem;
   }
 
   .hero-content {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    padding: 2rem 1.25rem;
+    padding: 0.5rem 0.25rem;
   }
 
   .hero-badge {
     align-self: flex-start;
-    margin-bottom: 0.8rem;
+    margin-bottom: 0.65rem;
     color: var(--salmon-hover);
-    font-size: 0.6875rem;
-    font-weight: 800;
-    letter-spacing: 0.09em;
+    font-size: 0.67rem;
+    font-weight: 850;
+    letter-spacing: 0.085em;
     text-transform: uppercase;
   }
 
   .hero-h1 {
-    max-width: 12.5ch;
+    max-width: 13ch;
     color: var(--ink);
     font-family: var(--font-display);
-    font-size: clamp(2.05rem, 7vw, 3.8rem);
+    font-size: clamp(2.15rem, 7vw, 4rem);
     font-weight: 700;
-    letter-spacing: -0.035em;
-    line-height: 1.04;
+    letter-spacing: -0.038em;
+    line-height: 1.01;
   }
 
   .hero-lead {
-    max-width: 48ch;
-    margin-top: 1rem;
+    max-width: 51ch;
+    margin-top: 0.9rem;
     color: var(--ink-2);
-    font-size: clamp(0.96rem, 2vw, 1.08rem);
-    line-height: 1.55;
+    font-size: clamp(0.94rem, 2vw, 1.07rem);
+    line-height: 1.5;
   }
 
   .hero-search {
@@ -171,13 +101,13 @@
     gap: 0.65rem;
     width: 100%;
     max-width: 650px;
-    margin-top: 1.35rem;
+    margin-top: 1.15rem;
     padding: 0.4rem;
     padding-left: 1rem;
     background: var(--surface);
     border: 1.5px solid #d8cfc4;
     border-radius: 0.875rem;
-    box-shadow: 0 8px 28px rgba(24, 18, 14, 0.06);
+    box-shadow: 0 8px 28px rgba(24, 18, 14, 0.07);
   }
 
   .hero-search:focus-within {
@@ -185,10 +115,7 @@
     box-shadow: 0 0 0 4px rgba(228, 153, 130, 0.14);
   }
 
-  .hero-search-icon {
-    display: flex;
-    color: var(--ink);
-  }
+  .hero-search-icon { display: flex; color: var(--ink); }
 
   .hero-search input {
     min-width: 0;
@@ -201,10 +128,7 @@
     font: 500 1rem/1.2 var(--font-ui);
   }
 
-  .hero-search input::placeholder {
-    color: #8a8178;
-    opacity: 1;
-  }
+  .hero-search input::placeholder { color: #8a8178; opacity: 1; }
 
   .hero-search button {
     min-height: 44px;
@@ -213,203 +137,45 @@
     border-radius: 0.65rem;
     background: var(--salmon);
     color: #fff;
-    font: 700 0.95rem/1 var(--font-ui);
+    font: 750 0.95rem/1 var(--font-ui);
     cursor: pointer;
-    transition: background 0.15s, transform 0.15s;
   }
 
   .hero-search button:hover { background: var(--salmon-hover); }
-  .hero-search button:active { transform: translateY(1px); }
 
-  .hero-commercial {
-    padding: 1.4rem 1.25rem 1.6rem;
-    border-top: 1px solid var(--border);
-    background: var(--ink);
-    color: #fff;
-  }
-
-  .commercial-heading > span {
-    color: var(--salmon);
-    font-size: 0.68rem;
-    font-weight: 800;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  .commercial-heading h2 {
-    max-width: 22ch;
-    margin-top: 0.35rem;
-    color: #fff;
-    font-family: var(--font-display);
-    font-size: clamp(1.4rem, 4.5vw, 1.8rem);
-    line-height: 1.12;
-  }
-
-  .benefit-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.65rem;
-    margin-top: 1.1rem;
-    padding: 0;
-    list-style: none;
-  }
-
-  .benefit-grid li {
+  .hero-help {
     display: flex;
-    align-items: center;
-    gap: 0.65rem;
-    min-width: 0;
-    padding: 0.7rem;
-    border: 1px solid rgba(255, 255, 255, 0.14);
-    border-radius: 0.75rem;
-    background: rgba(255, 255, 255, 0.06);
+    flex-wrap: wrap;
+    gap: 0.25rem 0.55rem;
+    margin-top: 0.75rem;
+    color: var(--ink-2);
+    font-size: 0.73rem;
   }
 
-  .benefit-icon {
-    display: flex;
-    flex: 0 0 auto;
-    width: 28px;
-    height: 28px;
-    color: var(--salmon);
-  }
-
-  .benefit-icon svg {
-    width: 100%;
-    height: 100%;
-  }
-
-  .benefit-grid strong,
-  .benefit-grid small {
-    display: block;
-  }
-
-  .benefit-grid strong {
-    color: #fff;
-    font-size: 0.8rem;
-    line-height: 1.2;
-  }
-
-  .benefit-grid small {
-    margin-top: 0.2rem;
-    color: rgba(255, 255, 255, 0.72);
-    font-size: 0.68rem;
-    line-height: 1.25;
-  }
-
-  .delivery-disclaimer {
-    margin-top: 0.6rem;
-    color: rgba(255, 255, 255, 0.5);
-    font-size: 0.68rem;
-    line-height: 1.4;
-  }
-
-  .request-box {
-    display: grid;
-    gap: 0.85rem;
-    margin-top: 1rem;
-    padding-top: 1rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.16);
-  }
-
-  .request-box strong,
-  .request-box span {
-    display: block;
-  }
-
-  .request-box .request-guide {
-    display: inline-block;
-    min-height: 0;
-    margin-top: 0.45rem;
-    padding: 0;
-    border-radius: 0;
-    background: transparent;
-    color: #fff;
-    font-size: 0.76rem;
-    font-weight: 700;
-    line-height: 1.35;
-    text-align: left;
-    text-decoration: underline;
-    text-decoration-color: rgba(255, 255, 255, 0.45);
-    text-underline-offset: 0.18em;
-  }
-
-  .request-box .request-guide:hover {
-    background: transparent;
-    text-decoration-color: #fff;
-  }
-
-  .request-box strong {
-    color: #fff;
-    font-size: 0.95rem;
-  }
-
-  .request-box span {
-    margin-top: 0.2rem;
-    color: rgba(255, 255, 255, 0.72);
-    font-size: 0.78rem;
-  }
-
-  .request-box a {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 46px;
-    padding: 0.75rem 1rem;
-    border-radius: 0.65rem;
-    background: var(--salmon);
-    color: #fff;
-    font-size: 0.84rem;
+  .hero-help a {
+    color: var(--ink);
     font-weight: 800;
-    line-height: 1.15;
-    text-align: center;
-    text-decoration: none;
-    transition: background 0.15s, transform 0.15s;
+    text-decoration-color: var(--salmon);
+    text-underline-offset: 0.15em;
   }
-
-  .request-box a:hover { background: var(--salmon-hover); }
-  .request-box a:active { transform: translateY(1px); }
 
   @media (min-width: 700px) {
-    .hero-content { padding: 3rem 2rem; }
-
-    .hero-commercial {
-      padding: 2rem;
-    }
-
-    .request-box {
-      grid-template-columns: minmax(0, 1fr) auto;
-      align-items: center;
-    }
+    .hero { padding: 2.2rem 2rem; }
   }
 
-  @media (min-width: 900px) {
+  @media (min-width: 980px) {
     .hero {
-      grid-template-columns: minmax(0, 1.08fr) minmax(420px, 0.92fr);
-      min-height: 510px;
-      align-items: stretch;
+      grid-template-columns: minmax(340px, 0.78fr) minmax(550px, 1.22fr);
+      gap: 2rem;
+      min-height: 590px;
+      align-items: center;
+      padding-top: 2.5rem;
+      padding-bottom: 2.5rem;
     }
-
-    .hero-content {
-      padding: 3.5rem 3rem 3.5rem 2rem;
-    }
-
-    .hero-commercial {
-      align-self: center;
-      margin: 2.25rem 2rem 2.25rem 0;
-      padding: 1.75rem;
-      border: 0;
-      border-radius: 1rem;
-      box-shadow: 0 18px 48px rgba(24, 18, 14, 0.18);
-    }
-
-    .benefit-grid li { padding: 0.8rem; }
-    .benefit-grid strong { font-size: 0.84rem; }
-    .benefit-grid small { font-size: 0.72rem; }
   }
 
   @media (min-width: 1200px) {
-    .hero-content { padding-left: 0; }
-    .hero-commercial { margin-right: 0; }
+    .hero { padding-left: 0; padding-right: 0; }
   }
 
   @media (max-width: 430px) {
@@ -422,11 +188,5 @@
       grid-column: 1 / -1;
       width: 100%;
     }
-
-    .commercial-heading h2 { max-width: none; }
-  }
-
-  @media (max-width: 350px) {
-    .benefit-grid { grid-template-columns: 1fr; }
   }
 </style>

--- a/astro-front/src/pages/index.astro
+++ b/astro-front/src/pages/index.astro
@@ -7,15 +7,14 @@ import Hero                from '../components/Hero.astro';
 import DeliveryCoordination from '../components/DeliveryCoordination.astro';
 import BookDiscovery       from '../components/BookDiscovery.astro';
 import GuideAccess         from '../components/GuideAccess.astro';
-import CategoryAccess      from '../components/CategoryAccess.astro';
 import OrderHubAccess      from '../components/OrderHubAccess.astro';
 import BestsellerSection   from '../components/BestsellerSection.astro';
+import CommercialBenefits from '../components/CommercialBenefits.astro';
 import Footer              from '../components/Footer.astro';
 import WAFloat             from '../components/WAFloat.astro';
 import SearchOverlay          from '../components/SearchOverlay.astro';
 import CatalogSearchOverlay  from '../components/CatalogSearchOverlay.astro';
 import HowToBuy           from '../components/HowToBuy.astro';
-import ShippingPayments    from '../components/ShippingPayments.astro';
 import TrustStrip          from '../components/TrustStrip.astro';
 
 const jsonLd = {
@@ -28,7 +27,7 @@ const jsonLd = {
       url: 'https://www.amadolibros.com/',
       logo: 'https://www.amadolibros.com/images/logo-amado.webp',
       image: 'https://www.amadolibros.com/images/logo-amado.webp',
-      description: 'Librería online uruguaya, familiar y atendida por sus dueños. Vende libros disponibles y realiza búsquedas manuales de títulos agotados, importados o difíciles de conseguir.',
+      description: 'Librería online uruguaya especializada en Tarot, oráculos, Biblias, libros disponibles y búsquedas manuales de títulos agotados, importados o difíciles de conseguir.',
       telephone: '+59899841325',
       email: 'adm@amadolibros.com',
       sameAs: [
@@ -64,22 +63,21 @@ const jsonLd = {
 };
 ---
 <BaseLayout
-  title="Libros difíciles, agotados e importados | Amado Libros"
+  title="Librería online en Uruguay: Tarot, Biblias y más | Amado Libros"
   canonical="https://www.amadolibros.com/"
-  description="Conseguimos libros agotados, importados y difíciles de ubicar en Uruguay. Encargos desde Europa y otros mercados, con envíos a todo el país."
+  description="Comprá Tarot, oráculos, Biblias Reina-Valera, Biblias católicas y más libros en Uruguay. También buscamos ediciones agotadas, importadas o difíciles."
   jsonLd={jsonLd}
 >
   <Header showSearch={false} showMobileDeliveryBanner={true} />
   <main>
     <Hero />
-    <DeliveryCoordination />
-    <CategoryAccess />
-    <OrderHubAccess />
     <BestsellerSection />
     <BookDiscovery />
+    <OrderHubAccess />
     <GuideAccess />
+    <CommercialBenefits />
+    <DeliveryCoordination />
     <HowToBuy />
-    <ShippingPayments />
     <TrustStrip />
   </main>
   <Footer />

--- a/functions/__tests__/home-commercial-fold.test.js
+++ b/functions/__tests__/home-commercial-fold.test.js
@@ -14,23 +14,38 @@ const heroAstro = readFileSync(
   path.join(ROOT, 'astro-front', 'src', 'components', 'Hero.astro'),
   'utf8',
 );
+const commercialAstro = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'components', 'CommercialBenefits.astro'),
+  'utf8',
+);
+const homeAstro = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'pages', 'index.astro'),
+  'utf8',
+);
 
-test('Hero: muestra las cuatro ventajas comerciales sin prometer cuotas sin interés', () => {
-  assert.match(heroAstro, /Entrega en 2 horas/);
-  assert.match(heroAstro, /Hasta 12 cuotas/);
-  assert.match(heroAstro, /12% menos/);
-  assert.match(heroAstro, /Libros por encargo/);
-  assert.doesNotMatch(heroAstro, /cuotas sin interés/i);
+test('el primer pantallazo prioriza búsqueda y categorías, no el bloque comercial', () => {
+  assert.match(heroAstro, /<CategoryAccess \/>/);
+  assert.match(heroAstro, /Título, autor o ISBN/);
+  assert.doesNotMatch(heroAstro, /Claro, rápido y con atención personal/);
+  assert.ok(homeAstro.indexOf('<CommercialBenefits />') > homeAstro.indexOf('<BookDiscovery />'));
 });
 
-test('Hero: el CTA de encargos inicia la búsqueda manual guiada', () => {
+test('el bloque comercial conserva beneficios con condiciones explícitas', () => {
+  assert.match(commercialAstro, /Biblias seleccionadas en aprox\. 2 horas/);
+  assert.match(commercialAstro, /stock, zona, horario y disponibilidad/);
+  assert.match(commercialAstro, /Hasta 12 cuotas/);
+  assert.match(commercialAstro, /12% menos por transferencia/);
+  assert.match(commercialAstro, /Cuando corresponda para ese producto/);
+  assert.match(commercialAstro, /Libros por encargo/);
+  assert.doesNotMatch(commercialAstro, /cuotas sin interés|cuotas sin recargo/i);
+});
+
+test('los CTA de encargos inician el formulario guiado y explican el servicio', () => {
   assert.match(heroAstro, /href="\/pedir-libro\?tipo=exacto"/);
-  assert.match(heroAstro, /Buscamos agotados, importados y ediciones difíciles/i);
-  assert.match(heroAstro, />\s*Contanos qué libro buscás\s*</);
-  assert.doesNotMatch(heroAstro, /https:\/\/wa\.me/);
-});
-
-test('Hero: enlaza la explicación indexable del servicio de encargos', () => {
-  assert.match(heroAstro, /href="\/libros-agotados-importados-uruguay"/);
-  assert.match(heroAstro, /Cómo funciona nuestro servicio de encargos/);
+  assert.match(commercialAstro, /href="\/pedir-libro\?tipo=exacto"/);
+  assert.match(commercialAstro, /Buscamos agotados, importados y ediciones difíciles/i);
+  assert.match(commercialAstro, />\s*Contanos qué libro buscás\s*</);
+  assert.match(commercialAstro, /href="\/libros-agotados-importados-uruguay"/);
+  assert.match(commercialAstro, /Cómo funciona nuestro servicio de encargos/);
+  assert.doesNotMatch(`${heroAstro}\n${commercialAstro}`, /https:\/\/wa\.me/);
 });

--- a/functions/__tests__/home-priority-verticals.test.js
+++ b/functions/__tests__/home-priority-verticals.test.js
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const file = fileURLToPath(new URL('../../astro-front/src/components/CategoryAccess.astro', import.meta.url));
+const source = readFileSync(file, 'utf8');
+
+test('la portada abre con accesos distintos para Tarot, Biblias y Reina-Valera', () => {
+  const tarot = source.indexOf("id: 'tarot'");
+  const bibles = source.indexOf("id: 'biblias'");
+  const reinaValera = source.indexOf("id: 'reina-valera'");
+  const psychology = source.indexOf("id: 'psicologia'");
+  assert.ok(tarot > -1 && bibles > tarot && reinaValera > bibles && psychology > reinaValera);
+});
+
+test('Tarot y Biblias enlazan sus landings consolidadas sin crear URLs caníbales', () => {
+  assert.match(source, /name: 'Tarot y oráculos'/);
+  assert.match(source, /href: '\/libros\/esoterismo-tarot'/);
+  assert.match(source, /href: '\/libros\/biblias'/);
+  assert.match(source, /href: '\/libros\/biblias\/reina-valera'/);
+  assert.doesNotMatch(source, /subcategoria=biblia|subcategoria=reina-valera/);
+  assert.match(source, /href={`\/libros\/\$\{encodeURIComponent\(cat\.id\)\}`}/);
+  assert.doesNotMatch(source, /href: '\/tarot'|href: '\/oraculos'|href: '\/biblias'/);
+});
+
+test('Cábala y Sufismo son accesos secundarios reales dentro de Esoterismo', () => {
+  assert.match(source, /subcategoria=cabala-kabbalah/);
+  assert.match(source, /subcategoria=sufismo/);
+  assert.match(source, /name: 'Cábala y Kabbalah'/);
+  assert.match(source, /name: 'Sufismo'/);
+});
+
+test('la portada enlaza incorporaciones reales y no las llama más vendidos', () => {
+  assert.match(source, /href: '#incorporaciones-recientes'/);
+  assert.match(source, /name: 'Incorporaciones recientes'/);
+  assert.doesNotMatch(source, /más vendidos|bestsellers/i);
+});

--- a/functions/__tests__/manual-book-discovery.test.js
+++ b/functions/__tests__/manual-book-discovery.test.js
@@ -21,15 +21,16 @@ test('la portada incorpora descubrimiento por preguntas mobile-first', () => {
   assert.match(discovery, /@media \(min-width: 980px\)/);
 });
 
-test('la portada prioriza búsqueda, categorías y libros antes del descubrimiento asistido', () => {
+test('la portada prioriza búsqueda con categorías integradas y libros antes del descubrimiento asistido', () => {
   const heroPosition = home.indexOf('<Hero />');
-  const categoriesPosition = home.indexOf('<CategoryAccess />');
   const booksPosition = home.indexOf('<BestsellerSection />');
   const discoveryPosition = home.indexOf('<BookDiscovery />');
+  const hero = read('astro-front/src/components/Hero.astro');
 
   assert.ok(heroPosition >= 0, 'falta el buscador principal');
-  assert.ok(categoriesPosition > heroPosition, 'las categorías deben seguir al buscador');
-  assert.ok(booksPosition > categoriesPosition, 'los libros deben seguir a las categorías');
+  assert.match(hero, /import CategoryAccess/);
+  assert.match(hero, /<CategoryAccess \/>/);
+  assert.ok(booksPosition > heroPosition, 'los libros deben seguir al hero de búsqueda y categorías');
   assert.ok(discoveryPosition > booksPosition, 'las preguntas deben aparecer después de los libros');
 });
 

--- a/functions/__tests__/seo-category-pages.test.js
+++ b/functions/__tests__/seo-category-pages.test.js
@@ -199,14 +199,15 @@ test('la portada enlaza las landings limpias, incluyendo Biblias y Reina-Valera,
     const source = readFileSync(file, 'utf8');
 
     assert.match(source, /href={`\/libros\/\$\{encodeURIComponent\(cat\.id\)\}`}/);
-    assert.doesNotMatch(source, /href={`\/catalogo\?categoria=/);
-    assert.match(source, /\{cat\.count\} títulos/);
-    assert.match(source, />Disponibles y por encargo<\/span>/);
+    assert.match(source, /number\.format\(cat\.count\)/);
+    assert.doesNotMatch(source, /subcategoria=biblia/);
+    assert.doesNotMatch(source, /subcategoria=reina-valera/);
+    assert.doesNotMatch(source, /href="\/biblias"|href="\/reina-valera"/);
     for (const category of SEO_CATEGORIES.filter(entry => !entry.classificationId && !entry.classificationIds)) {
         assert.ok(source.includes(`'${category.id}'`), category.id);
     }
-    assert.match(source, /href="\/libros\/biblias"/);
-    assert.match(source, /href="\/libros\/biblias\/reina-valera"/);
+    assert.match(source, /href: '\/libros\/biblias'/);
+    assert.match(source, /href: '\/libros\/biblias\/reina-valera'/);
 });
 
 test('el sitemap de categorías publica las diez landings SEO', async () => {

--- a/functions/__tests__/seo-commercial-intents.test.js
+++ b/functions/__tests__/seo-commercial-intents.test.js
@@ -32,8 +32,8 @@ test('home posiciona el diferencial y enlaza la landing desde el footer', () => 
   const hero = read('astro-front/src/components/Hero.astro');
   const footer = read('astro-front/src/components/Footer.astro');
 
-  assert.match(home, /title="Libros difíciles, agotados e importados \| Amado Libros"/);
-  assert.match(home, /Encargos desde Europa y otros mercados/);
+  assert.match(home, /title="Librería online en Uruguay: Tarot, Biblias y más \| Amado Libros"/);
+  assert.match(home, /Biblias Reina-Valera, Biblias católicas/);
   assert.match(hero, /ediciones agotadas e importadas de Europa/);
   assert.match(footer, /href="\/libros-agotados-importados-uruguay"/);
 });


### PR DESCRIPTION
Reconstruye el objetivo de #239 sobre el `main` actual, después de #249 y #250, sin reutilizar su pila vieja.

## Qué cambia
- Hace visibles Tarot, Biblias, Reina-Valera, Psicología, Infantil e incorporaciones recientes desde la primera vista.
- Mantiene la búsqueda por título, autor o ISBN como acción principal.
- Enlaza Biblias y Reina-Valera a sus landings limpias, no a filtros viejos.
- Mueve beneficios comerciales debajo de los bloques editoriales para evitar duplicación y ruido arriba del pliegue.
- Actualiza title, description y JSON-LD de la portada.

## Verificación local
- Tests focales: 26/26.
- `scripts/validate-ci.sh`: completo en verde.
- Build Astro con checkout OFF y ON: correcto.

Reemplaza a #239; ese Draft se cerrará después de verificar el reemplazo en producción.