### PR TITLE
B11: limpiar autor genérico de textos alternativos

### DIFF
--- a/functions/__tests__/fichas-quality-guard-integration.test.js
+++ b/functions/__tests__/fichas-quality-guard-integration.test.js
@@ -44,6 +44,11 @@ const RELACIONADOS_GENERICOS = [
   { id: 'MLU900000002', title: 'Nuevo Testamento, de Desconocido', author: 'Desconocido', status: 'active', available_quantity: 1 },
 ];
 
+const TITULO_CON_AUTOR_GENERICO = Object.freeze({
+  ...MLU724888358,
+  title: 'La Biblia Palabra de Vida — Verbo Divino, de Desconocido',
+});
+
 const AUTOR_REAL = Object.freeze({
   ...MLU724888358,
   id: 'MLU111111111',
@@ -86,6 +91,38 @@ test('2. la ausencia se verifica superficie por superficie', () => {
   assert.doesNotMatch(html, /Otros libros de/);
   assert.doesNotMatch(html, /class="related-books"/);
   assert.doesNotMatch(html, /De Desconocido/i);
+});
+
+test('2b. la galería y los metadatos de imagen limpian «De Desconocido» sin mutar el título comercial', () => {
+  const html = renderPage(
+    TITULO_CON_AUTOR_GENERICO,
+    'la-biblia-palabra-de-vida-verbo-divino-de-desconocido',
+    false,
+    '',
+    '',
+    [],
+  );
+
+  const imageAltTags = [...html.matchAll(/<img\\b[^>]*\\balt="([^"]*)"/gi)].map(match => match[1]);
+  assert.ok(imageAltTags.length >= 3, 'debe revisar portada principal, lightbox y logo');
+  for (const alt of imageAltTags) {
+    assert.doesNotMatch(alt, /de Desconocido/i, `alt contaminado: ${alt}`);
+  }
+
+  const socialAltTags = html.match(
+    /<meta (?:property="og:image:alt"|name="twitter:image:alt")[^>]*>/g,
+  ) || [];
+  assert.equal(socialAltTags.length, 2, 'debe cubrir Open Graph y Twitter');
+  for (const tag of socialAltTags) {
+    assert.doesNotMatch(tag, /de Desconocido/i, `meta de imagen contaminada: ${tag}`);
+  }
+
+  assert.equal(
+    TITULO_CON_AUTOR_GENERICO.title,
+    'La Biblia Palabra de Vida — Verbo Divino, de Desconocido',
+    'la limpieza visual no debe mutar el título comercial',
+  );
+  assert.match(html, /la-biblia-palabra-de-vida-verbo-divino-de-desconocido/);
 });
 
 test('2b. el mensaje de WhatsApp omite la línea Autor cuando la autoría es genérica', () => {

--- a/functions/__tests__/fichas-quality-guard-integration.test.js
+++ b/functions/__tests__/fichas-quality-guard-integration.test.js
@@ -93,7 +93,7 @@ test('2. la ausencia se verifica superficie por superficie', () => {
   assert.doesNotMatch(html, /De Desconocido/i);
 });
 
-test('2b. la galería y los metadatos de imagen limpian «De Desconocido» sin mutar el título comercial', () => {
+test('2c. la galería y los metadatos de imagen limpian «De Desconocido» sin mutar el título comercial', () => {
   const html = renderPage(
     TITULO_CON_AUTOR_GENERICO,
     'la-biblia-palabra-de-vida-verbo-divino-de-desconocido',
@@ -103,7 +103,7 @@ test('2b. la galería y los metadatos de imagen limpian «De Desconocido» sin m
     [],
   );
 
-  const imageAltTags = [...html.matchAll(/<img\\b[^>]*\\balt="([^"]*)"/gi)].map(match => match[1]);
+  const imageAltTags = [...html.matchAll(/<img\b[^>]*\balt="([^"]*)"/gi)].map(match => match[1]);
   assert.ok(imageAltTags.length >= 3, 'debe revisar portada principal, lightbox y logo');
   for (const alt of imageAltTags) {
     assert.doesNotMatch(alt, /de Desconocido/i, `alt contaminado: ${alt}`);

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -379,6 +379,10 @@ function notFound() {
 export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverSrc = '', relatedBooks = []) {
     const canonicalUrl = `${BASE}/libro/${item.id}/${slug}`;
     const safeTitle    = escapeHtml(item.title);
+    // B11: los textos alternativos describen la portada sin arrastrar una
+    // autoría genérica del título comercial. El título almacenado, el slug,
+    // el canonical y la identidad de carrito permanecen intactos.
+    const safeImageTitle = escapeHtml(stripGenericAuthorMention(item.title) || item.title);
     // FICHAS-QUALITY-GUARD-1: 'Desconocido', 'Unknown', 'Varios autores'… no
     // son autoría. displayAuthor queda null y TODA superficie que dependa de
     // él (fila Autor, JSON-LD, WhatsApp, relacionados, meta description) omite
@@ -673,7 +677,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
   <meta property="og:description" content="${metaDesc}">
   <meta property="og:image"       content="${escapeHtml(socialImage)}">
   <meta property="og:image:secure_url" content="${escapeHtml(socialImage)}">
-  <meta property="og:image:alt"   content="Portada de ${safeTitle}">
+  <meta property="og:image:alt"   content="Portada de ${safeImageTitle}">
   <meta property="og:locale"      content="es_UY">
   <meta property="og:site_name"   content="Amado Libros">
 
@@ -681,7 +685,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
   <meta name="twitter:title"       content="${documentTitle} | Amado Libros">
   <meta name="twitter:description" content="${metaDesc}">
   <meta name="twitter:image"       content="${escapeHtml(socialImage)}">
-  <meta name="twitter:image:alt"   content="Portada de ${safeTitle}">
+  <meta name="twitter:image:alt"   content="Portada de ${safeImageTitle}">
 
   <script type="application/ld+json">${safeJson(schemaProduct)}</script>
   <script type="application/ld+json">${safeJson(schemaBreadcrumb)}</script>
@@ -902,7 +906,7 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
 </nav>
 
 <main>
-  ${renderGallery(images, safeTitle)}
+  ${renderGallery(images, safeImageTitle)}
   <div class="info">
     <h1>${safeTitle}</h1>
     ${inStock ? `<span class="badge in-stock">✓ En stock</span>` : ''}


### PR DESCRIPTION
## Objetivo

Primer control de B11 antes de ampliar el enriquecimiento: eliminar residuos como `De Desconocido` de los textos alternativos de la portada y de los metadatos sociales de imagen.

## Causa raíz

El middleware enriquecido reemplaza el H1, pero la galería SSR todavía construía sus `alt` desde el título comercial crudo. Por eso el texto genérico podía sobrevivir en portada principal, miniaturas, lightbox, Open Graph y Twitter.

## Cambio

- deriva un título exclusivo para imágenes mediante `stripGenericAuthorMention()`;
- lo usa en la galería y en `og:image:alt` / `twitter:image:alt`;
- agrega una regresión con un título realista que contiene `de Desconocido`.

## Guardas

- no modifica el título almacenado;
- no modifica slug ni canonical;
- no modifica precio, stock, ISBN, imágenes, carrito, checkout ni Merchant;
- no crea autoría sustituta;
- rama creada desde `main` en `24358f829c5e76ef56f300e520b9eedb6db0e5fb`.

## Estado

Draft. Ejecutar CI y Preview. No fusionar ni desplegar sin verificación y autorización posterior.