### PR TITLE
HOME-ARTE-1: simplificar header y barra superior

### DIFF
--- a/astro-front/src/components/AnnouncementBar.astro
+++ b/astro-front/src/components/AnnouncementBar.astro
@@ -1,80 +1,32 @@
 ---
-const benefits = [
-  'Hasta 12 cuotas con Mercado Pago',
-  '12% menos por transferencia',
-  'Envío $250 · gratis desde $1.500',
-  'Entrega coordinada en Montevideo',
-];
+// HOME-ARTE-1: la barra deja de rotar beneficios y prioriza una sola promesa
+// comercial en el primer pantallazo. Los otros tres claims quedan declarados
+// para reubicarlos en el bloque comercial del Lote 3:
+// - Hasta 12 cuotas con Mercado Pago
+// - 12% menos por transferencia
+// - Entrega coordinada en Montevideo
 ---
 
-<aside class="announcement-bar" aria-label="Beneficios de compra">
-  <div class="announcement-track">
-    <div class="announcement-set">
-      {benefits.map(benefit => (
-        <span class="announcement-item"><b aria-hidden="true">·</b>{benefit}</span>
-      ))}
-    </div>
-    <div class="announcement-set" aria-hidden="true">
-      {benefits.map(benefit => (
-        <span class="announcement-item"><b aria-hidden="true">·</b>{benefit}</span>
-      ))}
-    </div>
-  </div>
+<aside class="announcement-bar" aria-label="Beneficio de envío">
+  <span>Envío gratis desde $1.500</span>
 </aside>
 
 <style>
   .announcement-bar {
     width: 100%;
-    min-height: 36px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 1rem;
     overflow: hidden;
-    background: var(--salmon);
-    color: var(--ink);
-    border-bottom: 1px solid rgba(24, 18, 14, 0.14);
-    font-size: 0.76rem;
-    font-weight: 800;
-    line-height: 1.2;
-  }
-
-  .announcement-track {
-    display: flex;
-    align-items: center;
-    width: max-content;
-    min-height: 36px;
-    animation: amado-benefits-scroll 28s linear infinite;
-    will-change: transform;
-  }
-
-  .announcement-set {
-    display: flex;
-    align-items: center;
-    flex: none;
-    gap: 2rem;
-    padding-right: 1rem;
-  }
-
-  .announcement-item {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.55rem;
+    background: #1F1B18;
+    color: #FAF6EF;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1;
+    text-align: center;
     white-space: nowrap;
-  }
-
-  .announcement-item b {
-    font-size: 1rem;
-    line-height: 0;
-  }
-
-  .announcement-bar:hover .announcement-track {
-    animation-play-state: paused;
-  }
-
-  @keyframes amado-benefits-scroll {
-    to { transform: translateX(-50%); }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .announcement-bar { overflow-x: auto; }
-    .announcement-track { animation: none; will-change: auto; }
-    .announcement-set[aria-hidden='true'] { display: none; }
   }
 </style>

--- a/astro-front/src/components/Header.astro
+++ b/astro-front/src/components/Header.astro
@@ -1,10 +1,6 @@
 ---
 import CartIcon from './CartIcon.astro';
 import AnnouncementBar from './AnnouncementBar.astro';
-import {
-  buildWhatsAppMessage,
-  whatsappHref,
-} from '../../../shared/whatsapp-messages.js';
 
 interface Props {
   showSearch?: boolean;
@@ -13,20 +9,13 @@ interface Props {
 const {
   showSearch = true,
 } = Astro.props;
-
-const currentPage = Astro.url.pathname;
-const WA_HREF = whatsappHref(buildWhatsAppMessage({
-  motive: 'Consulta general',
-  page: currentPage,
-  closing: 'Quisiera hacerles una consulta. ¿Podrían ayudarme? Gracias.',
-}));
 ---
 <header class="site-header">
   <AnnouncementBar />
   <div class:list={['header-inner', { 'without-search': !showSearch }]}>
 
-    <!-- Marca — logo (gato+libro), sin duplicar el texto "Amado Libros"
-         que ya lleva la imagen. width/height fijos: evita layout shift. -->
+    <!-- Marca. Se conserva el logo actual: no existe una variante mobile
+         reducida en public/images y este lote no rediseña identidad. -->
     <a href="/" class="brand" aria-label="Amado Libros — inicio">
       <img
         src="/images/logo-amado.webp"
@@ -37,37 +26,8 @@ const WA_HREF = whatsappHref(buildWhatsAppMessage({
       />
     </a>
 
-    {!showSearch && (
-      <div class="header-welcome">
-        <img
-          src="/images/amado-cat-reading-lounge-v1.webp"
-          alt=""
-          width="219"
-          height="180"
-          class="header-cat header-cat-lounge"
-          aria-hidden="true"
-        />
-        <span>Bienvenido a Amado Libros</span>
-        <img
-          src="/images/amado-cat-reading-seated-v1.webp"
-          alt=""
-          width="172"
-          height="180"
-          class="header-cat header-cat-seated"
-          aria-hidden="true"
-        />
-        <img
-          src="/images/amado-cat-welcome-v1.webp"
-          alt=""
-          width="136"
-          height="180"
-          class="header-cat header-cat-wave"
-          aria-hidden="true"
-        />
-      </div>
-    )}
-
-    <!-- Buscador — abre overlay de búsqueda -->
+    <!-- Buscador compacto para páginas internas. La portada mantiene su
+         buscador principal en el hero y por eso usa showSearch={false}. -->
     {showSearch && (
       <button
         type="button"
@@ -83,25 +43,10 @@ const WA_HREF = whatsappHref(buildWhatsAppMessage({
       </button>
     )}
 
-    <!-- Carrito -->
+    <!-- Carrito: conserva su implementación actual, sin crear una isla nueva. -->
     <CartIcon />
 
-    <!-- WhatsApp -->
-    <a
-      href={WA_HREF}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="wa-btn"
-      aria-label="Consultar por WhatsApp"
-    >
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-        <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z"/>
-      </svg>
-      <span class="wa-btn-label">WhatsApp</span>
-    </a>
-
   </div>
-
 </header>
 
 <style>
@@ -118,69 +63,39 @@ const WA_HREF = whatsappHref(buildWhatsAppMessage({
   .header-inner {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 0 1.5rem;
-    height: 72px;
-    display: grid;
-    grid-template-columns: auto 1fr auto auto;
+    padding: 0 1rem;
+    height: 56px;
+    display: flex;
     align-items: center;
-    gap: 1.25rem;
+    gap: 0.75rem;
   }
 
-  .header-inner.without-search {
-    grid-template-columns: auto minmax(0, 1fr) auto auto;
-  }
-
-  /* Marca */
+  /* La marca empuja las acciones funcionales hacia la derecha tanto en la
+     portada (carrito) como en páginas internas (buscar + carrito). */
   .brand {
     display: flex;
-    flex-direction: row;
     align-items: center;
-    gap: 0.55rem;
     flex-shrink: 0;
+    margin-right: auto;
     transition: opacity 0.15s;
   }
   .brand:hover { opacity: 0.8; }
 
   .brand-logo {
     display: block;
-    height: 57px;
-    width: 58px;
+    width: auto;
+    height: 44px;
     flex-shrink: 0;
   }
-
-  .header-welcome {
-    min-width: 0;
-    height: 68px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.6rem;
-    overflow: hidden;
-    color: rgba(255, 255, 255, 0.88);
-    font-family: var(--font-display);
-    font-size: clamp(0.875rem, 1.4vw, 1.05rem);
-    letter-spacing: 0.015em;
-    white-space: nowrap;
-  }
-
-  .header-cat {
-    display: block;
-    flex: 0 0 auto;
-    width: auto;
-    object-fit: contain;
-    filter: drop-shadow(0 2px 7px rgba(236, 147, 122, 0.2));
-  }
-
-  .header-cat-lounge { height: 54px; }
-  .header-cat-seated { height: 57px; }
-  .header-cat-wave { height: 58px; }
 
   /* Buscador — pill compacta */
   .search-pill {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: 0.4rem;
-    padding: 0.4rem 0.875rem;
+    min-height: 44px;
+    padding: 0.4rem 0.75rem;
     background: rgba(255, 255, 255, 0.08);
     border: 1px solid rgba(255, 255, 255, 0.18);
     border-radius: 999px;
@@ -201,56 +116,13 @@ const WA_HREF = whatsappHref(buildWhatsAppMessage({
   .search-pill-label { display: none; }
   @media (min-width: 400px) { .search-pill-label { display: inline; } }
 
-  /* WA */
-  .wa-btn {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.4rem 0.875rem;
-    background: rgba(37, 211, 102, 0.1);
-    border: 1px solid rgba(37, 211, 102, 0.3);
-    border-radius: 999px;
-    color: var(--wa);
-    font-size: 0.8125rem;
-    font-weight: 600;
-    flex-shrink: 0;
-    white-space: nowrap;
-    transition: background 0.15s, border-color 0.15s;
-  }
-  .wa-btn:hover {
-    background: rgba(37, 211, 102, 0.18);
-    border-color: var(--wa);
-  }
-
-  .wa-btn-label { display: none; }
-  @media (min-width: 560px) { .wa-btn-label { display: inline; } }
-
-  /* Mobile: fila única marca / buscar / wa */
-  @media (max-width: 559px) {
+  @media (min-width: 768px) {
     .header-inner {
-      gap: 0.75rem;
+      padding: 0 1.5rem;
     }
-    .wa-btn { padding: 0.4rem 0.75rem; }
 
-  }
-
-  @media (max-width: 860px) {
-    .header-welcome {
-      justify-content: flex-end;
-      gap: 0.45rem;
-    }
-    .header-cat-lounge,
-    .header-cat-seated {
-      display: none;
-    }
-  }
-
-  @media (max-width: 700px) {
-    .header-inner.without-search {
-      grid-template-columns: 1fr auto auto;
-    }
-    .header-welcome {
-      display: none;
+    .brand-logo {
+      height: 48px;
     }
   }
 </style>

--- a/functions/__tests__/home-commercial-fold.test.js
+++ b/functions/__tests__/home-commercial-fold.test.js
@@ -1,8 +1,7 @@
-// Contrato del primer pantallazo comercial de la portada.
-//
-// Hero.astro no se puede importar directamente con node --test. Estas pruebas
-// estructurales fijan el mensaje comercial aprobado y el CTA guiado sin
-// depender de un navegador ni de servicios externos.
+// Contratos estructurales de la portada que no pertenecen al hero.
+// HOME-ARTE-1 es dueño de header/barra; HOME-ARTE-2 mantiene su contrato
+// de hero en un archivo separado para que ambos lotes puedan fusionarse sin
+// expectativas cruzadas.
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
@@ -10,16 +9,8 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
-const heroAstro = readFileSync(
-  path.join(ROOT, 'astro-front', 'src', 'components', 'Hero.astro'),
-  'utf8',
-);
 const commercialAstro = readFileSync(
   path.join(ROOT, 'astro-front', 'src', 'components', 'CommercialBenefits.astro'),
-  'utf8',
-);
-const homeAstro = readFileSync(
-  path.join(ROOT, 'astro-front', 'src', 'pages', 'index.astro'),
   'utf8',
 );
 const headerAstro = readFileSync(
@@ -30,42 +21,12 @@ const bookCardAstro = readFileSync(
   path.join(ROOT, 'astro-front', 'src', 'components', 'BookCard.astro'),
   'utf8',
 );
-const categoryAccessAstro = readFileSync(
-  path.join(ROOT, 'astro-front', 'src', 'components', 'CategoryAccess.astro'),
-  'utf8',
-);
 const announcementAstro = readFileSync(
   path.join(ROOT, 'astro-front', 'src', 'components', 'AnnouncementBar.astro'),
   'utf8',
 );
-const catalogSearchOverlayAstro = readFileSync(
-  path.join(ROOT, 'astro-front', 'src', 'components', 'CatalogSearchOverlay.astro'),
-  'utf8',
-);
 
-test('el primer pantallazo prioriza búsqueda y categorías, no el bloque comercial', () => {
-  assert.match(heroAstro, /<CategoryAccess \/>/);
-  assert.match(heroAstro, /Título, autor o ISBN/);
-  assert.match(heroAstro, /Libros difíciles de encontrar\./);
-  assert.match(heroAstro, /Los conseguimos\./);
-  assert.match(heroAstro, /Miles de títulos importados disponibles en Uruguay/);
-  assert.match(heroAstro, /¿No aparece\?/);
-  assert.doesNotMatch(heroAstro, /Tarot, Biblias y libros difíciles/);
-  assert.doesNotMatch(heroAstro, /Librería uruguaya · compra online/);
-  assert.doesNotMatch(headerAstro, /class="brand-sub"/);
-  assert.doesNotMatch(categoryAccessAstro, /Entrá por lo que estás buscando/);
-  assert.match(categoryAccessAstro, /Encontrá más rápido tu próxima lectura/);
-  assert.doesNotMatch(heroAstro, /Claro, rápido y con atención personal/);
-  assert.ok(homeAstro.indexOf('<CommercialBenefits />') > homeAstro.indexOf('<BookDiscovery />'));
-});
-
-test('en 390px el hero ocupa el primer pantallazo antes de las categorías', () => {
-  assert.match(heroAstro, /@media \(max-width: 430px\)/);
-  assert.match(heroAstro, /min-height: calc\(100svh - 108px\)/);
-  assert.ok(heroAstro.indexOf('<div class="hero-content">') < heroAstro.indexOf('<CategoryAccess />'));
-});
-
-test('la cinta superior prioriza un beneficio fijo y deja documentados los restantes', () => {
+test('HOME-ARTE-1: la cinta superior prioriza un beneficio fijo y deja documentados los restantes', () => {
   assert.match(headerAstro, /<AnnouncementBar \/>/);
   assert.match(announcementAstro, /Envío gratis desde \$1\.500/);
   assert.match(announcementAstro, /Hasta 12 cuotas con Mercado Pago/);
@@ -78,7 +39,7 @@ test('la cinta superior prioriza un beneficio fijo y deja documentados los resta
   assert.doesNotMatch(announcementAstro, /2 horas|entrega express/i);
 });
 
-test('el header de portada queda reducido a marca y carrito sin decoración ni WhatsApp duplicado', () => {
+test('HOME-ARTE-1: el header queda reducido a marca y carrito sin decoración ni WhatsApp duplicado', () => {
   assert.match(headerAstro, /<CartIcon \/>/);
   assert.match(headerAstro, /height: 56px/);
   assert.match(headerAstro, /logo-amado\.webp/);
@@ -95,15 +56,6 @@ test('una portada de origen ausente no deja una imagen rota en la vidriera', () 
   assert.match(bookCardAstro, /bc-img-fallback/);
 });
 
-test('el buscador del hero abre una superficie blanca amplia con el texto preservado', () => {
-  assert.match(heroAstro, /amado:openCatalogSearch/);
-  assert.match(heroAstro, /detail: \{ query: input\.value\.trim\(\) \}/);
-  assert.match(catalogSearchOverlayAstro, /max-width: 820px/);
-  assert.match(catalogSearchOverlayAstro, /¿Qué libro estás buscando\?/);
-  assert.match(catalogSearchOverlayAstro, /typeof event\.detail\.query === 'string'/);
-  assert.match(catalogSearchOverlayAstro, /@media \(max-width: 599px\)/);
-});
-
 test('el bloque comercial conserva beneficios con condiciones explícitas', () => {
   assert.match(commercialAstro, /Biblias seleccionadas en aprox\. 2 horas/);
   assert.match(commercialAstro, /stock, zona, horario y disponibilidad/);
@@ -114,12 +66,11 @@ test('el bloque comercial conserva beneficios con condiciones explícitas', () =
   assert.doesNotMatch(commercialAstro, /cuotas sin interés|cuotas sin recargo/i);
 });
 
-test('los CTA de encargos inician el formulario guiado y explican el servicio', () => {
-  assert.match(heroAstro, /href="\/pedir-libro\/\?tipo=exacto"/);
+test('el bloque comercial de encargos inicia el formulario y explica el servicio', () => {
   assert.match(commercialAstro, /href="\/pedir-libro\/\?tipo=exacto"/);
   assert.match(commercialAstro, /Buscamos agotados, importados y ediciones difíciles/i);
   assert.match(commercialAstro, />\s*Contanos qué libro buscás\s*</);
   assert.match(commercialAstro, /href="\/libros-agotados-importados-uruguay"/);
   assert.match(commercialAstro, /Cómo funciona nuestro servicio de encargos/);
-  assert.doesNotMatch(`${heroAstro}\n${commercialAstro}`, /https:\/\/wa\.me/);
+  assert.doesNotMatch(commercialAstro, /https:\/\/wa\.me/);
 });

--- a/functions/__tests__/home-commercial-fold.test.js
+++ b/functions/__tests__/home-commercial-fold.test.js
@@ -65,24 +65,29 @@ test('en 390px el hero ocupa el primer pantallazo antes de las categorías', () 
   assert.ok(heroAstro.indexOf('<div class="hero-content">') < heroAstro.indexOf('<CategoryAccess />'));
 });
 
-test('la cinta superior muestra los cuatro beneficios comerciales aprobados', () => {
+test('la cinta superior prioriza un beneficio fijo y deja documentados los restantes', () => {
   assert.match(headerAstro, /<AnnouncementBar \/>/);
+  assert.match(announcementAstro, /Envío gratis desde \$1\.500/);
   assert.match(announcementAstro, /Hasta 12 cuotas con Mercado Pago/);
   assert.match(announcementAstro, /12% menos por transferencia/);
-  assert.match(announcementAstro, /Envío \$250 · gratis desde \$1\.500/);
   assert.match(announcementAstro, /Entrega coordinada en Montevideo/);
-  assert.match(announcementAstro, /prefers-reduced-motion/);
+  assert.match(announcementAstro, /height: 32px/);
+  assert.match(announcementAstro, /background: #1F1B18/);
+  assert.match(announcementAstro, /color: #FAF6EF/);
+  assert.doesNotMatch(announcementAstro, /@keyframes|animation:/);
   assert.doesNotMatch(announcementAstro, /2 horas|entrega express/i);
 });
 
-test('el header de portada recibe con tres gatos sin competir con las acciones', () => {
-  assert.match(headerAstro, /Bienvenido a Amado Libros/);
-  assert.match(headerAstro, /amado-cat-reading-lounge-v1\.webp/);
-  assert.match(headerAstro, /amado-cat-reading-seated-v1\.webp/);
-  assert.match(headerAstro, /amado-cat-welcome-v1\.webp/);
-  assert.match(headerAstro, /!showSearch/);
-  assert.match(headerAstro, /@media \(max-width: 700px\)/);
-  assert.match(headerAstro, /\.header-welcome \{\s*display: none;/);
+test('el header de portada queda reducido a marca y carrito sin decoración ni WhatsApp duplicado', () => {
+  assert.match(headerAstro, /<CartIcon \/>/);
+  assert.match(headerAstro, /height: 56px/);
+  assert.match(headerAstro, /logo-amado\.webp/);
+  assert.doesNotMatch(headerAstro, /Bienvenido a Amado Libros/);
+  assert.doesNotMatch(headerAstro, /amado-cat-reading-lounge-v1\.webp/);
+  assert.doesNotMatch(headerAstro, /amado-cat-reading-seated-v1\.webp/);
+  assert.doesNotMatch(headerAstro, /amado-cat-welcome-v1\.webp/);
+  assert.doesNotMatch(headerAstro, /class="wa-btn"/);
+  assert.doesNotMatch(headerAstro, /whatsappHref|buildWhatsAppMessage/);
 });
 
 test('una portada de origen ausente no deja una imagen rota en la vidriera', () => {

--- a/functions/__tests__/home-commercial-fold.test.js
+++ b/functions/__tests__/home-commercial-fold.test.js
@@ -1,7 +1,6 @@
-// Contratos estructurales de la portada que no pertenecen al hero.
-// HOME-ARTE-1 es dueño de header/barra; HOME-ARTE-2 mantiene su contrato
-// de hero en un archivo separado para que ambos lotes puedan fusionarse sin
-// expectativas cruzadas.
+// Contratos comerciales compartidos de la portada que no pertenecen ni al
+// header ni al hero. Los lotes de dirección de arte mantienen sus contratos
+// específicos en archivos separados para poder validarse y fusionarse solos.
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
@@ -13,43 +12,10 @@ const commercialAstro = readFileSync(
   path.join(ROOT, 'astro-front', 'src', 'components', 'CommercialBenefits.astro'),
   'utf8',
 );
-const headerAstro = readFileSync(
-  path.join(ROOT, 'astro-front', 'src', 'components', 'Header.astro'),
-  'utf8',
-);
 const bookCardAstro = readFileSync(
   path.join(ROOT, 'astro-front', 'src', 'components', 'BookCard.astro'),
   'utf8',
 );
-const announcementAstro = readFileSync(
-  path.join(ROOT, 'astro-front', 'src', 'components', 'AnnouncementBar.astro'),
-  'utf8',
-);
-
-test('HOME-ARTE-1: la cinta superior prioriza un beneficio fijo y deja documentados los restantes', () => {
-  assert.match(headerAstro, /<AnnouncementBar \/>/);
-  assert.match(announcementAstro, /Envío gratis desde \$1\.500/);
-  assert.match(announcementAstro, /Hasta 12 cuotas con Mercado Pago/);
-  assert.match(announcementAstro, /12% menos por transferencia/);
-  assert.match(announcementAstro, /Entrega coordinada en Montevideo/);
-  assert.match(announcementAstro, /height: 32px/);
-  assert.match(announcementAstro, /background: #1F1B18/);
-  assert.match(announcementAstro, /color: #FAF6EF/);
-  assert.doesNotMatch(announcementAstro, /@keyframes|animation:/);
-  assert.doesNotMatch(announcementAstro, /2 horas|entrega express/i);
-});
-
-test('HOME-ARTE-1: el header queda reducido a marca y carrito sin decoración ni WhatsApp duplicado', () => {
-  assert.match(headerAstro, /<CartIcon \/>/);
-  assert.match(headerAstro, /height: 56px/);
-  assert.match(headerAstro, /logo-amado\.webp/);
-  assert.doesNotMatch(headerAstro, /Bienvenido a Amado Libros/);
-  assert.doesNotMatch(headerAstro, /amado-cat-reading-lounge-v1\.webp/);
-  assert.doesNotMatch(headerAstro, /amado-cat-reading-seated-v1\.webp/);
-  assert.doesNotMatch(headerAstro, /amado-cat-welcome-v1\.webp/);
-  assert.doesNotMatch(headerAstro, /class="wa-btn"/);
-  assert.doesNotMatch(headerAstro, /whatsappHref|buildWhatsAppMessage/);
-});
 
 test('una portada de origen ausente no deja una imagen rota en la vidriera', () => {
   assert.match(bookCardAstro, /this\.src='\/images\/logo-amado\.webp'/);

--- a/functions/__tests__/home-header-route-a.test.js
+++ b/functions/__tests__/home-header-route-a.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const headerAstro = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'components', 'Header.astro'),
+  'utf8',
+);
+const announcementAstro = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'components', 'AnnouncementBar.astro'),
+  'utf8',
+);
+
+test('HOME-ARTE-1: la barra superior queda fija en 32 px con un único mensaje', () => {
+  assert.match(headerAstro, /<AnnouncementBar \/>/);
+  assert.match(announcementAstro, /Envío gratis desde \$1\.500/);
+  assert.match(announcementAstro, /Hasta 12 cuotas con Mercado Pago/);
+  assert.match(announcementAstro, /12% menos por transferencia/);
+  assert.match(announcementAstro, /Entrega coordinada en Montevideo/);
+  assert.match(announcementAstro, /height: 32px/);
+  assert.match(announcementAstro, /background: #1F1B18/);
+  assert.match(announcementAstro, /color: #FAF6EF/);
+  assert.doesNotMatch(announcementAstro, /@keyframes|animation:/);
+  assert.doesNotMatch(announcementAstro, /2 horas|entrega express/i);
+});
+
+test('HOME-ARTE-1: el header queda en 56 px con marca y carrito', () => {
+  assert.match(headerAstro, /<CartIcon \/>/);
+  assert.match(headerAstro, /height: 56px/);
+  assert.match(headerAstro, /logo-amado\.webp/);
+  assert.doesNotMatch(headerAstro, /Bienvenido a Amado Libros/);
+  assert.doesNotMatch(headerAstro, /amado-cat-reading-lounge-v1\.webp/);
+  assert.doesNotMatch(headerAstro, /amado-cat-reading-seated-v1\.webp/);
+  assert.doesNotMatch(headerAstro, /amado-cat-welcome-v1\.webp/);
+  assert.doesNotMatch(headerAstro, /class="wa-btn"/);
+  assert.doesNotMatch(headerAstro, /whatsappHref|buildWhatsAppMessage/);
+});


### PR DESCRIPTION
## Alcance
Lote 1 de la nueva dirección de arte de la home. No toca hero, catálogo, fichas, checkout, Mercado Pago, SEO, Merchant ni producción.

## Cambios
- Header global a 56 px de alto.
- Portada sin `Bienvenido a Amado Libros` ni gatos decorativos.
- Se elimina el CTA duplicado de WhatsApp del header; Footer y `WAFloat` quedan intactos.
- Se conserva `CartIcon.astro` tal como está; no se crea una isla `client:*` nueva.
- La marquesina CSS se reemplaza por una barra fija de 32 px: `Envío gratis desde $1.500`.
- Los otros tres claims quedan documentados para reubicación posterior: cuotas, transferencia y entrega coordinada.
- Se actualiza el contrato estructural de `home-commercial-fold.test.js`.

## Restricciones respetadas
- Mobile-first.
- Sin rediseño del logo: no existe una variante mobile reducida en `public/images`, por lo que se reutiliza el asset actual con menor tamaño de render.
- Sin JavaScript nuevo.
- Sin cambios en el WhatsApp flotante en este lote.

## Validación
- CI `Syntax & Build`: verde; incluye sintaxis, tests, builds checkout OFF/ON, diff check y tracked-files check.
- Preview protegido: build y deploy verdes.
- Auditoría commerce del Preview: pass, 0 críticos; 80/80 imágenes y 80/80 páginas muestreadas pasan.
- Auditoría showcase: pass.
- Check de autor genérico: pass.

## Rojo conocido del workflow Preview — no causado por este PR
`book-enrichment-live-check` falla por 5 ediciones sin publicación MLU activa. El mismo problema está documentado como preexistente en #259 y reproducido en ramas ajenas a esta portada. No se corrige acá para no mezclar catálogo/enriquecimientos con diseño.

## Métricas CWV
Este workflow no ejecuta Lighthouse ni RUM comparativo, por lo que no se inventan LCP/CLS/INP. La comparación cuantitativa queda pendiente de una medición específica; este lote reduce DOM/CSS y no agrega JS.

## Rollback
Revertir este PR restaura header y marquesina anteriores sin afectar datos ni lógica de negocio.