### PR TITLE
SEO: Biblia/Tarot y galerías Merchant

### DIFF
--- a/astro-front/src/components/ShippingPayments.astro
+++ b/astro-front/src/components/ShippingPayments.astro
@@ -14,9 +14,9 @@
         </div>
         <h3 class="sp-col-title">Envíos</h3>
         <ul class="sp-list">
-          <li>Entrega en 2 horas en Montevideo.*</li>
+          <li>Entrega en el día en Montevideo, según zona, horario y confirmación.*</li>
           <li>Coordinamos la hora o franja antes de que salga el cadete.</li>
-          <li>Envíos a todo Uruguay.</li>
+          <li>Envíos a todo Uruguay por $250.</li>
           <li>Envío gratis desde $1.500.</li>
         </ul>
         <p class="sp-disclaimer">*El plazo depende de la zona y del horario del pedido. Si el cadete llega y no estás, te contactamos para resolver cómo completar la entrega.</p>

--- a/docs/ads/google-ads-biblia-tarot-pilot.md
+++ b/docs/ads/google-ads-biblia-tarot-pilot.md
@@ -1,0 +1,190 @@
+# Piloto Google Ads — Reina Valera y mazos de tarot
+
+Estado: listo para configurar, **no activado**.
+
+Objetivo: comprar tráfico de búsqueda con intención comercial mientras las nuevas landings ganan visibilidad orgánica. La campaña no reemplaza SEO ni Merchant; sirve para aparecer desde el primer día y medir demanda, consultas y compras.
+
+## Presupuesto recomendado
+
+- Duración inicial: 14 días.
+- Presupuesto total máximo: $2.800 UYU.
+- Dos campañas de búsqueda: $100 UYU diarios para Reina Valera y $100 UYU diarios para Tarot.
+- Red de Búsqueda únicamente. Red de Display y socios de búsqueda desactivados durante el piloto.
+- Ubicación: Uruguay.
+- Opción de ubicación: presencia — personas que están o suelen estar en Uruguay.
+- Idioma: español.
+- Puja inicial: maximizar clics. No usar maximizar conversiones hasta comprobar que `purchase` y `whatsapp_click` están llegando correctamente y acumular datos reales.
+
+El presupuesto es una recomendación operativa, no una estimación de clics. El CPC real debe observarse en la cuenta; no se inventa antes de acceder al Planificador de Palabras Clave y a la subasta.
+
+## Campaña 1 — Biblias Reina Valera
+
+Landing:
+
+`https://www.amadolibros.com/libros/biblias/reina-valera`
+
+### Palabras clave iniciales
+
+Exactas:
+
+- `[biblia reina valera uruguay]`
+- `[biblia reina valera 1960 uruguay]`
+- `[biblia rvr60 uruguay]`
+- `[comprar biblia reina valera]`
+- `[biblia reina valera montevideo]`
+
+De frase:
+
+- `"biblia reina valera uruguay"`
+- `"biblia reina valera entrega hoy"`
+- `"biblia reina valera montevideo"`
+- `"biblia letra grande rvr60"`
+- `"biblia reina valera con cierre"`
+
+Negativas iniciales:
+
+- `pdf`
+- `descargar`
+- `gratis`
+- `versículos`
+- `texto online`
+- `audio`
+- `aplicación`
+- `wikipedia`
+- `historia de la reina valera`
+
+### Anuncio adaptable
+
+Titulares, todos de hasta 30 caracteres:
+
+- Biblias Reina Valera
+- Reina Valera en Uruguay
+- Entrega Hoy Coordinada
+- Envío a $250
+- Gratis Desde $1.500
+- Stock Real en Uruguay
+- Atención Personalizada
+- Compará Ediciones RVR60
+- Letra Grande y de Estudio
+- Compra Online Segura
+- 12% Menos por Transferencia
+- Amado Libros Uruguay
+
+Descripciones, todas de hasta 90 caracteres:
+
+- Comprá Biblias Reina Valera con stock real. Entrega hoy según zona y horario.
+- Envío $250 y gratis desde $1.500. Te ayudamos a confirmar la edición correcta.
+- Compará RVR60, letra grande, estudio, cierre y formato antes de comprar.
+- Atención personalizada y envíos a todo Uruguay desde Amado Libros.
+
+## Campaña 2 — Mazos de tarot
+
+Landing:
+
+`https://www.amadolibros.com/libros/esoterismo-tarot/mazos`
+
+### Palabras clave iniciales
+
+Exactas:
+
+- `[mazo tarot uruguay]`
+- `[tarot uruguay]`
+- `[comprar tarot uruguay]`
+- `[tarot rider waite uruguay]`
+- `[tarot de marsella uruguay]`
+
+De frase:
+
+- `"mazos de tarot uruguay"`
+- `"tarot entrega hoy montevideo"`
+- `"comprar mazo tarot"`
+- `"tarot rider waite montevideo"`
+- `"tarot con guía español"`
+
+Negativas iniciales:
+
+- `tarot gratis`
+- `tarot online`
+- `tirada de tarot`
+- `lectura de tarot`
+- `consulta tarot`
+- `significado cartas`
+- `horóscopo`
+- `pdf`
+- `descargar`
+- `empleo`
+
+### Anuncio adaptable
+
+Titulares, todos de hasta 30 caracteres:
+
+- Mazos de Tarot Uruguay
+- Tarot: Entrega Coordinada
+- Mazos con Stock Real
+- Rider Waite y Marsella
+- Con Guía o Solo Mazo
+- Te Ayudamos a Elegir
+- Envío a $250
+- Gratis Desde $1.500
+- Atención Personalizada
+- Compra Online Segura
+- 12% Menos por Transferencia
+- Amado Libros Uruguay
+
+Descripciones, todas de hasta 90 caracteres:
+
+- Comprá mazos de tarot con stock real. Entrega hoy según zona y horario.
+- Compará sistema, idioma, cartas, guía y edición antes de elegir tu mazo.
+- Envío $250 y gratis desde $1.500. Atención personalizada por Amado Libros.
+- Rider-Waite, Marsella y otras ediciones con envíos a todo Uruguay.
+
+## Recursos comunes
+
+Enlaces de sitio:
+
+- Biblias Reina Valera — `/libros/biblias/reina-valera`
+- Todas las Biblias — `/libros/biblias`
+- Mazos de tarot — `/libros/esoterismo-tarot/mazos`
+- Tarot y oráculos — `/libros/esoterismo-tarot`
+- Envíos — `/envios`
+
+Textos destacados:
+
+- Entrega hoy coordinada
+- Envío $250
+- Gratis desde $1.500
+- Stock real
+- Atención personalizada
+- 12% menos por transferencia
+
+## Medición y reglas de corte
+
+Antes de activar:
+
+1. Vincular la propiedad GA4 correcta con Google Ads.
+2. Confirmar en DebugView o tiempo real que llegan `view_item`, `begin_checkout`, `whatsapp_click` y `purchase`.
+3. Importar `purchase` como conversión primaria.
+4. Usar `whatsapp_click` como conversión secundaria durante el piloto, para no optimizar sólo hacia clics fáciles en WhatsApp.
+5. Agregar UTMs distintas por campaña y grupo de anuncios.
+
+Revisión diaria durante los primeros tres días:
+
+- términos de búsqueda reales;
+- consultas irrelevantes para agregar como negativas;
+- gasto por campaña;
+- páginas de destino;
+- errores de Merchant o URLs;
+- compras, inicios de checkout y clics a WhatsApp.
+
+Revisión de decisión al día 7 y al día 14:
+
+- mantener palabras con intención comercial demostrada;
+- pausar términos informativos o ambiguos;
+- no aumentar presupuesto hasta tener medición confiable;
+- no declarar ganadora una campaña sólo por clics: la decisión se toma por compras y consultas útiles.
+
+## Fuentes oficiales
+
+- Google Ads, tipos de concordancia: https://support.google.com/google-ads/answer/7476658
+- Google Ads, opciones avanzadas de ubicación: https://support.google.com/google-ads/answer/1722038
+- Google Ads, anuncios adaptables de búsqueda: https://support.google.com/google-ads/answer/7684791

--- a/functions/__tests__/automatic-product-showcase.test.js
+++ b/functions/__tests__/automatic-product-showcase.test.js
@@ -162,6 +162,8 @@ test('el cierre comercial reconoce la clasificación Reina-Valera', () => {
   }), { classificationTags: ['religion-espiritualidad', 'reina-valera'] });
 
   assert.equal(showcase.requestHelp.question, '¿Buscás otra Biblia o una edición específica?');
+  assert.ok(showcase.links.some(link => link.href === '/libros/biblias/reina-valera'));
+  assert.ok(showcase.links.some(link => link.href === '/libros/biblias'));
 });
 
 test('el cierre comercial reconoce Esoterismo desde la clasificación real', () => {
@@ -174,6 +176,84 @@ test('el cierre comercial reconoce Esoterismo desde la clasificación real', () 
   }), { classificationTags: ['esoterismo-tarot'] });
 
   assert.equal(showcase.requestHelp.question, '¿Buscás otro tarot, oráculo o libro de esoterismo?');
+});
+
+test('una ficha de tarot enlaza la vertical de mazos y el hub general', () => {
+  const showcase = buildAutomaticProductShowcase(book({
+    title: 'Tarot Rider-Waite 78 cartas',
+    bibliographic: {
+      ...book().bibliographic,
+      genre: 'Tarot',
+    },
+  }), { classificationTags: ['esoterismo-tarot', 'tarot-oraculos'] });
+
+  assert.ok(showcase.links.some(link => link.href === '/libros/esoterismo-tarot/mazos'));
+  assert.ok(showcase.links.some(link => link.href === '/libros/esoterismo-tarot'));
+});
+
+test('un mazo de tarot verificado muestra sus datos comerciales sin inferir faltantes', () => {
+  const showcase = buildAutomaticProductShowcase(book({
+    title: 'Tarot Rider-Waite 78 cartas con guía',
+    bibliographic: {
+      ...book().bibliographic,
+      genre: 'Tarot',
+      language: null,
+    },
+  }), {
+    classificationTags: ['esoterismo-tarot', 'tarot-oraculos'],
+    tarotMerchTag: {
+      primary_type: 'tarot',
+      deck_family: 'rider_waite_smith',
+      format: 'mazo',
+      bundle: 'mazo_mas_guia',
+      language: 'espanol',
+      needs_review: false,
+    },
+  });
+
+  assert.equal(showcase.schemaKind, 'product');
+  assert.ok(showcase.editionFacts.some(fact =>
+    fact.label === 'Tipo de producto' && fact.value === 'Mazo de tarot'));
+  assert.ok(showcase.editionFacts.some(fact =>
+    fact.label === 'Sistema del mazo' && fact.value === 'Rider-Waite-Smith'));
+  assert.ok(showcase.editionFacts.some(fact =>
+    fact.label === 'Contenido informado' && fact.value === 'Mazo con guía o libro'));
+  assert.ok(showcase.editionFacts.some(fact =>
+    fact.label === 'Idioma informado' && fact.value === 'Español'));
+  assert.ok(showcase.structuredProperties.every(property => property['@type'] === 'PropertyValue'));
+});
+
+test('una clasificación Reina Valera agrega el tipo de producto verificable', () => {
+  const showcase = buildAutomaticProductShowcase(book({ title: 'Santa Biblia letra grande' }), {
+    classificationTags: ['religion-espiritualidad', 'reina-valera'],
+  });
+  assert.ok(showcase.editionFacts.some(fact =>
+    fact.label === 'Tipo de producto' && fact.value === 'Biblia Reina Valera'));
+  assert.equal(showcase.schemaKind, 'book');
+});
+
+test('el JSON-LD de un mazo verificado deja de declararlo como Book', () => {
+  const tag = {
+    primary_type: 'tarot',
+    deck_family: 'rider_waite_smith',
+    format: 'mazo',
+    bundle: 'mazo_mas_guia',
+    language: 'espanol',
+    needs_review: false,
+  };
+  const html = enrichAutomaticProductShowcaseHtml(
+    rendered(book({ title: 'Tarot Rider-Waite 78 cartas con guía' })),
+    PRODUCT_ID,
+    { classificationTags: ['esoterismo-tarot', 'tarot-oraculos'], tarotMerchTag: tag },
+  );
+  const schema = schemas(html).find(candidate => candidate.sku === PRODUCT_ID);
+
+  assert.equal(schema['@type'], 'Product');
+  assert.equal(schema.gtin13, '9788496836693');
+  assert.equal('isbn' in schema, false);
+  assert.equal('bookFormat' in schema, false);
+  assert.ok(schema.additionalProperty.some(property =>
+    property.name === 'Sistema del mazo' && property.value === 'Rider-Waite-Smith'));
 });
 
 test('el cierre comercial usa la clasificación, no palabras sueltas del título', () => {

--- a/functions/__tests__/feed-gtin-and-coverage.test.js
+++ b/functions/__tests__/feed-gtin-and-coverage.test.js
@@ -18,6 +18,8 @@ import {
     normalizePublisherForDescription,
     buildFeedDescription,
     merchantImageLink,
+    merchantImageSources,
+    additionalMerchantImageLinks,
     filterItemsWithReadyPrimaryCover,
     truncateMerchantText,
     renderFeedItem,
@@ -293,6 +295,25 @@ test('17b. La imagen Merchant siempre queda bajo dominio propio', () => {
         'https://www.amadolibros.com/book-cover/MLU123456/cover.jpg',
     );
     assert.equal(merchantImageLink(book({ id: 'otro' })), '');
+    assert.equal(
+        merchantImageLink(book({ id: 'MLU123456' }), 1),
+        'https://www.amadolibros.com/book-cover/MLU123456/cover-2.jpg',
+    );
+});
+
+test('17b2. Merchant normaliza, compacta y deduplica las fuentes igual que el mirror R2', () => {
+    const sources = merchantImageSources(book({
+        pictures: [
+            'http://http2.mlstatic.com/D_A-I.jpg',
+            'https://http2.mlstatic.com/D_A-O.jpg',
+            'https://evil.example/cover.jpg',
+            'https://http2.mlstatic.com/D_B-I.jpg',
+        ],
+    }));
+    assert.deepEqual(sources, [
+        'https://http2.mlstatic.com/D_A-O.jpg',
+        'https://http2.mlstatic.com/D_B-O.jpg',
+    ]);
 });
 
 test('17c. Exige moneda UYU explícita y no infiere precios ambiguos', () => {
@@ -348,6 +369,75 @@ test('17e. Producción publica sólo portadas primarias válidas y vigentes en R
         filterItemsWithReadyPrimaryCover([ready, stale, missing], manifest).map(item => item.id),
         ['MLU123456'],
     );
+});
+
+test('17e2. Publica hasta diez imágenes adicionales reales, en orden y validadas por manifest', () => {
+    const pictures = Array.from({ length: 13 }, (_, index) =>
+        `https://http2.mlstatic.com/D_IMAGE_${index + 1}-I.jpg`);
+    const item = book({ id: 'MLU123456', pictures });
+    const entries = {};
+    for (let position = 0; position < pictures.length; position += 1) {
+        const sha = String(position + 1).padStart(64, 'a');
+        entries[`MLU123456:${position}`] = {
+            current: {
+                object_key: `covers/v1/objects/${sha}.jpg`,
+                sha256: sha,
+                mime: 'image/jpeg',
+                source_url: `https://http2.mlstatic.com/D_IMAGE_${position + 1}-O.jpg`,
+            },
+        };
+    }
+    const manifest = { schema_version: 1, entries };
+    const links = additionalMerchantImageLinks(item, manifest);
+    assert.equal(links.length, 10);
+    assert.equal(links[0], 'https://www.amadolibros.com/book-cover/MLU123456/cover-2.jpg');
+    assert.equal(links[9], 'https://www.amadolibros.com/book-cover/MLU123456/cover-11.jpg');
+
+    const xml = renderFeedItem(item, manifest);
+    assert.equal((xml.match(/<g:additional_image_link>/g) || []).length, 10);
+    assert.doesNotMatch(xml, /mlstatic\.com/);
+});
+
+test('17e3. Omite imágenes secundarias faltantes, obsoletas o duplicadas sin excluir la oferta', () => {
+    const item = book({
+        id: 'MLU123456',
+        pictures: [
+            'https://http2.mlstatic.com/D_MAIN-I.jpg',
+            'https://http2.mlstatic.com/D_STALE-I.jpg',
+            'https://http2.mlstatic.com/D_DUPLICATE-I.jpg',
+            'https://http2.mlstatic.com/D_READY-I.jpg',
+            'https://http2.mlstatic.com/D_MISSING-I.jpg',
+        ],
+    });
+    const primarySha = 'a'.repeat(64);
+    const readySha = 'b'.repeat(64);
+    const manifest = {
+        schema_version: 1,
+        entries: {
+            'MLU123456:0': { current: {
+                object_key: `covers/v1/objects/${primarySha}.jpg`, sha256: primarySha,
+                mime: 'image/jpeg', source_url: 'https://http2.mlstatic.com/D_MAIN-O.jpg',
+            } },
+            'MLU123456:1': { current: {
+                object_key: `covers/v1/objects/${readySha}.jpg`, sha256: readySha,
+                mime: 'image/jpeg', source_url: 'https://http2.mlstatic.com/D_OLD-O.jpg',
+            } },
+            'MLU123456:2': { current: {
+                object_key: `covers/v1/objects/${primarySha}.jpg`, sha256: primarySha,
+                mime: 'image/jpeg', source_url: 'https://http2.mlstatic.com/D_DUPLICATE-O.jpg',
+            } },
+            'MLU123456:3': { current: {
+                object_key: `covers/v1/objects/${readySha}.jpg`, sha256: readySha,
+                mime: 'image/jpeg', source_url: 'https://http2.mlstatic.com/D_READY-O.jpg',
+            } },
+        },
+    };
+    assert.deepEqual(additionalMerchantImageLinks(item, manifest), [
+        'https://www.amadolibros.com/book-cover/MLU123456/cover-4.jpg',
+    ]);
+    const xml = renderFeedItem(item, manifest);
+    assert.match(xml, /<g:image_link>/);
+    assert.equal((xml.match(/<g:additional_image_link>/g) || []).length, 1);
 });
 
 test('17f. Título Merchant nunca supera 150 caracteres y corta por palabra', () => {

--- a/functions/__tests__/seo-category-pages.test.js
+++ b/functions/__tests__/seo-category-pages.test.js
@@ -12,7 +12,7 @@ import {
 import { SEO_CATEGORIES } from '../_shared/seo-categories.js';
 
 const ITEMS = SEO_CATEGORIES.map((category, index) => ({
-    id: `MLU${index + 1}`,
+    id: category.kind === 'tarot-decks' ? 'MLU624123456' : `MLU${index + 1}`,
     title: `Libro de prueba ${category.name}`,
     author: `Autor ${index + 1}`,
     price: 1000 + index,
@@ -29,12 +29,17 @@ const CATEGORY_DATA = {
         .map(category => ({
             id: category.id,
             name: category.name,
-            count: category.id === 'psicologia' ? 791 : category.id === 'religion-espiritualidad' ? 3 : 1,
+            count: category.id === 'psicologia' ? 791
+                : category.id === 'religion-espiritualidad' ? 3
+                    : category.id === 'esoterismo-tarot' ? 3
+                        : 1,
             subcategories: category.id === 'religion-espiritualidad'
                 ? [
                     { id: 'biblia', name: 'Biblia', count: 1 },
                     { id: 'reina-valera', name: 'Reina-Valera', count: 1 },
                 ]
+                : category.id === 'esoterismo-tarot'
+                    ? [{ id: 'tarot-oraculos', name: 'Tarot y oráculos', count: 1 }]
                 : [],
         })),
     items: Object.fromEntries(ITEMS.map((item, index) => [
@@ -42,7 +47,12 @@ const CATEGORY_DATA = {
         SEO_CATEGORIES[index].classificationIds
             ? ['religion-espiritualidad', SEO_CATEGORIES[index].classificationIds[0]]
             : SEO_CATEGORIES[index].classificationId
-                ? ['religion-espiritualidad', SEO_CATEGORIES[index].classificationId]
+                ? [
+                    SEO_CATEGORIES[index].id.startsWith('esoterismo-tarot/')
+                        ? 'esoterismo-tarot'
+                        : 'religion-espiritualidad',
+                    SEO_CATEGORIES[index].classificationId,
+                ]
                 : [SEO_CATEGORIES[index].id],
     ])),
 };
@@ -78,9 +88,9 @@ test.beforeEach(() => {
     };
 });
 
-test('la allowlist contiene las ocho categorías base y las dos landings bíblicas aprobadas', () => {
-    assert.equal(SEO_CATEGORIES.length, 10);
-    assert.equal(new Set(SEO_CATEGORIES.map(category => category.id)).size, 10);
+test('la allowlist contiene las categorías base y las verticales comerciales aprobadas', () => {
+    assert.equal(SEO_CATEGORIES.length, 11);
+    assert.equal(new Set(SEO_CATEGORIES.map(category => category.id)).size, 11);
     for (const category of SEO_CATEGORIES) {
         assert.match(category.title, /Uruguay.*\| Amado Libros$/);
         assert.ok(category.description.length >= 100);
@@ -106,14 +116,15 @@ test('cada categoría autorizada responde 200 con SEO y contenido diferenciados'
 });
 
 test('la landing filtra productos por la categoría solicitada', async () => {
+    const psychologyItem = ITEMS.find((_, index) => SEO_CATEGORIES[index].id === 'psicologia');
     const response = await categoryRequest(context('psicologia'));
     const html = await response.text();
 
     assert.match(html, /Libro de prueba Psicología/);
     assert.doesNotMatch(html, /Libro de prueba Infantil y juvenil/);
     assert.match(html, /<section class="books-grid"/);
-    assert.match(html, /href="https:\/\/www\.amadolibros\.com\/libro\/MLU6\//);
-    assert.match(html, /\/cdn-cgi\/image\/format=auto[^\"]+\/book-cover\/MLU6\/cover\.jpg/);
+    assert.ok(html.includes(`href="https://www.amadolibros.com/libro/${psychologyItem.id}/`));
+    assert.ok(html.includes(`/book-cover/${psychologyItem.id}/cover.jpg`));
     assert.match(html, /srcset="[^"]+240w,[^"]+360w,[^"]+480w"/);
     assert.match(html, /<strong>1 título disponible ahora\.<\/strong> Los 791 títulos informados en la portada incluyen disponibles y libros que podemos buscar por encargo\./);
 });
@@ -149,10 +160,25 @@ test('las landings bíblicas incluyen guía factual y una promesa logística con
 
     assert.match(html, /Cómo elegir una Biblia/);
     assert.match(html, /Traducción o tradición/);
-    assert.match(html, /pueden entregarse en 2 horas en Montevideo, según zona y horario/);
-    assert.match(html, /envío es gratis en compras desde \$1\.500/);
-    assert.match(html, /No todas las ediciones califican para entrega rápida/);
+    assert.match(html, /pueden coordinarse para entrega en el día en Montevideo, según zona, horario y confirmación/);
+    assert.match(html, /El envío cuesta \$250/);
+    assert.match(html, /es gratis en compras desde \$1\.500/);
+    assert.match(html, /La entrega rápida no se promete hasta verificar esos datos/);
     assert.doesNotMatch(html, /entrega gratis en el día en Uruguay/i);
+});
+
+test('la landing de mazos muestra sólo mazos de tarot verificados y su promesa comercial condicionada', async () => {
+    const response = await categoryRequest(context('esoterismo-tarot/mazos'));
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(html, /Mazos de tarot en Uruguay con entrega hoy en Montevideo/);
+    assert.match(html, /Libro de prueba Mazos de tarot/);
+    assert.match(html, /Los mazos con stock pueden coordinarse para entrega en el día/);
+    assert.match(html, /Envío \$250/);
+    assert.match(html, /Atención personalizada/);
+    assert.match(html, /Cómo elegir un mazo de tarot sin equivocarte de edición/);
+    assert.match(html, /"name":"Mazo de tarot"/);
 });
 
 test('las landings bíblicas conservan el contrato responsive para celular', async () => {
@@ -210,7 +236,7 @@ test('la portada enlaza las landings limpias, incluyendo Biblias y Reina-Valera,
     assert.match(source, /href: '\/libros\/biblias\/reina-valera'/);
 });
 
-test('el sitemap de categorías publica las diez landings SEO', async () => {
+test('el sitemap de categorías publica todas las landings SEO', async () => {
     const response = await categorySitemapRequest({
         request: new Request('https://www.amadolibros.com/sitemap-categories.xml'),
         env: { APP_ENV: 'production' },

--- a/functions/__tests__/vertical-landing-guides.test.js
+++ b/functions/__tests__/vertical-landing-guides.test.js
@@ -16,7 +16,7 @@ import { editorialGuideHtml } from '../libros/[[path]].js';
 
 // ── Tarot: el reposicionamiento ────────────────────────────────────────────
 
-test('refuerza Tarot en la landing consolidada sin crear otra URL indexable', () => {
+test('conserva el hub general de Tarot y separa la intención comercial de mazos', () => {
   const category = findSeoCategory('esoterismo-tarot');
   assert.ok(category);
   assert.match(category.title, /Tarot y oráculos en Uruguay/);
@@ -32,6 +32,7 @@ test('refuerza Tarot en la landing consolidada sin crear otra URL indexable', ()
   assert.doesNotMatch(html, /href="/);
   assert.equal(SEO_CATEGORY_IDS.has('tarot'), false);
   assert.equal(SEO_CATEGORY_IDS.has('oraculos'), false);
+  assert.equal(SEO_CATEGORY_IDS.has('esoterismo-tarot/mazos'), true);
 });
 
 test('el título y la descripción de Tarot nombran el mazo, no sólo el libro', () => {
@@ -95,10 +96,10 @@ test('las categorías sin guía no reciben contenido genérico', () => {
   assert.equal(editorialGuideHtml(category), '');
 });
 
-test('sólo esoterismo-tarot declara buyerGuide en esta entrega', () => {
+test('las guías quedan limitadas al hub esotérico y a la vertical de mazos', () => {
   const conGuia = [...SEO_CATEGORY_IDS]
     .map(findSeoCategory)
     .filter(category => category?.buyerGuide)
     .map(category => category.id);
-  assert.deepEqual(conGuia, ['esoterismo-tarot']);
+  assert.deepEqual(conGuia, ['esoterismo-tarot', 'esoterismo-tarot/mazos']);
 });

--- a/functions/_shared/automatic-product-showcase.js
+++ b/functions/_shared/automatic-product-showcase.js
@@ -145,6 +145,65 @@ function buildEditionFacts(item) {
     .map(([label, value]) => ({ label, value: String(value) }));
 }
 
+const TAROT_PRIMARY_TYPE_LABEL = {
+  tarot: 'Tarot',
+  oraculo: 'Oráculo',
+  lenormand: 'Lenormand',
+  kipper: 'Kipper',
+  otro_sistema: 'Cartomancia',
+};
+const TAROT_DECK_FAMILY_LABEL = {
+  rider_waite_smith: 'Rider-Waite-Smith',
+  marsella: 'Marsella',
+  thoth: 'Thoth',
+};
+const TAROT_BUNDLE_LABEL = {
+  mazo_mas_guia: 'Mazo con guía o libro',
+  solo_mazo: 'Sólo mazo',
+};
+const TAROT_LANGUAGE_LABEL = {
+  espanol: 'Español',
+  ingles: 'Inglés',
+  multilingue: 'Multilingüe',
+};
+
+function buildVerticalFacts(classificationTags, tarotMerchTag) {
+  const tags = new Set(classificationTags.map(normalizedText).filter(Boolean));
+  const facts = [];
+  if (tags.has('reina-valera')) {
+    facts.push({ label: 'Tipo de producto', value: 'Biblia Reina Valera' });
+  } else if (tags.has('biblia')) {
+    facts.push({ label: 'Tipo de producto', value: 'Biblia' });
+  }
+
+  const tag = tarotMerchTag;
+  if (!tag || tag.needs_review === true) return facts;
+  const system = TAROT_PRIMARY_TYPE_LABEL[tag.primary_type];
+  if (system) {
+    const type = tag.format === 'mazo'
+      ? `Mazo de ${system.toLocaleLowerCase('es')}`
+      : tag.format === 'libro'
+        ? `Libro sobre ${system.toLocaleLowerCase('es')}`
+        : system;
+    facts.push({ label: 'Tipo de producto', value: type });
+  }
+  if (TAROT_DECK_FAMILY_LABEL[tag.deck_family]) {
+    facts.push({ label: 'Sistema del mazo', value: TAROT_DECK_FAMILY_LABEL[tag.deck_family] });
+  }
+  if (tag.format === 'mazo') {
+    facts.push({ label: 'Formato comercial', value: 'Mazo físico' });
+  } else if (tag.format === 'libro') {
+    facts.push({ label: 'Formato comercial', value: 'Libro' });
+  }
+  if (TAROT_BUNDLE_LABEL[tag.bundle]) {
+    facts.push({ label: 'Contenido informado', value: TAROT_BUNDLE_LABEL[tag.bundle] });
+  }
+  if (TAROT_LANGUAGE_LABEL[tag.language]) {
+    facts.push({ label: 'Idioma informado', value: TAROT_LANGUAGE_LABEL[tag.language] });
+  }
+  return facts;
+}
+
 function buildFactualSummary(item, facts) {
   const title = clean(item.title);
   const author = !isGenericAuthor(item.author) ? clean(item.author) : null;
@@ -270,13 +329,33 @@ function contextualRequestHelp(item, classificationTags = []) {
   };
 }
 
-function buildLinks(item) {
+function buildLinks(item, classificationTags = []) {
   const links = [];
+  const tags = new Set(classificationTags.map(normalizedText).filter(Boolean));
   const author = !isGenericAuthor(item?.author) ? clean(item.author) : null;
   const bibliography = item?.bibliographic && typeof item.bibliographic === 'object'
     ? item.bibliographic
     : {};
   const genre = clean(bibliography.genre);
+  const titleAndGenre = normalizedText(`${item?.title || ''} ${genre}`);
+
+  if (tags.has('reina-valera')) {
+    links.push(
+      { href: '/libros/biblias/reina-valera', label: 'Comparar Biblias Reina Valera' },
+      { href: '/libros/biblias', label: 'Ver todas las Biblias disponibles' },
+    );
+  } else if (tags.has('biblia')) {
+    links.push(
+      { href: '/libros/biblias', label: 'Ver todas las Biblias disponibles' },
+      { href: '/libros/biblias/reina-valera', label: 'Comparar Biblias Reina Valera' },
+    );
+  } else if (tags.has('esoterismo-tarot')) {
+    if (/\btarot\b/u.test(titleAndGenre)) {
+      links.push({ href: '/libros/esoterismo-tarot/mazos', label: 'Comparar mazos de tarot disponibles' });
+    }
+    links.push({ href: '/libros/esoterismo-tarot', label: 'Ver tarot, oráculos y libros de esoterismo' });
+  }
+
   if (author) {
     links.push({
       href: `/catalogo?q=${encodeURIComponent(author)}`,
@@ -295,7 +374,7 @@ function buildLinks(item) {
       label: 'Seguir explorando el catálogo',
     });
   }
-  return links.slice(0, 2);
+  return links.slice(0, 3);
 }
 
 function shortenByWord(value, maxLength) {
@@ -422,9 +501,14 @@ export function productItemFromProductHtml(html, productId) {
 export function buildAutomaticProductShowcase(item, {
   classificationTags = [],
   enrichment = null,
+  tarotMerchTag = null,
 } = {}) {
   if (!item || typeof item !== 'object' || !clean(item.title)) return null;
-  const facts = buildEditionFacts(item);
+  const verticalFacts = buildVerticalFacts(classificationTags, tarotMerchTag);
+  const facts = [...buildEditionFacts(item), ...verticalFacts]
+    .filter((fact, index, rows) => rows.findIndex(candidate =>
+      normalizedText(candidate.label) === normalizedText(fact.label) &&
+      normalizedText(candidate.value) === normalizedText(fact.value)) === index);
   const description = clean(item.description);
   const descriptionParagraphs = description.length >= 80
     ? sentenceGroups(item.description)
@@ -469,7 +553,15 @@ export function buildAutomaticProductShowcase(item, {
       ? 'Edición identificada por ISBN'
       : 'Datos tomados de la publicación',
     editionFacts: facts,
-    links: editorial?.links || buildLinks(item),
+    structuredProperties: verticalFacts.map(fact => ({
+      '@type': 'PropertyValue',
+      'name': fact.label,
+      'value': fact.value,
+    })),
+    schemaKind: tarotMerchTag?.format === 'mazo' && tarotMerchTag?.needs_review !== true
+      ? 'product'
+      : 'book',
+    links: editorial?.links || buildLinks(item, classificationTags),
     requestHelp: contextualRequestHelp(item, classificationTags),
     sources: enrichment?.provenance || [],
     schemaDescription: editorial?.paragraphs?.join(' ') || schemaDescription,

--- a/functions/_shared/seo-categories.js
+++ b/functions/_shared/seo-categories.js
@@ -46,6 +46,43 @@ export const SEO_CATEGORIES = [
         },
     },
     {
+        id: 'esoterismo-tarot/mazos',
+        classificationId: 'tarot-oraculos',
+        parentId: 'esoterismo-tarot',
+        parentName: 'Tarot y oráculos',
+        kind: 'tarot-decks',
+        tarotFilter: 'verified-tarot-decks',
+        name: 'Mazos de tarot',
+        title: 'Mazos de Tarot Uruguay | Entrega hoy | Amado Libros',
+        h1: 'Mazos de tarot en Uruguay con entrega hoy en Montevideo',
+        description: 'Mazos de tarot disponibles en Uruguay con stock real, entrega en el día coordinada en Montevideo, envío a $250 y atención personalizada para elegir la edición correcta.',
+        intro: 'Compará mazos físicos de tarot disponibles ahora: sistema, idioma, cantidad de cartas, guía incluida y edición. Coordinamos entrega en el día en Montevideo según zona y horario, y te ayudamos personalmente a confirmar que sea el mazo que buscás.',
+        about: ['Mazo de tarot', 'Tarot Rider-Waite-Smith', 'Tarot de Marsella', 'Tarot Thoth'],
+        buyerGuide: {
+            title: 'Cómo elegir un mazo de tarot sin equivocarte de edición',
+            intro: 'La ilustración de la caja no alcanza para identificar un mazo. Antes de comprar, revisá el sistema, el contenido físico, el idioma y la edición exacta.',
+            points: [
+                {
+                    title: 'Sistema del mazo',
+                    text: 'Rider-Waite-Smith, Marsella y Thoth tienen estructuras e imágenes distintas. La ficha sólo declara el sistema cuando está verificado.',
+                },
+                {
+                    title: 'Cartas y contenido',
+                    text: 'Confirmá la cantidad de cartas y si el producto incluye libro, guía breve o solamente el mazo. No lo inferimos por la fotografía de portada.',
+                },
+                {
+                    title: 'Idioma',
+                    text: 'Revisá por separado el idioma de las cartas y el del manual. Algunas ediciones importadas combinan cartas sin texto con una guía en otro idioma.',
+                },
+                {
+                    title: 'Editorial e identificador',
+                    text: 'Usá editorial, ISBN, EAN o GTIN para distinguir reimpresiones y formatos. Si falta un dato decisivo, lo verificamos antes de la compra.',
+                },
+            ],
+            serviceNote: 'Te ayudamos a comparar ediciones y a encontrar un mazo específico. Amado Libros vende productos; no realiza lecturas ni interpretaciones de tarot.',
+        },
+    },
+    {
         id: 'medicina-salud',
         name: 'Medicina y salud',
         title: 'Libros de medicina y salud en Uruguay | Amado Libros',
@@ -113,10 +150,10 @@ export const SEO_CATEGORIES = [
         parentName: 'Biblias',
         kind: 'reina-valera',
         name: 'Reina-Valera',
-        title: 'Biblia Reina-Valera en Uruguay | RVR 1960 y ediciones | Amado Libros',
-        h1: 'Biblia Reina-Valera en Uruguay',
-        description: 'Biblias Reina-Valera disponibles en Uruguay: RVR 1960 y otras ediciones, letra grande, estudio y distintos formatos. Compará datos y consultá stock real.',
-        intro: 'Encontrá Biblias Reina-Valera y distinguí la revisión, el tamaño de letra, las ayudas de estudio y la encuadernación antes de comprar. Si buscás una edición exacta, la verificamos por ISBN.',
+        title: 'Biblia Reina Valera Uruguay | Entrega hoy | Amado Libros',
+        h1: 'Biblias Reina Valera en Uruguay con entrega hoy en Montevideo',
+        description: 'Biblias Reina Valera disponibles en Uruguay con stock real, entrega en el día coordinada en Montevideo, envío a $250 y atención personalizada para comparar ediciones.',
+        intro: 'Compará Biblias Reina Valera por revisión, tamaño de letra, ayudas de estudio, encuadernación e ISBN. Coordinamos entrega en el día en Montevideo según zona y horario, y verificamos personalmente la edición antes de la compra.',
     },
 ];
 

--- a/functions/book-cover/[[path]].js
+++ b/functions/book-cover/[[path]].js
@@ -25,13 +25,16 @@ export function primaryCoverSource(item) {
   return coverSource(item, 0);
 }
 
+export function coverSources(item) {
+  const pictures = Array.isArray(item?.pictures) ? item.pictures : [];
+  const candidates = pictures.length > 0 ? pictures : [item?.thumbnail];
+  return [...new Set(candidates.map(largeMlImage).filter(Boolean))]
+    .slice(0, MAX_GALLERY_IMAGES);
+}
+
 export function coverSource(item, position = 0) {
   if (!Number.isInteger(position) || position < 0 || position >= MAX_GALLERY_IMAGES) return '';
-  const pictures = Array.isArray(item?.pictures)
-    ? item.pictures.filter(value => typeof value === 'string')
-    : [];
-  const picture = pictures[position] || (position === 0 ? item?.thumbnail : '');
-  return largeMlImage(picture || '');
+  return coverSources(item)[position] || '';
 }
 
 function responseHeaders(source, contentType, etag = null) {

--- a/functions/feed.xml.js
+++ b/functions/feed.xml.js
@@ -66,6 +66,8 @@ const CANONICAL_BASE_URL = "https://www.amadolibros.com";
 const SITE_TITLE = "Amado Libros";
 const COVER_MANIFEST_KEY = 'covers/v1/manifest.json';
 const COVER_OBJECT_KEY_RE = /^covers\/v1\/objects\/([a-f0-9]{64})\.(jpg|png|webp)$/;
+const MAX_GALLERY_IMAGES = 16;
+const MAX_ADDITIONAL_IMAGE_LINKS = 10;
 
 export async function onRequest(context) {
     try {
@@ -105,7 +107,7 @@ export async function onRequest(context) {
 
         let feedItems = '';
         for (const item of sortedItems) {
-            feedItems += renderFeedItem(item);
+            feedItems += renderFeedItem(item, coverManifest);
         }
 
         const feed = `<?xml version="1.0" encoding="UTF-8"?>
@@ -382,16 +384,15 @@ export function truncateMerchantText(value, maxChars) {
     return clipped.slice(0, boundary >= Math.floor(maxChars * 0.7) ? boundary : maxChars).trim();
 }
 
-export function merchantImageLink(item) {
+export function merchantImageLink(item, position = 0) {
     const id = String(item?.id || '').trim().toUpperCase();
-    return /^MLU\d+$/.test(id)
-        ? `${CANONICAL_BASE_URL}/book-cover/${encodeURIComponent(id)}/cover.jpg`
-        : '';
+    if (!/^MLU\d+$/.test(id) || !Number.isInteger(position) ||
+        position < 0 || position >= MAX_GALLERY_IMAGES) return '';
+    const filename = position === 0 ? 'cover.jpg' : `cover-${position + 1}.jpg`;
+    return `${CANONICAL_BASE_URL}/book-cover/${encodeURIComponent(id)}/${filename}`;
 }
 
-function primaryMerchantSource(item) {
-    const pictures = Array.isArray(item?.pictures) ? item.pictures : [];
-    const raw = pictures[0] || item?.thumbnail;
+function normalizeMerchantImageSource(raw) {
     if (typeof raw !== 'string' || !raw.trim()) return '';
     try {
         const url = new URL(raw.trim());
@@ -409,12 +410,45 @@ function primaryMerchantSource(item) {
     }
 }
 
-function readyPrimaryCover(entry, sourceUrl) {
+export function merchantImageSources(item) {
+    const pictures = Array.isArray(item?.pictures) ? item.pictures : [];
+    const candidates = pictures.length > 0 ? pictures : [item?.thumbnail];
+    return [...new Set(candidates.map(normalizeMerchantImageSource).filter(Boolean))]
+        .slice(0, MAX_GALLERY_IMAGES);
+}
+
+function readyCoverCurrent(entry, sourceUrl) {
     const current = entry?.current;
     const match = COVER_OBJECT_KEY_RE.exec(String(current?.object_key || ''));
-    if (!match || current.sha256 !== match[1]) return false;
+    if (!match || current.sha256 !== match[1]) return null;
     const expectedMime = `image/${match[2] === 'jpg' ? 'jpeg' : match[2]}`;
-    return current.mime === expectedMime && current.source_url === sourceUrl;
+    return current.mime === expectedMime && current.source_url === sourceUrl
+        ? current
+        : null;
+}
+
+export function additionalMerchantImageLinks(item, manifest, limit = MAX_ADDITIONAL_IMAGE_LINKS) {
+    if (!manifest || manifest.schema_version !== 1 || !manifest.entries ||
+        typeof manifest.entries !== 'object' || Array.isArray(manifest.entries)) return [];
+    const id = String(item?.id || '').trim().toUpperCase();
+    if (!/^MLU\d+$/.test(id)) return [];
+
+    const sources = merchantImageSources(item);
+    const primary = readyCoverCurrent(manifest.entries[`${id}:0`], sources[0]);
+    if (!primary) return [];
+
+    const seenHashes = new Set([primary.sha256]);
+    const links = [];
+    const safeLimit = Math.min(MAX_ADDITIONAL_IMAGE_LINKS, Math.max(0, Number(limit) || 0));
+    for (let position = 1; position < sources.length && links.length < safeLimit; position += 1) {
+        const current = readyCoverCurrent(manifest.entries[`${id}:${position}`], sources[position]);
+        if (!current || seenHashes.has(current.sha256)) continue;
+        const link = merchantImageLink(item, position);
+        if (!link) continue;
+        seenHashes.add(current.sha256);
+        links.push(link);
+    }
+    return links;
 }
 
 export function filterItemsWithReadyPrimaryCover(items, manifest) {
@@ -424,8 +458,8 @@ export function filterItemsWithReadyPrimaryCover(items, manifest) {
     }
     return items.filter(item => {
         const id = String(item?.id || '').trim().toUpperCase();
-        const sourceUrl = primaryMerchantSource(item);
-        return Boolean(sourceUrl && readyPrimaryCover(manifest.entries[`${id}:0`], sourceUrl));
+        const sourceUrl = merchantImageSources(item)[0];
+        return Boolean(sourceUrl && readyCoverCurrent(manifest.entries[`${id}:0`], sourceUrl));
     });
 }
 
@@ -451,7 +485,7 @@ async function readMerchantCoverManifest(context) {
 // Render de un <item>
 // ---------------------------------------------------------------------------
 
-export function renderFeedItem(item) {
+export function renderFeedItem(item, coverManifest = null) {
     item = applyBookEnrichment(item);
     const stock = Number(item.available_quantity) || 0;
     const currency = String(item.currency || item.currency_id || '').trim().toUpperCase();
@@ -463,6 +497,9 @@ export function renderFeedItem(item) {
     // El feed nunca expone mlstatic.com: Google obtiene la portada desde el
     // proxy/cache de Amado Libros, bajo un dominio que controlamos.
     const imageLink = merchantImageLink(item);
+    const additionalImageTags = additionalMerchantImageLinks(item, coverManifest)
+        .map(link => `\n        <g:additional_image_link>${escapeXml(link)}</g:additional_image_link>`)
+        .join('');
 
     const isbnResult = normalizeIsbnToGtin(item.isbn);
     // GTIN válido: se omite identifier_exists (default = yes, según spec de
@@ -483,7 +520,7 @@ export function renderFeedItem(item) {
         <g:title>${escapeXml(title)}</g:title>
         <g:description>${escapeXml(description)}</g:description>
         <g:link>${escapeXml(`${CANONICAL_BASE_URL}/libro/${item.id}/${slugify(item.title || '')}`)}</g:link>
-        ${imageLink ? `<g:image_link>${escapeXml(imageLink)}</g:image_link>` : ''}
+        ${imageLink ? `<g:image_link>${escapeXml(imageLink)}</g:image_link>${additionalImageTags}` : ''}
         <g:availability>${availability}</g:availability>
         <g:price>${escapeXml(price)}</g:price>
         <g:condition>${escapeXml(cond)}</g:condition>${gtinTag}${identifierExistsTag}

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -914,7 +914,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     ${!inStock ? moreDetailsHtml : ''}
     ${seoOpportunityHtml}
     <p class="shipping">${inStock
-      ? '🚚 Entrega en 2 horas en Montevideo · Envíos a todo Uruguay · Envío gratis desde $1.500.'
+      ? '🚚 Entrega en el día en Montevideo según zona, horario y confirmación · Envío $250 · Gratis desde $1.500 · Atención personalizada.'
       : '🌎 Si preferís no esperar, también podemos buscarlo por encargo en el exterior.'
     } <a href="/politicas#envios">Ver política de envíos</a>.</p>
   </div>

--- a/functions/libro/_middleware.js
+++ b/functions/libro/_middleware.js
@@ -12,6 +12,8 @@ import { isProductInShowcaseCohort } from '../_shared/showcase-cohort.js';
 import { PRODUCT_SHOWCASE_OVERRIDES } from '../_shared/product-showcases.js';
 import { applyShowcaseTitleQuality } from '../_shared/showcase-title-quality.js';
 import { getBookEnrichmentByIsbn } from '../_shared/book-enrichment-registry.js';
+import { TAROT_MERCH_TAGS } from '../_shared/tarot-merch-tags.js';
+import { buildTagLookup } from '../_shared/tarot-hub-modules.js';
 
 const PRODUCT_PATH_RE = /^\/libro\/(MLU\d+)(?:\/|$)/i;
 const BREADCRUMB_RE = /<nav>\s*<a href="\/">Inicio<\/a>\s*›\s*<span>/;
@@ -33,6 +35,7 @@ let categoryTagsMemory = {
   expiresAt: 0,
   items: null,
 };
+const tarotTagForProduct = buildTagLookup(TAROT_MERCH_TAGS);
 
 function escapeHtml(value) {
   return String(value ?? '')
@@ -402,7 +405,18 @@ function enrichAutomaticShowcaseSchema(html, productId, config) {
 
     const rawType = schema?.['@type'];
     const types = Array.isArray(rawType) ? rawType : [rawType].filter(Boolean);
-    if (!types.includes('Book') || String(schema.sku || '').toUpperCase() !== productId) return full;
+    if ((!types.includes('Book') && !types.includes('Product')) ||
+        String(schema.sku || '').toUpperCase() !== productId) return full;
+
+    if (config.schemaKind === 'product') {
+      schema['@type'] = 'Product';
+      const identifier = String(schema.isbn || '').replace(/\D/g, '');
+      if (/^\d{13}$/.test(identifier)) schema.gtin13 = identifier;
+      delete schema.isbn;
+      delete schema.bookFormat;
+      delete schema.bookEdition;
+      delete schema.numberOfPages;
+    }
 
     if (config.titleChanged) {
       schema.name = config.h1;
@@ -410,8 +424,15 @@ function enrichAutomaticShowcaseSchema(html, productId, config) {
     }
     schema.description = config.schemaDescription;
     if (config.schemaVerified?.inLanguage) schema.inLanguage = config.schemaVerified.inLanguage;
-    if (config.schemaVerified?.bookFormat) schema.bookFormat = config.schemaVerified.bookFormat;
-    if (config.schemaVerified?.bookEdition) schema.bookEdition = config.schemaVerified.bookEdition;
+    if (config.schemaKind !== 'product' && config.schemaVerified?.bookFormat) {
+      schema.bookFormat = config.schemaVerified.bookFormat;
+    }
+    if (config.schemaKind !== 'product' && config.schemaVerified?.bookEdition) {
+      schema.bookEdition = config.schemaVerified.bookEdition;
+    }
+    if (Array.isArray(config.structuredProperties) && config.structuredProperties.length > 0) {
+      schema.additionalProperty = config.structuredProperties;
+    }
     return `<script type="application/ld+json">${serializeSchema(schema)}</script>`;
   });
 }
@@ -608,13 +629,16 @@ export async function onRequest(context) {
     // haya quedado dentro de la cohorte general de 3.000 fichas.
     const extractedItem = productItemFromProductHtml(withByRequestCx, productId);
     const hasVerifiedEnrichment = Boolean(getBookEnrichmentByIsbn(extractedItem?.isbn));
-    const selected = hasVerifiedEnrichment || await isProductInShowcaseCohort(context, productId);
+    const classificationTags = await classificationTagsForProduct(context, productId);
+    const isPriorityVertical = classificationTags.some(tag =>
+      ['biblia', 'reina-valera', 'esoterismo-tarot'].includes(String(tag || '')));
+    const selected = hasVerifiedEnrichment || isPriorityVertical ||
+      await isProductInShowcaseCohort(context, productId);
     if (selected) {
-      const classificationTags = await classificationTagsForProduct(context, productId);
       withAutomaticShowcase = enrichAutomaticProductShowcaseHtml(
         withByRequestCx,
         productId,
-        { classificationTags },
+        { classificationTags, tarotMerchTag: tarotTagForProduct(productId) },
       );
     }
   }

--- a/functions/libros/[[path]].js
+++ b/functions/libros/[[path]].js
@@ -29,7 +29,9 @@ import { buildTagLookup, buildTarotHubModules } from '../_shared/tarot-hub-modul
 import { buildTarotFinderDataset } from '../_shared/tarot-finder-dataset.js';
 
 const TAROT_CATEGORY_ID = 'esoterismo-tarot';
+const TAROT_DECKS_CATEGORY_ID = 'esoterismo-tarot/mazos';
 const BIBLE_CATEGORY_IDS = new Set(['biblias', 'biblias/reina-valera']);
+const PRIORITY_LOCAL_INTENT_IDS = new Set(['biblias/reina-valera', TAROT_DECKS_CATEGORY_ID]);
 const tarotTagLookup = buildTagLookup(TAROT_MERCH_TAGS);
 // DEMAND-LEDGER-1 (PR #206) todavía no está mergeado a main: no hay
 // functions/_shared/demand-ledger.js en esta rama. "Lo más buscado" queda
@@ -212,9 +214,36 @@ function categoryBreadcrumbHtml(category) {
 function bibleCommercialPromiseHtml() {
     return `<aside class="bible-delivery" aria-label="Entrega y envío de Biblias">
     <h2>¿La necesitás hoy?</h2>
-    <p>Algunas Biblias con stock pueden entregarse en 2 horas en Montevideo, según zona y horario. El envío es gratis en compras desde $1.500.</p>
-    <p class="bible-delivery-note">Confirmamos disponibilidad, dirección y plazo antes de coordinar. No todas las ediciones califican para entrega rápida.</p>
+    <p>Las Biblias con stock pueden coordinarse para entrega en el día en Montevideo, según zona, horario y confirmación. El envío cuesta $250 y es gratis en compras desde $1.500.</p>
+    <p class="bible-delivery-note">Te confirmamos personalmente la edición, la disponibilidad, la dirección y el plazo antes de coordinar. La entrega rápida no se promete hasta verificar esos datos.</p>
   </aside>`;
+}
+
+function tarotPathwaysHtml(category) {
+    if (category.id === TAROT_CATEGORY_ID) {
+        return `<section class="bible-pathways" aria-labelledby="tarot-decks-path-title">
+    <h2 id="tarot-decks-path-title">¿Buscás específicamente un mazo de tarot?</h2>
+    <p>Entrá a la selección de mazos físicos verificados. Separamos los mazos de tarot de los oráculos y de los libros para que puedas comparar sistema, idioma, guía y edición.</p>
+    <div class="bible-pathway-grid">
+      <a href="/libros/${TAROT_DECKS_CATEGORY_ID}"><strong>Mazos de tarot disponibles</strong><span>Rider-Waite-Smith, Marsella, Thoth y otras ediciones identificadas.</span></a>
+      <a href="#tarot-finder"><strong>Ayuda para elegir</strong><span>Usá el buscador guiado si todavía no sabés qué sistema o formato necesitás.</span></a>
+    </div>
+  </section>`;
+    }
+    if (category.id !== TAROT_DECKS_CATEGORY_ID) return '';
+
+    return `<aside class="bible-delivery" aria-label="Entrega y envío de mazos de tarot">
+    <h2>¿Lo querés recibir hoy?</h2>
+    <p>Los mazos con stock pueden coordinarse para entrega en el día en Montevideo, según zona, horario y confirmación. El envío cuesta $250 y es gratis en compras desde $1.500.</p>
+    <p class="bible-delivery-note">Te ayudamos personalmente a confirmar sistema, idioma, contenido y edición antes de coordinar la entrega.</p>
+  </aside>`;
+}
+
+function commerceBenefitsHtml(category) {
+    if (PRIORITY_LOCAL_INTENT_IDS.has(category.id)) {
+        return '<div class="benefits"><span>Entrega hoy en Montevideo*</span><span>Envío $250</span><span>Gratis desde $1.500</span><span>Atención personalizada</span></div>';
+    }
+    return '<div class="benefits"><span>12% menos por transferencia</span><span>Hasta 12 cuotas</span><span>Envíos a todo Uruguay</span><span>Encargos del exterior</span></div>';
 }
 
 function biblePathwaysHtml(category) {
@@ -644,7 +673,12 @@ function renderPage({ category, categoryUniverseCount, items, isPreview, hasUnex
     // grilla ya no es lo primero de la página — forceLazy evita eager-load
     // de imágenes fuera del primer viewport.
     const cards = visibleItems
-        .map((item, index) => cardHtml(item, index, navigationBase, { forceLazy: Boolean(tarotModules?.length) }))
+        .map((item, index) => cardHtml(item, index, navigationBase, {
+            forceLazy: Boolean(tarotModules?.length),
+            badges: category.kind === 'tarot-decks'
+                ? tarotBadgesFor(tarotTagLookup(item.id))
+                : [],
+        }))
         .join('\n');
     const robots = isPreview || hasUnexpectedParameters || items.length === 0
         ? 'noindex, follow'
@@ -705,9 +739,10 @@ ${categoryBreadcrumbHtml(category)}
     <h1>${escapeHtml(category.h1)}</h1>
     <p>${escapeHtml(category.intro)}</p>
     <p class="category-scope">${scopeText}</p>
-    <div class="benefits"><span>12% menos por transferencia</span><span>Hasta 12 cuotas</span><span>Envíos a todo Uruguay</span><span>Encargos del exterior</span></div>
+    ${commerceBenefitsHtml(category)}
   </section>
   ${biblePathwaysHtml(category)}
+  ${tarotPathwaysHtml(category)}
   ${tarotFinderHtml(tarotFinderDataset, canonical)}
   ${editorialGuideHtml(category)}
   ${tarotModulesHtml(tarotModules, navigationBase, canonical, Boolean(tarotFinderDataset?.length))}
@@ -775,8 +810,16 @@ export async function onRequest(ctx) {
     const categoryItems = activeItems
         .filter(item => {
             const tags = categoryData.items[item.id] || [];
-            return classificationIds.some(id => tags.includes(id))
+            const matchesClassification = classificationIds.some(id => tags.includes(id))
                 && !excludedClassificationIds.some(id => tags.includes(id));
+            if (!matchesClassification) return false;
+            if (category.tarotFilter === 'verified-tarot-decks') {
+                const tarotTag = tarotTagLookup(item.id);
+                return tarotTag?.primary_type === 'tarot'
+                    && tarotTag?.format === 'mazo'
+                    && tarotTag?.needs_review !== true;
+            }
+            return true;
         })
         .sort((a, b) => {
             const stock = Number(b.available_quantity || 0) - Number(a.available_quantity || 0);


### PR DESCRIPTION
## Resultado
- landings específicas para Biblias Reina Valera y mazos de tarot
- fichas enriquecidas con enlaces internos, datos estructurados y promesa logística condicionada
- feed Merchant con hasta 10 imágenes adicionales validadas y deduplicadas
- piloto Google Ads documentado, sin credenciales ni gasto desde el repositorio

## Validación
- 1263/1263 pruebas verdes
- build Astro: 13 páginas
- audit comercial: 0 críticos
- imágenes: 80/80 válidas y >=500 px
- fichas: 80/80
- showcase: 5/5
- enriquecimientos ISBN: 1005/1006
- excepción documentada: ISBN 9788496614895 ya no tiene publicación activa en el catálogo dinámico; no es una regresión del PR
- sin cambios de precio, stock ni checkout

Autorizado por Seba para merge y producción.