### PR TITLE
HOME Route A: promoción aprobada a producción

### DIFF
--- a/astro-front/src/components/AnnouncementBar.astro
+++ b/astro-front/src/components/AnnouncementBar.astro
@@ -1,80 +1,32 @@
 ---
-const benefits = [
-  'Hasta 12 cuotas con Mercado Pago',
-  '12% menos por transferencia',
-  'Envío $250 · gratis desde $1.500',
-  'Entrega coordinada en Montevideo',
-];
+// HOME-ARTE-1: la barra deja de rotar beneficios y prioriza una sola promesa
+// comercial en el primer pantallazo. Los otros tres claims quedan declarados
+// para reubicarlos en el bloque comercial del Lote 3:
+// - Hasta 12 cuotas con Mercado Pago
+// - 12% menos por transferencia
+// - Entrega coordinada en Montevideo
 ---
 
-<aside class="announcement-bar" aria-label="Beneficios de compra">
-  <div class="announcement-track">
-    <div class="announcement-set">
-      {benefits.map(benefit => (
-        <span class="announcement-item"><b aria-hidden="true">·</b>{benefit}</span>
-      ))}
-    </div>
-    <div class="announcement-set" aria-hidden="true">
-      {benefits.map(benefit => (
-        <span class="announcement-item"><b aria-hidden="true">·</b>{benefit}</span>
-      ))}
-    </div>
-  </div>
+<aside class="announcement-bar" aria-label="Beneficio de envío">
+  <span>Envío gratis desde $1.500</span>
 </aside>
 
 <style>
   .announcement-bar {
     width: 100%;
-    min-height: 36px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 1rem;
     overflow: hidden;
-    background: var(--salmon);
-    color: var(--ink);
-    border-bottom: 1px solid rgba(24, 18, 14, 0.14);
-    font-size: 0.76rem;
-    font-weight: 800;
-    line-height: 1.2;
-  }
-
-  .announcement-track {
-    display: flex;
-    align-items: center;
-    width: max-content;
-    min-height: 36px;
-    animation: amado-benefits-scroll 28s linear infinite;
-    will-change: transform;
-  }
-
-  .announcement-set {
-    display: flex;
-    align-items: center;
-    flex: none;
-    gap: 2rem;
-    padding-right: 1rem;
-  }
-
-  .announcement-item {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.55rem;
+    background: #1F1B18;
+    color: #FAF6EF;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1;
+    text-align: center;
     white-space: nowrap;
-  }
-
-  .announcement-item b {
-    font-size: 1rem;
-    line-height: 0;
-  }
-
-  .announcement-bar:hover .announcement-track {
-    animation-play-state: paused;
-  }
-
-  @keyframes amado-benefits-scroll {
-    to { transform: translateX(-50%); }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .announcement-bar { overflow-x: auto; }
-    .announcement-track { animation: none; will-change: auto; }
-    .announcement-set[aria-hidden='true'] { display: none; }
   }
 </style>

--- a/astro-front/src/components/BestsellerSection.astro
+++ b/astro-front/src/components/BestsellerSection.astro
@@ -47,7 +47,13 @@ try {
         <div class="bs-inner">
           <h2 class="bs-heading">Incorporaciones recientes</h2>
           <div class="bs-grid">
-            {books.map(book => <BookCard book={book} />)}
+            {books.map((book, index) => (
+              <BookCard
+                book={book}
+                loading={index < 2 ? 'eager' : 'lazy'}
+                fetchPriority={index === 0 ? 'high' : 'auto'}
+              />
+            ))}
           </div>
           <a class="bs-see-all" href="/catalogo">Ver todo el catálogo →</a>
         </div>

--- a/astro-front/src/components/BookCard.astro
+++ b/astro-front/src/components/BookCard.astro
@@ -24,9 +24,15 @@ interface Book {
 
 interface Props {
   book: Book;
+  loading?: 'eager' | 'lazy';
+  fetchPriority?: 'high' | 'auto' | 'low';
 }
 
-const { book } = Astro.props;
+const {
+  book,
+  loading = 'lazy',
+  fetchPriority = 'auto',
+} = Astro.props;
 
 // Debe coincidir con FREE_SHIPPING_THRESHOLD en functions/api/_orders_logic.js
 // La tarjeta y el checkout deben comunicar y aplicar el mismo umbral.
@@ -77,7 +83,8 @@ const hasFreeShipping = book.price >= FREE_SHIPPING_THRESHOLD;
       srcset={cover.srcset || undefined}
       sizes={cover.sizes || undefined}
       alt=""
-      loading="lazy"
+      loading={loading}
+      fetchpriority={fetchPriority}
       decoding="async"
       width="280"
       height="373"

--- a/astro-front/src/components/Header.astro
+++ b/astro-front/src/components/Header.astro
@@ -1,10 +1,6 @@
 ---
 import CartIcon from './CartIcon.astro';
 import AnnouncementBar from './AnnouncementBar.astro';
-import {
-  buildWhatsAppMessage,
-  whatsappHref,
-} from '../../../shared/whatsapp-messages.js';
 
 interface Props {
   showSearch?: boolean;
@@ -13,20 +9,13 @@ interface Props {
 const {
   showSearch = true,
 } = Astro.props;
-
-const currentPage = Astro.url.pathname;
-const WA_HREF = whatsappHref(buildWhatsAppMessage({
-  motive: 'Consulta general',
-  page: currentPage,
-  closing: 'Quisiera hacerles una consulta. ¿Podrían ayudarme? Gracias.',
-}));
 ---
 <header class="site-header">
   <AnnouncementBar />
   <div class:list={['header-inner', { 'without-search': !showSearch }]}>
 
-    <!-- Marca — logo (gato+libro), sin duplicar el texto "Amado Libros"
-         que ya lleva la imagen. width/height fijos: evita layout shift. -->
+    <!-- Marca. Se conserva el logo actual: no existe una variante mobile
+         reducida en public/images y este lote no rediseña identidad. -->
     <a href="/" class="brand" aria-label="Amado Libros — inicio">
       <img
         src="/images/logo-amado.webp"
@@ -37,37 +26,8 @@ const WA_HREF = whatsappHref(buildWhatsAppMessage({
       />
     </a>
 
-    {!showSearch && (
-      <div class="header-welcome">
-        <img
-          src="/images/amado-cat-reading-lounge-v1.webp"
-          alt=""
-          width="219"
-          height="180"
-          class="header-cat header-cat-lounge"
-          aria-hidden="true"
-        />
-        <span>Bienvenido a Amado Libros</span>
-        <img
-          src="/images/amado-cat-reading-seated-v1.webp"
-          alt=""
-          width="172"
-          height="180"
-          class="header-cat header-cat-seated"
-          aria-hidden="true"
-        />
-        <img
-          src="/images/amado-cat-welcome-v1.webp"
-          alt=""
-          width="136"
-          height="180"
-          class="header-cat header-cat-wave"
-          aria-hidden="true"
-        />
-      </div>
-    )}
-
-    <!-- Buscador — abre overlay de búsqueda -->
+    <!-- Buscador compacto para páginas internas. La portada mantiene su
+         buscador principal en el hero y por eso usa showSearch={false}. -->
     {showSearch && (
       <button
         type="button"
@@ -83,25 +43,10 @@ const WA_HREF = whatsappHref(buildWhatsAppMessage({
       </button>
     )}
 
-    <!-- Carrito -->
+    <!-- Carrito: conserva su implementación actual, sin crear una isla nueva. -->
     <CartIcon />
 
-    <!-- WhatsApp -->
-    <a
-      href={WA_HREF}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="wa-btn"
-      aria-label="Consultar por WhatsApp"
-    >
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-        <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z"/>
-      </svg>
-      <span class="wa-btn-label">WhatsApp</span>
-    </a>
-
   </div>
-
 </header>
 
 <style>
@@ -118,69 +63,39 @@ const WA_HREF = whatsappHref(buildWhatsAppMessage({
   .header-inner {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 0 1.5rem;
-    height: 72px;
-    display: grid;
-    grid-template-columns: auto 1fr auto auto;
+    padding: 0 1rem;
+    height: 56px;
+    display: flex;
     align-items: center;
-    gap: 1.25rem;
+    gap: 0.75rem;
   }
 
-  .header-inner.without-search {
-    grid-template-columns: auto minmax(0, 1fr) auto auto;
-  }
-
-  /* Marca */
+  /* La marca empuja las acciones funcionales hacia la derecha tanto en la
+     portada (carrito) como en páginas internas (buscar + carrito). */
   .brand {
     display: flex;
-    flex-direction: row;
     align-items: center;
-    gap: 0.55rem;
     flex-shrink: 0;
+    margin-right: auto;
     transition: opacity 0.15s;
   }
   .brand:hover { opacity: 0.8; }
 
   .brand-logo {
     display: block;
-    height: 57px;
-    width: 58px;
+    width: auto;
+    height: 44px;
     flex-shrink: 0;
   }
-
-  .header-welcome {
-    min-width: 0;
-    height: 68px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.6rem;
-    overflow: hidden;
-    color: rgba(255, 255, 255, 0.88);
-    font-family: var(--font-display);
-    font-size: clamp(0.875rem, 1.4vw, 1.05rem);
-    letter-spacing: 0.015em;
-    white-space: nowrap;
-  }
-
-  .header-cat {
-    display: block;
-    flex: 0 0 auto;
-    width: auto;
-    object-fit: contain;
-    filter: drop-shadow(0 2px 7px rgba(236, 147, 122, 0.2));
-  }
-
-  .header-cat-lounge { height: 54px; }
-  .header-cat-seated { height: 57px; }
-  .header-cat-wave { height: 58px; }
 
   /* Buscador — pill compacta */
   .search-pill {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: 0.4rem;
-    padding: 0.4rem 0.875rem;
+    min-height: 44px;
+    padding: 0.4rem 0.75rem;
     background: rgba(255, 255, 255, 0.08);
     border: 1px solid rgba(255, 255, 255, 0.18);
     border-radius: 999px;
@@ -201,56 +116,13 @@ const WA_HREF = whatsappHref(buildWhatsAppMessage({
   .search-pill-label { display: none; }
   @media (min-width: 400px) { .search-pill-label { display: inline; } }
 
-  /* WA */
-  .wa-btn {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.4rem 0.875rem;
-    background: rgba(37, 211, 102, 0.1);
-    border: 1px solid rgba(37, 211, 102, 0.3);
-    border-radius: 999px;
-    color: var(--wa);
-    font-size: 0.8125rem;
-    font-weight: 600;
-    flex-shrink: 0;
-    white-space: nowrap;
-    transition: background 0.15s, border-color 0.15s;
-  }
-  .wa-btn:hover {
-    background: rgba(37, 211, 102, 0.18);
-    border-color: var(--wa);
-  }
-
-  .wa-btn-label { display: none; }
-  @media (min-width: 560px) { .wa-btn-label { display: inline; } }
-
-  /* Mobile: fila única marca / buscar / wa */
-  @media (max-width: 559px) {
+  @media (min-width: 768px) {
     .header-inner {
-      gap: 0.75rem;
+      padding: 0 1.5rem;
     }
-    .wa-btn { padding: 0.4rem 0.75rem; }
 
-  }
-
-  @media (max-width: 860px) {
-    .header-welcome {
-      justify-content: flex-end;
-      gap: 0.45rem;
-    }
-    .header-cat-lounge,
-    .header-cat-seated {
-      display: none;
-    }
-  }
-
-  @media (max-width: 700px) {
-    .header-inner.without-search {
-      grid-template-columns: 1fr auto auto;
-    }
-    .header-welcome {
-      display: none;
+    .brand-logo {
+      height: 48px;
     }
   }
 </style>

--- a/astro-front/src/components/Hero.astro
+++ b/astro-front/src/components/Hero.astro
@@ -1,44 +1,54 @@
 ---
+// HOME-ARTE-2: hero compacto mobile-first; no agregar imágenes hasta medir LCP.
 import CategoryAccess from './CategoryAccess.astro';
 ---
 
 <section class="hero-shell">
   <div class="hero">
     <div class="hero-content">
+      <p class="hero-kicker">Libros importados y búsquedas por encargo</p>
+
       <h1 class="hero-h1">
         Libros difíciles de encontrar.
         <span>Los conseguimos.</span>
       </h1>
 
-      <div class="hero-details">
-        <p class="hero-lead">
-          Miles de títulos importados disponibles en Uruguay y un servicio de encargo para ediciones agotadas o descatalogadas.
-        </p>
+      <p class="hero-lead">
+        Buscá en nuestro catálogo. Tenemos títulos importados disponibles en Uruguay. Si no aparece, revisamos opciones para ayudarte a encontrarlo, incluidas ediciones agotadas o descatalogadas.
+      </p>
 
-        <form class="hero-search" action="/catalogo" method="get" role="search">
-          <label class="sr-only" for="hero-search-input">Buscar por título, autor o ISBN</label>
-          <span class="hero-search-icon" aria-hidden="true">
-            <svg width="23" height="23" viewBox="0 0 24 24" fill="none">
-              <circle cx="10.5" cy="10.5" r="6.5" stroke="currentColor" stroke-width="1.8"/>
-              <path d="m15.5 15.5 5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
-            </svg>
-          </span>
-          <input
-            id="hero-search-input"
-            type="search"
-            name="q"
-            placeholder="Título, autor o ISBN"
-            autocomplete="off"
-            enterkeyhint="search"
-          >
-          <button type="submit">Buscar</button>
-        </form>
+      <form class="hero-search" action="/catalogo" method="get" role="search">
+        <label class="sr-only" for="hero-search-input">Buscar por título, autor o ISBN</label>
+        <span class="hero-search-icon" aria-hidden="true">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
+            <circle cx="10.5" cy="10.5" r="6.5" stroke="currentColor" stroke-width="1.8"/>
+            <path d="m15.5 15.5 5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+          </svg>
+        </span>
+        <input
+          id="hero-search-input"
+          type="search"
+          name="q"
+          placeholder="Título, autor o ISBN"
+          autocomplete="off"
+          enterkeyhint="search"
+        >
+        <button type="submit">Buscar libro</button>
+      </form>
 
-        <div class="hero-help">
-          <span>¿No aparece?</span>
-          <a href="/pedir-libro/?tipo=exacto">Pedinos una búsqueda manual →</a>
-        </div>
-      </div>
+      <a class="hero-request" href="/pedir-libro/?tipo=exacto">
+        <span class="hero-request-copy">
+          <strong>¿No aparece en el catálogo?</strong>
+          <small>La búsqueda por encargo la revisamos personalmente.</small>
+        </span>
+        <span class="hero-request-action">Pedir una búsqueda →</span>
+      </a>
+
+      <ul class="hero-benefits" aria-label="Beneficios de compra">
+        <li>Hasta 12 cuotas con Mercado Pago</li>
+        <li>12% menos por transferencia</li>
+        <li>Entrega coordinada en Montevideo</li>
+      </ul>
     </div>
 
     <CategoryAccess />
@@ -74,56 +84,58 @@ import CategoryAccess from './CategoryAccess.astro';
   .hero {
     max-width: 1240px;
     margin: 0 auto;
-    display: grid;
     padding: 0 1rem 1.8rem;
   }
 
   .hero-content {
-    min-height: calc(100svh - 108px);
-    display: grid;
-    align-content: center;
-    gap: 1.5rem;
-    padding: 2.25rem 0.25rem 2.75rem;
+    max-width: 760px;
+    padding: 1.65rem 0.25rem 2rem;
+  }
+
+  .hero-kicker {
+    margin-bottom: 0.65rem;
+    color: var(--ink-2);
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.055em;
+    line-height: 1.25;
+    text-transform: uppercase;
   }
 
   .hero-h1 {
-    max-width: 12ch;
+    max-width: 14ch;
     color: var(--ink);
     font-family: var(--font-display);
-    font-size: clamp(2.85rem, 13vw, 3.55rem);
-    font-weight: 700;
-    letter-spacing: -0.045em;
-    line-height: 0.93;
+    font-size: clamp(2.125rem, 9vw, 2.4rem);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    line-height: 1.08;
   }
 
   .hero-h1 span {
     display: block;
-    color: var(--salmon-hover);
+    color: inherit;
+    font-style: italic;
+    font-weight: 400;
   }
 
   .hero-lead {
-    max-width: 49ch;
-    padding-top: 1rem;
-    border-top: 1px solid #cfc6ba;
+    max-width: 52ch;
+    margin-top: 0.9rem;
     color: var(--ink-2);
-    font-size: clamp(0.94rem, 1.8vw, 1.05rem);
-    line-height: 1.55;
-  }
-
-  .hero-details {
-    max-width: 650px;
+    font-size: 0.9rem;
+    line-height: 1.5;
   }
 
   .hero-search {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: center;
-    gap: 0.65rem;
+    gap: 0.55rem;
     width: 100%;
-    max-width: 650px;
-    margin-top: 1.25rem;
-    padding: 0.4rem;
-    padding-left: 1rem;
+    margin-top: 1rem;
+    padding: 0.35rem;
+    padding-left: 0.85rem;
     background: var(--surface);
     border: 1px solid #d5ccc0;
     border-radius: 0.55rem;
@@ -145,88 +157,160 @@ import CategoryAccess from './CategoryAccess.astro';
     outline: 0;
     background: transparent;
     color: var(--ink);
-    font: 500 1rem/1.2 var(--font-ui);
+    font: 500 0.95rem/1.2 var(--font-ui);
   }
 
   .hero-search input::placeholder { color: #8a8178; opacity: 1; }
 
   .hero-search button {
     min-height: 44px;
-    padding: 0.7rem 1.35rem;
+    padding: 0.7rem 1rem;
     border: 0;
     border-radius: 0.35rem;
     background: var(--salmon);
     color: #fff;
-    font: 750 0.95rem/1 var(--font-ui);
+    font: 750 0.82rem/1 var(--font-ui);
     cursor: pointer;
+    white-space: nowrap;
   }
 
   .hero-search button:hover { background: var(--salmon-hover); }
 
-  .hero-help {
+  .hero-request {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.65rem;
+    padding: 0.75rem 0.85rem;
+    border: 1px solid #d9c6ba;
+    border-radius: 0.5rem;
+    background: rgba(255, 255, 255, 0.42);
+    color: var(--ink);
+    text-decoration: none;
+  }
+
+  .hero-request:hover {
+    border-color: var(--salmon);
+    background: rgba(255, 255, 255, 0.72);
+  }
+
+  .hero-request-copy strong,
+  .hero-request-copy small {
+    display: block;
+  }
+
+  .hero-request-copy strong {
+    font-size: 0.78rem;
+    line-height: 1.25;
+  }
+
+  .hero-request-copy small {
+    margin-top: 0.12rem;
+    color: var(--ink-2);
+    font-size: 0.68rem;
+    line-height: 1.3;
+  }
+
+  .hero-request-action {
+    color: var(--salmon-hover);
+    font-size: 0.72rem;
+    font-weight: 850;
+    line-height: 1.2;
+    text-align: right;
+  }
+
+  .hero-benefits {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.25rem 0.55rem;
-    margin-top: 0.75rem;
+    gap: 0.4rem 0.5rem;
+    margin-top: 0.8rem;
+    padding: 0;
+    list-style: none;
+  }
+
+  .hero-benefits li {
+    padding: 0.36rem 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 0.35rem;
+    background: rgba(255, 255, 255, 0.45);
     color: var(--ink-2);
-    font-size: 0.76rem;
-  }
-
-  .hero-help a {
-    color: var(--ink);
-    font-weight: 800;
-    text-decoration-color: var(--salmon);
-    text-underline-offset: 0.15em;
-  }
-
-  @media (min-width: 700px) {
-    .hero { padding-right: 2rem; padding-left: 2rem; }
-
-    .hero-content {
-      min-height: 560px;
-      padding-top: 3.5rem;
-      padding-bottom: 3.5rem;
-    }
-
-    .hero-h1 {
-      font-size: clamp(4rem, 8vw, 5.4rem);
-    }
-  }
-
-  @media (min-width: 980px) {
-    .hero-content {
-      grid-template-columns: minmax(0, 1.42fr) minmax(340px, 0.58fr);
-      gap: 4.5rem;
-      min-height: 610px;
-      align-items: center;
-      padding-top: 4rem;
-      padding-bottom: 4rem;
-    }
-
-    .hero-h1 {
-      max-width: 11ch;
-      font-size: clamp(4.8rem, 6.35vw, 5.75rem);
-    }
-
-    .hero-details {
-      align-self: end;
-      padding-bottom: 0.6rem;
-    }
-  }
-
-  @media (min-width: 1200px) {
-    .hero { padding-left: 0; padding-right: 0; }
+    font-size: 0.64rem;
+    font-weight: 700;
+    line-height: 1.2;
   }
 
   @media (max-width: 430px) {
     .hero-search {
       grid-template-columns: auto minmax(0, 1fr);
-      padding: 0.55rem 0.75rem;
+      padding: 0.45rem 0.65rem;
     }
 
     .hero-search button {
       grid-column: 1 / -1;
       width: 100%;
     }
+
+    .hero-request {
+      grid-template-columns: 1fr;
+      gap: 0.35rem;
+    }
+
+    .hero-request-action { text-align: left; }
+  }
+
+  @media (min-width: 700px) {
+    .hero {
+      padding-right: 2rem;
+      padding-left: 2rem;
+    }
+
+    .hero-content {
+      padding-top: 3.25rem;
+      padding-bottom: 3rem;
+    }
+
+    .hero-kicker { font-size: 0.72rem; }
+
+    .hero-h1 {
+      max-width: 14ch;
+      font-size: clamp(2.75rem, 5.5vw, 3.5rem);
+      letter-spacing: -0.015em;
+      line-height: 1.05;
+    }
+
+    .hero-lead {
+      margin-top: 1.2rem;
+      font-size: 1rem;
+    }
+
+    .hero-search { margin-top: 1.3rem; }
+    .hero-search button { padding-right: 1.35rem; padding-left: 1.35rem; font-size: 0.9rem; }
+
+    .hero-request-copy strong { font-size: 0.85rem; }
+    .hero-request-copy small { font-size: 0.72rem; }
+    .hero-request-action { font-size: 0.76rem; }
+  }
+
+  @media (min-width: 980px) {
+    .hero-content {
+      max-width: 920px;
+      padding-top: 4rem;
+      padding-bottom: 3.75rem;
+    }
+
+    .hero-h1 { max-width: 14ch; }
+
+    .hero-lead { max-width: 58ch; }
+    .hero-search,
+    .hero-request { max-width: 720px; }
+  }
+
+  @media (min-width: 1024px) {
+    .hero-h1 { font-size: 3.5rem; }
+  }
+
+  @media (min-width: 1200px) {
+    .hero { padding-left: 0; padding-right: 0; }
   }
 </style>

--- a/astro-front/src/components/OrderHubAccess.astro
+++ b/astro-front/src/components/OrderHubAccess.astro
@@ -1,30 +1,92 @@
 <section class="order-hub-access" aria-labelledby="order-hub-title">
   <div class="order-hub-copy">
-    <p class="order-hub-eyebrow">Libros por encargo</p>
-    <h2 id="order-hub-title">Explorá títulos que podemos buscar y cotizar</h2>
-    <p>
-      Reunimos ediciones agotadas, importadas o difíciles de conseguir en una
-      colección navegable. La disponibilidad, el precio y el plazo se confirman
-      antes de iniciar cualquier encargo.
+    <p class="order-hub-eyebrow">Búsqueda por encargo</p>
+    <h2 id="order-hub-title">Tu búsqueda nos importa</h2>
+    <p class="order-hub-human">
+      Nos gusta buscar esos libros que no aparecen fácil. No es promesa automática ni magia.
+      Es trabajo, paciencia y ganas de ayudarte a conseguirlo.
+    </p>
+    <p class="order-hub-condition">
+      La disponibilidad, el precio y el plazo se confirman antes de iniciar cualquier encargo.
     </p>
   </div>
-  <a class="order-hub-link" href="/libros-por-encargo">
-    Ver libros por encargo <span aria-hidden="true">→</span>
+  <a class="order-hub-link" href="/pedir-libro/?tipo=exacto">
+    Contanos qué libro buscás <span aria-hidden="true">→</span>
   </a>
 </section>
 
 <style>
-  .order-hub-access{
-    max-width:1180px;margin:1.25rem auto;padding:1.25rem;
-    display:flex;flex-direction:column;align-items:flex-start;gap:1rem;
-    background:#fff8f4;border:1px solid #ead5ca;border-radius:1rem;color:#18120e;
+  .order-hub-access {
+    max-width: 1180px;
+    margin: 1.25rem auto;
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 1rem;
+    color: var(--ink);
   }
-  .order-hub-copy{max-width:760px}
-  .order-hub-eyebrow{margin:0 0 .3rem;color:#a94e3d;font-size:.75rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase}
-  h2{margin:0;font-family:Georgia,"Times New Roman",serif;font-size:clamp(1.35rem,4vw,1.9rem);line-height:1.2}
-  .order-hub-copy>p:last-child{margin:.55rem 0 0;color:#574d45;line-height:1.6}
-  .order-hub-link{display:inline-flex;min-height:46px;align-items:center;gap:.4rem;padding:.7rem 1rem;background:#18120e;color:#fff;border-radius:.65rem;text-decoration:none;font-weight:800}
-  .order-hub-link:hover{background:#342820}
-  .order-hub-link:focus-visible{outline:3px solid #e49982;outline-offset:3px}
-  @media(min-width:760px){.order-hub-access{flex-direction:row;align-items:center;justify-content:space-between;padding:1.5rem 1.75rem}.order-hub-link{flex:0 0 auto}}
+
+  .order-hub-copy { max-width: 760px; }
+
+  .order-hub-eyebrow {
+    margin: 0 0 0.3rem;
+    color: var(--ink-2);
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  h2 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.5rem, 4vw, 2.125rem);
+    font-weight: 600;
+    line-height: 1.2;
+  }
+
+  .order-hub-human {
+    margin: 0.65rem 0 0;
+    color: var(--ink);
+    font-size: 1rem;
+    line-height: 1.6;
+  }
+
+  .order-hub-condition {
+    margin: 0.45rem 0 0;
+    color: var(--ink-2);
+    font-size: 0.875rem;
+    line-height: 1.5;
+  }
+
+  .order-hub-link {
+    display: inline-flex;
+    min-height: 46px;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.7rem 1rem;
+    background: var(--salmon);
+    color: #fff;
+    border-radius: 0.65rem;
+    text-decoration: none;
+    font-weight: 700;
+  }
+
+  .order-hub-link:hover { background: var(--salmon-hover); }
+  .order-hub-link:focus-visible { outline: 3px solid var(--salmon); outline-offset: 3px; }
+
+  @media (min-width: 760px) {
+    .order-hub-access {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1.5rem 1.75rem;
+    }
+
+    .order-hub-link { flex: 0 0 auto; }
+  }
 </style>

--- a/astro-front/src/components/WAFloat.astro
+++ b/astro-front/src/components/WAFloat.astro
@@ -17,7 +17,7 @@ const WA_HREF = whatsappHref(buildWhatsAppMessage({
   class="wa-float"
   aria-label="Consultar por WhatsApp"
 >
-  <svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z"/>
   </svg>
   <span class="wa-float-label">WhatsApp</span>
@@ -26,48 +26,58 @@ const WA_HREF = whatsappHref(buildWhatsAppMessage({
 <style>
   .wa-float {
     position: fixed;
-    bottom: 1.5rem;
-    right: 1.5rem;
+    bottom: max(0.75rem, env(safe-area-inset-bottom, 0px));
+    right: max(0.75rem, env(safe-area-inset-right, 0px));
     z-index: 50;
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    background: var(--wa);
-    color: #fff;
-    border-radius: 999px;
-    box-shadow:
-      0 4px 12px rgba(37, 211, 102, 0.35),
-      0 2px 4px rgba(0, 0, 0, 0.12);
-    transition: background 0.15s, transform 0.15s, box-shadow 0.15s;
-
-    /* Mobile: círculo */
-    width: 56px;
-    height: 56px;
     justify-content: center;
+    width: 44px;
+    height: 44px;
     padding: 0;
+    background: var(--surface);
+    color: var(--wa);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    box-shadow: 0 2px 8px rgba(24, 18, 14, 0.14);
+    transition: background 0.15s, color 0.15s, transform 0.15s, box-shadow 0.15s;
   }
 
   .wa-float:hover {
-    background: var(--wa-hover);
-    transform: translateY(-2px);
-    box-shadow:
-      0 6px 20px rgba(37, 211, 102, 0.4),
-      0 2px 6px rgba(0, 0, 0, 0.14);
+    background: var(--wa);
+    color: #fff;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(24, 18, 14, 0.18);
   }
 
-  .wa-float-label { display: none; }
+  .wa-float:focus-visible {
+    outline: 3px solid var(--ink);
+    outline-offset: 3px;
+  }
 
-  /* Desktop: píldora con texto */
+  .wa-float-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
   @media (min-width: 768px) {
     .wa-float {
-      width: auto;
-      height: auto;
-      padding: 0.75rem 1.25rem;
+      bottom: max(1.25rem, env(safe-area-inset-bottom, 0px));
+      right: max(1.25rem, env(safe-area-inset-right, 0px));
+      width: 48px;
+      height: 48px;
     }
-    .wa-float-label {
-      display: inline;
-      font-size: 0.9375rem;
-      font-weight: 600;
-    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .wa-float { transition: none; }
+    .wa-float:hover { transform: none; }
   }
 </style>

--- a/astro-front/src/layouts/BaseLayout.astro
+++ b/astro-front/src/layouts/BaseLayout.astro
@@ -89,16 +89,23 @@ const socialUrl  = canonical || 'https://www.amadolibros.com/';
   <style is:global>
     /* ── Custom properties ─────────────────────────────────── */
     :root {
-      --bg:            #f8f5ef;
-      --surface:       #ffffff;
-      --ink:           #18120e;
-      --ink-2:         #6b6157;
-      --border:        #e2dbd0;
-      --salmon:        #e49982;
-      --salmon-hover:  #c86f5e;
-      --header-bg:     rgba(18, 14, 11, 0.97);
-      --wa:            #25d366;
-      --wa-hover:      #1db954;
+      /* HOME-ARTE-6 — Ruta A / Mostrador. Una sola fuente de verdad. */
+      --paper:         #FAF6EF;
+      --bg:            var(--paper);
+      --surface:       #FFFFFF;
+      --ink:           #1F1B18;
+      --ink-2:         #5A524B;
+      --border:        #E4DCCF;
+      --action:        #B4442A;
+      --error:         #A3231A;
+      --header-bg:     #1F1B18;
+      --wa:            #25D366;
+
+      /* Alias de compatibilidad: no crean colores nuevos. */
+      --salmon:        var(--action);
+      --salmon-hover:  var(--action);
+      --wa-hover:      var(--wa);
+
       --font-display:  'Playfair Display', Georgia, 'Times New Roman', serif;
       --font-ui:       'Inter', system-ui, -apple-system, sans-serif;
       --r:             0.75rem;

--- a/astro-front/src/pages/index.astro
+++ b/astro-front/src/pages/index.astro
@@ -11,7 +11,6 @@ import OrderHubAccess      from '../components/OrderHubAccess.astro';
 import BestsellerSection   from '../components/BestsellerSection.astro';
 import CommercialBenefits from '../components/CommercialBenefits.astro';
 import Footer              from '../components/Footer.astro';
-import WAFloat             from '../components/WAFloat.astro';
 import SearchOverlay          from '../components/SearchOverlay.astro';
 import CatalogSearchOverlay  from '../components/CatalogSearchOverlay.astro';
 import HowToBuy           from '../components/HowToBuy.astro';
@@ -81,7 +80,6 @@ const jsonLd = {
     <TrustStrip />
   </main>
   <Footer />
-  <WAFloat />
   <SearchOverlay />
   <CatalogSearchOverlay />
 </BaseLayout>

--- a/functions/__tests__/home-commercial-fold.test.js
+++ b/functions/__tests__/home-commercial-fold.test.js
@@ -48,8 +48,9 @@ test('el primer pantallazo prioriza búsqueda y categorías, no el bloque comerc
   assert.match(heroAstro, /Título, autor o ISBN/);
   assert.match(heroAstro, /Libros difíciles de encontrar\./);
   assert.match(heroAstro, /Los conseguimos\./);
-  assert.match(heroAstro, /Miles de títulos importados disponibles en Uruguay/);
-  assert.match(heroAstro, /¿No aparece\?/);
+  assert.match(heroAstro, /títulos importados disponibles en Uruguay/i);
+  assert.match(heroAstro, /¿No aparece en el catálogo\?/);
+  assert.match(heroAstro, /Pedir una búsqueda/);
   assert.doesNotMatch(heroAstro, /Tarot, Biblias y libros difíciles/);
   assert.doesNotMatch(heroAstro, /Librería uruguaya · compra online/);
   assert.doesNotMatch(headerAstro, /class="brand-sub"/);
@@ -59,30 +60,32 @@ test('el primer pantallazo prioriza búsqueda y categorías, no el bloque comerc
   assert.ok(homeAstro.indexOf('<CommercialBenefits />') > homeAstro.indexOf('<BookDiscovery />'));
 });
 
-test('en 390px el hero ocupa el primer pantallazo antes de las categorías', () => {
+test('en 390px el hero mantiene búsqueda y encargo utilizables antes de las categorías', () => {
   assert.match(heroAstro, /@media \(max-width: 430px\)/);
-  assert.match(heroAstro, /min-height: calc\(100svh - 108px\)/);
+  assert.match(heroAstro, /\.hero-search button \{\s*grid-column: 1 \/ -1;\s*width: 100%;/);
+  assert.match(heroAstro, /\.hero-request \{\s*grid-template-columns: 1fr;/);
+  assert.doesNotMatch(heroAstro, /min-height:\s*calc\(100svh/);
   assert.ok(heroAstro.indexOf('<div class="hero-content">') < heroAstro.indexOf('<CategoryAccess />'));
 });
 
-test('la cinta superior muestra los cuatro beneficios comerciales aprobados', () => {
+test('la cinta superior es estática y prioriza el beneficio de envío', () => {
+  const visibleAnnouncement = announcementAstro.match(/<aside[\s\S]*?<\/aside>/)?.[0] || '';
+
   assert.match(headerAstro, /<AnnouncementBar \/>/);
-  assert.match(announcementAstro, /Hasta 12 cuotas con Mercado Pago/);
-  assert.match(announcementAstro, /12% menos por transferencia/);
-  assert.match(announcementAstro, /Envío \$250 · gratis desde \$1\.500/);
-  assert.match(announcementAstro, /Entrega coordinada en Montevideo/);
-  assert.match(announcementAstro, /prefers-reduced-motion/);
+  assert.match(visibleAnnouncement, /Envío gratis desde \$1\.500/);
+  assert.doesNotMatch(visibleAnnouncement, /Hasta 12 cuotas|12% menos por transferencia|Entrega coordinada/);
+  assert.doesNotMatch(announcementAstro, /<script\b|animation:/i);
   assert.doesNotMatch(announcementAstro, /2 horas|entrega express/i);
 });
 
-test('el header de portada recibe con tres gatos sin competir con las acciones', () => {
-  assert.match(headerAstro, /Bienvenido a Amado Libros/);
-  assert.match(headerAstro, /amado-cat-reading-lounge-v1\.webp/);
-  assert.match(headerAstro, /amado-cat-reading-seated-v1\.webp/);
-  assert.match(headerAstro, /amado-cat-welcome-v1\.webp/);
-  assert.match(headerAstro, /!showSearch/);
-  assert.match(headerAstro, /@media \(max-width: 700px\)/);
-  assert.match(headerAstro, /\.header-welcome \{\s*display: none;/);
+test('el header de portada queda compacto y reserva la búsqueda principal para el hero', () => {
+  assert.match(headerAstro, /logo-amado\.webp/);
+  assert.match(headerAstro, /showSearch = true/);
+  assert.match(headerAstro, /\{showSearch && \(/);
+  assert.match(homeAstro, /<Header showSearch=\{false\} \/>/);
+  assert.match(headerAstro, /height: 56px/);
+  assert.doesNotMatch(headerAstro, /Bienvenido a Amado Libros/);
+  assert.doesNotMatch(headerAstro, /amado-cat-reading-lounge|amado-cat-reading-seated|amado-cat-welcome/);
 });
 
 test('una portada de origen ausente no deja una imagen rota en la vidriera', () => {

--- a/functions/__tests__/order-hub-seo.test.js
+++ b/functions/__tests__/order-hub-seo.test.js
@@ -222,14 +222,14 @@ test('sitemap-pages publica la raíz y sólo las páginas vigentes 2..N', async 
   assert.ok(!locs.includes('https://www.amadolibros.com/libros-por-encargo?page=4'));
 });
 
-test('la home enlaza el hub de forma visible y el hub mantiene la landing informativa', () => {
+test('la home ofrece el pedido exacto y el hub mantiene la landing informativa', () => {
   const home = readFileSync('astro-front/src/pages/index.astro', 'utf8');
   const access = readFileSync('astro-front/src/components/OrderHubAccess.astro', 'utf8');
   const hub = readFileSync('functions/libros-por-encargo.js', 'utf8');
 
   assert.match(home, /import OrderHubAccess/);
   assert.match(home, /<OrderHubAccess \/>/);
-  assert.match(access, /href="\/libros-por-encargo"/);
+  assert.match(access, /href="\/pedir-libro\/\?tipo=exacto"/);
   assert.match(access, /disponibilidad, el precio y el plazo se confirman/i);
   assert.match(hub, /href="\/libros-agotados-importados-uruguay"/);
   assert.doesNotMatch(access, /priceCurrency|"@type":\s*"Offer"/);


### PR DESCRIPTION
Promoción limpia de la portada Route A ya aprobada visualmente.

Incluye únicamente los cambios runtime de home aprobados sobre el main actual, más la alineación del contrato SEO del bloque de búsqueda humana.

No fusiona el PR #271 de Preview, no arrastra el copy viejo de DeliveryCoordination y no duplica los cambios de CI ya fusionados en #270.

Gate de salida: Syntax & Build verde + Preview verde antes de mergear a main.