### PR TITLE
HOME-ARTE-2: hero mobile-first y búsqueda por encargo

### DIFF
--- a/astro-front/src/components/Hero.astro
+++ b/astro-front/src/components/Hero.astro
@@ -1,4 +1,5 @@
 ---
+// HOME-ARTE-2: hero compacto mobile-first; no agregar imágenes hasta medir LCP.
 import CategoryAccess from './CategoryAccess.astro';
 ---
 

--- a/astro-front/src/components/Hero.astro
+++ b/astro-front/src/components/Hero.astro
@@ -5,40 +5,49 @@ import CategoryAccess from './CategoryAccess.astro';
 <section class="hero-shell">
   <div class="hero">
     <div class="hero-content">
+      <p class="hero-kicker">Libros importados y búsquedas por encargo</p>
+
       <h1 class="hero-h1">
         Libros difíciles de encontrar.
         <span>Los conseguimos.</span>
       </h1>
 
-      <div class="hero-details">
-        <p class="hero-lead">
-          Miles de títulos importados disponibles en Uruguay y un servicio de encargo para ediciones agotadas o descatalogadas.
-        </p>
+      <p class="hero-lead">
+        Buscá en nuestro catálogo. Si no aparece, contanos cuál es y revisamos opciones para ayudarte a encontrarlo.
+      </p>
 
-        <form class="hero-search" action="/catalogo" method="get" role="search">
-          <label class="sr-only" for="hero-search-input">Buscar por título, autor o ISBN</label>
-          <span class="hero-search-icon" aria-hidden="true">
-            <svg width="23" height="23" viewBox="0 0 24 24" fill="none">
-              <circle cx="10.5" cy="10.5" r="6.5" stroke="currentColor" stroke-width="1.8"/>
-              <path d="m15.5 15.5 5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
-            </svg>
-          </span>
-          <input
-            id="hero-search-input"
-            type="search"
-            name="q"
-            placeholder="Título, autor o ISBN"
-            autocomplete="off"
-            enterkeyhint="search"
-          >
-          <button type="submit">Buscar</button>
-        </form>
+      <form class="hero-search" action="/catalogo" method="get" role="search">
+        <label class="sr-only" for="hero-search-input">Buscar por título, autor o ISBN</label>
+        <span class="hero-search-icon" aria-hidden="true">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
+            <circle cx="10.5" cy="10.5" r="6.5" stroke="currentColor" stroke-width="1.8"/>
+            <path d="m15.5 15.5 5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+          </svg>
+        </span>
+        <input
+          id="hero-search-input"
+          type="search"
+          name="q"
+          placeholder="Título, autor o ISBN"
+          autocomplete="off"
+          enterkeyhint="search"
+        >
+        <button type="submit">Buscar libro</button>
+      </form>
 
-        <div class="hero-help">
-          <span>¿No aparece?</span>
-          <a href="/pedir-libro/?tipo=exacto">Pedinos una búsqueda manual →</a>
-        </div>
-      </div>
+      <a class="hero-request" href="/pedir-libro/?tipo=exacto">
+        <span class="hero-request-copy">
+          <strong>¿No aparece en el catálogo?</strong>
+          <small>La búsqueda por encargo la revisamos personalmente.</small>
+        </span>
+        <span class="hero-request-action">Pedir una búsqueda →</span>
+      </a>
+
+      <ul class="hero-benefits" aria-label="Beneficios de compra">
+        <li>Hasta 12 cuotas con Mercado Pago</li>
+        <li>12% menos por transferencia</li>
+        <li>Entrega coordinada en Montevideo</li>
+      </ul>
     </div>
 
     <CategoryAccess />
@@ -74,26 +83,32 @@ import CategoryAccess from './CategoryAccess.astro';
   .hero {
     max-width: 1240px;
     margin: 0 auto;
-    display: grid;
     padding: 0 1rem 1.8rem;
   }
 
   .hero-content {
-    min-height: calc(100svh - 108px);
-    display: grid;
-    align-content: center;
-    gap: 1.5rem;
-    padding: 2.25rem 0.25rem 2.75rem;
+    max-width: 760px;
+    padding: 1.65rem 0.25rem 2rem;
+  }
+
+  .hero-kicker {
+    margin-bottom: 0.65rem;
+    color: var(--ink-2);
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.055em;
+    line-height: 1.25;
+    text-transform: uppercase;
   }
 
   .hero-h1 {
-    max-width: 12ch;
+    max-width: 14ch;
     color: var(--ink);
     font-family: var(--font-display);
-    font-size: clamp(2.85rem, 13vw, 3.55rem);
+    font-size: clamp(2.125rem, 9vw, 2.4rem);
     font-weight: 700;
-    letter-spacing: -0.045em;
-    line-height: 0.93;
+    letter-spacing: -0.035em;
+    line-height: 1.02;
   }
 
   .hero-h1 span {
@@ -102,28 +117,22 @@ import CategoryAccess from './CategoryAccess.astro';
   }
 
   .hero-lead {
-    max-width: 49ch;
-    padding-top: 1rem;
-    border-top: 1px solid #cfc6ba;
+    max-width: 52ch;
+    margin-top: 0.9rem;
     color: var(--ink-2);
-    font-size: clamp(0.94rem, 1.8vw, 1.05rem);
-    line-height: 1.55;
-  }
-
-  .hero-details {
-    max-width: 650px;
+    font-size: 0.9rem;
+    line-height: 1.5;
   }
 
   .hero-search {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: center;
-    gap: 0.65rem;
+    gap: 0.55rem;
     width: 100%;
-    max-width: 650px;
-    margin-top: 1.25rem;
-    padding: 0.4rem;
-    padding-left: 1rem;
+    margin-top: 1rem;
+    padding: 0.35rem;
+    padding-left: 0.85rem;
     background: var(--surface);
     border: 1px solid #d5ccc0;
     border-radius: 0.55rem;
@@ -145,88 +154,158 @@ import CategoryAccess from './CategoryAccess.astro';
     outline: 0;
     background: transparent;
     color: var(--ink);
-    font: 500 1rem/1.2 var(--font-ui);
+    font: 500 0.95rem/1.2 var(--font-ui);
   }
 
   .hero-search input::placeholder { color: #8a8178; opacity: 1; }
 
   .hero-search button {
     min-height: 44px;
-    padding: 0.7rem 1.35rem;
+    padding: 0.7rem 1rem;
     border: 0;
     border-radius: 0.35rem;
     background: var(--salmon);
     color: #fff;
-    font: 750 0.95rem/1 var(--font-ui);
+    font: 750 0.82rem/1 var(--font-ui);
     cursor: pointer;
+    white-space: nowrap;
   }
 
   .hero-search button:hover { background: var(--salmon-hover); }
 
-  .hero-help {
+  .hero-request {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.65rem;
+    padding: 0.75rem 0.85rem;
+    border: 1px solid #d9c6ba;
+    border-radius: 0.5rem;
+    background: rgba(255, 255, 255, 0.42);
+    color: var(--ink);
+    text-decoration: none;
+  }
+
+  .hero-request:hover {
+    border-color: var(--salmon);
+    background: rgba(255, 255, 255, 0.72);
+  }
+
+  .hero-request-copy strong,
+  .hero-request-copy small {
+    display: block;
+  }
+
+  .hero-request-copy strong {
+    font-size: 0.78rem;
+    line-height: 1.25;
+  }
+
+  .hero-request-copy small {
+    margin-top: 0.12rem;
+    color: var(--ink-2);
+    font-size: 0.68rem;
+    line-height: 1.3;
+  }
+
+  .hero-request-action {
+    color: var(--salmon-hover);
+    font-size: 0.72rem;
+    font-weight: 850;
+    line-height: 1.2;
+    text-align: right;
+  }
+
+  .hero-benefits {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.25rem 0.55rem;
-    margin-top: 0.75rem;
+    gap: 0.4rem 0.5rem;
+    margin-top: 0.8rem;
+    padding: 0;
+    list-style: none;
+  }
+
+  .hero-benefits li {
+    padding: 0.36rem 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 0.35rem;
+    background: rgba(255, 255, 255, 0.45);
     color: var(--ink-2);
-    font-size: 0.76rem;
-  }
-
-  .hero-help a {
-    color: var(--ink);
-    font-weight: 800;
-    text-decoration-color: var(--salmon);
-    text-underline-offset: 0.15em;
-  }
-
-  @media (min-width: 700px) {
-    .hero { padding-right: 2rem; padding-left: 2rem; }
-
-    .hero-content {
-      min-height: 560px;
-      padding-top: 3.5rem;
-      padding-bottom: 3.5rem;
-    }
-
-    .hero-h1 {
-      font-size: clamp(4rem, 8vw, 5.4rem);
-    }
-  }
-
-  @media (min-width: 980px) {
-    .hero-content {
-      grid-template-columns: minmax(0, 1.42fr) minmax(340px, 0.58fr);
-      gap: 4.5rem;
-      min-height: 610px;
-      align-items: center;
-      padding-top: 4rem;
-      padding-bottom: 4rem;
-    }
-
-    .hero-h1 {
-      max-width: 11ch;
-      font-size: clamp(4.8rem, 6.35vw, 5.75rem);
-    }
-
-    .hero-details {
-      align-self: end;
-      padding-bottom: 0.6rem;
-    }
-  }
-
-  @media (min-width: 1200px) {
-    .hero { padding-left: 0; padding-right: 0; }
+    font-size: 0.64rem;
+    font-weight: 700;
+    line-height: 1.2;
   }
 
   @media (max-width: 430px) {
     .hero-search {
       grid-template-columns: auto minmax(0, 1fr);
-      padding: 0.55rem 0.75rem;
+      padding: 0.45rem 0.65rem;
     }
 
     .hero-search button {
       grid-column: 1 / -1;
       width: 100%;
     }
+
+    .hero-request {
+      grid-template-columns: 1fr;
+      gap: 0.35rem;
+    }
+
+    .hero-request-action { text-align: left; }
+  }
+
+  @media (min-width: 700px) {
+    .hero {
+      padding-right: 2rem;
+      padding-left: 2rem;
+    }
+
+    .hero-content {
+      padding-top: 3.25rem;
+      padding-bottom: 3rem;
+    }
+
+    .hero-kicker { font-size: 0.72rem; }
+
+    .hero-h1 {
+      max-width: 12ch;
+      font-size: clamp(3.65rem, 7vw, 5rem);
+      line-height: 0.96;
+    }
+
+    .hero-lead {
+      margin-top: 1.2rem;
+      font-size: 1rem;
+    }
+
+    .hero-search { margin-top: 1.3rem; }
+    .hero-search button { padding-right: 1.35rem; padding-left: 1.35rem; font-size: 0.9rem; }
+
+    .hero-request-copy strong { font-size: 0.85rem; }
+    .hero-request-copy small { font-size: 0.72rem; }
+    .hero-request-action { font-size: 0.76rem; }
+  }
+
+  @media (min-width: 980px) {
+    .hero-content {
+      max-width: 920px;
+      padding-top: 4rem;
+      padding-bottom: 3.75rem;
+    }
+
+    .hero-h1 {
+      max-width: 13ch;
+      font-size: clamp(4.5rem, 6.1vw, 5.4rem);
+    }
+
+    .hero-lead { max-width: 58ch; }
+    .hero-search,
+    .hero-request { max-width: 720px; }
+  }
+
+  @media (min-width: 1200px) {
+    .hero { padding-left: 0; padding-right: 0; }
   }
 </style>

--- a/functions/__tests__/home-commercial-fold.test.js
+++ b/functions/__tests__/home-commercial-fold.test.js
@@ -43,26 +43,41 @@ const catalogSearchOverlayAstro = readFileSync(
   'utf8',
 );
 
-test('el primer pantallazo prioriza búsqueda y categorías, no el bloque comercial', () => {
+test('el primer pantallazo prioriza catálogo y búsqueda humana por encargo', () => {
   assert.match(heroAstro, /<CategoryAccess \/>/);
-  assert.match(heroAstro, /Título, autor o ISBN/);
+  assert.match(heroAstro, /Libros importados y búsquedas por encargo/);
   assert.match(heroAstro, /Libros difíciles de encontrar\./);
   assert.match(heroAstro, /Los conseguimos\./);
-  assert.match(heroAstro, /Miles de títulos importados disponibles en Uruguay/);
-  assert.match(heroAstro, /¿No aparece\?/);
+  assert.match(heroAstro, /Buscá en nuestro catálogo\./);
+  assert.match(heroAstro, /revisamos opciones para ayudarte a encontrarlo/);
+  assert.match(heroAstro, /Título, autor o ISBN/);
+  assert.match(heroAstro, />Buscar libro</);
+  assert.match(heroAstro, /¿No aparece en el catálogo\?/);
+  assert.match(heroAstro, /La búsqueda por encargo la revisamos personalmente\./);
+  assert.match(heroAstro, /Pedir una búsqueda →/);
+  assert.doesNotMatch(heroAstro, /16\.000|16000/);
+  assert.doesNotMatch(heroAstro, /automátic|gratuit/i);
   assert.doesNotMatch(heroAstro, /Tarot, Biblias y libros difíciles/);
-  assert.doesNotMatch(heroAstro, /Librería uruguaya · compra online/);
   assert.doesNotMatch(headerAstro, /class="brand-sub"/);
   assert.doesNotMatch(categoryAccessAstro, /Entrá por lo que estás buscando/);
   assert.match(categoryAccessAstro, /Encontrá más rápido tu próxima lectura/);
-  assert.doesNotMatch(heroAstro, /Claro, rápido y con atención personal/);
   assert.ok(homeAstro.indexOf('<CommercialBenefits />') > homeAstro.indexOf('<BookDiscovery />'));
 });
 
-test('en 390px el hero ocupa el primer pantallazo antes de las categorías', () => {
+test('en mobile el hero es compacto y no fuerza una pantalla completa antes de categorías', () => {
   assert.match(heroAstro, /@media \(max-width: 430px\)/);
-  assert.match(heroAstro, /min-height: calc\(100svh - 108px\)/);
+  assert.match(heroAstro, /font-size: clamp\(2\.125rem, 9vw, 2\.4rem\)/);
+  assert.match(heroAstro, /padding: 1\.65rem 0\.25rem 2rem/);
+  assert.doesNotMatch(heroAstro, /100svh|100vh/);
   assert.ok(heroAstro.indexOf('<div class="hero-content">') < heroAstro.indexOf('<CategoryAccess />'));
+});
+
+test('el hero conserva visibles los tres beneficios que luego saldrán de la marquesina', () => {
+  assert.match(heroAstro, /Hasta 12 cuotas con Mercado Pago/);
+  assert.match(heroAstro, /12% menos por transferencia/);
+  assert.match(heroAstro, /Entrega coordinada en Montevideo/);
+  assert.match(heroAstro, /class="hero-benefits"/);
+  assert.doesNotMatch(heroAstro, /cuotas sin interés|cuotas sin recargo/i);
 });
 
 test('la cinta superior muestra los cuatro beneficios comerciales aprobados', () => {
@@ -111,6 +126,8 @@ test('el bloque comercial conserva beneficios con condiciones explícitas', () =
 
 test('los CTA de encargos inician el formulario guiado y explican el servicio', () => {
   assert.match(heroAstro, /href="\/pedir-libro\/\?tipo=exacto"/);
+  assert.match(heroAstro, /Pedir una búsqueda →/);
+  assert.match(heroAstro, /revisamos personalmente/);
   assert.match(commercialAstro, /href="\/pedir-libro\/\?tipo=exacto"/);
   assert.match(commercialAstro, /Buscamos agotados, importados y ediciones difíciles/i);
   assert.match(commercialAstro, />\s*Contanos qué libro buscás\s*</);


### PR DESCRIPTION
SUPERSEDIDO por un PR nuevo contra `main` para recuperar los workflows automáticos de CI/Preview. El código de este lote no se descarta: se reutiliza desde el mismo head limpio.

Motivo: este PR nació con base `home-arte-1-header-bar`; aunque luego se retargeteó a `main`, GitHub Actions no generó los runs esperados. No se modifica ningún workflow para resolver este problema administrativo.