### PR TITLE
RADAR DATA 2 — ventas ML 7/30/90, revenue y última venta (#276)

### DIFF
--- a/.github/workflows/radar-data-2-live-verify.yml
+++ b/.github/workflows/radar-data-2-live-verify.yml
@@ -1,0 +1,85 @@
+name: RADAR DATA 2 live read-only verify
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: radar-data-2-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    if: github.event.pull_request.head.ref == 'radar/data-2-ml-orders-276' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Upload isolated Worker version — no production deploy
+        id: upload
+        working-directory: worker-sync
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          OUTPUT=$(npx wrangler@4.107.0 versions upload \
+            --preview-alias radar-sales-${{ github.event.pull_request.number }} \
+            --keep-vars \
+            --message "RADAR DATA 2 lectura real sin despliegue")
+          echo "$OUTPUT"
+          PREVIEW_URL=$(echo "$OUTPUT" | grep -Eo 'https://[^[:space:]]+\.workers\.dev' | tail -1)
+          if [ -z "$PREVIEW_URL" ]; then
+            echo "ERROR: Wrangler no devolvió URL de versión Preview."
+            exit 1
+          fi
+          echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Verify real ML sales read-only
+        env:
+          PREVIEW_URL: ${{ steps.upload.outputs.preview_url }}
+          SYNC_SECRET: ${{ secrets.SYNC_SECRET }}
+        run: |
+          sleep 8
+          mkdir -p artifacts/radar-data-2
+          RESPONSE=$(curl -sS --max-time 180 -w "\nHTTP_STATUS:%{http_code}" \
+            "$PREVIEW_URL/sales/verify?days=7&pages=1" \
+            -H "Authorization: Bearer $SYNC_SECRET")
+          HTTP_STATUS=$(echo "$RESPONSE" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+          BODY=$(echo "$RESPONSE" | sed '/HTTP_STATUS:/d')
+          echo "HTTP status: $HTTP_STATUS"
+          echo "$BODY" | tee artifacts/radar-data-2/live-sales-verify.json
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "ERROR: /sales/verify respondió HTTP $HTTP_STATUS."
+            exit 1
+          fi
+          echo "$BODY" | node -e '
+            let input="";
+            process.stdin.on("data", c => input += c);
+            process.stdin.on("end", () => {
+              const result = JSON.parse(input);
+              if (result.writes_to_ml !== false) throw new Error("No confirmó writes_to_ml=false");
+              if (result.pii_persisted !== false) throw new Error("No confirmó pii_persisted=false");
+              if (!Array.isArray(result.sample)) throw new Error("sample no es array");
+              for (const row of result.sample) {
+                const allowed = new Set(["item_id","units","revenue","last_sale_at"]);
+                for (const key of Object.keys(row)) if (!allowed.has(key)) throw new Error(`Campo inesperado en sample: ${key}`);
+              }
+            });
+          '
+
+      - name: Upload read-only verification artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: radar-data-2-live-pr-${{ github.event.pull_request.number }}
+          path: artifacts/radar-data-2/
+          if-no-files-found: warn
+          retention-days: 30

--- a/migrations/0011_ml_order_items.sql
+++ b/migrations/0011_ml_order_items.sql
@@ -1,0 +1,42 @@
+-- RADAR DATA 2 (#276): ventas reales de Mercado Libre por publicación.
+--
+-- Fuente: API oficial de órdenes del seller. Esta tabla NO contiene PII de
+-- compradores: no se guardan buyer, teléfono, email ni dirección.
+--
+-- Una fila representa un item_id dentro de una order_id. El upsert es
+-- idempotente por (order_id, item_id), de modo que una orden actualizada puede
+-- reobservarse sin duplicar ventas.
+CREATE TABLE IF NOT EXISTS ml_order_items (
+  order_id          TEXT    NOT NULL,
+  item_id           TEXT    NOT NULL,
+  quantity          INTEGER NOT NULL CHECK (quantity > 0),
+  unit_price        REAL    NOT NULL CHECK (unit_price >= 0),
+  gross_price       REAL,
+  currency_id       TEXT,
+  order_status      TEXT    NOT NULL,
+  date_created      TEXT    NOT NULL,
+  date_closed       TEXT,
+  date_last_updated TEXT,
+  commercial_date   TEXT    NOT NULL,
+  observed_at       TEXT    NOT NULL,
+  PRIMARY KEY (order_id, item_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ml_order_items_item_date
+  ON ml_order_items (item_id, commercial_date);
+CREATE INDEX IF NOT EXISTS idx_ml_order_items_status_date
+  ON ml_order_items (order_status, commercial_date);
+
+-- Cobertura de la ingesta. Permite distinguir "0 ventas" de "todavía no
+-- observamos completamente esa ventana". Un único row id=1 describe el
+-- backfill/mantenimiento más reciente.
+CREATE TABLE IF NOT EXISTS ml_sales_sync_state (
+  id                INTEGER PRIMARY KEY CHECK (id = 1),
+  coverage_from     TEXT,
+  coverage_to       TEXT,
+  last_sync_at      TEXT    NOT NULL,
+  last_status       TEXT    NOT NULL,
+  last_order_count  INTEGER NOT NULL DEFAULT 0,
+  last_item_rows    INTEGER NOT NULL DEFAULT 0,
+  last_error        TEXT
+);

--- a/worker-sync/__tests__/ml-orders.test.js
+++ b/worker-sync/__tests__/ml-orders.test.js
@@ -1,0 +1,134 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildSellerOrdersUrl,
+  fetchSellerOrders,
+  fetchSellerOrdersPage,
+  normalizeMlOrderItems,
+  summarizeNormalizedSales,
+} from '../ml-orders.js';
+
+function response(body, { status = 200 } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    async json() { return body; },
+  };
+}
+
+test('buildSellerOrdersUrl usa seller, paid, date_closed, limit y offset', () => {
+  const url = new URL(buildSellerOrdersUrl({
+    sellerId: '440298103',
+    dateFrom: '2026-06-01T00:00:00Z',
+    dateTo: '2026-08-27T12:00:00Z',
+    offset: 50,
+    limit: 50,
+  }));
+  assert.equal(url.pathname, '/orders/search');
+  assert.equal(url.searchParams.get('seller'), '440298103');
+  assert.equal(url.searchParams.get('order.status'), 'paid');
+  assert.equal(url.searchParams.get('order.date_closed.from'), '2026-06-01T00:00:00.000Z');
+  assert.equal(url.searchParams.get('order.date_closed.to'), '2026-08-27T12:00:00.000Z');
+  assert.equal(url.searchParams.get('offset'), '50');
+  assert.equal(url.searchParams.get('limit'), '50');
+});
+
+test('fetchSellerOrdersPage acepta HTTP 206 Partial Content como éxito', async () => {
+  const payload = { results: [{ id: 1 }], paging: { total: 1, offset: 0, limit: 50 } };
+  const result = await fetchSellerOrdersPage('token', {
+    sellerId: '440298103',
+    dateFrom: '2026-08-01T00:00:00Z',
+    dateTo: '2026-08-27T00:00:00Z',
+    mlGetDeps: { fetchFn: async () => response(payload, { status: 206 }) },
+  });
+  assert.deepEqual(result, payload);
+});
+
+test('fetchSellerOrders pagina hasta cubrir paging.total', async () => {
+  const offsets = [];
+  const pages = [
+    { results: [{ id: 1 }, { id: 2 }], paging: { total: 3, offset: 0, limit: 2 } },
+    { results: [{ id: 3 }], paging: { total: 3, offset: 2, limit: 2 } },
+  ];
+  const result = await fetchSellerOrders('token', {
+    sellerId: '440298103',
+    dateFrom: '2026-08-01T00:00:00Z',
+    dateTo: '2026-08-27T00:00:00Z',
+    limit: 2,
+    mlGetDeps: {
+      fetchFn: async url => {
+        offsets.push(Number(new URL(String(url)).searchParams.get('offset')));
+        return response(pages.shift());
+      },
+    },
+  });
+  assert.deepEqual(offsets, [0, 2]);
+  assert.equal(result.orders.length, 3);
+  assert.equal(result.pages, 2);
+  assert.equal(result.total_reported, 3);
+});
+
+test('fetchSellerOrders deduplica order.id observado en páginas', async () => {
+  const pages = [
+    { results: [{ id: 1 }, { id: 2 }], paging: { total: 4, offset: 0, limit: 2 } },
+    { results: [{ id: 2 }, { id: 3 }], paging: { total: 4, offset: 2, limit: 2 } },
+  ];
+  const result = await fetchSellerOrders('token', {
+    sellerId: '440298103', dateFrom: '2026-08-01', dateTo: '2026-08-27', limit: 2,
+    mlGetDeps: { fetchFn: async () => response(pages.shift()) },
+  });
+  assert.deepEqual(result.orders.map(o => o.id), [1, 2, 3]);
+});
+
+test('normalizeMlOrderItems conserva sólo datos de producto y omite PII', () => {
+  const rows = normalizeMlOrderItems([{
+    id: 9001,
+    status: 'paid',
+    date_created: '2026-08-20T10:00:00Z',
+    date_closed: '2026-08-20T10:05:00Z',
+    date_last_updated: '2026-08-20T10:06:00Z',
+    buyer: { id: 1, nickname: 'privado', phone: { number: '099' } },
+    order_items: [{ item: { id: 'MLU123' }, quantity: 2, unit_price: 1000, gross_price: 1100, currency_id: 'UYU' }],
+  }], { observedAt: '2026-08-27T12:00:00Z' });
+  assert.equal(rows.length, 1);
+  assert.deepEqual(rows[0], {
+    order_id: '9001', item_id: 'MLU123', quantity: 2, unit_price: 1000, gross_price: 1100,
+    currency_id: 'UYU', order_status: 'paid', date_created: '2026-08-20T10:00:00Z',
+    date_closed: '2026-08-20T10:05:00Z', date_last_updated: '2026-08-20T10:06:00Z',
+    commercial_date: '2026-08-20T10:05:00Z', observed_at: '2026-08-27T12:00:00Z',
+  });
+  assert.equal('buyer' in rows[0], false);
+  assert.equal(JSON.stringify(rows).includes('privado'), false);
+  assert.equal(JSON.stringify(rows).includes('099'), false);
+});
+
+test('normalizeMlOrderItems agrega líneas duplicadas del mismo MLU dentro de una orden', () => {
+  const rows = normalizeMlOrderItems([{
+    id: 1, status: 'paid', date_created: '2026-08-20T00:00:00Z', date_closed: '2026-08-20T01:00:00Z',
+    order_items: [
+      { item: { id: 'MLU1' }, quantity: 1, unit_price: 100, currency_id: 'UYU' },
+      { item: { id: 'MLU1' }, quantity: 2, unit_price: 200, currency_id: 'UYU' },
+    ],
+  }]);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].quantity, 3);
+  assert.equal(Math.round(rows[0].unit_price * 100) / 100, 166.67);
+});
+
+test('normalizeMlOrderItems usa date_created como fallback de commercial_date', () => {
+  const [row] = normalizeMlOrderItems([{
+    id: 1, status: 'paid', date_created: '2026-08-20T00:00:00Z',
+    order_items: [{ item: { id: 'MLU1' }, quantity: 1, unit_price: 100 }],
+  }]);
+  assert.equal(row.commercial_date, '2026-08-20T00:00:00Z');
+});
+
+test('summarizeNormalizedSales agrega unidades/revenue por MLU', () => {
+  const summary = summarizeNormalizedSales([
+    { item_id: 'MLU1', quantity: 2, unit_price: 100, commercial_date: '2026-08-20' },
+    { item_id: 'MLU1', quantity: 1, unit_price: 120, commercial_date: '2026-08-21' },
+    { item_id: 'MLU2', quantity: 1, unit_price: 50, commercial_date: '2026-08-20' },
+  ]);
+  assert.deepEqual(summary[0], { item_id: 'MLU1', units: 3, revenue: 320, last_sale_at: '2026-08-21' });
+});

--- a/worker-sync/__tests__/ml-orders.test.js
+++ b/worker-sync/__tests__/ml-orders.test.js
@@ -17,7 +17,7 @@ function response(body, { status = 200 } = {}) {
   };
 }
 
-test('buildSellerOrdersUrl usa seller, paid, date_closed, limit y offset', () => {
+test('buildSellerOrdersUrl usa seller, paid, date_closed, limit y offset por defecto', () => {
   const url = new URL(buildSellerOrdersUrl({
     sellerId: '440298103',
     dateFrom: '2026-06-01T00:00:00Z',
@@ -32,6 +32,24 @@ test('buildSellerOrdersUrl usa seller, paid, date_closed, limit y offset', () =>
   assert.equal(url.searchParams.get('order.date_closed.to'), '2026-08-27T12:00:00.000Z');
   assert.equal(url.searchParams.get('offset'), '50');
   assert.equal(url.searchParams.get('limit'), '50');
+});
+
+test('buildSellerOrdersUrl permite mantenimiento por date_last_updated sin filtro de status', () => {
+  const url = new URL(buildSellerOrdersUrl({
+    sellerId: '440298103',
+    dateFrom: '2026-08-20T00:00:00Z',
+    dateTo: '2026-08-27T12:00:00Z',
+    status: null,
+    dateField: 'last_updated',
+  }));
+  assert.equal(url.searchParams.get('order.status'), null);
+  assert.equal(url.searchParams.get('order.date_last_updated.from'), '2026-08-20T00:00:00.000Z');
+  assert.equal(url.searchParams.get('order.date_last_updated.to'), '2026-08-27T12:00:00.000Z');
+  assert.equal(url.searchParams.get('order.date_closed.from'), null);
+});
+
+test('buildSellerOrdersUrl rechaza dateField no documentado', () => {
+  assert.throws(() => buildSellerOrdersUrl({ sellerId: '1', dateFrom: '2026-08-20', dateTo: '2026-08-27', dateField: 'hacked' }), /dateField inválido/);
 });
 
 test('fetchSellerOrdersPage acepta HTTP 206 Partial Content como éxito', async () => {
@@ -103,6 +121,19 @@ test('normalizeMlOrderItems conserva sólo datos de producto y omite PII', () =>
   assert.equal(JSON.stringify(rows).includes('099'), false);
 });
 
+test('normalizeMlOrderItems conserva estado no-paid para corregir una venta anterior', () => {
+  const [row] = normalizeMlOrderItems([{
+    id: 9002,
+    status: 'cancelled',
+    date_created: '2026-08-20T10:00:00Z',
+    date_closed: '2026-08-20T10:05:00Z',
+    date_last_updated: '2026-08-26T10:00:00Z',
+    order_items: [{ item: { id: 'MLU123' }, quantity: 1, unit_price: 1000, currency_id: 'UYU' }],
+  }]);
+  assert.equal(row.order_status, 'cancelled');
+  assert.equal(row.item_id, 'MLU123');
+});
+
 test('normalizeMlOrderItems agrega líneas duplicadas del mismo MLU dentro de una orden', () => {
   const rows = normalizeMlOrderItems([{
     id: 1, status: 'paid', date_created: '2026-08-20T00:00:00Z', date_closed: '2026-08-20T01:00:00Z',
@@ -124,11 +155,12 @@ test('normalizeMlOrderItems usa date_created como fallback de commercial_date', 
   assert.equal(row.commercial_date, '2026-08-20T00:00:00Z');
 });
 
-test('summarizeNormalizedSales agrega unidades/revenue por MLU', () => {
+test('summarizeNormalizedSales agrega unidades/revenue por MLU y excluye no-paid', () => {
   const summary = summarizeNormalizedSales([
-    { item_id: 'MLU1', quantity: 2, unit_price: 100, commercial_date: '2026-08-20' },
-    { item_id: 'MLU1', quantity: 1, unit_price: 120, commercial_date: '2026-08-21' },
-    { item_id: 'MLU2', quantity: 1, unit_price: 50, commercial_date: '2026-08-20' },
+    { item_id: 'MLU1', quantity: 2, unit_price: 100, commercial_date: '2026-08-20', order_status: 'paid' },
+    { item_id: 'MLU1', quantity: 1, unit_price: 120, commercial_date: '2026-08-21', order_status: 'paid' },
+    { item_id: 'MLU1', quantity: 9, unit_price: 999, commercial_date: '2026-08-22', order_status: 'cancelled' },
+    { item_id: 'MLU2', quantity: 1, unit_price: 50, commercial_date: '2026-08-20', order_status: 'paid' },
   ]);
   assert.deepEqual(summary[0], { item_id: 'MLU1', units: 3, revenue: 320, last_sale_at: '2026-08-21' });
 });

--- a/worker-sync/__tests__/ml-sales-store.test.js
+++ b/worker-sync/__tests__/ml-sales-store.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   getMlSalesWindows,
+  mlSalesWindowComplete,
   upsertMlOrderItems,
   writeMlSalesSyncState,
 } from '../ml-sales-store.js';
@@ -31,6 +32,15 @@ function fakeDb({ summaryRow = null, stateRow = null, rawRows = [] } = {}) {
   return { db, prepared, batches };
 }
 
+function emptySummary() {
+  return {
+    units_7: null, orders_7: 0, revenue_7: null, rows_7: 0,
+    units_30: null, orders_30: 0, revenue_30: null, rows_30: 0,
+    units_90: null, orders_90: 0, revenue_90: null, rows_90: 0,
+    last_sale_at: null, observed_rows: 0,
+  };
+}
+
 test('upsertMlOrderItems usa clave idempotente SQL y batch D1', async () => {
   const { db, batches } = fakeDb();
   const rows = [
@@ -56,38 +66,83 @@ test('writeMlSalesSyncState persiste cobertura sin datos personales', async () =
   assert.deepEqual(stmt.bindings, ['2026-06-01', '2026-08-27', '2026-08-27T12:00:00Z', 'ok', 10, 12, null]);
 });
 
-test('getMlSalesWindows devuelve 7/30/90 + última venta y cobertura', async () => {
-  const { db } = fakeDb({
-    summaryRow: {
-      units_7: 2, orders_7: 2, revenue_7: 250,
-      units_30: 5, orders_30: 4, revenue_30: 700,
-      units_90: 9, orders_90: 7, revenue_90: 1400,
-      last_sale_at: '2026-08-26T10:00:00Z', observed_rows: 7,
-    },
-    stateRow: { coverage_from: '2026-05-29', coverage_to: '2026-08-27', last_sync_at: '2026-08-27T12:00:00Z', last_status: 'ok' },
-  });
-  const result = await getMlSalesWindows({ ORDERS_DB: db }, 'MLU1', { asOf: '2026-08-27T12:00:00Z' });
-  assert.deepEqual(result.windows['7'], { units: 2, orders: 2, revenue: 250 });
-  assert.equal(result.windows['90'].units, 9);
-  assert.equal(result.last_sale_at, '2026-08-26T10:00:00Z');
-  assert.equal(result.coverage.from, '2026-05-29');
+test('mlSalesWindowComplete exige inicio suficiente, sync ok y frescura del mismo día', () => {
+  const state = {
+    coverage_from: '2026-05-29T12:00:00Z',
+    coverage_to: '2026-08-27T10:00:00Z',
+    last_status: 'ok',
+  };
+  assert.equal(mlSalesWindowComplete(state, '2026-08-27T12:00:00Z', 90), true);
+  assert.equal(mlSalesWindowComplete({ ...state, coverage_from: '2026-06-01T00:00:00Z' }, '2026-08-27T12:00:00Z', 90), false);
+  assert.equal(mlSalesWindowComplete({ ...state, last_status: 'error' }, '2026-08-27T12:00:00Z', 7), false);
+  assert.equal(mlSalesWindowComplete({ ...state, coverage_to: '2026-08-26T23:59:59Z' }, '2026-08-27T12:00:00Z', 7), false);
 });
 
-test('getMlSalesWindows sin observaciones ni cobertura devuelve null, no inventa cero', async () => {
+test('getMlSalesWindows devuelve 7/30/90 + última venta + complete', async () => {
   const { db } = fakeDb({
-    summaryRow: { units_7: null, orders_7: 0, revenue_7: null, units_30: null, orders_30: 0, revenue_30: null, units_90: null, orders_90: 0, revenue_90: null, last_sale_at: null, observed_rows: 0 },
-    stateRow: null,
+    summaryRow: {
+      units_7: 2, orders_7: 2, revenue_7: 250, rows_7: 2,
+      units_30: 5, orders_30: 4, revenue_30: 700, rows_30: 4,
+      units_90: 9, orders_90: 7, revenue_90: 1400, rows_90: 7,
+      last_sale_at: '2026-08-26T10:00:00Z', observed_rows: 7,
+    },
+    stateRow: { coverage_from: '2026-05-29T12:00:00Z', coverage_to: '2026-08-27T10:00:00Z', last_sync_at: '2026-08-27T10:00:00Z', last_status: 'ok' },
   });
-  const result = await getMlSalesWindows({ ORDERS_DB: db }, 'MLU1');
-  assert.deepEqual(result.windows['7'], { units: null, orders: null, revenue: null });
+  const result = await getMlSalesWindows({ ORDERS_DB: db }, 'MLU1', { asOf: '2026-08-27T12:00:00Z' });
+  assert.deepEqual(result.windows['7'], {
+    units: 2, orders: 2, revenue: 250, complete: true, observed_sale_rows: 2,
+    data_through: '2026-08-27T10:00:00Z',
+  });
+  assert.equal(result.windows['90'].units, 9);
+  assert.equal(result.windows['90'].complete, true);
+  assert.equal(result.last_sale_at, '2026-08-26T10:00:00Z');
+  assert.equal(result.coverage.from, '2026-05-29T12:00:00Z');
+});
+
+test('sin observaciones ni cobertura devuelve null, no inventa cero', async () => {
+  const { db } = fakeDb({ summaryRow: emptySummary(), stateRow: null });
+  const result = await getMlSalesWindows({ ORDERS_DB: db }, 'MLU1', { asOf: '2026-08-27T12:00:00Z' });
+  assert.deepEqual(result.windows['7'], {
+    units: null, orders: null, revenue: null, complete: false, observed_sale_rows: 0, data_through: null,
+  });
   assert.equal(result.last_sale_at, null);
 });
 
-test('getMlSalesWindows con backfill observado puede representar cero ventas', async () => {
+test('backfill completo puede representar cero ventas de forma legítima', async () => {
   const { db } = fakeDb({
-    summaryRow: { units_7: null, orders_7: 0, revenue_7: null, units_30: null, orders_30: 0, revenue_30: null, units_90: null, orders_90: 0, revenue_90: null, last_sale_at: null, observed_rows: 0 },
-    stateRow: { coverage_from: '2026-05-29', coverage_to: '2026-08-27', last_sync_at: '2026-08-27', last_status: 'ok' },
+    summaryRow: emptySummary(),
+    stateRow: { coverage_from: '2026-05-29T12:00:00Z', coverage_to: '2026-08-27T10:00:00Z', last_sync_at: '2026-08-27T10:00:00Z', last_status: 'ok' },
   });
-  const result = await getMlSalesWindows({ ORDERS_DB: db }, 'MLU1');
-  assert.deepEqual(result.windows['90'], { units: 0, orders: 0, revenue: 0 });
+  const result = await getMlSalesWindows({ ORDERS_DB: db }, 'MLU1', { asOf: '2026-08-27T12:00:00Z' });
+  assert.deepEqual(result.windows['90'], {
+    units: 0, orders: 0, revenue: 0, complete: true, observed_sale_rows: 0,
+    data_through: '2026-08-27T10:00:00Z',
+  });
+});
+
+test('cobertura de 30d no inventa cero en la ventana 90d', async () => {
+  const { db } = fakeDb({
+    summaryRow: emptySummary(),
+    stateRow: { coverage_from: '2026-07-28T12:00:00Z', coverage_to: '2026-08-27T10:00:00Z', last_sync_at: '2026-08-27T10:00:00Z', last_status: 'ok' },
+  });
+  const result = await getMlSalesWindows({ ORDERS_DB: db }, 'MLU1', { asOf: '2026-08-27T12:00:00Z' });
+  assert.equal(result.windows['7'].complete, true);
+  assert.equal(result.windows['7'].units, 0);
+  assert.equal(result.windows['30'].complete, true);
+  assert.equal(result.windows['90'].complete, false);
+  assert.equal(result.windows['90'].units, null);
+});
+
+test('ventana parcial conserva ventas observadas pero las marca complete=false', async () => {
+  const row = emptySummary();
+  Object.assign(row, { units_90: 2, orders_90: 2, revenue_90: 500, rows_90: 2, observed_rows: 2, last_sale_at: '2026-08-10T00:00:00Z' });
+  const { db } = fakeDb({
+    summaryRow: row,
+    stateRow: { coverage_from: '2026-07-28T12:00:00Z', coverage_to: '2026-08-27T10:00:00Z', last_sync_at: '2026-08-27T10:00:00Z', last_status: 'ok' },
+  });
+  const result = await getMlSalesWindows({ ORDERS_DB: db }, 'MLU1', { asOf: '2026-08-27T12:00:00Z' });
+  assert.deepEqual(result.windows['90'], {
+    units: 2, orders: 2, revenue: 500, complete: false, observed_sale_rows: 2,
+    data_through: '2026-08-27T10:00:00Z',
+  });
 });

--- a/worker-sync/__tests__/ml-sales-store.test.js
+++ b/worker-sync/__tests__/ml-sales-store.test.js
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getMlSalesWindows,
+  upsertMlOrderItems,
+  writeMlSalesSyncState,
+} from '../ml-sales-store.js';
+
+function fakeDb({ summaryRow = null, stateRow = null, rawRows = [] } = {}) {
+  const prepared = [];
+  const batches = [];
+  const db = {
+    prepare(sql) {
+      const statement = {
+        sql,
+        bindings: [],
+        bind(...args) { this.bindings = args; return this; },
+        async run() { return { success: true }; },
+        async first() {
+          if (sql.includes('FROM ml_sales_sync_state')) return stateRow;
+          if (sql.includes('FROM ml_order_items')) return summaryRow;
+          return null;
+        },
+        async all() { return { results: rawRows }; },
+      };
+      prepared.push(statement);
+      return statement;
+    },
+    async batch(statements) { batches.push(statements); return statements.map(() => ({ success: true })); },
+  };
+  return { db, prepared, batches };
+}
+
+test('upsertMlOrderItems usa clave idempotente SQL y batch D1', async () => {
+  const { db, batches } = fakeDb();
+  const rows = [
+    { order_id: '1', item_id: 'MLU1', quantity: 2, unit_price: 100, gross_price: 120, currency_id: 'UYU', order_status: 'paid', date_created: 'a', date_closed: 'b', date_last_updated: 'c', commercial_date: 'b', observed_at: 'd' },
+    { order_id: '2', item_id: 'MLU2', quantity: 1, unit_price: 200, gross_price: null, currency_id: 'UYU', order_status: 'paid', date_created: 'a', date_closed: 'b', date_last_updated: null, commercial_date: 'b', observed_at: 'd' },
+  ];
+  const result = await upsertMlOrderItems({ ORDERS_DB: db }, rows);
+  assert.equal(result.written, 2);
+  assert.equal(batches.length, 1);
+  assert.equal(batches[0].length, 2);
+  assert.match(batches[0][0].sql, /ON CONFLICT\(order_id, item_id\) DO UPDATE/);
+  assert.deepEqual(batches[0][0].bindings.slice(0, 4), ['1', 'MLU1', 2, 100]);
+});
+
+test('writeMlSalesSyncState persiste cobertura sin datos personales', async () => {
+  const { db, prepared } = fakeDb();
+  await writeMlSalesSyncState({ ORDERS_DB: db }, {
+    coverageFrom: '2026-06-01', coverageTo: '2026-08-27', lastSyncAt: '2026-08-27T12:00:00Z',
+    status: 'ok', orderCount: 10, itemRows: 12,
+  });
+  const stmt = prepared.at(-1);
+  assert.match(stmt.sql, /ml_sales_sync_state/);
+  assert.deepEqual(stmt.bindings, ['2026-06-01', '2026-08-27', '2026-08-27T12:00:00Z', 'ok', 10, 12, null]);
+});
+
+test('getMlSalesWindows devuelve 7/30/90 + última venta y cobertura', async () => {
+  const { db } = fakeDb({
+    summaryRow: {
+      units_7: 2, orders_7: 2, revenue_7: 250,
+      units_30: 5, orders_30: 4, revenue_30: 700,
+      units_90: 9, orders_90: 7, revenue_90: 1400,
+      last_sale_at: '2026-08-26T10:00:00Z', observed_rows: 7,
+    },
+    stateRow: { coverage_from: '2026-05-29', coverage_to: '2026-08-27', last_sync_at: '2026-08-27T12:00:00Z', last_status: 'ok' },
+  });
+  const result = await getMlSalesWindows({ ORDERS_DB: db }, 'MLU1', { asOf: '2026-08-27T12:00:00Z' });
+  assert.deepEqual(result.windows['7'], { units: 2, orders: 2, revenue: 250 });
+  assert.equal(result.windows['90'].units, 9);
+  assert.equal(result.last_sale_at, '2026-08-26T10:00:00Z');
+  assert.equal(result.coverage.from, '2026-05-29');
+});
+
+test('getMlSalesWindows sin observaciones ni cobertura devuelve null, no inventa cero', async () => {
+  const { db } = fakeDb({
+    summaryRow: { units_7: null, orders_7: 0, revenue_7: null, units_30: null, orders_30: 0, revenue_30: null, units_90: null, orders_90: 0, revenue_90: null, last_sale_at: null, observed_rows: 0 },
+    stateRow: null,
+  });
+  const result = await getMlSalesWindows({ ORDERS_DB: db }, 'MLU1');
+  assert.deepEqual(result.windows['7'], { units: null, orders: null, revenue: null });
+  assert.equal(result.last_sale_at, null);
+});
+
+test('getMlSalesWindows con backfill observado puede representar cero ventas', async () => {
+  const { db } = fakeDb({
+    summaryRow: { units_7: null, orders_7: 0, revenue_7: null, units_30: null, orders_30: 0, revenue_30: null, units_90: null, orders_90: 0, revenue_90: null, last_sale_at: null, observed_rows: 0 },
+    stateRow: { coverage_from: '2026-05-29', coverage_to: '2026-08-27', last_sync_at: '2026-08-27', last_status: 'ok' },
+  });
+  const result = await getMlSalesWindows({ ORDERS_DB: db }, 'MLU1');
+  assert.deepEqual(result.windows['90'], { units: 0, orders: 0, revenue: 0 });
+});

--- a/worker-sync/__tests__/run-ml-sales-sync.test.js
+++ b/worker-sync/__tests__/run-ml-sales-sync.test.js
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { runMlSalesSync, salesSyncWindow } from '../radar-data-worker.js';
+
+test('salesSyncWindow hace backfill 90d sin cobertura previa', () => {
+  const now = new Date('2026-08-27T12:00:00Z');
+  const result = salesSyncWindow(now, null, {});
+  assert.equal(result.mode, 'backfill');
+  assert.equal(result.days, 90);
+  assert.equal(result.to, '2026-08-27T12:00:00.000Z');
+  assert.equal(result.from, '2026-05-29T12:00:00.000Z');
+});
+
+test('salesSyncWindow usa mantenimiento corto tras backfill exitoso', () => {
+  const now = new Date('2026-08-27T12:00:00Z');
+  const result = salesSyncWindow(now, { coverage_from: '2026-05-29', coverage_to: '2026-08-26', last_status: 'ok' }, { ML_SALES_MAINTENANCE_DAYS: '5' });
+  assert.equal(result.mode, 'maintenance');
+  assert.equal(result.days, 5);
+  assert.equal(result.from, '2026-08-22T12:00:00.000Z');
+});
+
+test('runMlSalesSync apagado por defecto no toca OAuth ni ML', async () => {
+  let called = false;
+  const result = await runMlSalesSync({}, { source: 'cron' }, {
+    getAccessTokenFn: async () => { called = true; return 'token'; },
+  });
+  assert.equal(result.status, 'skipped');
+  assert.equal(result.reason, 'ml_sales_sync_disabled');
+  assert.equal(called, false);
+});
+
+test('runMlSalesSync hace backfill, normaliza, persiste y guarda cobertura', async () => {
+  const writes = [];
+  const states = [];
+  const env = { ML_SALES_SYNC_ENABLED: 'true', USER_ID: '440298103' };
+  const nowValues = [new Date('2026-08-27T12:00:00Z'), new Date('2026-08-27T12:00:01Z')];
+  const result = await runMlSalesSync(env, { source: 'manual-await' }, {
+    getMlSalesSyncStateFn: async () => null,
+    getAccessTokenFn: async () => 'token',
+    fetchSellerOrdersFn: async (_token, options) => {
+      assert.equal(options.sellerId, '440298103');
+      assert.equal(options.status, 'paid');
+      return { orders: [{ id: 1 }], pages: 1 };
+    },
+    normalizeMlOrderItemsFn: (_orders, { observedAt }) => [{ order_id: '1', item_id: 'MLU1', quantity: 2, unit_price: 100, observed_at: observedAt }],
+    upsertMlOrderItemsFn: async (_env, rows) => { writes.push(...rows); return { written: rows.length }; },
+    writeMlSalesSyncStateFn: async (_env, state) => { states.push(state); },
+    now: () => nowValues.shift() || new Date('2026-08-27T12:00:01Z'),
+  });
+  assert.equal(result.status, 'ok');
+  assert.equal(result.mode, 'backfill');
+  assert.equal(result.fetched_orders, 1);
+  assert.equal(result.rows_upserted, 1);
+  assert.equal(writes[0].item_id, 'MLU1');
+  assert.equal(states[0].status, 'ok');
+  assert.equal(states[0].coverageFrom, '2026-05-29T12:00:00.000Z');
+});
+
+test('runMlSalesSync preserva coverage_from anterior en mantenimiento', async () => {
+  const states = [];
+  const env = { ML_SALES_SYNC_ENABLED: 'true', USER_ID: '440298103', ML_SALES_MAINTENANCE_DAYS: '7' };
+  const result = await runMlSalesSync(env, {}, {
+    getMlSalesSyncStateFn: async () => ({ coverage_from: '2026-05-01T00:00:00Z', coverage_to: '2026-08-20T00:00:00Z', last_status: 'ok' }),
+    getAccessTokenFn: async () => 'token',
+    fetchSellerOrdersFn: async () => ({ orders: [], pages: 1 }),
+    normalizeMlOrderItemsFn: () => [],
+    upsertMlOrderItemsFn: async () => ({ written: 0 }),
+    writeMlSalesSyncStateFn: async (_env, state) => states.push(state),
+    now: () => new Date('2026-08-27T12:00:00Z'),
+  });
+  assert.equal(result.mode, 'maintenance');
+  assert.equal(states[0].coverageFrom, '2026-05-01T00:00:00Z');
+  assert.equal(states[0].coverageTo, '2026-08-27T12:00:00.000Z');
+});
+
+test('runMlSalesSync registra error sin exponer token', async () => {
+  const states = [];
+  const result = await runMlSalesSync({ ML_SALES_SYNC_ENABLED: 'true', USER_ID: '440298103' }, {}, {
+    getMlSalesSyncStateFn: async () => null,
+    getAccessTokenFn: async () => 'SUPER-SECRET-TOKEN',
+    fetchSellerOrdersFn: async () => { throw new Error('ML HTTP 500'); },
+    writeMlSalesSyncStateFn: async (_env, state) => states.push(state),
+    now: () => new Date('2026-08-27T12:00:00Z'),
+  });
+  assert.equal(result.status, 'error');
+  assert.match(result.error, /ML HTTP 500/);
+  assert.equal(JSON.stringify(result).includes('SUPER-SECRET-TOKEN'), false);
+  assert.equal(states[0].status, 'error');
+});

--- a/worker-sync/__tests__/run-ml-sales-sync.test.js
+++ b/worker-sync/__tests__/run-ml-sales-sync.test.js
@@ -29,7 +29,7 @@ test('runMlSalesSync apagado por defecto no toca OAuth ni ML', async () => {
   assert.equal(called, false);
 });
 
-test('runMlSalesSync hace backfill, normaliza, persiste y guarda cobertura', async () => {
+test('runMlSalesSync hace backfill paid por date_closed, persiste y guarda cobertura', async () => {
   const writes = [];
   const states = [];
   const env = { ML_SALES_SYNC_ENABLED: 'true', USER_ID: '440298103' };
@@ -40,6 +40,7 @@ test('runMlSalesSync hace backfill, normaliza, persiste y guarda cobertura', asy
     fetchSellerOrdersFn: async (_token, options) => {
       assert.equal(options.sellerId, '440298103');
       assert.equal(options.status, 'paid');
+      assert.equal(options.dateField, 'closed');
       return { orders: [{ id: 1 }], pages: 1 };
     },
     normalizeMlOrderItemsFn: (_orders, { observedAt }) => [{ order_id: '1', item_id: 'MLU1', quantity: 2, unit_price: 100, observed_at: observedAt }],
@@ -49,6 +50,8 @@ test('runMlSalesSync hace backfill, normaliza, persiste y guarda cobertura', asy
   });
   assert.equal(result.status, 'ok');
   assert.equal(result.mode, 'backfill');
+  assert.equal(result.query_status, 'paid');
+  assert.equal(result.query_date_field, 'closed');
   assert.equal(result.fetched_orders, 1);
   assert.equal(result.rows_upserted, 1);
   assert.equal(writes[0].item_id, 'MLU1');
@@ -56,19 +59,24 @@ test('runMlSalesSync hace backfill, normaliza, persiste y guarda cobertura', asy
   assert.equal(states[0].coverageFrom, '2026-05-29T12:00:00.000Z');
 });
 
-test('runMlSalesSync preserva coverage_from anterior en mantenimiento', async () => {
+test('mantenimiento consulta date_last_updated sin filtro de estado y preserva coverage_from', async () => {
   const states = [];
+  const requests = [];
   const env = { ML_SALES_SYNC_ENABLED: 'true', USER_ID: '440298103', ML_SALES_MAINTENANCE_DAYS: '7' };
   const result = await runMlSalesSync(env, {}, {
     getMlSalesSyncStateFn: async () => ({ coverage_from: '2026-05-01T00:00:00Z', coverage_to: '2026-08-20T00:00:00Z', last_status: 'ok' }),
     getAccessTokenFn: async () => 'token',
-    fetchSellerOrdersFn: async () => ({ orders: [], pages: 1 }),
+    fetchSellerOrdersFn: async (_token, options) => { requests.push(options); return { orders: [], pages: 1 }; },
     normalizeMlOrderItemsFn: () => [],
     upsertMlOrderItemsFn: async () => ({ written: 0 }),
     writeMlSalesSyncStateFn: async (_env, state) => states.push(state),
     now: () => new Date('2026-08-27T12:00:00Z'),
   });
   assert.equal(result.mode, 'maintenance');
+  assert.equal(result.query_status, null);
+  assert.equal(result.query_date_field, 'last_updated');
+  assert.equal(requests[0].status, null);
+  assert.equal(requests[0].dateField, 'last_updated');
   assert.equal(states[0].coverageFrom, '2026-05-01T00:00:00Z');
   assert.equal(states[0].coverageTo, '2026-08-27T12:00:00.000Z');
 });

--- a/worker-sync/ml-orders.js
+++ b/worker-sync/ml-orders.js
@@ -1,0 +1,188 @@
+/**
+ * RADAR DATA 2 (#276) — lectura de ventas reales de Mercado Libre.
+ *
+ * Usa el OAuth rotativo de worker-sync y mlGet(), por lo que hereda retry,
+ * backoff y tratamiento de HTTP 206 como respuesta exitosa (Response.ok).
+ * No persiste ni expone PII de compradores.
+ */
+
+import { createSyncRetryBudget, mlGet } from './meli-catalog.js';
+
+export const DEFAULT_ORDER_PAGE_LIMIT = 50;
+export const DEFAULT_MAX_ORDER_PAGES = 200;
+
+function normalizedIso(value) {
+  if (value instanceof Date) return value.toISOString();
+  const parsed = Date.parse(String(value || ''));
+  if (!Number.isFinite(parsed)) throw new Error(`[ML sales] Fecha inválida: ${value}`);
+  return new Date(parsed).toISOString();
+}
+
+export function buildSellerOrdersUrl({
+  sellerId,
+  dateFrom,
+  dateTo,
+  status = 'paid',
+  offset = 0,
+  limit = DEFAULT_ORDER_PAGE_LIMIT,
+} = {}) {
+  if (!sellerId) throw new Error('[ML sales] sellerId es requerido.');
+  if (!dateFrom || !dateTo) throw new Error('[ML sales] dateFrom y dateTo son requeridos.');
+  const params = new URLSearchParams({
+    seller: String(sellerId),
+    'order.status': String(status),
+    'order.date_closed.from': normalizedIso(dateFrom),
+    'order.date_closed.to': normalizedIso(dateTo),
+    sort: 'date_desc',
+    offset: String(Math.max(0, Number(offset) || 0)),
+    limit: String(Math.min(50, Math.max(1, Number(limit) || DEFAULT_ORDER_PAGE_LIMIT))),
+  });
+  return `https://api.mercadolibre.com/orders/search?${params.toString()}`;
+}
+
+export async function fetchSellerOrdersPage(accessToken, options = {}) {
+  const {
+    retryBudget = createSyncRetryBudget(),
+    mlGetDeps = {},
+    ...query
+  } = options;
+  const url = buildSellerOrdersUrl(query);
+  return mlGet(url, accessToken, { ...mlGetDeps, retryBudget });
+}
+
+export async function fetchSellerOrders(accessToken, {
+  sellerId,
+  dateFrom,
+  dateTo,
+  status = 'paid',
+  limit = DEFAULT_ORDER_PAGE_LIMIT,
+  maxPages = DEFAULT_MAX_ORDER_PAGES,
+  retryBudget = createSyncRetryBudget(),
+  mlGetDeps = {},
+} = {}) {
+  const orders = [];
+  let offset = 0;
+  let pages = 0;
+  let total = null;
+
+  while (pages < maxPages) {
+    const payload = await fetchSellerOrdersPage(accessToken, {
+      sellerId,
+      dateFrom,
+      dateTo,
+      status,
+      offset,
+      limit,
+      retryBudget,
+      mlGetDeps,
+    });
+    const results = Array.isArray(payload?.results) ? payload.results : [];
+    const paging = payload?.paging || {};
+    if (Number.isFinite(Number(paging.total))) total = Number(paging.total);
+    orders.push(...results);
+    pages++;
+
+    if (results.length === 0) break;
+    offset += results.length;
+    if (total != null && offset >= total) break;
+    if (results.length < Math.min(50, Math.max(1, Number(limit) || DEFAULT_ORDER_PAGE_LIMIT))) break;
+  }
+
+  if (pages >= maxPages && total != null && offset < total) {
+    throw new Error(`[ML sales] Paginación incompleta: ${offset}/${total} órdenes tras ${maxPages} páginas.`);
+  }
+
+  const deduped = new Map();
+  for (const order of orders) {
+    if (order?.id == null) continue;
+    deduped.set(String(order.id), order);
+  }
+  return {
+    orders: [...deduped.values()],
+    pages,
+    total_reported: total,
+  };
+}
+
+function finiteMoney(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+/**
+ * Convierte órdenes a filas por order_id/item_id. Si una orden repite el
+ * mismo item_id, agrega cantidades y calcula precio unitario ponderado para
+ * conservar la clave idempotente (order_id, item_id).
+ */
+export function normalizeMlOrderItems(orders, { observedAt = new Date().toISOString() } = {}) {
+  const rows = new Map();
+
+  for (const order of orders || []) {
+    if (order?.id == null) continue;
+    const orderId = String(order.id);
+    const orderStatus = String(order.status || 'unknown');
+    const dateCreated = order.date_created || null;
+    if (!dateCreated) continue;
+    const dateClosed = order.date_closed || null;
+    const dateLastUpdated = order.date_last_updated || null;
+    const commercialDate = dateClosed || order.paid_date || dateCreated;
+
+    for (const line of order.order_items || []) {
+      const itemId = line?.item?.id ? String(line.item.id) : null;
+      const quantity = Number(line?.quantity);
+      const unitPrice = finiteMoney(line?.unit_price);
+      if (!itemId || !Number.isFinite(quantity) || quantity <= 0 || unitPrice == null) continue;
+      const grossPrice = finiteMoney(line?.gross_price);
+      const currencyId = line?.currency_id || order.currency_id || null;
+      const key = `${orderId}::${itemId}`;
+      const lineRevenue = unitPrice * quantity;
+      const grossRevenue = grossPrice == null ? null : grossPrice * quantity;
+      const existing = rows.get(key);
+
+      if (!existing) {
+        rows.set(key, {
+          order_id: orderId,
+          item_id: itemId,
+          quantity,
+          unit_price: unitPrice,
+          gross_price: grossPrice,
+          currency_id: currencyId,
+          order_status: orderStatus,
+          date_created: dateCreated,
+          date_closed: dateClosed,
+          date_last_updated: dateLastUpdated,
+          commercial_date: commercialDate,
+          observed_at: observedAt,
+          _revenue: lineRevenue,
+          _gross_revenue: grossRevenue,
+        });
+        continue;
+      }
+
+      existing.quantity += quantity;
+      existing._revenue += lineRevenue;
+      existing.unit_price = existing._revenue / existing.quantity;
+      if (grossRevenue != null) {
+        existing._gross_revenue = (existing._gross_revenue || 0) + grossRevenue;
+        existing.gross_price = existing._gross_revenue / existing.quantity;
+      }
+      if (dateLastUpdated && (!existing.date_last_updated || dateLastUpdated > existing.date_last_updated)) {
+        existing.date_last_updated = dateLastUpdated;
+      }
+    }
+  }
+
+  return [...rows.values()].map(({ _revenue, _gross_revenue, ...row }) => row);
+}
+
+export function summarizeNormalizedSales(rows) {
+  const byItem = new Map();
+  for (const row of rows || []) {
+    const current = byItem.get(row.item_id) || { item_id: row.item_id, units: 0, revenue: 0, last_sale_at: null };
+    current.units += Number(row.quantity) || 0;
+    current.revenue += (Number(row.unit_price) || 0) * (Number(row.quantity) || 0);
+    if (!current.last_sale_at || row.commercial_date > current.last_sale_at) current.last_sale_at = row.commercial_date;
+    byItem.set(row.item_id, current);
+  }
+  return [...byItem.values()].sort((a, b) => b.units - a.units || String(a.item_id).localeCompare(String(b.item_id)));
+}

--- a/worker-sync/ml-orders.js
+++ b/worker-sync/ml-orders.js
@@ -10,6 +10,7 @@ import { createSyncRetryBudget, mlGet } from './meli-catalog.js';
 
 export const DEFAULT_ORDER_PAGE_LIMIT = 50;
 export const DEFAULT_MAX_ORDER_PAGES = 200;
+const DATE_FIELDS = new Set(['closed', 'last_updated', 'created']);
 
 function normalizedIso(value) {
   if (value instanceof Date) return value.toISOString();
@@ -23,20 +24,22 @@ export function buildSellerOrdersUrl({
   dateFrom,
   dateTo,
   status = 'paid',
+  dateField = 'closed',
   offset = 0,
   limit = DEFAULT_ORDER_PAGE_LIMIT,
 } = {}) {
   if (!sellerId) throw new Error('[ML sales] sellerId es requerido.');
   if (!dateFrom || !dateTo) throw new Error('[ML sales] dateFrom y dateTo son requeridos.');
+  if (!DATE_FIELDS.has(dateField)) throw new Error(`[ML sales] dateField inválido: ${dateField}`);
   const params = new URLSearchParams({
     seller: String(sellerId),
-    'order.status': String(status),
-    'order.date_closed.from': normalizedIso(dateFrom),
-    'order.date_closed.to': normalizedIso(dateTo),
+    [`order.date_${dateField}.from`]: normalizedIso(dateFrom),
+    [`order.date_${dateField}.to`]: normalizedIso(dateTo),
     sort: 'date_desc',
     offset: String(Math.max(0, Number(offset) || 0)),
     limit: String(Math.min(50, Math.max(1, Number(limit) || DEFAULT_ORDER_PAGE_LIMIT))),
   });
+  if (status) params.set('order.status', String(status));
   return `https://api.mercadolibre.com/orders/search?${params.toString()}`;
 }
 
@@ -55,6 +58,7 @@ export async function fetchSellerOrders(accessToken, {
   dateFrom,
   dateTo,
   status = 'paid',
+  dateField = 'closed',
   limit = DEFAULT_ORDER_PAGE_LIMIT,
   maxPages = DEFAULT_MAX_ORDER_PAGES,
   retryBudget = createSyncRetryBudget(),
@@ -71,6 +75,7 @@ export async function fetchSellerOrders(accessToken, {
       dateFrom,
       dateTo,
       status,
+      dateField,
       offset,
       limit,
       retryBudget,
@@ -113,6 +118,10 @@ function finiteMoney(value) {
  * Convierte órdenes a filas por order_id/item_id. Si una orden repite el
  * mismo item_id, agrega cantidades y calcula precio unitario ponderado para
  * conservar la clave idempotente (order_id, item_id).
+ *
+ * También normaliza órdenes que ya no estén `paid`: el mantenimiento consulta
+ * por `date_last_updated` sin filtro de estado para que una cancelación/cambio
+ * posterior reemplace la fila anterior y deje de contarse en los agregados.
  */
 export function normalizeMlOrderItems(orders, { observedAt = new Date().toISOString() } = {}) {
   const rows = new Map();
@@ -178,6 +187,7 @@ export function normalizeMlOrderItems(orders, { observedAt = new Date().toISOStr
 export function summarizeNormalizedSales(rows) {
   const byItem = new Map();
   for (const row of rows || []) {
+    if (row.order_status && row.order_status !== 'paid') continue;
     const current = byItem.get(row.item_id) || { item_id: row.item_id, units: 0, revenue: 0, last_sale_at: null };
     current.units += Number(row.quantity) || 0;
     current.revenue += (Number(row.unit_price) || 0) * (Number(row.quantity) || 0);

--- a/worker-sync/ml-sales-store.js
+++ b/worker-sync/ml-sales-store.js
@@ -104,6 +104,50 @@ export async function getMlSalesSyncState(env) {
   return row || null;
 }
 
+function sameUtcDay(a, b) {
+  const aMs = Date.parse(String(a || ''));
+  const bMs = Date.parse(String(b || ''));
+  if (!Number.isFinite(aMs) || !Number.isFinite(bMs)) return false;
+  return new Date(aMs).toISOString().slice(0, 10) === new Date(bMs).toISOString().slice(0, 10);
+}
+
+/**
+ * Cobertura completa significa que la búsqueda de órdenes alcanzó el inicio
+ * de la ventana y llegó hasta el mismo día UTC de `asOf`. La tolerancia del
+ * mismo día evita declarar incompleta una consulta hecha minutos después del
+ * sync, pero `data_through` conserva el timestamp exacto de frescura.
+ */
+export function mlSalesWindowComplete(state, asOf, days) {
+  if (!state || state.last_status !== 'ok') return false;
+  const asMs = Date.parse(String(asOf || ''));
+  const fromMs = Date.parse(String(state.coverage_from || ''));
+  const toMs = Date.parse(String(state.coverage_to || ''));
+  if (![asMs, fromMs, toMs].every(Number.isFinite)) return false;
+  const requiredFrom = asMs - Number(days) * 86400000;
+  return fromMs <= requiredFrom && (toMs >= asMs || sameUtcDay(toMs, asMs));
+}
+
+function numericOrZero(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function buildWindow(row, state, asOf, days) {
+  const suffix = String(days);
+  const rowsInWindow = numericOrZero(row?.[`rows_${suffix}`]);
+  const complete = mlSalesWindowComplete(state, asOf, days);
+  const hasObservedSales = rowsInWindow > 0;
+  const canReportNumber = complete || hasObservedSales;
+  return {
+    units: canReportNumber ? numericOrZero(row?.[`units_${suffix}`]) : null,
+    orders: canReportNumber ? numericOrZero(row?.[`orders_${suffix}`]) : null,
+    revenue: canReportNumber ? numericOrZero(row?.[`revenue_${suffix}`]) : null,
+    complete,
+    observed_sale_rows: rowsInWindow,
+    data_through: state?.coverage_to || null,
+  };
+}
+
 export async function getMlSalesWindows(env, itemId, {
   asOf = new Date().toISOString(),
 } = {}) {
@@ -114,12 +158,15 @@ export async function getMlSalesWindows(env, itemId, {
       SUM(CASE WHEN julianday(commercial_date) > julianday(?) - 7  THEN quantity ELSE 0 END) AS units_7,
       COUNT(DISTINCT CASE WHEN julianday(commercial_date) > julianday(?) - 7  THEN order_id END) AS orders_7,
       SUM(CASE WHEN julianday(commercial_date) > julianday(?) - 7  THEN unit_price * quantity ELSE 0 END) AS revenue_7,
+      COUNT(CASE WHEN julianday(commercial_date) > julianday(?) - 7 THEN 1 END) AS rows_7,
       SUM(CASE WHEN julianday(commercial_date) > julianday(?) - 30 THEN quantity ELSE 0 END) AS units_30,
       COUNT(DISTINCT CASE WHEN julianday(commercial_date) > julianday(?) - 30 THEN order_id END) AS orders_30,
       SUM(CASE WHEN julianday(commercial_date) > julianday(?) - 30 THEN unit_price * quantity ELSE 0 END) AS revenue_30,
+      COUNT(CASE WHEN julianday(commercial_date) > julianday(?) - 30 THEN 1 END) AS rows_30,
       SUM(CASE WHEN julianday(commercial_date) > julianday(?) - 90 THEN quantity ELSE 0 END) AS units_90,
       COUNT(DISTINCT CASE WHEN julianday(commercial_date) > julianday(?) - 90 THEN order_id END) AS orders_90,
       SUM(CASE WHEN julianday(commercial_date) > julianday(?) - 90 THEN unit_price * quantity ELSE 0 END) AS revenue_90,
+      COUNT(CASE WHEN julianday(commercial_date) > julianday(?) - 90 THEN 1 END) AS rows_90,
       MAX(commercial_date) AS last_sale_at,
       COUNT(*) AS observed_rows
     FROM ml_order_items
@@ -127,9 +174,9 @@ export async function getMlSalesWindows(env, itemId, {
       AND order_status = 'paid'
       AND julianday(commercial_date) <= julianday(?)
   `).bind(
-    asOf, asOf, asOf,
-    asOf, asOf, asOf,
-    asOf, asOf, asOf,
+    asOf, asOf, asOf, asOf,
+    asOf, asOf, asOf, asOf,
+    asOf, asOf, asOf, asOf,
     itemId, asOf,
   ).first();
 
@@ -147,21 +194,9 @@ export async function getMlSalesWindows(env, itemId, {
     as_of: asOf,
     coverage,
     windows: {
-      '7': {
-        units: observedRows || state ? Number(row?.units_7) || 0 : null,
-        orders: observedRows || state ? Number(row?.orders_7) || 0 : null,
-        revenue: observedRows || state ? Number(row?.revenue_7) || 0 : null,
-      },
-      '30': {
-        units: observedRows || state ? Number(row?.units_30) || 0 : null,
-        orders: observedRows || state ? Number(row?.orders_30) || 0 : null,
-        revenue: observedRows || state ? Number(row?.revenue_30) || 0 : null,
-      },
-      '90': {
-        units: observedRows || state ? Number(row?.units_90) || 0 : null,
-        orders: observedRows || state ? Number(row?.orders_90) || 0 : null,
-        revenue: observedRows || state ? Number(row?.revenue_90) || 0 : null,
-      },
+      '7': buildWindow(row, state, asOf, 7),
+      '30': buildWindow(row, state, asOf, 30),
+      '90': buildWindow(row, state, asOf, 90),
     },
     last_sale_at: row?.last_sale_at || null,
     observed_rows: observedRows,

--- a/worker-sync/ml-sales-store.js
+++ b/worker-sync/ml-sales-store.js
@@ -104,9 +104,14 @@ export async function getMlSalesSyncState(env) {
   return row || null;
 }
 
+function timestampMs(value) {
+  if (Number.isFinite(value)) return Number(value);
+  return Date.parse(String(value || ''));
+}
+
 function sameUtcDay(a, b) {
-  const aMs = Date.parse(String(a || ''));
-  const bMs = Date.parse(String(b || ''));
+  const aMs = timestampMs(a);
+  const bMs = timestampMs(b);
   if (!Number.isFinite(aMs) || !Number.isFinite(bMs)) return false;
   return new Date(aMs).toISOString().slice(0, 10) === new Date(bMs).toISOString().slice(0, 10);
 }
@@ -119,9 +124,9 @@ function sameUtcDay(a, b) {
  */
 export function mlSalesWindowComplete(state, asOf, days) {
   if (!state || state.last_status !== 'ok') return false;
-  const asMs = Date.parse(String(asOf || ''));
-  const fromMs = Date.parse(String(state.coverage_from || ''));
-  const toMs = Date.parse(String(state.coverage_to || ''));
+  const asMs = timestampMs(asOf);
+  const fromMs = timestampMs(state.coverage_from);
+  const toMs = timestampMs(state.coverage_to);
   if (![asMs, fromMs, toMs].every(Number.isFinite)) return false;
   const requiredFrom = asMs - Number(days) * 86400000;
   return fromMs <= requiredFrom && (toMs >= asMs || sameUtcDay(toMs, asMs));

--- a/worker-sync/ml-sales-store.js
+++ b/worker-sync/ml-sales-store.js
@@ -1,0 +1,184 @@
+/**
+ * RADAR DATA 2 (#276) — persistencia D1 y consultas de ventas por MLU.
+ */
+
+const UPSERT_SQL = `
+INSERT INTO ml_order_items (
+  order_id, item_id, quantity, unit_price, gross_price, currency_id,
+  order_status, date_created, date_closed, date_last_updated,
+  commercial_date, observed_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(order_id, item_id) DO UPDATE SET
+  quantity=excluded.quantity,
+  unit_price=excluded.unit_price,
+  gross_price=excluded.gross_price,
+  currency_id=excluded.currency_id,
+  order_status=excluded.order_status,
+  date_created=excluded.date_created,
+  date_closed=excluded.date_closed,
+  date_last_updated=excluded.date_last_updated,
+  commercial_date=excluded.commercial_date,
+  observed_at=excluded.observed_at
+`;
+
+function dbFrom(env) {
+  if (!env?.ORDERS_DB || typeof env.ORDERS_DB.prepare !== 'function') {
+    throw new Error('[ML sales] ORDERS_DB no disponible.');
+  }
+  return env.ORDERS_DB;
+}
+
+export async function upsertMlOrderItems(env, rows, { batchSize = 50 } = {}) {
+  const db = dbFrom(env);
+  const input = Array.isArray(rows) ? rows : [];
+  let written = 0;
+
+  for (let offset = 0; offset < input.length; offset += batchSize) {
+    const chunk = input.slice(offset, offset + batchSize);
+    const statements = chunk.map(row => db.prepare(UPSERT_SQL).bind(
+      row.order_id,
+      row.item_id,
+      row.quantity,
+      row.unit_price,
+      row.gross_price ?? null,
+      row.currency_id ?? null,
+      row.order_status,
+      row.date_created,
+      row.date_closed ?? null,
+      row.date_last_updated ?? null,
+      row.commercial_date,
+      row.observed_at,
+    ));
+    if (typeof db.batch === 'function') {
+      await db.batch(statements);
+    } else {
+      for (const statement of statements) await statement.run();
+    }
+    written += chunk.length;
+  }
+
+  return { status: 'ok', written };
+}
+
+export async function writeMlSalesSyncState(env, {
+  coverageFrom = null,
+  coverageTo = null,
+  lastSyncAt = new Date().toISOString(),
+  status,
+  orderCount = 0,
+  itemRows = 0,
+  error = null,
+} = {}) {
+  const db = dbFrom(env);
+  await db.prepare(`
+    INSERT INTO ml_sales_sync_state (
+      id, coverage_from, coverage_to, last_sync_at, last_status,
+      last_order_count, last_item_rows, last_error
+    ) VALUES (1, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      coverage_from=excluded.coverage_from,
+      coverage_to=excluded.coverage_to,
+      last_sync_at=excluded.last_sync_at,
+      last_status=excluded.last_status,
+      last_order_count=excluded.last_order_count,
+      last_item_rows=excluded.last_item_rows,
+      last_error=excluded.last_error
+  `).bind(
+    coverageFrom,
+    coverageTo,
+    lastSyncAt,
+    status || 'unknown',
+    Number(orderCount) || 0,
+    Number(itemRows) || 0,
+    error ? String(error).slice(0, 400) : null,
+  ).run();
+}
+
+export async function getMlSalesSyncState(env) {
+  const db = dbFrom(env);
+  const row = await db.prepare(`
+    SELECT coverage_from, coverage_to, last_sync_at, last_status,
+           last_order_count, last_item_rows, last_error
+    FROM ml_sales_sync_state WHERE id = 1
+  `).first();
+  return row || null;
+}
+
+export async function getMlSalesWindows(env, itemId, {
+  asOf = new Date().toISOString(),
+} = {}) {
+  const db = dbFrom(env);
+  if (!itemId) throw new Error('[ML sales] itemId es requerido.');
+  const row = await db.prepare(`
+    SELECT
+      SUM(CASE WHEN julianday(commercial_date) > julianday(?) - 7  THEN quantity ELSE 0 END) AS units_7,
+      COUNT(DISTINCT CASE WHEN julianday(commercial_date) > julianday(?) - 7  THEN order_id END) AS orders_7,
+      SUM(CASE WHEN julianday(commercial_date) > julianday(?) - 7  THEN unit_price * quantity ELSE 0 END) AS revenue_7,
+      SUM(CASE WHEN julianday(commercial_date) > julianday(?) - 30 THEN quantity ELSE 0 END) AS units_30,
+      COUNT(DISTINCT CASE WHEN julianday(commercial_date) > julianday(?) - 30 THEN order_id END) AS orders_30,
+      SUM(CASE WHEN julianday(commercial_date) > julianday(?) - 30 THEN unit_price * quantity ELSE 0 END) AS revenue_30,
+      SUM(CASE WHEN julianday(commercial_date) > julianday(?) - 90 THEN quantity ELSE 0 END) AS units_90,
+      COUNT(DISTINCT CASE WHEN julianday(commercial_date) > julianday(?) - 90 THEN order_id END) AS orders_90,
+      SUM(CASE WHEN julianday(commercial_date) > julianday(?) - 90 THEN unit_price * quantity ELSE 0 END) AS revenue_90,
+      MAX(commercial_date) AS last_sale_at,
+      COUNT(*) AS observed_rows
+    FROM ml_order_items
+    WHERE item_id = ?
+      AND order_status = 'paid'
+      AND julianday(commercial_date) <= julianday(?)
+  `).bind(
+    asOf, asOf, asOf,
+    asOf, asOf, asOf,
+    asOf, asOf, asOf,
+    itemId, asOf,
+  ).first();
+
+  const state = await getMlSalesSyncState(env);
+  const observedRows = Number(row?.observed_rows) || 0;
+  const coverage = state ? {
+    from: state.coverage_from || null,
+    to: state.coverage_to || null,
+    last_sync_at: state.last_sync_at || null,
+    status: state.last_status || null,
+  } : null;
+
+  return {
+    item_id: itemId,
+    as_of: asOf,
+    coverage,
+    windows: {
+      '7': {
+        units: observedRows || state ? Number(row?.units_7) || 0 : null,
+        orders: observedRows || state ? Number(row?.orders_7) || 0 : null,
+        revenue: observedRows || state ? Number(row?.revenue_7) || 0 : null,
+      },
+      '30': {
+        units: observedRows || state ? Number(row?.units_30) || 0 : null,
+        orders: observedRows || state ? Number(row?.orders_30) || 0 : null,
+        revenue: observedRows || state ? Number(row?.revenue_30) || 0 : null,
+      },
+      '90': {
+        units: observedRows || state ? Number(row?.units_90) || 0 : null,
+        orders: observedRows || state ? Number(row?.orders_90) || 0 : null,
+        revenue: observedRows || state ? Number(row?.revenue_90) || 0 : null,
+      },
+    },
+    last_sale_at: row?.last_sale_at || null,
+    observed_rows: observedRows,
+  };
+}
+
+export async function getMlOrderItemsForItem(env, itemId, { limit = 100 } = {}) {
+  const db = dbFrom(env);
+  if (!itemId) throw new Error('[ML sales] itemId es requerido.');
+  const result = await db.prepare(`
+    SELECT order_id, item_id, quantity, unit_price, gross_price, currency_id,
+           order_status, date_created, date_closed, date_last_updated,
+           commercial_date, observed_at
+    FROM ml_order_items
+    WHERE item_id = ?
+    ORDER BY commercial_date DESC
+    LIMIT ?
+  `).bind(itemId, Math.min(500, Math.max(1, Number(limit) || 100))).all();
+  return Array.isArray(result?.results) ? result.results : [];
+}

--- a/worker-sync/radar-data-worker.js
+++ b/worker-sync/radar-data-worker.js
@@ -1,0 +1,227 @@
+/**
+ * Entrada compuesta para RADAR DATA (#276).
+ *
+ * Sigue siendo el mismo Worker: delega todo el comportamiento existente a
+ * index.js y añade únicamente rutas/ingesta read-only de ventas ML. El flag
+ * ML_SALES_SYNC_ENABLED está apagado por defecto.
+ */
+
+import baseWorker from './index.js';
+import { getAccessToken } from './meli-auth.js';
+import { fetchSellerOrders, normalizeMlOrderItems, summarizeNormalizedSales } from './ml-orders.js';
+import {
+  getMlOrderItemsForItem,
+  getMlSalesSyncState,
+  getMlSalesWindows,
+  upsertMlOrderItems,
+  writeMlSalesSyncState,
+} from './ml-sales-store.js';
+
+const DEFAULT_BACKFILL_DAYS = 90;
+const DEFAULT_MAINTENANCE_DAYS = 7;
+
+function positiveInt(value, fallback, max = 365) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? Math.min(max, parsed) : fallback;
+}
+
+function isoDaysAgo(now, days) {
+  return new Date(now.getTime() - days * 86400000).toISOString();
+}
+
+export function salesSyncWindow(now, state, env = {}) {
+  const backfillDays = positiveInt(env.ML_SALES_BACKFILL_DAYS, DEFAULT_BACKFILL_DAYS, 365);
+  const maintenanceDays = positiveInt(env.ML_SALES_MAINTENANCE_DAYS, DEFAULT_MAINTENANCE_DAYS, 90);
+  const hasCoverage = Boolean(state?.coverage_from && state?.coverage_to && state?.last_status === 'ok');
+  const days = hasCoverage ? maintenanceDays : backfillDays;
+  return {
+    mode: hasCoverage ? 'maintenance' : 'backfill',
+    days,
+    from: isoDaysAgo(now, days),
+    to: now.toISOString(),
+  };
+}
+
+function earlierIso(a, b) {
+  if (!a) return b || null;
+  if (!b) return a;
+  return a < b ? a : b;
+}
+
+function laterIso(a, b) {
+  if (!a) return b || null;
+  if (!b) return a;
+  return a > b ? a : b;
+}
+
+export async function runMlSalesSync(env, { source = 'unknown' } = {}, {
+  getAccessTokenFn = getAccessToken,
+  fetchSellerOrdersFn = fetchSellerOrders,
+  normalizeMlOrderItemsFn = normalizeMlOrderItems,
+  upsertMlOrderItemsFn = upsertMlOrderItems,
+  getMlSalesSyncStateFn = getMlSalesSyncState,
+  writeMlSalesSyncStateFn = writeMlSalesSyncState,
+  now = () => new Date(),
+} = {}) {
+  if (String(env?.ML_SALES_SYNC_ENABLED) !== 'true') {
+    return { status: 'skipped', reason: 'ml_sales_sync_disabled', source };
+  }
+  const sellerId = env?.USER_ID;
+  if (!sellerId) return { status: 'error', error: 'USER_ID no configurado.', source };
+
+  const startedAt = now();
+  let previousState = null;
+  let window = null;
+  try {
+    previousState = await getMlSalesSyncStateFn(env);
+    window = salesSyncWindow(startedAt, previousState, env);
+    const token = await getAccessTokenFn(env);
+    const fetched = await fetchSellerOrdersFn(token, {
+      sellerId,
+      dateFrom: window.from,
+      dateTo: window.to,
+      status: 'paid',
+    });
+    const observedAt = now().toISOString();
+    const rows = normalizeMlOrderItemsFn(fetched.orders, { observedAt });
+    const persisted = await upsertMlOrderItemsFn(env, rows);
+    const coverageFrom = earlierIso(previousState?.coverage_from, window.from);
+    const coverageTo = laterIso(previousState?.coverage_to, window.to);
+    await writeMlSalesSyncStateFn(env, {
+      coverageFrom,
+      coverageTo,
+      lastSyncAt: observedAt,
+      status: 'ok',
+      orderCount: fetched.orders.length,
+      itemRows: persisted.written,
+      error: null,
+    });
+    return {
+      status: 'ok',
+      source,
+      mode: window.mode,
+      coverage_from: coverageFrom,
+      coverage_to: coverageTo,
+      fetched_orders: fetched.orders.length,
+      pages: fetched.pages,
+      item_rows: rows.length,
+      rows_upserted: persisted.written,
+      observed_at: observedAt,
+    };
+  } catch (error) {
+    const observedAt = now().toISOString();
+    try {
+      await writeMlSalesSyncStateFn(env, {
+        coverageFrom: previousState?.coverage_from || window?.from || null,
+        coverageTo: previousState?.coverage_to || null,
+        lastSyncAt: observedAt,
+        status: 'error',
+        error: error?.message || 'Error',
+      });
+    } catch {
+      // La falla al registrar observabilidad no oculta la causa principal.
+    }
+    return {
+      status: 'error',
+      source,
+      observed_at: observedAt,
+      error: String(error?.message || 'Error').slice(0, 400),
+    };
+  }
+}
+
+function unauthorized(env, request) {
+  if (!env?.SYNC_SECRET) return new Response(JSON.stringify({ error: 'Server misconfiguration: SYNC_SECRET not set.' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+  const authHeader = request.headers.get('Authorization') || '';
+  if (authHeader !== `Bearer ${env.SYNC_SECRET}`) return new Response(JSON.stringify({ error: 'Unauthorized.' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+  return null;
+}
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+  });
+}
+
+async function verifySalesLive(env, url) {
+  const days = positiveInt(url.searchParams.get('days'), 7, 90);
+  const maxPages = positiveInt(url.searchParams.get('pages'), 1, 5);
+  const now = new Date();
+  const token = await getAccessToken(env);
+  const fetched = await fetchSellerOrders(token, {
+    sellerId: env.USER_ID,
+    dateFrom: isoDaysAgo(now, days),
+    dateTo: now.toISOString(),
+    status: 'paid',
+    maxPages,
+  });
+  const rows = normalizeMlOrderItems(fetched.orders, { observedAt: now.toISOString() });
+  return {
+    checked_at: now.toISOString(),
+    days,
+    pages: fetched.pages,
+    orders_observed: fetched.orders.length,
+    item_rows: rows.length,
+    sample: summarizeNormalizedSales(rows).slice(0, 20),
+    pii_persisted: false,
+    writes_to_ml: false,
+  };
+}
+
+export default {
+  async scheduled(event, env, ctx) {
+    await baseWorker.scheduled(event, env, ctx);
+    if (event?.cron === '15 7 * * *' && String(env?.ML_SALES_SYNC_ENABLED) === 'true') {
+      ctx.waitUntil(runMlSalesSync(env, { source: 'cron' }));
+    }
+  },
+
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    if (!url.pathname.startsWith('/sales/')) return baseWorker.fetch(request, env, ctx);
+    const authError = unauthorized(env, request);
+    if (authError) return authError;
+
+    if (request.method === 'POST' && url.pathname === '/sales/sync') {
+      if (String(env?.ML_SALES_SYNC_ENABLED) !== 'true') return json({ error: 'Not found.' }, 404);
+      const mode = url.searchParams.get('mode') || 'async';
+      if (mode === 'await') {
+        const result = await runMlSalesSync(env, { source: 'manual-await' });
+        return json(result, result.status === 'error' ? 500 : 200);
+      }
+      ctx.waitUntil(runMlSalesSync(env, { source: 'manual-async' }));
+      return json({ status: 'ML_SALES_SYNC_TRIGGERED', mode: 'async' }, 202);
+    }
+
+    if (request.method === 'GET' && url.pathname === '/sales/summary') {
+      const ids = (url.searchParams.get('ids') || '').split(',').map(v => v.trim()).filter(Boolean);
+      if (ids.length === 0) return json({ error: 'Falta ?ids=MLU1,MLU2.' }, 400);
+      if (ids.length > 20) return json({ error: 'Máximo 20 item_id por consulta.' }, 400);
+      const asOf = url.searchParams.get('as_of') || undefined;
+      const items = await Promise.all(ids.map(itemId => getMlSalesWindows(env, itemId, { asOf })));
+      return json({ generated_at: new Date().toISOString(), items });
+    }
+
+    if (request.method === 'GET' && url.pathname === '/sales/raw') {
+      const itemId = url.searchParams.get('item_id');
+      if (!itemId) return json({ error: 'Falta ?item_id=MLUxxxxxxxxx.' }, 400);
+      const rows = await getMlOrderItemsForItem(env, itemId, { limit: url.searchParams.get('limit') || 100 });
+      return json({ item_id: itemId, rows });
+    }
+
+    if (request.method === 'GET' && url.pathname === '/sales/state') {
+      return json({ state: await getMlSalesSyncState(env) });
+    }
+
+    if (request.method === 'GET' && url.pathname === '/sales/verify') {
+      try {
+        return json(await verifySalesLive(env, url));
+      } catch (error) {
+        return json({ error: String(error?.message || 'Error').slice(0, 400) }, 502);
+      }
+    }
+
+    return json({ error: 'Not found.' }, 404);
+  },
+};

--- a/worker-sync/radar-data-worker.js
+++ b/worker-sync/radar-data-worker.js
@@ -76,11 +76,18 @@ export async function runMlSalesSync(env, { source = 'unknown' } = {}, {
     previousState = await getMlSalesSyncStateFn(env);
     window = salesSyncWindow(startedAt, previousState, env);
     const token = await getAccessTokenFn(env);
+
+    // Backfill: sólo órdenes actualmente pagas, por fecha de cierre comercial.
+    // Mantenimiento: todas las órdenes actualizadas, sin filtrar estado. Así
+    // una cancelación/cambio posterior reescribe su fila y deja de contarse.
+    const queryStatus = window.mode === 'backfill' ? 'paid' : null;
+    const queryDateField = window.mode === 'backfill' ? 'closed' : 'last_updated';
     const fetched = await fetchSellerOrdersFn(token, {
       sellerId,
       dateFrom: window.from,
       dateTo: window.to,
-      status: 'paid',
+      status: queryStatus,
+      dateField: queryDateField,
     });
     const observedAt = now().toISOString();
     const rows = normalizeMlOrderItemsFn(fetched.orders, { observedAt });
@@ -100,6 +107,8 @@ export async function runMlSalesSync(env, { source = 'unknown' } = {}, {
       status: 'ok',
       source,
       mode: window.mode,
+      query_date_field: queryDateField,
+      query_status: queryStatus,
       coverage_from: coverageFrom,
       coverage_to: coverageTo,
       fetched_orders: fetched.orders.length,
@@ -154,6 +163,7 @@ async function verifySalesLive(env, url) {
     dateFrom: isoDaysAgo(now, days),
     dateTo: now.toISOString(),
     status: 'paid',
+    dateField: 'closed',
     maxPages,
   });
   const rows = normalizeMlOrderItems(fetched.orders, { observedAt: now.toISOString() });

--- a/worker-sync/wrangler.toml
+++ b/worker-sync/wrangler.toml
@@ -4,7 +4,9 @@
 # (auth:refresh_token) y R2 bucket (amadolibros-catalog).
 
 name = "amadolibros-sync"
-main = "index.js"
+# RADAR DATA 2: entrada compuesta que delega todo el comportamiento histórico
+# a index.js y añade únicamente rutas/ingesta read-only de ventas ML.
+main = "radar-data-worker.js"
 compatibility_date = "2024-09-23"
 
 # ── Cron: sincronización automática 1 vez por día — 07:15 UTC (04:15 Montevideo)
@@ -36,6 +38,11 @@ ML_CATALOG_GALLERY_PRIORITY_IDS = "MLU63131903"
 COVER_MIRROR_BATCH_SIZE = "100"
 CANONICAL_ORIGIN = "https://www.amadolibros.com"
 INDEXNOW_ENABLED = "true"
+# RADAR DATA 2 permanece apagado aun si el código se fusionara. Habilitar sólo
+# después de aplicar la migración D1 y validar /sales/verify read-only.
+ML_SALES_SYNC_ENABLED = "false"
+ML_SALES_BACKFILL_DAYS = "90"
+ML_SALES_MAINTENANCE_DAYS = "7"
 # Clave pública verificada por el archivo homónimo en astro-front/public.
 INDEXNOW_KEY = "944e65e97fd0a8c242c495ccf458d3c3"
 SALES_NOTIFICATION_FROM = "Amado Libros <web@notificaciones.amadolibros.com>"
@@ -65,7 +72,7 @@ binding = "IMAGES"
 binding = "AMADO_KV"
 id      = "6ea0ff4682d647118442a24fe384abc4"
 
-# D1 productiva: únicamente lee y actualiza solicitudes de aviso de stock.
+# D1 productiva: órdenes web + waitlist + telemetría operativa RADAR.
 [[d1_databases]]
 binding = "ORDERS_DB"
 database_name = "amadolibros-orders-production"


### PR DESCRIPTION
Implementa #276, parte del programa maestro #274. **Read-only hacia Mercado Libre; Draft; sin merge ni Producción.**

## Estado actual
- CI `Syntax & Build` sobre head `8e2ecb4`: **success**.
- Verificación real read-only en una **versión aislada** del Worker: **success / HTTP 200**.
- No se aplicó la migración D1.
- `ML_SALES_SYNC_ENABLED=false`; no hay polling automático activo.
- No se desplegó la versión del PR al tráfico productivo.

## Verificación real con Mercado Libre
Workflow dedicado `RADAR DATA 2 live read-only verify`:
1. sube con `wrangler versions upload` una versión aislada del Worker — no `versions deploy`;
2. reutiliza los bindings/secrets existentes sin imprimirlos;
3. llama `GET /sales/verify?days=7&pages=1`;
4. no escribe D1 ni Mercado Libre;
5. valida que la salida no contenga PII.

Última corrida verificada:
- HTTP 200;
- 48 órdenes pagas observadas en la página consultada;
- 48 filas MLU normalizadas;
- `pii_persisted=false`;
- `writes_to_ml=false`.

Ejemplos reales de la muestra:
- `MLU631885765`: 3 unidades, revenue 3303, última venta 2026-08-25T19:05:48-04:00;
- `MLU1472001988`: 2 unidades, revenue 3900, última venta 2026-08-23T19:27:34-04:00;
- `MLU1029309702`: 1 unidad, revenue 2550, última venta 2026-08-25T19:48:49-04:00;
- `MLU1069010642`: 1 unidad, revenue 882, última venta 2026-08-27T10:11:02-04:00.

**Importante:** `/sales/verify` está limitado deliberadamente a la cantidad de páginas pedida; estos 48 registros demuestran acceso y shape reales, pero no se presentan como el total definitivo de 7 días hasta completar el backfill/paginación persistente.

## Arquitectura
- Reutiliza `worker-sync/meli-auth.js`: refresh token rotativo en KV; no crea otro OAuth.
- Reutiliza `mlGet()` de `meli-catalog.js` con retry/backoff; HTTP 206 se acepta como 2xx.
- D1 `ORDERS_DB` será la fuente de verdad histórica.
- No usa `order_items` del checkout de amadolibros.com como proxy de ventas ML.
- El webhook viejo `functions/api/webhooks/mercadolibre.js` queda intacto: hoy guarda resumen efímero en KV y tiene un OAuth distinto; no se convierte en fuente del Radar en este lote.

## Persistencia D1
Migración `0011_ml_order_items.sql` — se usa 0011 para no colisionar con el Draft #283, que reservó 0010.

`ml_order_items`, PK `(order_id,item_id)`:
- quantity;
- unit_price;
- gross_price nullable;
- currency_id;
- order_status;
- date_created / date_closed / date_last_updated;
- commercial_date;
- observed_at.

**No guarda buyer, email, teléfono, dirección ni otra PII.**

`ml_sales_sync_state` guarda cobertura del backfill para distinguir correctamente:
- `0 ventas` cuando la ventana fue observada por completo;
- `null / complete=false` cuando todavía falta cobertura.

Cada ventana 7/30/90 expone además `complete`, `observed_sale_rows` y `data_through`. Una ventana parcial con ventas puede mostrar el subtotal observado, siempre marcado `complete=false`.

## Ingesta
### Primer run
Backfill de 90 días:
- `/orders/search?seller=...`;
- `order.status=paid`;
- filtro por `order.date_closed`;
- paginación completa;
- upsert idempotente.

### Mantenimiento
Ventana corta de 7 días por defecto:
- filtro por `order.date_last_updated`;
- **sin filtrar status**, para reobservar cancelaciones/cambios posteriores;
- una orden que deja de estar `paid` actualiza su fila y deja de entrar en los agregados de ventas.

Esto evita contar indefinidamente una venta que luego cambió de estado.

## Readouts protegidos por SYNC_SECRET
- `POST /sales/sync?mode=await|async`
- `GET /sales/summary?ids=MLU1,MLU2`
- `GET /sales/raw?item_id=MLU...`
- `GET /sales/state`
- `GET /sales/verify?days=7&pages=1` — lectura directa para gate real; no persiste.

## Métricas derivables por MLU
- unidades 7/30/90;
- cantidad de órdenes 7/30/90;
- revenue 7/30/90 (`unit_price × quantity`);
- última venta;
- cobertura/frescura de la observación.

No se calcula todavía scoring ni días de stock: eso corresponde a #281 una vez estén completas las fuentes DATA.

## Seguridad
- cero escrituras a Mercado Libre;
- cero PII persistida;
- no modifica precio, stock ni publicaciones;
- no toca frontend público;
- no modifica `replenishment_score_v1/v2`;
- no aplicar la migración D1 ni activar el flag desde este PR sin la siguiente revisión.

## Integración del Worker
`wrangler.toml` apunta a `radar-data-worker.js`, una entrada compuesta que delega todo el comportamiento histórico a `index.js` y añade únicamente `/sales/*` y la ingesta condicional. Sigue siendo el mismo Worker/bindings; no crea infraestructura paralela.

## Pendiente antes de cualquier activación
1. revisión final del diff;
2. aplicar `0011_ml_order_items.sql` primero en entorno controlado cuando se autorice;
3. ejecutar backfill real de 90 días con flag explícito;
4. verificar `/sales/summary` contra una muestra de MLU;
5. sólo después evaluar promoción a producción.
