### PR TITLE
SEGURIDAD: completar headers en respuestas Functions

### DIFF
--- a/functions/__tests__/security-headers.test.js
+++ b/functions/__tests__/security-headers.test.js
@@ -9,6 +9,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { onRequest as middlewareRequest } from '../_middleware.js';
 
 const HEADERS_PATH = fileURLToPath(new URL('../../astro-front/public/_headers', import.meta.url));
 const content = readFileSync(HEADERS_PATH, 'utf8');
@@ -39,4 +40,39 @@ test('no se agrega Content-Security-Policy en este Bloque', () => {
 
 test('las reglas previas del archivo (historial del incidente de robots/no-store) siguen documentadas', () => {
   assert.match(content, /No agregar reglas de robots\/caché en este archivo/);
+});
+
+const expectedSecurityHeaders = {
+  'strict-transport-security': 'max-age=31536000; includeSubDomains',
+  'x-frame-options': 'SAMEORIGIN',
+  'referrer-policy': 'strict-origin-when-cross-origin',
+};
+
+async function throughFunctions(pathname) {
+  return middlewareRequest({
+    request: new Request(`https://www.amadolibros.com${pathname}`),
+    async next() {
+      return new Response('SSR');
+    },
+  });
+}
+
+test('Functions agrega los tres headers a catálogo, fichas, carrito y API sin CSP', async () => {
+  for (const pathname of ['/catalogo', '/libro/MLU1/prueba', '/carrito', '/api/health']) {
+    const response = await throughFunctions(pathname);
+    for (const [name, value] of Object.entries(expectedSecurityHeaders)) {
+      assert.equal(response.headers.get(name), value, `${pathname}: ${name}`);
+    }
+    assert.equal(response.headers.has('content-security-policy'), false, pathname);
+    assert.equal(response.headers.has('content-security-policy-report-only'), false, pathname);
+  }
+});
+
+test('Functions conserva los headers también en redirects tempranos', async () => {
+  const response = await throughFunctions('/tienda');
+  assert.equal(response.status, 301);
+  assert.equal(response.headers.get('location'), 'https://www.amadolibros.com/catalogo');
+  for (const [name, value] of Object.entries(expectedSecurityHeaders)) {
+    assert.equal(response.headers.get(name), value, name);
+  }
 });

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -203,6 +203,24 @@ function appendServerTiming(headers, name, duration) {
     );
 }
 
+const SECURITY_HEADERS = Object.freeze({
+    'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+    'X-Frame-Options': 'SAMEORIGIN',
+    'Referrer-Policy': 'strict-origin-when-cross-origin',
+});
+
+function withSecurityHeaders(response) {
+    const headers = new Headers(response.headers);
+    for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+        headers.set(name, value);
+    }
+    return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+    });
+}
+
 export async function onRequest(context) {
     const workerStartedAt = perfNow();
     const url = new URL(context.request.url);
@@ -210,10 +228,11 @@ export async function onRequest(context) {
     const isHashedAstroAsset = /^\/_astro\/[^/]+\.[A-Za-z0-9_-]{6,}\.(?:css|js)$/.test(url.pathname);
 
     const finish = response => {
+        const securedResponse = withSecurityHeaders(response);
         if (!isHashedAstroAsset) {
-            scheduleCrawlAnalytics(context, response, perfNow() - workerStartedAt);
+            scheduleCrawlAnalytics(context, securedResponse, perfNow() - workerStartedAt);
         }
-        return response;
+        return securedResponse;
     };
 
     const legacyResponse = await legacyResponseForRequest(context);
@@ -259,11 +278,11 @@ export async function onRequest(context) {
         const response = await context.next();
         const newHeaders = new Headers(response.headers);
         newHeaders.set('Cache-Control', 'public, max-age=31536000, immutable');
-        return new Response(response.body, {
+        return finish(new Response(response.body, {
             status: response.status,
             statusText: response.statusText,
             headers: newHeaders,
-        });
+        }));
     }
 
     // Producción también expone el tramo que antes quedaba fuera de los


### PR DESCRIPTION
## Corrección postproducción de #258

La verificación viva mostró que `_headers` cubre páginas Astro estáticas, pero no las respuestas SSR de Cloudflare Pages Functions (`/catalogo`, `/libro/...`, API y redirects).

### Cambio

- replica HSTS sin `preload`, `X-Frame-Options: SAMEORIGIN` y `Referrer-Policy: strict-origin-when-cross-origin` en `functions/_middleware.js`;
- conserva headers, status, body y `Server-Timing` existentes;
- cubre respuestas SSR, redirects tempranos, Preview y assets que pasan por Functions;
- no agrega CSP ni CSP Report-Only;
- no modifica lógica de carrito, checkout, Mercado Pago, precios, stock, catálogo, Merchant, GA4, R2 ni worker-sync.

### Validación local

- pruebas específicas y middleware: 32/32;
- suite completa: 270/270 paquetes;
- build checkout OFF: OK;
- build checkout ON: OK;
- `git diff --check`: limpio.

PR Draft. No mergear sin verificar CI y Preview.