### PR TITLE
RADAR DATA 1 — visitas ML 7/30/90 por publicación (#275)

### DIFF
--- a/migrations/0010_item_daily_visits.sql
+++ b/migrations/0010_item_daily_visits.sql
@@ -1,0 +1,22 @@
+-- RADAR DATA 1 (issue #275): serie diaria de visitas por publicación de
+-- Mercado Libre. Guardamos un número compacto por día — nunca 7/30/90 ya
+-- sumados — y derivamos esas ventanas por query (ver worker-sync/visits-store.js).
+--
+-- Clave primaria (item_id, visit_date): upsert idempotente. Un mismo día
+-- puede reprocesarse varias veces (ML documenta hasta 48h de demora en
+-- consolidar el conteo) sin crear filas duplicadas — la última escritura
+-- gana y `observed_at` deja rastro de cuándo se escribió por última vez.
+--
+-- Ausencia de fila = dato no observado, nunca 0 inventado. Si Mercado Libre
+-- no devuelve un item_id en la respuesta de /items/visits para un día dado,
+-- no se escribe fila para ese día — no se asume que tuvo cero visitas.
+CREATE TABLE IF NOT EXISTS item_daily_visits (
+  item_id     TEXT NOT NULL,
+  visit_date  TEXT NOT NULL, -- 'YYYY-MM-DD', día calendario que reporta Mercado Libre
+  visits      INTEGER NOT NULL CHECK (visits >= 0),
+  source      TEXT NOT NULL, -- procedencia: qué endpoint/función escribió esta fila
+  observed_at TEXT NOT NULL, -- ISO timestamp de cuándo la escribimos (auditoría)
+  PRIMARY KEY (item_id, visit_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_item_daily_visits_date ON item_daily_visits (visit_date);

--- a/worker-sync/__tests__/ml-visits.test.js
+++ b/worker-sync/__tests__/ml-visits.test.js
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fetchVisitsRange, fetchVisitsTimeWindow } from '../ml-visits.js';
+
+function jsonResponse(body) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    async json() { return body; },
+  };
+}
+
+test('fetchVisitsRange: arma la URL con ids separados por coma y date_from/date_to', async () => {
+  let capturedUrl;
+  const fetchFn = async url => {
+    capturedUrl = String(url);
+    return jsonResponse([
+      { item_id: 'MLU1', date_from: '2026-08-24', date_to: '2026-08-24', total_visits: 12 },
+      { item_id: 'MLU2', date_from: '2026-08-24', date_to: '2026-08-24', total_visits: 0 },
+    ]);
+  };
+
+  const rows = await fetchVisitsRange(['MLU1', 'MLU2'], 'token', {
+    dateFrom: '2026-08-24',
+    mlGetDeps: { fetchFn },
+  });
+
+  assert.match(capturedUrl, /^https:\/\/api\.mercadolibre\.com\/items\/visits\?ids=MLU1,MLU2&date_from=2026-08-24&date_to=2026-08-24$/);
+  assert.deepEqual(rows, [
+    { item_id: 'MLU1', total_visits: 12 },
+    { item_id: 'MLU2', total_visits: 0 },
+  ]);
+});
+
+test('fetchVisitsRange: dateTo por defecto es igual a dateFrom (un solo día calendario)', async () => {
+  let capturedUrl;
+  const fetchFn = async url => { capturedUrl = String(url); return jsonResponse([]); };
+  await fetchVisitsRange(['MLU1'], 'token', { dateFrom: '2026-08-20', mlGetDeps: { fetchFn } });
+  assert.ok(capturedUrl.includes('date_from=2026-08-20&date_to=2026-08-20'));
+});
+
+test('fetchVisitsRange: ids vacío no llama a fetch y devuelve []', async () => {
+  let called = false;
+  const fetchFn = async () => { called = true; return jsonResponse([]); };
+  const rows = await fetchVisitsRange([], 'token', { dateFrom: '2026-08-20', mlGetDeps: { fetchFn } });
+  assert.deepEqual(rows, []);
+  assert.equal(called, false);
+});
+
+test('fetchVisitsRange: exige dateFrom', async () => {
+  await assert.rejects(() => fetchVisitsRange(['MLU1'], 'token', {}), /dateFrom es requerido/);
+});
+
+test('fetchVisitsRange: ignora entradas sin item_id — nunca inventa filas', async () => {
+  const fetchFn = async () => jsonResponse([
+    { item_id: 'MLU1', total_visits: 5 },
+    { total_visits: 99 }, // sin item_id — Mercado Libre no debería mandar esto, pero no se inventa a quién pertenece
+    null,
+  ]);
+  const rows = await fetchVisitsRange(['MLU1'], 'token', { dateFrom: '2026-08-20', mlGetDeps: { fetchFn } });
+  assert.deepEqual(rows, [{ item_id: 'MLU1', total_visits: 5 }]);
+});
+
+test('fetchVisitsTimeWindow: arma la URL con last/unit/ending', async () => {
+  let capturedUrl;
+  const fetchFn = async url => { capturedUrl = String(url); return jsonResponse({ total_visits: 42 }); };
+  const result = await fetchVisitsTimeWindow('MLU1', 'token', {
+    last: 30, unit: 'day', ending: '2026-08-27', mlGetDeps: { fetchFn },
+  });
+  assert.equal(capturedUrl, 'https://api.mercadolibre.com/items/MLU1/visits/time_window?last=30&unit=day&ending=2026-08-27');
+  assert.deepEqual(result, { total_visits: 42 });
+});
+
+test('fetchVisitsTimeWindow: exige itemId', async () => {
+  await assert.rejects(() => fetchVisitsTimeWindow('', 'token'), /itemId es requerido/);
+});

--- a/worker-sync/__tests__/run-visits-sync.test.js
+++ b/worker-sync/__tests__/run-visits-sync.test.js
@@ -1,0 +1,111 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  lastNCalendarDates,
+  readCatalogItemIdsFromR2,
+  runVisitsSync,
+} from '../index.js';
+
+test('lastNCalendarDates: aplica el lag y devuelve fechas consecutivas oldest→newest', () => {
+  const referenceDate = new Date('2026-08-27T10:00:00.000Z');
+  assert.deepEqual(lastNCalendarDates(referenceDate, 3, 1), ['2026-08-24']);
+  assert.deepEqual(lastNCalendarDates(referenceDate, 3, 3), ['2026-08-22', '2026-08-23', '2026-08-24']);
+});
+
+test('readCatalogItemIdsFromR2: sin CATALOG_R2 o sin catalog.json devuelve []', async () => {
+  assert.deepEqual(await readCatalogItemIdsFromR2({}), []);
+  assert.deepEqual(await readCatalogItemIdsFromR2({ CATALOG_R2: { async get() { return null; } } }), []);
+});
+
+test('readCatalogItemIdsFromR2: extrae los id del catálogo publicado', async () => {
+  const env = {
+    CATALOG_R2: {
+      async get() {
+        return { async text() { return JSON.stringify({ items: [{ id: 'MLU1' }, { id: 'MLU2' }, {}] }); } };
+      },
+    },
+  };
+  assert.deepEqual(await readCatalogItemIdsFromR2(env), ['MLU1', 'MLU2']);
+});
+
+test('runVisitsSync: apagado por defecto no llama a ninguna dependencia', async () => {
+  let called = false;
+  const result = await runVisitsSync({}, { source: 'cron' }, {
+    getAccessTokenFn: async () => { called = true; return 'token'; },
+  });
+  assert.equal(result.status, 'skipped');
+  assert.equal(result.reason, 'visits_sync_disabled');
+  assert.equal(called, false);
+});
+
+test('runVisitsSync: habilitado, agrupa en lotes de VISITS_BATCH_SIZE por cada fecha del backfill', async () => {
+  const env = { VISITS_SYNC_ENABLED: 'true', VISITS_BATCH_SIZE: '2', VISITS_AVAILABILITY_LAG_DAYS: '3', VISITS_BACKFILL_DAYS: '2' };
+  const batches = [];
+  const upserts = [];
+
+  const result = await runVisitsSync(env, { source: 'cron' }, {
+    getAccessTokenFn: async () => 'token',
+    readCatalogItemIdsFn: async () => ['MLU1', 'MLU2', 'MLU3'],
+    fetchVisitsRangeFn: async (ids, token, { dateFrom, dateTo }) => {
+      batches.push({ ids: [...ids], dateFrom, dateTo });
+      return ids.map(id => ({ item_id: id, total_visits: 7 }));
+    },
+    upsertDailyVisitsFn: async (_env, rows) => { upserts.push(...rows); return { status: 'ok', written: rows.length }; },
+    now: () => new Date('2026-08-27T07:20:00.000Z'),
+  });
+
+  assert.equal(result.status, 'ok');
+  assert.equal(result.items_considered, 3);
+  assert.equal(result.batch_size, 2);
+  assert.deepEqual(result.dates, ['2026-08-23', '2026-08-24']);
+  // 2 fechas × 2 lotes (tamaño 2 y 1) = 4 lotes.
+  assert.equal(result.request_batches, 4);
+  assert.equal(result.failed_batches, 0);
+  assert.equal(result.rows_upserted, 6);
+  assert.deepEqual(batches.map(b => b.ids), [['MLU1', 'MLU2'], ['MLU3'], ['MLU1', 'MLU2'], ['MLU3']]);
+  assert.ok(upserts.every(row => row.source === 'items_visits_range'));
+  assert.ok(upserts.every(row => row.observed_at === '2026-08-27T07:20:00.000Z'));
+});
+
+test('runVisitsSync: un lote fallido no aborta el resto — queda reportado como partial', async () => {
+  const env = { VISITS_SYNC_ENABLED: 'true', VISITS_BATCH_SIZE: '1', VISITS_BACKFILL_DAYS: '1' };
+  let calls = 0;
+
+  const result = await runVisitsSync(env, { source: 'cron' }, {
+    getAccessTokenFn: async () => 'token',
+    readCatalogItemIdsFn: async () => ['MLU1', 'MLU2'],
+    fetchVisitsRangeFn: async ids => {
+      calls++;
+      if (ids[0] === 'MLU1') throw new Error('ML caído para este lote');
+      return ids.map(id => ({ item_id: id, total_visits: 3 }));
+    },
+    upsertDailyVisitsFn: async () => ({ status: 'ok', written: 1 }),
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(result.status, 'partial');
+  assert.equal(result.failed_batches, 1);
+  assert.equal(result.rows_upserted, 1);
+});
+
+test('runVisitsSync: sin items en catalog.json devuelve error explícito, no inventa datos', async () => {
+  const env = { VISITS_SYNC_ENABLED: 'true' };
+  const result = await runVisitsSync(env, { source: 'cron' }, {
+    getAccessTokenFn: async () => 'token',
+    readCatalogItemIdsFn: async () => [],
+  });
+  assert.equal(result.status, 'error');
+  assert.match(result.error, /catalog\.json sin items/);
+});
+
+test('runVisitsSync: un fallo de autenticación no intenta pedir visitas', async () => {
+  const env = { VISITS_SYNC_ENABLED: 'true' };
+  let fetchCalled = false;
+  const result = await runVisitsSync(env, { source: 'cron' }, {
+    getAccessTokenFn: async () => { throw new Error('auth falló'); },
+    readCatalogItemIdsFn: async () => { fetchCalled = true; return ['MLU1']; },
+  });
+  assert.equal(result.status, 'error');
+  assert.match(result.error, /auth falló/);
+  assert.equal(fetchCalled, false);
+});

--- a/worker-sync/__tests__/visits-store.test.js
+++ b/worker-sync/__tests__/visits-store.test.js
@@ -1,0 +1,117 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getDailyVisits, getVisitWindows, upsertDailyVisits } from '../visits-store.js';
+
+function fakeOrdersDb() {
+  const rows = new Map(); // key: item_id|visit_date
+  return {
+    rows,
+    prepare(sql) {
+      return {
+        bind(...args) {
+          return {
+            async run() {
+              if (sql.startsWith('INSERT INTO item_daily_visits')) {
+                const [item_id, visit_date, visits, source, observed_at] = args;
+                rows.set(`${item_id}|${visit_date}`, { item_id, visit_date, visits, source, observed_at });
+                return { meta: { changes: 1 } };
+              }
+              throw new Error(`SQL run inesperado: ${sql}`);
+            },
+            async all() {
+              if (sql.startsWith('SELECT visit_date, visits, source, observed_at FROM item_daily_visits')) {
+                const [itemId, ...rest] = args;
+                let results = [...rows.values()].filter(row => row.item_id === itemId);
+                // El resto de los binds corresponde a from/to en el mismo orden que las
+                // condiciones agregadas dinámicamente — replicamos ese orden acá.
+                const conditions = sql.match(/WHERE (.+) ORDER BY/)[1];
+                let cursor = 0;
+                if (conditions.includes('visit_date >= ?')) {
+                  const from = rest[cursor++];
+                  results = results.filter(row => row.visit_date >= from);
+                }
+                if (conditions.includes('visit_date <= ?')) {
+                  const to = rest[cursor++];
+                  results = results.filter(row => row.visit_date <= to);
+                }
+                results.sort((a, b) => a.visit_date.localeCompare(b.visit_date));
+                return { results };
+              }
+              throw new Error(`SQL all inesperado: ${sql}`);
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+test('upsertDailyVisits: sin ORDERS_DB devuelve skipped sin lanzar', async () => {
+  const result = await upsertDailyVisits({}, [{ item_id: 'MLU1', visit_date: '2026-08-24', visits: 5, source: 'x', observed_at: 'now' }]);
+  assert.equal(result.status, 'skipped');
+  assert.equal(result.reason, 'orders_db_missing');
+});
+
+test('upsertDailyVisits: idempotente — misma (item_id, visit_date) actualiza en vez de duplicar', async () => {
+  const db = fakeOrdersDb();
+  const env = { ORDERS_DB: db };
+  await upsertDailyVisits(env, [{ item_id: 'MLU1', visit_date: '2026-08-24', visits: 5, source: 'items_visits_range', observed_at: '2026-08-25T07:00:00.000Z' }]);
+  await upsertDailyVisits(env, [{ item_id: 'MLU1', visit_date: '2026-08-24', visits: 8, source: 'items_visits_range', observed_at: '2026-08-26T07:00:00.000Z' }]);
+
+  assert.equal(db.rows.size, 1);
+  const row = db.rows.get('MLU1|2026-08-24');
+  assert.equal(row.visits, 8);
+  assert.equal(row.observed_at, '2026-08-26T07:00:00.000Z');
+});
+
+test('getDailyVisits: filtra por item_id y rango, ordenado ascendente', async () => {
+  const db = fakeOrdersDb();
+  const env = { ORDERS_DB: db };
+  await upsertDailyVisits(env, [
+    { item_id: 'MLU1', visit_date: '2026-08-20', visits: 1, source: 's', observed_at: 'now' },
+    { item_id: 'MLU1', visit_date: '2026-08-22', visits: 3, source: 's', observed_at: 'now' },
+    { item_id: 'MLU1', visit_date: '2026-08-25', visits: 2, source: 's', observed_at: 'now' },
+    { item_id: 'MLU2', visit_date: '2026-08-22', visits: 9, source: 's', observed_at: 'now' },
+  ]);
+
+  const all = await getDailyVisits(env, 'MLU1');
+  assert.deepEqual(all.map(row => row.visit_date), ['2026-08-20', '2026-08-22', '2026-08-25']);
+
+  const ranged = await getDailyVisits(env, 'MLU1', { from: '2026-08-21', to: '2026-08-24' });
+  assert.deepEqual(ranged.map(row => row.visit_date), ['2026-08-22']);
+});
+
+test('getVisitWindows: sin ninguna fila en la ventana, visits es null (nunca 0 inventado)', async () => {
+  const db = fakeOrdersDb();
+  const env = { ORDERS_DB: db };
+  const summary = await getVisitWindows(env, 'MLU1', { asOf: '2026-08-27' });
+  assert.deepEqual(summary.windows[7], { visits: null, days_with_data: 0, window_days: 7, data_through: null });
+  assert.deepEqual(summary.windows[30], { visits: null, days_with_data: 0, window_days: 30, data_through: null });
+  assert.deepEqual(summary.windows[90], { visits: null, days_with_data: 0, window_days: 90, data_through: null });
+});
+
+test('getVisitWindows: suma sólo los días observados y marca cobertura parcial', async () => {
+  const db = fakeOrdersDb();
+  const env = { ORDERS_DB: db };
+  // Sólo 3 de los últimos 7 días tienen dato — simula un sync recién prendido.
+  await upsertDailyVisits(env, [
+    { item_id: 'MLU1', visit_date: '2026-08-23', visits: 10, source: 's', observed_at: 'now' },
+    { item_id: 'MLU1', visit_date: '2026-08-24', visits: 5, source: 's', observed_at: 'now' },
+    { item_id: 'MLU1', visit_date: '2026-08-25', visits: 7, source: 's', observed_at: 'now' },
+  ]);
+
+  const summary = await getVisitWindows(env, 'MLU1', { asOf: '2026-08-27', windows: [7] });
+  assert.deepEqual(summary.windows[7], { visits: 22, days_with_data: 3, window_days: 7, data_through: '2026-08-25' });
+});
+
+test('getVisitWindows: respeta ventanas personalizadas', async () => {
+  const db = fakeOrdersDb();
+  const env = { ORDERS_DB: db };
+  await upsertDailyVisits(env, [
+    { item_id: 'MLU1', visit_date: '2026-08-27', visits: 4, source: 's', observed_at: 'now' },
+  ]);
+  const summary = await getVisitWindows(env, 'MLU1', { asOf: '2026-08-27', windows: [1, 3] });
+  assert.deepEqual(Object.keys(summary.windows), ['1', '3']);
+  assert.equal(summary.windows[1].visits, 4);
+  assert.equal(summary.windows[3].visits, 4);
+});

--- a/worker-sync/index.js
+++ b/worker-sync/index.js
@@ -18,6 +18,13 @@
  *                      productivo separado (prefijo catalog/*, nunca
  *                      stock1-preview/*) cuando PRODUCTION_PAUSED_CATALOG_PUBLISH_ENABLED
  *                      lo habilita. No toca catalog.json ni meta.json.
+ *                    — POST /visits/sync dispara manualmente RADAR DATA 1
+ *                      (issue #275) — ingesta de visitas ML — cuando
+ *                      VISITS_SYNC_ENABLED lo habilita.
+ *                    — GET /visits/summary?ids=MLU1,MLU2 devuelve ventanas
+ *                      7/30/90 de visitas ya persistidas en D1. Sólo lectura.
+ *                    — GET /visits/daily?item_id=MLU1 devuelve la serie
+ *                      diaria cruda de un item_id (readout de validación).
  *
  * Flujo de runSync():
  *   1. Obtener ML access token (meli-auth.js — KV lock + retry)
@@ -25,6 +32,18 @@
  *   3. Escribir catalog.json y meta.json en R2 (r2-publish.js)
  *   4. Notificar a IndexNow únicamente URLs indexables que cambiaron
  *   5. Guardar estado mínimo en KV (sync:last_ok / sync:last_error)
+ *
+ * Flujo de runVisitsSync() — RADAR DATA 1 (issue #275), apagado por
+ * defecto (VISITS_SYNC_ENABLED debe ser 'true'):
+ *   1. Leer los item_id activos desde catalog.json en R2 (no vuelve a
+ *      pedirle el catálogo a ML — reutiliza lo que runSync ya publicó).
+ *   2. Pedir GET /items/visits?ids=...&date_from=...&date_to=... en lotes
+ *      (ml-visits.js), para cada día calendario en la ventana de backfill.
+ *   3. Guardar cada fila en D1 (visits-store.js, tabla item_daily_visits)
+ *      de forma idempotente por (item_id, visit_date).
+ *   Un lote fallido no aborta la corrida completa: ML documenta hasta 48h
+ *   de demora en consolidar visitas, así que el día se reintenta solo en
+ *   la próxima corrida (VISITS_BACKFILL_DAYS).
  *
  * KV keys escritas por este Worker:
  *   auth:refresh_token       — compartido con Pages (se actualiza en meli-auth.js)
@@ -46,7 +65,7 @@
  */
 
 import { getAccessToken } from './meli-auth.js';
-import { buildCatalog   } from './meli-catalog.js';
+import { buildCatalog, createSyncRetryBudget } from './meli-catalog.js';
 import { publishToR2    } from './r2-publish.js';
 import { notifyHealthcheck } from './healthcheck.js';
 import { processStockWaitlist } from './stock-waitlist-notifier.js';
@@ -63,6 +82,8 @@ import {
   PRODUCTION_MANIFEST_KEY,
   PRODUCTION_PREFIX_ROOT,
 } from './paused-catalog.js';
+import { fetchVisitsRange, fetchVisitsTimeWindow, DEFAULT_VISITS_BATCH_SIZE } from './ml-visits.js';
+import { getDailyVisits, getVisitWindows, upsertDailyVisits } from './visits-store.js';
 
 export const STOCK1_PREVIEW_CATALOG_KEY = PAUSED_MANIFEST_KEY;
 export const PRODUCTION_CATALOG_KEY = PRODUCTION_MANIFEST_KEY;
@@ -87,7 +108,14 @@ export default {
       ]));
       return;
     }
-    ctx.waitUntil(runSync(env, { source: 'cron' }));
+    ctx.waitUntil((async () => {
+      await runSync(env, { source: 'cron' });
+      // RADAR DATA 1 (issue #275): corre después de runSync para leer el
+      // catalog.json recién publicado. Apagado por defecto — nunca hace
+      // nada salvo que VISITS_SYNC_ENABLED='true'. Nunca lanza (siempre
+      // devuelve un status), así que jamás enmascara el resultado de runSync.
+      await runVisitsSync(env, { source: 'cron' });
+    })());
   },
 
   // ── Manual trigger / status ─────────────────────────────────────────────────
@@ -106,6 +134,54 @@ export default {
 
     if (request.method === 'GET' && url.pathname === '/status') {
       return json(await readStatus(env));
+    }
+
+    if (request.method === 'POST' && url.pathname === '/visits/sync') {
+      if (String(env.VISITS_SYNC_ENABLED) !== 'true') {
+        return json({ error: 'Not found.' }, 404);
+      }
+      const mode = url.searchParams.get('mode') || 'async';
+      if (mode === 'await') {
+        const result = await runVisitsSync(env, { source: 'manual-await' });
+        return json(result, result.status === 'error' ? 500 : 200);
+      }
+      ctx.waitUntil(runVisitsSync(env, { source: 'manual-async' }));
+      return json({ status: 'VISITS_SYNC_TRIGGERED', mode: 'async' }, 202);
+    }
+
+    if (request.method === 'GET' && url.pathname === '/visits/summary') {
+      const ids = (url.searchParams.get('ids') || '').split(',').map(id => id.trim()).filter(Boolean);
+      if (ids.length === 0) {
+        return json({ error: 'Falta ?ids=MLU1,MLU2 (máximo 20 por consulta).' }, 400);
+      }
+      if (ids.length > 20) {
+        return json({ error: 'Máximo 20 item_id por consulta a /visits/summary.' }, 400);
+      }
+      const asOf = url.searchParams.get('as_of') || undefined;
+      const items = await Promise.all(ids.map(id => getVisitWindows(env, id, { asOf })));
+      return json({ generated_at: new Date().toISOString(), items });
+    }
+
+    if (request.method === 'GET' && url.pathname === '/visits/daily') {
+      const itemId = url.searchParams.get('item_id');
+      if (!itemId) return json({ error: 'Falta ?item_id=MLUxxxxxxxxx.' }, 400);
+      const from = url.searchParams.get('from') || undefined;
+      const to = url.searchParams.get('to') || undefined;
+      const daily = await getDailyVisits(env, itemId, { from, to });
+      return json({ item_id: itemId, from: from || null, to: to || null, daily });
+    }
+
+    if (request.method === 'GET' && url.pathname === '/visits/verify') {
+      const itemId = url.searchParams.get('item_id');
+      if (!itemId) return json({ error: 'Falta ?item_id=MLUxxxxxxxxx.' }, 400);
+      const last = Number(url.searchParams.get('last') || 90);
+      try {
+        const accessToken = await getAccessToken(env);
+        const result = await fetchVisitsTimeWindow(itemId, accessToken, { last });
+        return json({ item_id: itemId, last, source: 'items_visits_time_window', result });
+      } catch (error) {
+        return json({ error: String(error?.message || 'Error').slice(0, 400) }, 502);
+      }
     }
 
     if (request.method === 'GET' && url.pathname === '/bing-webmaster/summary') {
@@ -581,6 +657,145 @@ export async function runSync(env, options = {}, {
       finished_at: finishedAt,
       duration_ms: durationMs,
       error:       err.message,
+    };
+  }
+}
+
+// ── RADAR DATA 1 (issue #275) — visitas ML ──────────────────────────────────
+
+const VISITS_AVAILABILITY_LAG_DAYS_DEFAULT = 3; // ML documenta hasta 48h de demora en consolidar el conteo.
+const VISITS_BACKFILL_DAYS_DEFAULT = 1; // día lagueado únicamente; ver nota de costo en el PR antes de subirlo.
+
+function positiveIntEnv(value, fallback) {
+  const parsed = parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Fechas 'YYYY-MM-DD' consecutivas (oldest→newest), terminando en
+ * referenceDate menos lagDays. Ej.: lagDays=3, count=1, referenceDate=hoy
+ * → [hoy-3]. Con count=3 → [hoy-5, hoy-4, hoy-3].
+ */
+export function lastNCalendarDates(referenceDate, lagDays, count) {
+  const base = new Date(Date.UTC(
+    referenceDate.getUTCFullYear(),
+    referenceDate.getUTCMonth(),
+    referenceDate.getUTCDate(),
+  ));
+  const dates = [];
+  for (let i = count - 1; i >= 0; i--) {
+    const day = new Date(base);
+    day.setUTCDate(day.getUTCDate() - lagDays - i);
+    dates.push(day.toISOString().slice(0, 10));
+  }
+  return dates;
+}
+
+/**
+ * Lista de item_id a auditar: se lee directamente del catalog.json que
+ * runSync ya publicó en R2 — RADAR DATA 1 no vuelve a pedirle el listado
+ * completo a Mercado Libre.
+ */
+export async function readCatalogItemIdsFromR2(env) {
+  try {
+    const object = await env?.CATALOG_R2?.get?.('catalog.json');
+    if (!object) return [];
+    const catalog = JSON.parse(await object.text());
+    return (catalog?.items || []).map(item => item?.id).filter(Boolean);
+  } catch (error) {
+    console.error(`[Visits] No se pudo leer catalog.json: ${error?.message || 'Error'}`);
+    return [];
+  }
+}
+
+/**
+ * Ingesta diaria de visitas (RADAR DATA 1). Apagada por defecto: exige
+ * VISITS_SYNC_ENABLED='true'. Sólo lectura de Mercado Libre + escritura en
+ * D1 (item_daily_visits) — nunca toca catalog.json, precio ni estado de
+ * publicación.
+ */
+export async function runVisitsSync(env, options = {}, {
+  getAccessTokenFn = getAccessToken,
+  readCatalogItemIdsFn = readCatalogItemIdsFromR2,
+  fetchVisitsRangeFn = fetchVisitsRange,
+  upsertDailyVisitsFn = upsertDailyVisits,
+  now = () => new Date(),
+} = {}) {
+  const startedAt = now().toISOString();
+  const source = options.source || 'unknown';
+
+  if (String(env?.VISITS_SYNC_ENABLED) !== 'true') {
+    return { status: 'skipped', reason: 'visits_sync_disabled', started_at: startedAt, source };
+  }
+
+  try {
+    const accessToken = await getAccessTokenFn(env);
+    const itemIds = await readCatalogItemIdsFn(env);
+    if (itemIds.length === 0) {
+      return {
+        status: 'error',
+        started_at: startedAt,
+        source,
+        error: 'catalog.json sin items en R2 — no hay publicaciones para auditar visitas.',
+      };
+    }
+
+    const lagDays = positiveIntEnv(env?.VISITS_AVAILABILITY_LAG_DAYS, VISITS_AVAILABILITY_LAG_DAYS_DEFAULT);
+    const backfillDays = positiveIntEnv(env?.VISITS_BACKFILL_DAYS, VISITS_BACKFILL_DAYS_DEFAULT);
+    const batchSize = positiveIntEnv(env?.VISITS_BATCH_SIZE, DEFAULT_VISITS_BATCH_SIZE);
+    const targetDates = lastNCalendarDates(now(), lagDays, backfillDays);
+    const retryBudget = createSyncRetryBudget();
+
+    let rowsUpserted = 0;
+    let requestBatches = 0;
+    let failedBatches = 0;
+
+    for (const date of targetDates) {
+      for (let offset = 0; offset < itemIds.length; offset += batchSize) {
+        const batch = itemIds.slice(offset, offset + batchSize);
+        requestBatches++;
+        try {
+          const entries = await fetchVisitsRangeFn(batch, accessToken, {
+            dateFrom: date,
+            dateTo: date,
+            retryBudget,
+          });
+          const rows = entries.map(entry => ({
+            item_id: entry.item_id,
+            visit_date: date,
+            visits: entry.total_visits,
+            source: 'items_visits_range',
+            observed_at: startedAt,
+          }));
+          await upsertDailyVisitsFn(env, rows);
+          rowsUpserted += rows.length;
+        } catch (error) {
+          failedBatches++;
+          console.error(
+            `[Visits] Lote ${offset}-${offset + batch.length} (${date}) falló: ${error?.message || 'Error'}`
+          );
+        }
+      }
+    }
+
+    return {
+      status: failedBatches > 0 ? 'partial' : 'ok',
+      started_at: startedAt,
+      finished_at: now().toISOString(),
+      source,
+      dates: targetDates,
+      items_considered: itemIds.length,
+      batch_size: batchSize,
+      request_batches: requestBatches,
+      failed_batches: failedBatches,
+      rows_upserted: rowsUpserted,
+    };
+  } catch (error) {
+    return {
+      status: 'error',
+      started_at: startedAt,
+      source,
+      error: String(error?.message || 'Error').slice(0, 400),
     };
   }
 }

--- a/worker-sync/ml-visits.js
+++ b/worker-sync/ml-visits.js
@@ -1,0 +1,94 @@
+/**
+ * worker-sync/ml-visits.js
+ *
+ * RADAR DATA 1 (issue #275) — cliente de sólo lectura para el recurso de
+ * visitas de Mercado Libre. Reutiliza mlGet() de meli-catalog.js (mismo
+ * retry/backoff/rate-limit que ya usa el sync de catálogo) — no crea un
+ * cliente HTTP paralelo.
+ *
+ * AUDITORÍA DE ENDPOINTS (2026-08-27) — ver también el cuerpo del PR:
+ *
+ *   GET /items/visits?ids=$IDS&date_from=$FROM&date_to=$FROM
+ *     — Único de los tres candidatos que acepta múltiples item_id separados
+ *       por coma en una sola request (según documentación pública de ML y
+ *       una librería cliente de referencia). Se usa acá como la vía de
+ *       ingesta diaria en lote: date_from=date_to=un único día calendario,
+ *       así el resultado es directamente "visitas de ESE día", no un
+ *       acumulado a repartir. Devuelve, por item, un total_visits para el
+ *       rango pedido.
+ *
+ *   GET /items/$ITEM_ID/visits/time_window?last=$LAST&unit=day&ending=$END
+ *     — Un solo item_id por request. Se reserva para verificación puntual
+ *       (el endpoint /visits/verify de este PR) y para un futuro backfill
+ *       histórico dirigido, nunca para la ingesta diaria de todo el
+ *       catálogo (sería ~16.000 requests/día).
+ *
+ *   GET /visits/items?ids=$IDS
+ *     — Total histórico acumulado, sin rango de fechas. No sirve para
+ *       ventanas 7/30/90 y no se usa en este PR.
+ *
+ * LÍMITES DOCUMENTADOS (verificados sólo por búsqueda pública — este
+ * entorno no tiene salida de red hacia mercadolibre.com ni credenciales
+ * OAuth reales, así que ningún número de esta sección fue confirmado
+ * empíricamente contra la API real; ver limitación explícita en el PR):
+ *   - Rango máximo de fechas: 150 días.
+ *   - Datos definitivos hasta ~48h después de ocurridos (por eso
+ *     VISITS_AVAILABILITY_LAG_DAYS en index.js).
+ *   - El máximo de ids por request en /items/visits no está confirmado de
+ *     forma primaria; una fuente secundaria (librería cliente de terceros)
+ *     sugiere 50. DEFAULT_VISITS_BATCH_SIZE acá es deliberadamente más
+ *     conservador (20, igual que el multi-get de catálogo ya probado en
+ *     producción) hasta poder confirmarlo con una corrida real.
+ */
+
+import { mlGet } from './meli-catalog.js';
+
+export const DEFAULT_VISITS_BATCH_SIZE = 20;
+
+/**
+ * Trae visitas totales para un lote de item_ids en un único rango de
+ * fechas (para ingesta diaria, dateFrom === dateTo). No banca deduplicar
+ * ni completar ítems ausentes: si Mercado Libre no devuelve un item_id, no
+ * se inventa un cero para él — el llamador simplemente no escribe fila.
+ */
+export async function fetchVisitsRange(itemIds, accessToken, {
+  dateFrom,
+  dateTo = dateFrom,
+  retryBudget,
+  mlGetDeps = {},
+} = {}) {
+  const ids = (itemIds || []).filter(Boolean);
+  if (ids.length === 0) return [];
+  if (!dateFrom) throw new Error('[Visits] dateFrom es requerido.');
+
+  const url = `https://api.mercadolibre.com/items/visits` +
+    `?ids=${ids.map(encodeURIComponent).join(',')}` +
+    `&date_from=${encodeURIComponent(dateFrom)}&date_to=${encodeURIComponent(dateTo)}`;
+
+  const data = await mlGet(url, accessToken, { ...mlGetDeps, retryBudget });
+  const entries = Array.isArray(data) ? data : [data];
+  return entries
+    .filter(entry => entry && entry.item_id)
+    .map(entry => ({
+      item_id: entry.item_id,
+      total_visits: Number(entry.total_visits) || 0,
+    }));
+}
+
+/**
+ * Verificación puntual de un solo item_id contra /visits/time_window —
+ * usada por el endpoint interno de validación, no por la ingesta diaria.
+ */
+export async function fetchVisitsTimeWindow(itemId, accessToken, {
+  last = 90,
+  unit = 'day',
+  ending,
+  retryBudget,
+  mlGetDeps = {},
+} = {}) {
+  if (!itemId) throw new Error('[Visits] itemId es requerido.');
+  const params = new URLSearchParams({ last: String(last), unit });
+  if (ending) params.set('ending', ending);
+  const url = `https://api.mercadolibre.com/items/${encodeURIComponent(itemId)}/visits/time_window?${params.toString()}`;
+  return mlGet(url, accessToken, { ...mlGetDeps, retryBudget });
+}

--- a/worker-sync/visits-store.js
+++ b/worker-sync/visits-store.js
@@ -1,0 +1,82 @@
+/**
+ * worker-sync/visits-store.js
+ *
+ * RADAR DATA 1 (issue #275) — persistencia D1 de la serie diaria de
+ * visitas (tabla item_daily_visits, migración 0010) y derivación de
+ * ventanas 7/30/90 por query, sin guardar agregados redundantes.
+ *
+ * "Sin inventar ceros ante datos ausentes" (criterio de salida del issue):
+ * si no hay ninguna fila para un item_id dentro de la ventana pedida,
+ * `visits` es `null`, no 0. `days_with_data` siempre viaja junto al total
+ * para que quien lea el resultado sepa si la ventana está completa o es
+ * parcial (por ejemplo, 3 de 7 días si el sync arrancó hace poco).
+ */
+
+export async function upsertDailyVisits(env, rows) {
+  const db = env?.ORDERS_DB;
+  if (!db) return { status: 'skipped', reason: 'orders_db_missing', written: 0 };
+  let written = 0;
+  for (const row of rows) {
+    await db.prepare(
+      `INSERT INTO item_daily_visits (item_id, visit_date, visits, source, observed_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(item_id, visit_date) DO UPDATE SET
+         visits = excluded.visits,
+         source = excluded.source,
+         observed_at = excluded.observed_at`
+    ).bind(row.item_id, row.visit_date, row.visits, row.source, row.observed_at).run();
+    written++;
+  }
+  return { status: 'ok', written };
+}
+
+/**
+ * Serie diaria cruda para un item_id, opcionalmente acotada a [from, to]
+ * (inclusive, formato 'YYYY-MM-DD'). Es el "readout" para validar a mano
+ * que un número 7/30/90 realmente sale de días concretos observados.
+ */
+export async function getDailyVisits(env, itemId, { from, to } = {}) {
+  const db = env?.ORDERS_DB;
+  if (!db || !itemId) return [];
+  const conditions = ['item_id = ?'];
+  const params = [itemId];
+  if (from) { conditions.push('visit_date >= ?'); params.push(from); }
+  if (to) { conditions.push('visit_date <= ?'); params.push(to); }
+  const result = await db.prepare(
+    `SELECT visit_date, visits, source, observed_at FROM item_daily_visits
+     WHERE ${conditions.join(' AND ')} ORDER BY visit_date ASC`
+  ).bind(...params).all();
+  return result?.results || [];
+}
+
+function isoDateMinusDays(dateStr, days) {
+  const date = new Date(`${dateStr}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() - (days - 1));
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Ventanas 7/30/90 (configurable) derivadas de la serie diaria, tomando
+ * `asOf` como el último día calendario a incluir (default: hoy UTC).
+ */
+export async function getVisitWindows(env, itemId, { asOf, windows = [7, 30, 90] } = {}) {
+  const asOfDate = asOf || new Date().toISOString().slice(0, 10);
+  const earliestFrom = isoDateMinusDays(asOfDate, Math.max(...windows));
+  const rows = await getDailyVisits(env, itemId, { from: earliestFrom, to: asOfDate });
+
+  const result = {};
+  for (const windowDays of windows) {
+    const from = isoDateMinusDays(asOfDate, windowDays);
+    const inWindow = rows.filter(row => row.visit_date >= from && row.visit_date <= asOfDate);
+    result[windowDays] = inWindow.length === 0
+      ? { visits: null, days_with_data: 0, window_days: windowDays, data_through: null }
+      : {
+          visits: inWindow.reduce((sum, row) => sum + Number(row.visits || 0), 0),
+          days_with_data: inWindow.length,
+          window_days: windowDays,
+          data_through: inWindow[inWindow.length - 1].visit_date,
+        };
+  }
+
+  return { item_id: itemId, as_of: asOfDate, windows: result };
+}

--- a/worker-sync/wrangler.toml
+++ b/worker-sync/wrangler.toml
@@ -65,7 +65,8 @@ binding = "IMAGES"
 binding = "AMADO_KV"
 id      = "6ea0ff4682d647118442a24fe384abc4"
 
-# D1 productiva: únicamente lee y actualiza solicitudes de aviso de stock.
+# D1 productiva: lee/actualiza solicitudes de aviso de stock (stock_waitlist)
+# y persiste la serie diaria de visitas ML (item_daily_visits, issue #275).
 [[d1_databases]]
 binding = "ORDERS_DB"
 database_name = "amadolibros-orders-production"


### PR DESCRIPTION
Implementa #275, parte del programa maestro #274. Sigue el contrato de trabajo de #274: auditoría primero, PR pequeño y temático, read-only, migración separada, tests `node --test`, Draft, sin merge ni producción.

## ESTADO DE REVISIÓN — BLOQUEADO ANTES DE MERGE

Revisión externa 2026-08-27 encontró una contradicción relevante en documentación oficial de Mercado Libre:

- La documentación vigente de Visitas para Uruguay (actualizada 02/01/2026) documenta el endpoint `GET /items/visits?ids=...&date_from=...&date_to=...`, pero también lista explícitamente el error `maximum amount of items to query is 1` cuando se intenta consultar más de un ítem mediante `ids`.
- Una página oficial más vieja de Metrics (última actualización 15/03/2023) sí muestra ejemplos Multi-Get para `/items/visits?...` y `/items/visits/time_window?...`.

Conclusión: el supuesto central de este PR — batching de múltiples MLU en una sola request — NO queda confirmado por la documentación vigente y debe validarse empíricamente antes de considerar listo el diseño.

Hasta esa validación, NO asumir ~800 requests/día ni promover `VISITS_BATCH_SIZE=20` como capacidad real de la API.

## Diseño que sí queda bien encaminado

- `item_daily_visits` como serie diaria compacta en D1.
- ausencia de observación ≠ cero.
- `visits: null` cuando no hay datos observados.
- 7/30/90 derivados por query.
- read-only hacia Mercado Libre.
- mismo OAuth/D1/worker-sync existentes.
- flag `VISITS_SYNC_ENABLED` apagado por defecto.

## Pendiente obligatorio antes de merge

1. Probar con un token real, en entorno seguro, si `/items/visits` acepta 2+ MLU en `ids` hoy.
2. Probar también si `/items/visits/time_window?ids=...` sigue aceptando multi-get o fue restringido.
3. Medir respuesta y error reales con MLU de Amado sin modificar nada.
4. Si el límite actual es 1 ítem por request, rediseñar ingesta para evitar 7.000+ requests/día: priorización/cohortes, refresh escalonado o captura 90d por candidato, sin barrido diario masivo.
5. Recalcular costo/frecuencia recién con ese dato real.

## Entrega actual

- Migración `0010_item_daily_visits.sql`.
- `worker-sync/ml-visits.js`.
- `worker-sync/visits-store.js`.
- `runVisitsSync` y endpoints internos.
- Tests en verde según la rama.

## Restricciones

No merge. No producción. No activar `VISITS_SYNC_ENABLED` hasta resolver el límite real de la API de visitas.

---
_Generated initially by Claude Code; revisión posterior incorporada en #274/#275._