### PR TITLE
CI: no bloquear Preview por ISBN sin MLU activo

### DIFF
--- a/functions/__tests__/book-enrichment-live-check.test.js
+++ b/functions/__tests__/book-enrichment-live-check.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  classifyBookEnrichmentCoverage,
   verifyBookEnrichmentFeed,
   verifyBookEnrichmentHtml,
 } from '../../scripts/seo/book-enrichment-live-check.mjs';
@@ -109,4 +110,28 @@ test('Merchant exige cada hecho factual que su generador debe publicar', () => {
   const feed = `<item><g:id>MLU724888358</g:id><g:description>Libro. ISBN 9788490739808.</g:description><g:gtin>9788490739808</g:gtin><g:price>1950 UYU</g:price><g:availability>in stock</g:availability><g:link>x</g:link><g:image_link>y</g:image_link></item>`;
   const failures = verifyBookEnrichmentFeed(feed, factual, factualItem);
   assert.ok(failures.some(failure => failure.startsWith('Merchant no recibió el hecho verificado:')));
+});
+
+test('una edición real sin MLU activo queda como no aplicable y no como fallo', () => {
+  const inactiveEdition = { isbn: '9788434436442' };
+  const catalog = [
+    { id: 'MLU111111111', isbn: inactiveEdition.isbn, status: 'paused', available_quantity: 0 },
+    { id: 'MLU222222222', isbn: '9780000000000', status: 'active', available_quantity: 3 },
+  ];
+  assert.deepEqual(classifyBookEnrichmentCoverage(catalog, inactiveEdition), {
+    status: 'not_applicable',
+    reason: 'no_active_publication',
+    candidates: [],
+  });
+});
+
+test('si reaparece una oferta MLU activa el control estricto se reactiva automáticamente', () => {
+  const edition = { isbn: '9788434436442' };
+  const catalog = [
+    { id: 'MLU333333333', isbn: edition.isbn, status: 'active', available_quantity: 1 },
+  ];
+  const coverage = classifyBookEnrichmentCoverage(catalog, edition);
+  assert.equal(coverage.status, 'pending');
+  assert.equal(coverage.reason, null);
+  assert.deepEqual(coverage.candidates.map(candidate => candidate.id), ['MLU333333333']);
 });

--- a/scripts/seo/book-enrichment-live-check.mjs
+++ b/scripts/seo/book-enrichment-live-check.mjs
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 // FICHAS-ENRICHMENT-BIBLIAS-1 — gate HTTP real del Preview.
 //
-// Verifica todas las ediciones del registro, no una muestra. Si una futura
-// entrada queda fuera del render SSR, del showcase o de Merchant, el Preview
-// falla antes de que el PR pueda llegar a Producción.
+// Verifica todas las ediciones enriquecidas que tengan al menos una oferta
+// activa en el catálogo. Una edición sin publicación MLU activa se conserva
+// en el registro y queda reportada como not_applicable: no existe una ficha
+// comercial ni una oferta Merchant que tenga sentido exigir en ese momento.
+// Si vuelve a aparecer una publicación activa para ese ISBN, el gate estricto
+// se reactiva automáticamente.
 
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
@@ -106,6 +109,26 @@ function changedFactSignals(record, original) {
   return [...new Set(signals)];
 }
 
+export function classifyBookEnrichmentCoverage(items, record) {
+  const candidates = (Array.isArray(items) ? items : [])
+    .filter(item => item?.status === 'active' && normalizeValidIsbn(item?.isbn) === record?.isbn)
+    .sort((a, b) => (Number(b.available_quantity) || 0) - (Number(a.available_quantity) || 0));
+
+  if (!candidates.length) {
+    return {
+      status: 'not_applicable',
+      reason: 'no_active_publication',
+      candidates: [],
+    };
+  }
+
+  return {
+    status: 'pending',
+    reason: null,
+    candidates,
+  };
+}
+
 export function verifyBookEnrichmentHtml(html, record, productId, originalItem = null) {
   const text = clean(html);
   const failures = [];
@@ -201,11 +224,18 @@ async function main() {
   const pageTasks = [];
 
   for (const record of listBookEnrichments()) {
-    const candidates = items
-      .filter(item => item?.status === 'active' && normalizeValidIsbn(item?.isbn) === record.isbn)
-      .sort((a, b) => (Number(b.available_quantity) || 0) - (Number(a.available_quantity) || 0));
-    if (!candidates.length) {
-      reports.push({ isbn: record.isbn, status: 'failed', failures: ['no hay publicación activa para la edición'] });
+    const coverage = classifyBookEnrichmentCoverage(items, record);
+    const candidates = coverage.candidates;
+    if (coverage.status === 'not_applicable') {
+      reports.push({
+        isbn: record.isbn,
+        product_ids: [],
+        merchant_product_id: null,
+        pages: [],
+        status: 'not_applicable',
+        reason: coverage.reason,
+        failures: [],
+      });
       continue;
     }
 
@@ -221,6 +251,7 @@ async function main() {
       merchant_product_id: null,
       pages: [],
       status: 'pending',
+      reason: null,
       failures: [],
     };
     reports.push(report);
@@ -252,24 +283,39 @@ async function main() {
     });
     report.failures.push(...failures.map(failure => `${item.id}: ${failure}`));
   });
-  for (const report of reports) report.status = report.failures.length ? 'failed' : 'verified';
 
-  const failed = reports.filter(report => report.status !== 'verified');
+  for (const report of reports) {
+    if (report.status === 'not_applicable') continue;
+    report.status = report.failures.length ? 'failed' : 'verified';
+  }
+
+  const failed = reports.filter(report => report.status === 'failed');
+  const verified = reports.filter(report => report.status === 'verified');
+  const notApplicable = reports.filter(report => report.status === 'not_applicable');
+
   mkdirSync(OUTPUT_DIR, { recursive: true });
   writeFileSync(`${OUTPUT_DIR}/book-enrichment-live-check.json`, `${JSON.stringify({
     base_url: BASE_URL,
     checked_at: new Date().toISOString(),
-    verified: reports.length - failed.length,
+    verified: verified.length,
+    not_applicable: notApplicable.length,
     failed: failed.length,
     reports,
   }, null, 2)}\n`);
 
   for (const report of reports) {
-    console.log(`  ${report.isbn} · ${(report.product_ids || []).join(', ') || 'sin MLU'} · ${report.status}`);
+    console.log(`  ${report.isbn} · ${(report.product_ids || []).join(', ') || 'sin MLU activo'} · ${report.status}`);
+    if (report.status === 'not_applicable') {
+      console.warn('    - edición enriquecida conservada; sin oferta activa para verificar en este Preview');
+    }
     for (const failure of report.failures) console.error(`    - ${failure}`);
   }
-  if (failed.length) throw new Error(`${failed.length} edición(es) fallaron la verificación HTTP.`);
-  console.log(`OK: ${reports.length} ediciones enriquecidas verificadas en ficha y Merchant.`);
+
+  if (failed.length) throw new Error(`${failed.length} edición(es) activas fallaron la verificación HTTP.`);
+  console.log(
+    `OK: ${verified.length} ediciones activas verificadas en ficha y Merchant; ` +
+    `${notApplicable.length} sin oferta activa quedaron como no aplicables.`
+  );
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
## Problema
El Preview ejecutaba `book-enrichment-live-check.mjs` contra todas las ediciones enriquecidas. Hasta ahora, una edición bibliográficamente válida pero sin ninguna publicación MLU activa se clasificaba como `failed` y pintaba el workflow de rojo en todos los PR, aunque el cambio no tuviera relación con catálogo o Mercado Libre.

## Nueva regla
- Sin publicación MLU activa para ese ISBN: `not_applicable`. Se conserva en el reporte, no bloquea el Preview.
- Si reaparece una publicación activa del mismo ISBN: el gate estricto se reactiva automáticamente.
- Si hay oferta activa, siguen siendo obligatorias las verificaciones de ficha y Merchant: ISBN, hechos enriquecidos, precio, disponibilidad, enlace, imagen y ausencia de autoría genérica.

## Ejemplo cubierto por test
`9788434436442` queda `not_applicable` si sólo existe una publicación pausada o ninguna activa; vuelve a `pending`/verificación estricta cuando aparece una oferta activa.

## Observabilidad
El artefacto ahora separa `verified`, `not_applicable` y `failed`. Los ISBN sin oferta activa siguen visibles como advertencia en el log.

## Validación — head `8d15698`
- CI completo: verde.
- Preview, intento 3: build, deploy, auditoría comercial, showcase y autor genérico: verdes.
- `Verify ISBN enrichments on ficha and Merchant`: VERDE. Los ISBN sin MLU activo ya no bloquean el gate.
- Preview completo: VERDE.
- El intento 2 había fallado antes de llegar a este gate por una portada R2 transitoria (79/80); al reintentar, esa auditoría pasó.

## Guardrails
- No se elimina ni se omite ningún enriquecimiento del registro.
- No se convierte en warning un fallo real de una oferta activa.
- No toca catálogo, Merchant generator, fichas, SEO render, checkout ni diseño.

## Rollback
Revertir este PR restaura el comportamiento anterior, donde cualquier ISBN sin MLU activo bloqueaba el Preview.