### PR TITLE
SEO: reducir profundidad del catálogo con accesos por tramos

### DIFF
--- a/functions/__tests__/catalogo-paginacion.test.js
+++ b/functions/__tests__/catalogo-paginacion.test.js
@@ -326,3 +326,36 @@ test('26. sin resultados no hay paginación ni contador de rango', async () => {
   assert.match(html, /No encontramos resultados\./);
   assert.doesNotMatch(html, /<nav class="pg"/);
 });
+
+test('27. el catálogo grande ofrece 16 accesos HTML a tramos distribuidos', async () => {
+  CATALOG = buildCatalog(PAGE_SIZE * 400);
+  const { html } = await render(BASE_URL);
+  const block = html.slice(html.indexOf('<details class="pg-shortcuts">'), html.indexOf('</details>') + 10);
+  const targets = [...block.matchAll(/href="\/catalogo\?page=(\d+)"/g)].map(match => Number(match[1]));
+
+  // La página 1 se marca como actual; las otras 15 son enlaces reales.
+  assert.equal(targets.length, 15);
+  assert.deepEqual(targets, [...targets].sort((a, b) => a - b));
+  assert.equal(targets.at(-1), 400);
+  assert.match(block, /<span class="pg-shortcut is-current" aria-current="page">Página 1<\/span>/);
+  assert.doesNotMatch(block, /onclick=|javascript:/);
+});
+
+test('28. los accesos reducen la distancia máxima a un tramo del catálogo', async () => {
+  CATALOG = buildCatalog(PAGE_SIZE * 400);
+  const { html } = await render(BASE_URL);
+  const block = html.slice(html.indexOf('<details class="pg-shortcuts">'), html.indexOf('</details>') + 10);
+  const linked = [...block.matchAll(/(?:href="\/catalogo\?page=(\d+)"|aria-current="page">Página (\d+))/g)]
+    .map(match => Number(match[1] || match[2]))
+    .sort((a, b) => a - b);
+
+  assert.equal(linked.length, 16);
+  const largestGap = Math.max(...linked.slice(1).map((target, index) => target - linked[index]));
+  assert.ok(largestGap <= 27, `ningún tramo debe quedar separado por más de 27 páginas; dio ${largestGap}`);
+});
+
+test('29. búsquedas y filtros no duplican los accesos del catálogo limpio', async () => {
+  CATALOG = buildCatalog(PAGE_SIZE * 20);
+  const { html } = await render(`${BASE_URL}?q=prueba`);
+  assert.doesNotMatch(html, /<details class="pg-shortcuts">/);
+});

--- a/functions/__tests__/catalogo-paginacion.test.js
+++ b/functions/__tests__/catalogo-paginacion.test.js
@@ -359,3 +359,15 @@ test('29. búsquedas y filtros no duplican los accesos del catálogo limpio', as
   const { html } = await render(`${BASE_URL}?q=prueba`);
   assert.doesNotMatch(html, /<details class="pg-shortcuts">/);
 });
+
+test('30. una página intermedia conserva los 16 accesos al catálogo limpio', async () => {
+  CATALOG = buildCatalog(PAGE_SIZE * 400);
+  const { html } = await render(`${BASE_URL}?page=200`);
+  const block = html.slice(html.indexOf('<details class="pg-shortcuts">'), html.indexOf('</details>') + 10);
+  const links = [...block.matchAll(/<a class="pg-shortcut" href="([^"]+)">/g)].map(match => match[1]);
+
+  assert.equal(links.length, 16);
+  assert.equal(links[0], '/catalogo');
+  assert.equal(links.at(-1), '/catalogo?page=400');
+  assert.doesNotMatch(block, /q=|categoria=|subcategoria=|disponibilidad=/);
+});

--- a/functions/catalogo.js
+++ b/functions/catalogo.js
@@ -457,13 +457,34 @@ function paginationWindow(page, totalPages) {
     return cells;
 }
 
+// Atajos editoriales para que el catálogo completo no dependa de recorrer
+// cientos de veces “Siguiente”. Repartimos 16 puntos de entrada de forma
+// uniforme entre la primera y la última página. En un catálogo de 400
+// páginas, cualquier tramo queda a no más de ~14 pasos de uno de estos
+// accesos, en vez de quedar a casi 200 desde un extremo.
+//
+// Los enlaces viven en un <details> visible y usable: en mobile ocupa una
+// sola línea hasta que la persona decide abrirlo, pero siguen siendo anchors
+// HTML server-side (sin JavaScript ni contenido exclusivo para crawlers).
+const CATALOG_SHORTCUT_COUNT = 16;
+
+function paginationShortcuts(totalPages) {
+    if (totalPages <= 9) return [];
+    const count = Math.min(CATALOG_SHORTCUT_COUNT, totalPages);
+    const pages = new Set();
+    for (let index = 0; index < count; index += 1) {
+        pages.add(1 + Math.round(index * (totalPages - 1) / (count - 1)));
+    }
+    return [...pages].sort((a, b) => a - b);
+}
+
 // Dos filas, pensadas para mobile primero:
 //   fila 1 → ‹ Anterior · Página N de M · Siguiente ›
 //   fila 2 → 1 … n-1 [n] n+1 … M
 // Todo son <a href> reales: la navegación funciona sin JavaScript. Los
 // extremos deshabilitados se renderizan como <span>, nunca como enlaces a
 // una página inexistente.
-function paginationHtml({ page, totalPages, hrefFor }) {
+function paginationHtml({ page, totalPages, hrefFor, showCatalogShortcuts = false }) {
     if (totalPages <= 1) return '';
 
     const prevControl = page > 1
@@ -484,6 +505,19 @@ function paginationHtml({ page, totalPages, hrefFor }) {
         return `<a class="pg-num" href="${escapeHtml(hrefFor(cell))}" aria-label="${label}">${cell}</a>`;
     }).join('');
 
+    const shortcutPages = showCatalogShortcuts ? paginationShortcuts(totalPages) : [];
+    const shortcuts = shortcutPages.length > 0
+        ? `<details class="pg-shortcuts">
+    <summary>Ir a otra parte del catálogo</summary>
+    <div class="pg-shortcut-links" aria-label="Accesos a tramos del catálogo">
+      ${shortcutPages.map(target => target === page
+            ? `<span class="pg-shortcut is-current" aria-current="page">Página ${target}</span>`
+            : `<a class="pg-shortcut" href="${escapeHtml(hrefFor(target))}">Página ${target}</a>`
+        ).join('')}
+    </div>
+  </details>`
+        : '';
+
     return `<nav class="pg" aria-label="Paginación de resultados">
   <div class="pg-row pg-main">
     ${prevControl}
@@ -491,6 +525,7 @@ function paginationHtml({ page, totalPages, hrefFor }) {
     ${nextControl}
   </div>
   <div class="pg-row pg-nums">${numbers}</div>
+  ${shortcuts}
 </nav>`;
 }
 
@@ -512,6 +547,18 @@ const PAGINATION_STYLES = `
     .pg-gap{border:0;background:none;color:#94a3b8;min-width:24px}
     .pg-status{flex:1;text-align:center;font-size:.8rem;color:#64748b}
     .pg-ctl:focus-visible,.pg-num:focus-visible{outline:2px solid #a94e3d;
+        outline-offset:2px}
+    .pg-shortcuts{margin-top:.25rem;border-top:1px solid #e2dbd0;padding-top:.65rem}
+    .pg-shortcuts summary{width:max-content;max-width:100%;margin:0 auto;cursor:pointer;
+        color:#4a3d30;font-size:.8rem;font-weight:700;list-style-position:inside}
+    .pg-shortcut-links{display:flex;flex-wrap:wrap;justify-content:center;gap:.35rem;
+        margin-top:.65rem}
+    .pg-shortcut{display:inline-flex;align-items:center;justify-content:center;
+        min-height:36px;padding:.35rem .6rem;border:1px solid #e2dbd0;border-radius:999px;
+        background:#fff;color:#4a3d30;font-size:.75rem;text-decoration:none}
+    .pg-shortcut:hover{background:#f5efe6}
+    .pg-shortcut.is-current{background:#18120e;color:#fff;border-color:#18120e}
+    .pg-shortcut:focus-visible,.pg-shortcuts summary:focus-visible{outline:2px solid #a94e3d;
         outline-offset:2px}
 `;
 
@@ -902,6 +949,7 @@ export async function onRequest(ctx) {
     const paginationBlock = paginationHtml({
         page,
         totalPages,
+        showCatalogShortcuts: isIndex,
         hrefFor: target => catalogPath({
             q: rawQ, categoria, subcategoria, disponibilidad, page: target,
         }),


### PR DESCRIPTION
## Objetivo
Reducir la profundidad de navegación del catálogo sin reauditar el sitio ni cambiar el comportamiento comercial.

## Cambio
- Mantiene la paginación mobile-first actual.
- Agrega una navegación secundaria plegable con 16 accesos HTML reales, distribuidos entre la primera y la última página del catálogo limpio.
- No agrega estos accesos a búsquedas o filtros `noindex`.
- En el catálogo productivo observado (198 páginas), ningún tramo queda a más de ~7 páginas de un acceso directo.

## Alcance
Solo `functions/catalogo.js` y sus pruebas. No toca checkout, Mercado Pago, stock, precios, Merchant, schema ni fichas.

## Validación
- Suite específica local: 44/44.
- Suite completa local: 270/270.
- Build checkout OFF: OK.
- Build checkout ON: OK.
- `git diff --check`: limpio.
- CI GitHub `Syntax & Build`: OK (run 32984978414).

## Estado de Preview
El workflow de Preview quedó marcado como fallo antes de ejecutar pasos; el job no generó logs ni desplegó URL. Se reintentó con un commit vacío y ocurrió lo mismo. No se fusiona ni se produce hasta contar con Preview verificable.