### PR TITLE
HOME-ARTE-4: prioridad LCP de portadas

### DIFF
--- a/astro-front/src/components/BestsellerSection.astro
+++ b/astro-front/src/components/BestsellerSection.astro
@@ -47,7 +47,13 @@ try {
         <div class="bs-inner">
           <h2 class="bs-heading">Incorporaciones recientes</h2>
           <div class="bs-grid">
-            {books.map(book => <BookCard book={book} />)}
+            {books.map((book, index) => (
+              <BookCard
+                book={book}
+                loading={index < 2 ? 'eager' : 'lazy'}
+                fetchPriority={index === 0 ? 'high' : 'auto'}
+              />
+            ))}
           </div>
           <a class="bs-see-all" href="/catalogo">Ver todo el catálogo →</a>
         </div>

--- a/astro-front/src/components/BookCard.astro
+++ b/astro-front/src/components/BookCard.astro
@@ -24,9 +24,15 @@ interface Book {
 
 interface Props {
   book: Book;
+  loading?: 'eager' | 'lazy';
+  fetchPriority?: 'high' | 'auto' | 'low';
 }
 
-const { book } = Astro.props;
+const {
+  book,
+  loading = 'lazy',
+  fetchPriority = 'auto',
+} = Astro.props;
 
 // Debe coincidir con FREE_SHIPPING_THRESHOLD en functions/api/_orders_logic.js
 // La tarjeta y el checkout deben comunicar y aplicar el mismo umbral.
@@ -77,7 +83,8 @@ const hasFreeShipping = book.price >= FREE_SHIPPING_THRESHOLD;
       srcset={cover.srcset || undefined}
       sizes={cover.sizes || undefined}
       alt=""
-      loading="lazy"
+      loading={loading}
+      fetchpriority={fetchPriority}
       decoding="async"
       width="280"
       height="373"

--- a/functions/__tests__/home-cover-priority.test.js
+++ b/functions/__tests__/home-cover-priority.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const bookCardAstro = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'components', 'BookCard.astro'),
+  'utf8',
+);
+const bestsellerAstro = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'components', 'BestsellerSection.astro'),
+  'utf8',
+);
+const imagesJs = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'lib', 'cloudflare-images.js'),
+  'utf8',
+);
+
+test('HOME-ARTE-4: sólo la primera portada recibe prioridad alta', () => {
+  assert.match(bestsellerAstro, /fetchPriority=\{index === 0 \? 'high' : 'auto'\}/);
+  assert.match(bookCardAstro, /fetchpriority=\{fetchPriority\}/);
+  assert.doesNotMatch(bestsellerAstro, /index < 2 \? 'high'/);
+});
+
+test('HOME-ARTE-4: las dos primeras portadas cargan eager y desde la tercera se difieren', () => {
+  assert.match(bestsellerAstro, /loading=\{index < 2 \? 'eager' : 'lazy'\}/);
+  assert.match(bookCardAstro, /loading\?: 'eager' \| 'lazy'/);
+  assert.match(bookCardAstro, /loading = 'lazy'/);
+  assert.match(bookCardAstro, /loading=\{loading\}/);
+});
+
+test('HOME-ARTE-4: la card reserva espacio y conserva la portada controlada por Amado Libros', () => {
+  assert.match(bookCardAstro, /responsiveBookCover\(book\.id/);
+  assert.match(bookCardAstro, /width="280"/);
+  assert.match(bookCardAstro, /height="373"/);
+  assert.match(bookCardAstro, /decoding="async"/);
+  assert.doesNotMatch(bookCardAstro, /src=\{book\.thumbnail\}/);
+  assert.match(imagesJs, /const BASE = 'https:\/\/www\.amadolibros\.com'/);
+  assert.match(imagesJs, /\/book-cover\/\$\{encodeURIComponent\(id\)\}/);
+});
+
+test('HOME-ARTE-4: no agrega otro host de imagen ni preconnect desde la sección', () => {
+  assert.doesNotMatch(bestsellerAstro, /preconnect|mlstatic|http:\/\/|https:\/\//);
+});


### PR DESCRIPTION
## Alcance
Lote 4 de Ruta A. Ajusta únicamente la prioridad de carga de las portadas que ya están inmediatamente debajo del hero.

## Cambios
- Primera portada: `loading=eager` + `fetchpriority=high`.
- Segunda portada: `loading=eager`, prioridad normal.
- Tercera en adelante: `loading=lazy`.
- `BookCard` conserva `lazy/auto` como defaults fuera de esta sección.
- Se conservan `width=280`, `height=373`, `decoding=async`, `srcset` y la fuente controlada por Amado Libros/R2/Cloudflare.
- No se agrega preconnect externo: las portadas salen del propio dominio.

## Guardrails
- No cambia qué libros aparecen ni su orden.
- No toca precios, carrito, WhatsApp, catálogo, checkout ni Merchant.
- No usa `book.thumbnail` como `src` directo.
- No agrega JavaScript ni otro proveedor de imágenes.

## Validación — head `fa3393e`
- CI `Syntax & Build`: verde completo.
- Preview: build, deploy, propagación, auditoría protegida, showcase y autor genérico pasan.
- El workflow termina rojo sólo en `Verify ISBN enrichments on ficha and Merchant`, el mismo bloqueo heredado de ISBN/MLU que afecta los PR de diseño anteriores.
- Contrato estructural aprobado: prioridad alta sólo primera portada, carga diferida desde tercera y reserva dimensional intacta.

## Orden de merge
Después de #263, #265 y #266.

## Rollback
Revertir este PR restaura el `loading=lazy` uniforme anterior.