### PR TITLE
HOME-ARTE-3: WhatsApp fuera del primer viewport

### DIFF
--- a/astro-front/src/components/WAFloat.astro
+++ b/astro-front/src/components/WAFloat.astro
@@ -17,7 +17,7 @@ const WA_HREF = whatsappHref(buildWhatsAppMessage({
   class="wa-float"
   aria-label="Consultar por WhatsApp"
 >
-  <svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z"/>
   </svg>
   <span class="wa-float-label">WhatsApp</span>
@@ -26,48 +26,58 @@ const WA_HREF = whatsappHref(buildWhatsAppMessage({
 <style>
   .wa-float {
     position: fixed;
-    bottom: 1.5rem;
-    right: 1.5rem;
+    bottom: max(0.75rem, env(safe-area-inset-bottom, 0px));
+    right: max(0.75rem, env(safe-area-inset-right, 0px));
     z-index: 50;
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    background: var(--wa);
-    color: #fff;
-    border-radius: 999px;
-    box-shadow:
-      0 4px 12px rgba(37, 211, 102, 0.35),
-      0 2px 4px rgba(0, 0, 0, 0.12);
-    transition: background 0.15s, transform 0.15s, box-shadow 0.15s;
-
-    /* Mobile: círculo */
-    width: 56px;
-    height: 56px;
     justify-content: center;
+    width: 44px;
+    height: 44px;
     padding: 0;
+    background: var(--surface);
+    color: var(--wa);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    box-shadow: 0 2px 8px rgba(24, 18, 14, 0.14);
+    transition: background 0.15s, color 0.15s, transform 0.15s, box-shadow 0.15s;
   }
 
   .wa-float:hover {
-    background: var(--wa-hover);
-    transform: translateY(-2px);
-    box-shadow:
-      0 6px 20px rgba(37, 211, 102, 0.4),
-      0 2px 6px rgba(0, 0, 0, 0.14);
+    background: var(--wa);
+    color: #fff;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(24, 18, 14, 0.18);
   }
 
-  .wa-float-label { display: none; }
+  .wa-float:focus-visible {
+    outline: 3px solid var(--ink);
+    outline-offset: 3px;
+  }
 
-  /* Desktop: píldora con texto */
+  .wa-float-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
   @media (min-width: 768px) {
     .wa-float {
-      width: auto;
-      height: auto;
-      padding: 0.75rem 1.25rem;
+      bottom: max(1.25rem, env(safe-area-inset-bottom, 0px));
+      right: max(1.25rem, env(safe-area-inset-right, 0px));
+      width: 48px;
+      height: 48px;
     }
-    .wa-float-label {
-      display: inline;
-      font-size: 0.9375rem;
-      font-weight: 600;
-    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .wa-float { transition: none; }
+    .wa-float:hover { transform: none; }
   }
 </style>

--- a/astro-front/src/pages/index.astro
+++ b/astro-front/src/pages/index.astro
@@ -11,7 +11,6 @@ import OrderHubAccess      from '../components/OrderHubAccess.astro';
 import BestsellerSection   from '../components/BestsellerSection.astro';
 import CommercialBenefits from '../components/CommercialBenefits.astro';
 import Footer              from '../components/Footer.astro';
-import WAFloat             from '../components/WAFloat.astro';
 import SearchOverlay          from '../components/SearchOverlay.astro';
 import CatalogSearchOverlay  from '../components/CatalogSearchOverlay.astro';
 import HowToBuy           from '../components/HowToBuy.astro';
@@ -81,7 +80,6 @@ const jsonLd = {
     <TrustStrip />
   </main>
   <Footer />
-  <WAFloat />
   <SearchOverlay />
   <CatalogSearchOverlay />
 </BaseLayout>

--- a/functions/__tests__/wa-float-art-direction.test.js
+++ b/functions/__tests__/wa-float-art-direction.test.js
@@ -9,8 +9,17 @@ const waFloatAstro = readFileSync(
   path.join(ROOT, 'astro-front', 'src', 'components', 'WAFloat.astro'),
   'utf8',
 );
+const homeAstro = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'pages', 'index.astro'),
+  'utf8',
+);
 
-test('HOME-ARTE-3: el WhatsApp flotante reduce su huella visual en mobile', () => {
+test('HOME-ARTE-3: la home saca el WhatsApp flotante del primer viewport', () => {
+  assert.doesNotMatch(homeAstro, /import\s+WAFloat\s+from/);
+  assert.doesNotMatch(homeAstro, /<WAFloat\s*\/>/);
+});
+
+test('HOME-ARTE-3: donde se conserva, el flotante reduce su huella visual', () => {
   assert.match(waFloatAstro, /width:\s*44px/);
   assert.match(waFloatAstro, /height:\s*44px/);
   assert.match(waFloatAstro, /background:\s*var\(--surface\)/);

--- a/functions/__tests__/wa-float-art-direction.test.js
+++ b/functions/__tests__/wa-float-art-direction.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const waFloatAstro = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'components', 'WAFloat.astro'),
+  'utf8',
+);
+
+test('HOME-ARTE-3: el WhatsApp flotante reduce su huella visual en mobile', () => {
+  assert.match(waFloatAstro, /width:\s*44px/);
+  assert.match(waFloatAstro, /height:\s*44px/);
+  assert.match(waFloatAstro, /background:\s*var\(--surface\)/);
+  assert.match(waFloatAstro, /color:\s*var\(--wa\)/);
+  assert.doesNotMatch(waFloatAstro, /width:\s*56px|height:\s*56px/);
+});
+
+test('HOME-ARTE-3: escritorio conserva acceso directo sin volver a una píldora dominante', () => {
+  assert.match(waFloatAstro, /@media \(min-width: 768px\)/);
+  assert.match(waFloatAstro, /width:\s*48px/);
+  assert.match(waFloatAstro, /height:\s*48px/);
+  assert.doesNotMatch(waFloatAstro, /width:\s*auto|display:\s*inline;\s*font-size:\s*0\.9375rem/);
+});
+
+test('HOME-ARTE-3: conserva accesibilidad, safe-area y el contrato de WhatsApp', () => {
+  assert.match(waFloatAstro, /class="wa-float"/);
+  assert.match(waFloatAstro, /aria-label="Consultar por WhatsApp"/);
+  assert.match(waFloatAstro, /target="_blank"/);
+  assert.match(waFloatAstro, /rel="noopener noreferrer"/);
+  assert.match(waFloatAstro, /buildWhatsAppMessage/);
+  assert.match(waFloatAstro, /whatsappHref/);
+  assert.match(waFloatAstro, /env\(safe-area-inset-bottom, 0px\)/);
+  assert.match(waFloatAstro, /env\(safe-area-inset-right, 0px\)/);
+  assert.match(waFloatAstro, /@media \(prefers-reduced-motion: reduce\)/);
+  assert.match(waFloatAstro, /:focus-visible/);
+});


### PR DESCRIPTION
## Alcance
Lote 3 de la dirección de arte Ruta A. PR independiente contra `main`.

## Cambios
- La home deja de renderizar `WAFloat`: el canal flotante sale por completo del primer viewport y deja de superponerse al hero, buscador y primeras cards.
- En las demás superficies que todavía usan `WAFloat`, el acceso persistente queda más sobrio: 44×44 px en mobile y 48×48 px en desktop, sin píldora grande con texto.
- Tratamiento visual secundario: superficie clara, icono WhatsApp; se conserva la clase `.wa-float` para analytics y reglas existentes.
- Safe-area y `prefers-reduced-motion` preservados.
- Sin JavaScript nuevo; el componente sigue siendo un enlace HTML directo.

## Guardrails
- No toca Header (#263) ni Hero (#265).
- No cambia teléfono, mensajes, rutas, analytics ni lógica comercial.
- No toca checkout; la regla existente que oculta `.wa-float` cuando compite con la barra mobile de pago sigue vigente.
- No modifica tokens globales de color.

## Validación — head `7ffd70d`
- CI `Syntax & Build`: verde completo.
- Preview: build, deploy, propagación, auditoría protegida, showcase y autor genérico pasan.
- El workflow termina rojo sólo en `Verify ISBN enrichments on ficha and Merchant`, el mismo bloqueo heredado de ISBN/MLU que afecta #263/#265 y PRs ajenos al diseño.
- El contrato nuevo impide reintroducir `<WAFloat />` en la home.

## Orden de merge
1. #263 HOME-ARTE-1.
2. #265 HOME-ARTE-2.
3. Este PR.

## Rollback
Revertir este PR restaura únicamente el WhatsApp flotante de la home y su presentación anterior en las demás superficies.