### PR TITLE
HOME-ARTE-6: paleta exacta Ruta A

### DIFF
--- a/astro-front/src/layouts/BaseLayout.astro
+++ b/astro-front/src/layouts/BaseLayout.astro
@@ -89,16 +89,23 @@ const socialUrl  = canonical || 'https://www.amadolibros.com/';
   <style is:global>
     /* ── Custom properties ─────────────────────────────────── */
     :root {
-      --bg:            #f8f5ef;
-      --surface:       #ffffff;
-      --ink:           #18120e;
-      --ink-2:         #6b6157;
-      --border:        #e2dbd0;
-      --salmon:        #e49982;
-      --salmon-hover:  #c86f5e;
-      --header-bg:     rgba(18, 14, 11, 0.97);
-      --wa:            #25d366;
-      --wa-hover:      #1db954;
+      /* HOME-ARTE-6 — Ruta A / Mostrador. Una sola fuente de verdad. */
+      --paper:         #FAF6EF;
+      --bg:            var(--paper);
+      --surface:       #FFFFFF;
+      --ink:           #1F1B18;
+      --ink-2:         #5A524B;
+      --border:        #E4DCCF;
+      --action:        #B4442A;
+      --error:         #A3231A;
+      --header-bg:     #1F1B18;
+      --wa:            #25D366;
+
+      /* Alias de compatibilidad: no crean colores nuevos. */
+      --salmon:        var(--action);
+      --salmon-hover:  var(--action);
+      --wa-hover:      var(--wa);
+
       --font-display:  'Playfair Display', Georgia, 'Times New Roman', serif;
       --font-ui:       'Inter', system-ui, -apple-system, sans-serif;
       --r:             0.75rem;

--- a/functions/__tests__/route-a-palette.test.js
+++ b/functions/__tests__/route-a-palette.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const baseLayout = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'layouts', 'BaseLayout.astro'),
+  'utf8',
+);
+
+test('HOME-ARTE-6: BaseLayout expone exactamente la paleta aprobada de Ruta A', () => {
+  assert.match(baseLayout, /--paper:\s*#FAF6EF/);
+  assert.match(baseLayout, /--surface:\s*#FFFFFF/);
+  assert.match(baseLayout, /--ink:\s*#1F1B18/);
+  assert.match(baseLayout, /--ink-2:\s*#5A524B/);
+  assert.match(baseLayout, /--border:\s*#E4DCCF/);
+  assert.match(baseLayout, /--action:\s*#B4442A/);
+  assert.match(baseLayout, /--error:\s*#A3231A/);
+  assert.match(baseLayout, /--header-bg:\s*#1F1B18/);
+  assert.match(baseLayout, /--wa:\s*#25D366/);
+});
+
+test('HOME-ARTE-6: los aliases existentes no inventan tonos fuera del sistema', () => {
+  assert.match(baseLayout, /--bg:\s*var\(--paper\)/);
+  assert.match(baseLayout, /--salmon:\s*var\(--action\)/);
+  assert.match(baseLayout, /--salmon-hover:\s*var\(--action\)/);
+  assert.match(baseLayout, /--wa-hover:\s*var\(--wa\)/);
+});
+
+test('HOME-ARTE-6: los colores anteriores salen de la fuente global de tokens', () => {
+  for (const legacy of ['#f8f5ef', '#18120e', '#6b6157', '#e2dbd0', '#e49982', '#c86f5e', '#1db954']) {
+    assert.equal(baseLayout.toLowerCase().includes(legacy), false, `color legado presente: ${legacy}`);
+  }
+});


### PR DESCRIPTION
## Alcance
Lote 6 de Ruta A. Cambia únicamente la fuente global de tokens de color y agrega su contrato de pruebas.

## Paleta aprobada
- Papel: `#FAF6EF`
- Superficie: `#FFFFFF`
- Texto principal / barra: `#1F1B18`
- Texto secundario: `#5A524B`
- Borde: `#E4DCCF`
- Acción: `#B4442A`
- Error: `#A3231A`
- WhatsApp: `#25D366`

## Compatibilidad
- `--salmon` y `--salmon-hover` quedan temporalmente como aliases de `--action`; no se crea un segundo terracota.
- `--wa-hover` queda como alias de `--wa`; no se crea un segundo verde.
- `--bg` apunta a `--paper`.

## Guardrails
- No toca tipografía ni la dependencia actual de fuentes; ese lote requiere autoalojado real y queda separado.
- No modifica componentes, checkout, catálogo, imágenes ni lógica comercial.
- Debe fusionarse después de #265 para que el titular ya no use el color de acción como énfasis.

## Validación esperada
- CI completo y Preview aislado.
- Test explícito de los ocho colores aprobados y ausencia de los tonos globales anteriores.

## Rollback
Revertir este PR restaura únicamente los tokens de color anteriores.