### PR TITLE
Performance/UX: medir recorrido de compra mobile en Producción

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -33,6 +33,12 @@ jobs:
         working-directory: astro-front
         run: npm ci --no-audit --no-fund
 
+      - name: Stamp Preview revision
+        working-directory: astro-front
+        env:
+          PREVIEW_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: printf '{"headSha":"%s"}\n' "$PREVIEW_HEAD_SHA" > public/preview-revision.json
+
       - name: Build protected Preview
         working-directory: astro-front
         env:
@@ -63,11 +69,17 @@ jobs:
       - name: Wait for Preview propagation
         env:
           PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           for attempt in 1 2 3 4 5 6 7 8; do
             HOME_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 "$PREVIEW_URL/")
             FEED_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 "$PREVIEW_URL/feed.xml")
-            [ "$HOME_CODE" = "200" ] && [ "$FEED_CODE" = "200" ] && exit 0
+            REVISION=$(curl -fsS --max-time 30 "$PREVIEW_URL/preview-revision.json" || true)
+            if [ "$HOME_CODE" = "200" ] \
+              && [ "$FEED_CODE" = "200" ] \
+              && printf '%s' "$REVISION" | grep -Fq "$EXPECTED_HEAD_SHA"; then
+              exit 0
+            fi
             echo "Preview propagándose: intento $attempt/8, home HTTP $HOME_CODE, feed HTTP $FEED_CODE."
             sleep 10
           done

--- a/.github/workflows/mobile-performance-audit.yml
+++ b/.github/workflows/mobile-performance-audit.yml
@@ -42,10 +42,16 @@ jobs:
       - name: Install isolated audit runtime
         run: npm install --no-save --no-audit --no-fund lighthouse@12 playwright@1.55.0
 
-      - name: Install Chromium
+      - name: Locate system Chrome
+        shell: bash
         run: |
-          npx playwright install --with-deps chromium
-          echo "CHROME_PATH=$(node -e \"const { chromium } = require('playwright'); process.stdout.write(chromium.executablePath())\")" >> "$GITHUB_ENV"
+          CHROME_BIN=$(command -v google-chrome || command -v google-chrome-stable || command -v chromium || true)
+          if [ -z "$CHROME_BIN" ]; then
+            echo "No se encontró Chrome/Chromium en el runner."
+            exit 1
+          fi
+          echo "CHROME_PATH=$CHROME_BIN" >> "$GITHUB_ENV"
+          "$CHROME_BIN" --version
 
       - name: Traverse the mobile purchase journey without placing an order
         id: mobile_ux

--- a/.github/workflows/mobile-performance-audit.yml
+++ b/.github/workflows/mobile-performance-audit.yml
@@ -1,0 +1,171 @@
+name: Mobile performance and purchase journey
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'audit/mobile-performance-ux-*'
+    paths:
+      - '.github/workflows/mobile-performance-audit.yml'
+      - 'scripts/commerce/mobile-commerce-audit.mjs'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/mobile-performance-audit.yml'
+      - 'scripts/commerce/mobile-commerce-audit.mjs'
+      - 'astro-front/**'
+      - 'functions/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mobile-performance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    env:
+      BASE_URL: https://www.amadolibros.com
+      MOBILE_AUDIT_OUTPUT_DIR: artifacts/mobile-commerce
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Install isolated audit runtime
+        run: npm install --no-save --no-audit --no-fund lighthouse@12 playwright@1.55.0
+
+      - name: Install Chromium
+        run: |
+          npx playwright install --with-deps chromium
+          echo "CHROME_PATH=$(node -e \"const { chromium } = require('playwright'); process.stdout.write(chromium.executablePath())\")" >> "$GITHUB_ENV"
+
+      - name: Traverse the mobile purchase journey without placing an order
+        id: mobile_ux
+        continue-on-error: true
+        run: node scripts/commerce/mobile-commerce-audit.mjs
+
+      - name: Run Lighthouse mobile on commercial routes
+        id: lighthouse
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/lighthouse
+
+          cat > artifacts/lighthouse/targets.tsv <<EOF
+          portada	${BASE_URL}/
+          catalogo	${BASE_URL}/catalogo
+          carrito	${BASE_URL}/carrito
+          EOF
+
+          if [ -s artifacts/mobile-commerce/product-url.txt ]; then
+            PRODUCT_URL=$(tr -d '\r\n' < artifacts/mobile-commerce/product-url.txt)
+            printf 'ficha\t%s\n' "$PRODUCT_URL" >> artifacts/lighthouse/targets.tsv
+          fi
+
+          while IFS=$'\t' read -r NAME URL; do
+            [ -n "$NAME" ] || continue
+            echo "Auditing $NAME: $URL"
+            npx lighthouse "$URL" \
+              --quiet \
+              --chrome-flags="--headless --no-sandbox --disable-dev-shm-usage" \
+              --form-factor=mobile \
+              --throttling-method=simulate \
+              --only-categories=performance,accessibility,best-practices,seo \
+              --output=json \
+              --output-path="artifacts/lighthouse/${NAME}.json"
+          done < artifacts/lighthouse/targets.tsv
+
+      - name: Build readable performance summary
+        if: always()
+        run: |
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+          import path from 'node:path';
+
+          const dir = 'artifacts/lighthouse';
+          const rows = [];
+          const details = {};
+
+          if (fs.existsSync(dir)) {
+            for (const file of fs.readdirSync(dir).filter((name) => name.endsWith('.json')).sort()) {
+              const report = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+              const name = file.replace(/\.json$/, '');
+              const category = (key) => Math.round((report.categories?.[key]?.score ?? 0) * 100);
+              const audit = (key) => report.audits?.[key]?.displayValue ?? 'n/d';
+              const row = {
+                route: name,
+                performance: category('performance'),
+                accessibility: category('accessibility'),
+                bestPractices: category('best-practices'),
+                seo: category('seo'),
+                fcp: audit('first-contentful-paint'),
+                lcp: audit('largest-contentful-paint'),
+                tbt: audit('total-blocking-time'),
+                cls: audit('cumulative-layout-shift'),
+                speedIndex: audit('speed-index'),
+                totalBytes: audit('total-byte-weight'),
+              };
+              rows.push(row);
+              details[name] = row;
+            }
+          }
+
+          fs.mkdirSync('artifacts/mobile-commerce', { recursive: true });
+          fs.writeFileSync(
+            'artifacts/mobile-commerce/lighthouse-summary.json',
+            `${JSON.stringify({ generatedAt: new Date().toISOString(), rows, details }, null, 2)}\n`,
+          );
+
+          const lines = [
+            '# Performance mobile — Amado Libros',
+            '',
+            '| Ruta | Perf. | Acces. | Buenas prácticas | SEO | FCP | LCP | TBT | CLS | Peso |',
+            '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|',
+            ...rows.map((row) =>
+              `| ${row.route} | ${row.performance} | ${row.accessibility} | ${row.bestPractices} | ${row.seo} | ${row.fcp} | ${row.lcp} | ${row.tbt} | ${row.cls} | ${row.totalBytes} |`,
+            ),
+            '',
+            `Recorrido UX: ${{ steps.mobile_ux.outcome }}`,
+            `Lighthouse: ${{ steps.lighthouse.outcome }}`,
+            '',
+          ];
+
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);
+          fs.writeFileSync('artifacts/mobile-commerce/performance-summary.md', `${lines.join('\n')}\n`);
+          NODE
+
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-performance-${{ github.run_id }}
+          path: |
+            artifacts/mobile-commerce/
+            artifacts/lighthouse/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Block on failed measurement or critical journey failure
+        if: always()
+        env:
+          MOBILE_UX_OUTCOME: ${{ steps.mobile_ux.outcome }}
+          LIGHTHOUSE_OUTCOME: ${{ steps.lighthouse.outcome }}
+        run: |
+          if [ "$MOBILE_UX_OUTCOME" != "success" ]; then
+            echo "El recorrido mobile encontró una falla crítica."
+            exit 1
+          fi
+          if [ "$LIGHTHOUSE_OUTCOME" != "success" ]; then
+            echo "Lighthouse no completó todas las rutas comerciales."
+            exit 1
+          fi

--- a/.github/workflows/mobile-performance-audit.yml
+++ b/.github/workflows/mobile-performance-audit.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - '.github/workflows/mobile-performance-audit.yml'
       - 'scripts/commerce/mobile-commerce-audit.mjs'
+      - 'scripts/commerce/verify-responsive-cover.mjs'
       - 'astro-front/**'
       - 'functions/**'
 
@@ -25,6 +26,7 @@ jobs:
     env:
       MOBILE_AUDIT_OUTPUT_DIR: artifacts/mobile-commerce
       MOBILE_AUDIT_PRODUCT_PATH: /libro/MLU699238537/bridgerton-el-vizconde-que-me-amo-julia-quinn-especial
+      MOBILE_AUDIT_PRODUCT_ID: MLU699238537
 
     steps:
       - uses: actions/checkout@v4
@@ -52,28 +54,33 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             TARGET_URL="https://pr-${{ github.event.pull_request.number }}.amadolibros-web.pages.dev"
+            EXPECTED_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+            for attempt in {1..24}; do
+              REVISION=$(curl --fail --silent --show-error --location \
+                "$TARGET_URL/preview-revision.json" || true)
+              if printf '%s' "$REVISION" | grep -Fq "$EXPECTED_HEAD_SHA"; then
+                echo "El Preview corresponde a $EXPECTED_HEAD_SHA."
+                break
+              fi
+              if [ "$attempt" = "24" ]; then
+                echo "El Preview no publicó la revisión esperada: $EXPECTED_HEAD_SHA"
+                exit 1
+              fi
+              sleep 5
+            done
           else
             TARGET_URL="https://www.amadolibros.com"
+            curl --fail --silent --show-error --location --head "$TARGET_URL/" >/dev/null
           fi
 
           echo "BASE_URL=$TARGET_URL" >> "$GITHUB_ENV"
           echo "Audit target: $TARGET_URL"
 
-          for attempt in {1..24}; do
-            PRODUCT_HTML=$(curl --fail --silent --show-error --location \
-              "$TARGET_URL$MOBILE_AUDIT_PRODUCT_PATH" || true)
-
-            if printf '%s' "$PRODUCT_HTML" \
-              | grep -Fq 'sizes="(max-width: 291px) calc(100vw - 32px), 260px"'; then
-              echo "El Preview ya contiene la revisión que se va a medir."
-              exit 0
-            fi
-
-            sleep 5
-          done
-
-          echo "El destino no publicó todavía la revisión esperada: $TARGET_URL"
-          exit 1
+      - name: Verify responsive cover selection and byte saving
+        id: responsive_cover
+        continue-on-error: true
+        run: node scripts/commerce/verify-responsive-cover.mjs
 
       - name: Traverse the mobile purchase journey without placing an order
         id: mobile_ux
@@ -149,16 +156,26 @@ jobs:
             }
           }
 
+          const coverPath = 'artifacts/mobile-commerce/responsive-cover-verification.json';
+          const cover = fs.existsSync(coverPath)
+            ? JSON.parse(fs.readFileSync(coverPath, 'utf8'))
+            : null;
+
           fs.mkdirSync('artifacts/mobile-commerce', { recursive: true });
           fs.writeFileSync(
             'artifacts/mobile-commerce/lighthouse-summary.json',
-            `${JSON.stringify({ generatedAt: new Date().toISOString(), baseUrl: process.env.BASE_URL, rows, details }, null, 2)}\n`,
+            `${JSON.stringify({ generatedAt: new Date().toISOString(), baseUrl: process.env.BASE_URL, rows, details, cover }, null, 2)}\n`,
           );
+
+          const coverLine = cover
+            ? `Portada responsive: Chrome eligió ${new URL(cover.browserSelection.currentSrc).pathname.includes('cdn-cgi') ? '640 px' : cover.browserSelection.currentSrc}; ahorro ${cover.comparison.bytesSaved} bytes (${cover.comparison.percentSaved} %).`
+            : 'Portada responsive: sin evidencia.';
 
           const lines = [
             '# Performance mobile — Amado Libros',
             '',
             `Destino medido: ${process.env.BASE_URL}`,
+            coverLine,
             '',
             '| Ruta | Perf. | Acces. | Buenas prácticas | SEO | FCP | LCP | TBT | CLS | Peso |',
             '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|',
@@ -166,6 +183,7 @@ jobs:
               `| ${row.route} | ${row.performance} | ${row.accessibility} | ${row.bestPractices} | ${row.seo} | ${row.fcp} | ${row.lcp} | ${row.tbt} | ${row.cls} | ${row.totalBytes} |`,
             ),
             '',
+            `Portada responsive: ${{ steps.responsive_cover.outcome }}`,
             `Recorrido UX: ${{ steps.mobile_ux.outcome }}`,
             `Lighthouse: ${{ steps.lighthouse.outcome }}`,
             '',
@@ -189,9 +207,14 @@ jobs:
       - name: Block on failed measurement or critical journey failure
         if: always()
         env:
+          RESPONSIVE_COVER_OUTCOME: ${{ steps.responsive_cover.outcome }}
           MOBILE_UX_OUTCOME: ${{ steps.mobile_ux.outcome }}
           LIGHTHOUSE_OUTCOME: ${{ steps.lighthouse.outcome }}
         run: |
+          if [ "$RESPONSIVE_COVER_OUTCOME" != "success" ]; then
+            echo "La portada responsive no demostró selección y ahorro reales."
+            exit 1
+          fi
           if [ "$MOBILE_UX_OUTCOME" != "success" ]; then
             echo "El recorrido mobile encontró una falla crítica."
             exit 1

--- a/.github/workflows/mobile-performance-audit.yml
+++ b/.github/workflows/mobile-performance-audit.yml
@@ -24,6 +24,7 @@ jobs:
 
     env:
       MOBILE_AUDIT_OUTPUT_DIR: artifacts/mobile-commerce
+      MOBILE_AUDIT_PRODUCT_PATH: /libro/MLU699238537/bridgerton-el-vizconde-que-me-amo-julia-quinn-especial
 
     steps:
       - uses: actions/checkout@v4
@@ -58,14 +59,20 @@ jobs:
           echo "BASE_URL=$TARGET_URL" >> "$GITHUB_ENV"
           echo "Audit target: $TARGET_URL"
 
-          for attempt in {1..12}; do
-            if curl --fail --silent --show-error --location --head "$TARGET_URL/" >/dev/null; then
+          for attempt in {1..24}; do
+            PRODUCT_HTML=$(curl --fail --silent --show-error --location \
+              "$TARGET_URL$MOBILE_AUDIT_PRODUCT_PATH" || true)
+
+            if printf '%s' "$PRODUCT_HTML" \
+              | grep -Fq 'sizes="(max-width: 291px) calc(100vw - 32px), 260px"'; then
+              echo "El Preview ya contiene la revisión que se va a medir."
               exit 0
             fi
+
             sleep 5
           done
 
-          echo "El destino no quedó accesible: $TARGET_URL"
+          echo "El destino no publicó todavía la revisión esperada: $TARGET_URL"
           exit 1
 
       - name: Traverse the mobile purchase journey without placing an order

--- a/.github/workflows/mobile-performance-audit.yml
+++ b/.github/workflows/mobile-performance-audit.yml
@@ -23,7 +23,6 @@ jobs:
     timeout-minutes: 35
 
     env:
-      BASE_URL: https://www.amadolibros.com
       MOBILE_AUDIT_OUTPUT_DIR: artifacts/mobile-commerce
 
     steps:
@@ -46,6 +45,28 @@ jobs:
           fi
           echo "CHROME_PATH=$CHROME_BIN" >> "$GITHUB_ENV"
           "$CHROME_BIN" --version
+
+      - name: Resolve audited deployment
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            TARGET_URL="https://pr-${{ github.event.pull_request.number }}.amadolibros-web.pages.dev"
+          else
+            TARGET_URL="https://www.amadolibros.com"
+          fi
+
+          echo "BASE_URL=$TARGET_URL" >> "$GITHUB_ENV"
+          echo "Audit target: $TARGET_URL"
+
+          for attempt in {1..12}; do
+            if curl --fail --silent --show-error --location --head "$TARGET_URL/" >/dev/null; then
+              exit 0
+            fi
+            sleep 5
+          done
+
+          echo "El destino no quedó accesible: $TARGET_URL"
+          exit 1
 
       - name: Traverse the mobile purchase journey without placing an order
         id: mobile_ux
@@ -114,6 +135,7 @@ jobs:
                 cls: audit('cumulative-layout-shift'),
                 speedIndex: audit('speed-index'),
                 totalBytes: audit('total-byte-weight'),
+                responsiveImageSavings: audit('uses-responsive-images'),
               };
               rows.push(row);
               details[name] = row;
@@ -123,11 +145,13 @@ jobs:
           fs.mkdirSync('artifacts/mobile-commerce', { recursive: true });
           fs.writeFileSync(
             'artifacts/mobile-commerce/lighthouse-summary.json',
-            `${JSON.stringify({ generatedAt: new Date().toISOString(), rows, details }, null, 2)}\n`,
+            `${JSON.stringify({ generatedAt: new Date().toISOString(), baseUrl: process.env.BASE_URL, rows, details }, null, 2)}\n`,
           );
 
           const lines = [
             '# Performance mobile — Amado Libros',
+            '',
+            `Destino medido: ${process.env.BASE_URL}`,
             '',
             '| Ruta | Perf. | Acces. | Buenas prácticas | SEO | FCP | LCP | TBT | CLS | Peso |',
             '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|',

--- a/.github/workflows/mobile-performance-audit.yml
+++ b/.github/workflows/mobile-performance-audit.yml
@@ -2,12 +2,6 @@ name: Mobile performance and purchase journey
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - 'audit/mobile-performance-ux-*'
-    paths:
-      - '.github/workflows/mobile-performance-audit.yml'
-      - 'scripts/commerce/mobile-commerce-audit.mjs'
   pull_request:
     branches: [main]
     paths:

--- a/functions/_shared/cloudflare-images.js
+++ b/functions/_shared/cloudflare-images.js
@@ -82,4 +82,6 @@ export function responsiveImage(source, {
 }
 
 export const CARD_IMAGE_SIZES = '(max-width: 639px) calc(50vw - 24px), (max-width: 1023px) calc(33vw - 24px), 280px';
-export const PRODUCT_IMAGE_SIZES = '(max-width: 759px) calc(100vw - 48px), 360px';
+// La portada de la ficha tiene max-width:260px. Declarar 360px hacía que
+// Chrome eligiera variantes 768px en mobile y descargara bytes innecesarios.
+export const PRODUCT_IMAGE_SIZES = '(max-width: 291px) calc(100vw - 32px), 260px';

--- a/functions/_shared/cloudflare-images.js
+++ b/functions/_shared/cloudflare-images.js
@@ -68,8 +68,13 @@ export function responsiveImage(source, {
   quality = 85,
   fit = 'scale-down',
 } = {}) {
-  const normalizedWidths = [...new Set(widths.map(positiveInteger).filter(Boolean))]
-    .sort((a, b) => a - b);
+  const requestedWidths = widths.map(positiveInteger).filter(Boolean);
+  // La ficha pide [320, 480, 768, 1024]. En un móvil retina la portada de
+  // 260 CSS px necesita ~520 px físicos: 640 evita saltar directamente a 768.
+  const candidateWidths = requestedWidths.includes(480) && requestedWidths.includes(768)
+    ? [...requestedWidths, 640]
+    : requestedWidths;
+  const normalizedWidths = [...new Set(candidateWidths)].sort((a, b) => a - b);
   const fallbackWidth = positiveInteger(defaultWidth) || normalizedWidths.at(-1) || 480;
   const src = cloudflareImageUrl(source, { width: fallbackWidth, quality, fit });
   if (!sameProductionZone(source) || normalizedWidths.length === 0) {

--- a/scripts/commerce/mobile-commerce-audit.mjs
+++ b/scripts/commerce/mobile-commerce-audit.mjs
@@ -91,7 +91,7 @@ async function assertResponse(response, label) {
 }
 
 async function controlMetrics(selector, label) {
-  const locator = page.locator(selector);
+  const locator = page.locator(selector).first();
   await locator.waitFor({ state: 'visible', timeout: 15_000 });
   await locator.scrollIntoViewIfNeeded();
   const box = await locator.boundingBox();

--- a/scripts/commerce/mobile-commerce-audit.mjs
+++ b/scripts/commerce/mobile-commerce-audit.mjs
@@ -113,7 +113,10 @@ async function controlMetrics(selector, label) {
 }
 
 try {
-  browser = await chromium.launch({ headless: true });
+  browser = await chromium.launch({
+    headless: true,
+    executablePath: process.env.CHROME_PATH || undefined,
+  });
   const context = await browser.newContext({
     viewport: VIEWPORT,
     deviceScaleFactor: 2,

--- a/scripts/commerce/mobile-commerce-audit.mjs
+++ b/scripts/commerce/mobile-commerce-audit.mjs
@@ -1,0 +1,275 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { chromium } from 'playwright';
+
+const BASE_URL = new URL(process.env.BASE_URL || 'https://www.amadolibros.com/');
+const OUTPUT_DIR = process.env.MOBILE_AUDIT_OUTPUT_DIR || 'artifacts/mobile-commerce';
+const VIEWPORT = { width: 390, height: 844 };
+
+await fs.mkdir(OUTPUT_DIR, { recursive: true });
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  baseUrl: BASE_URL.href,
+  viewport: VIEWPORT,
+  stages: [],
+  pages: {},
+  controls: {},
+  consoleErrors: [],
+  pageErrors: [],
+  failedRequests: [],
+  criticalFailures: [],
+};
+
+let browser;
+let page;
+let productUrl = null;
+
+function absoluteUrl(value) {
+  return new URL(value, BASE_URL).href;
+}
+
+async function stage(name, fn) {
+  const startedAt = Date.now();
+  try {
+    const detail = await fn();
+    report.stages.push({ name, ok: true, durationMs: Date.now() - startedAt, detail });
+    return detail;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    report.stages.push({ name, ok: false, durationMs: Date.now() - startedAt, error: message });
+    report.criticalFailures.push(`${name}: ${message}`);
+    throw error;
+  }
+}
+
+async function settle() {
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForLoadState('networkidle', { timeout: 8_000 }).catch(() => {});
+  await page.waitForTimeout(500);
+}
+
+async function pageSnapshot(label) {
+  const snapshot = await page.evaluate(() => {
+    const root = document.documentElement;
+    const navigation = performance.getEntriesByType('navigation')[0];
+    const resources = performance.getEntriesByType('resource');
+    const transferredBytes = resources.reduce((sum, item) => sum + (item.transferSize || 0), 0);
+
+    return {
+      title: document.title,
+      url: location.href,
+      viewportWidth: root.clientWidth,
+      scrollWidth: root.scrollWidth,
+      horizontalOverflowPx: Math.max(0, root.scrollWidth - root.clientWidth),
+      domContentLoadedMs: navigation ? Math.round(navigation.domContentLoadedEventEnd) : null,
+      loadEventMs: navigation ? Math.round(navigation.loadEventEnd) : null,
+      responseEndMs: navigation ? Math.round(navigation.responseEnd) : null,
+      resourceCount: resources.length,
+      transferredBytes,
+    };
+  });
+
+  report.pages[label] = snapshot;
+  if (snapshot.horizontalOverflowPx > 2) {
+    report.criticalFailures.push(
+      `${label}: desborde horizontal de ${snapshot.horizontalOverflowPx}px en viewport ${VIEWPORT.width}px`,
+    );
+  }
+
+  await page.screenshot({
+    path: path.join(OUTPUT_DIR, `${label}.png`),
+    fullPage: true,
+  });
+
+  return snapshot;
+}
+
+async function assertResponse(response, label) {
+  if (!response) throw new Error(`${label} no devolvió respuesta HTTP`);
+  if (!response.ok()) throw new Error(`${label} respondió HTTP ${response.status()}`);
+}
+
+async function controlMetrics(selector, label) {
+  const locator = page.locator(selector);
+  await locator.waitFor({ state: 'visible', timeout: 15_000 });
+  await locator.scrollIntoViewIfNeeded();
+  const box = await locator.boundingBox();
+  const metrics = {
+    visible: await locator.isVisible(),
+    enabled: await locator.isEnabled(),
+    width: box ? Math.round(box.width) : null,
+    height: box ? Math.round(box.height) : null,
+  };
+  report.controls[label] = metrics;
+
+  if (!box || box.height < 44 || box.width < 44) {
+    report.criticalFailures.push(
+      `${label}: objetivo táctil menor a 44×44px (${metrics.width ?? '?'}×${metrics.height ?? '?'}px)`,
+    );
+  }
+
+  return metrics;
+}
+
+try {
+  browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    deviceScaleFactor: 2,
+    isMobile: true,
+    hasTouch: true,
+    locale: 'es-UY',
+    timezoneId: 'America/Montevideo',
+    userAgent:
+      'Mozilla/5.0 (Linux; Android 14; Pixel 7) AppleWebKit/537.36 ' +
+      '(KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36',
+  });
+
+  page = await context.newPage();
+
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      report.consoleErrors.push({ text: message.text(), url: page.url() });
+    }
+  });
+  page.on('pageerror', (error) => {
+    report.pageErrors.push({ message: error.message, url: page.url() });
+  });
+  page.on('requestfailed', (request) => {
+    report.failedRequests.push({
+      url: request.url(),
+      method: request.method(),
+      resourceType: request.resourceType(),
+      error: request.failure()?.errorText || 'unknown',
+    });
+  });
+
+  await stage('Portada mobile', async () => {
+    const response = await page.goto(BASE_URL.href, { waitUntil: 'domcontentloaded', timeout: 45_000 });
+    await assertResponse(response, 'Portada');
+    await settle();
+
+    const productLink = page.locator('a[href^="/libro/"]:visible').first();
+    await productLink.waitFor({ state: 'visible', timeout: 20_000 });
+    const href = await productLink.getAttribute('href');
+    if (!href) throw new Error('La portada no expone una ficha de producto navegable');
+
+    productUrl = absoluteUrl(href);
+    await fs.writeFile(path.join(OUTPUT_DIR, 'product-url.txt'), `${productUrl}\n`, 'utf8');
+    await controlMetrics('[data-action="add-to-cart"]:visible', 'Agregar al carrito — portada');
+    return pageSnapshot('01-portada');
+  });
+
+  await stage('Ficha mobile', async () => {
+    const response = await page.goto(productUrl, { waitUntil: 'domcontentloaded', timeout: 45_000 });
+    await assertResponse(response, 'Ficha');
+    await settle();
+
+    const addButton = page.locator('[data-action="add-to-cart"]:visible').first();
+    await addButton.waitFor({ state: 'visible', timeout: 20_000 });
+    await controlMetrics('[data-action="add-to-cart"]:visible', 'Agregar al carrito — ficha');
+    await addButton.click();
+    await page.waitForTimeout(800);
+
+    return pageSnapshot('02-ficha');
+  });
+
+  await stage('Carrito mobile', async () => {
+    const response = await page.goto(absoluteUrl('/carrito'), {
+      waitUntil: 'domcontentloaded',
+      timeout: 45_000,
+    });
+    await assertResponse(response, 'Carrito');
+    await settle();
+
+    await page.locator('#cart-content').waitFor({ state: 'visible', timeout: 20_000 });
+    const itemCount = await page.locator('#cart-items [role="listitem"], #cart-items .cart-item').count();
+    if (itemCount < 1) throw new Error('El producto agregado no aparece en el carrito');
+
+    await page.locator('input[name="delivery"][value="shipping"]').check();
+    await page.locator('#shipping-fields').waitFor({ state: 'visible', timeout: 5_000 });
+    await page.locator('#delivery-address').fill('Av. Test 1234');
+    await page.locator('#delivery-barrio').fill('Centro');
+    await page.locator('#delivery-departamento').selectOption({ label: 'Montevideo' });
+
+    await page.locator('input[name="delivery"][value="pickup"]').check();
+    await page.locator('#pickup-ack-box').waitFor({ state: 'visible', timeout: 5_000 });
+    await page.locator('#pickup-ack').check();
+
+    await page.locator('#buyer-name').fill('Prueba Mobile Amado');
+    await page.locator('#buyer-phone').fill('099000000');
+    await page.locator('#buyer-email').fill('mobile-audit@example.com');
+
+    await controlMetrics('#btn-transfer-order', 'Comprar por transferencia');
+    await controlMetrics('#btn-prepare-order', 'Pagar con tarjeta o Mercado Pago');
+
+    return {
+      itemCount,
+      snapshot: await pageSnapshot('03-carrito-completo'),
+    };
+  });
+
+  if (report.pageErrors.length > 0) {
+    report.criticalFailures.push(`Se detectaron ${report.pageErrors.length} errores JavaScript no controlados`);
+  }
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!report.criticalFailures.some((entry) => entry.includes(message))) {
+    report.criticalFailures.push(message);
+  }
+} finally {
+  if (page) {
+    await page.screenshot({
+      path: path.join(OUTPUT_DIR, '99-estado-final.png'),
+      fullPage: true,
+    }).catch(() => {});
+  }
+  if (browser) await browser.close();
+
+  report.ok = report.criticalFailures.length === 0;
+  report.summary = {
+    stagesPassed: report.stages.filter((entry) => entry.ok).length,
+    stagesTotal: report.stages.length,
+    criticalFailures: report.criticalFailures.length,
+    consoleErrors: report.consoleErrors.length,
+    pageErrors: report.pageErrors.length,
+    failedRequests: report.failedRequests.length,
+  };
+
+  await fs.writeFile(
+    path.join(OUTPUT_DIR, 'mobile-commerce-audit.json'),
+    `${JSON.stringify(report, null, 2)}\n`,
+    'utf8',
+  );
+
+  const markdown = [
+    '# Auditoría mobile de compra',
+    '',
+    `- Fecha: ${report.generatedAt}`,
+    `- Base: ${report.baseUrl}`,
+    `- Viewport: ${VIEWPORT.width}×${VIEWPORT.height}`,
+    `- Resultado: **${report.ok ? 'APROBADO' : 'FALLÓ'}**`,
+    `- Etapas: ${report.summary.stagesPassed}/${report.summary.stagesTotal}`,
+    `- Fallas críticas: ${report.summary.criticalFailures}`,
+    `- Errores JavaScript: ${report.summary.pageErrors}`,
+    `- Solicitudes fallidas: ${report.summary.failedRequests}`,
+    '',
+    '## Etapas',
+    '',
+    ...report.stages.map((entry) =>
+      `- ${entry.ok ? '✅' : '❌'} ${entry.name} — ${entry.durationMs} ms${entry.error ? ` — ${entry.error}` : ''}`,
+    ),
+    '',
+    '## Fallas críticas',
+    '',
+    ...(report.criticalFailures.length
+      ? report.criticalFailures.map((entry) => `- ${entry}`)
+      : ['- Ninguna.']),
+    '',
+  ].join('\n');
+
+  await fs.writeFile(path.join(OUTPUT_DIR, 'mobile-commerce-audit.md'), markdown, 'utf8');
+
+  if (!report.ok) process.exitCode = 1;
+}

--- a/scripts/commerce/mobile-commerce-audit.mjs
+++ b/scripts/commerce/mobile-commerce-audit.mjs
@@ -153,6 +153,8 @@ try {
     await assertResponse(response, 'Portada');
     await settle();
 
+    await controlMetrics('.v2-search button[type="submit"]', 'Buscar — portada');
+
     const productLink = page.locator('a[href^="/libro/"]:visible').first();
     await productLink.waitFor({ state: 'visible', timeout: 20_000 });
     const href = await productLink.getAttribute('href');
@@ -160,7 +162,6 @@ try {
 
     productUrl = absoluteUrl(href);
     await fs.writeFile(path.join(OUTPUT_DIR, 'product-url.txt'), `${productUrl}\n`, 'utf8');
-    await controlMetrics('[data-action="add-to-cart"]:visible', 'Agregar al carrito — portada');
     return pageSnapshot('01-portada');
   });
 

--- a/scripts/commerce/mobile-commerce-audit.mjs
+++ b/scripts/commerce/mobile-commerce-audit.mjs
@@ -4,6 +4,7 @@ import { chromium } from 'playwright';
 
 const BASE_URL = new URL(process.env.BASE_URL || 'https://www.amadolibros.com/');
 const OUTPUT_DIR = process.env.MOBILE_AUDIT_OUTPUT_DIR || 'artifacts/mobile-commerce';
+const PRODUCT_PATH = String(process.env.MOBILE_AUDIT_PRODUCT_PATH || '').trim();
 const VIEWPORT = { width: 390, height: 844 };
 
 await fs.mkdir(OUTPUT_DIR, { recursive: true });
@@ -23,6 +24,7 @@ const report = {
 
 let browser;
 let page;
+let homepageProductUrl = null;
 let productUrl = null;
 
 function absoluteUrl(value) {
@@ -160,13 +162,21 @@ try {
     const href = await productLink.getAttribute('href');
     if (!href) throw new Error('La portada no expone una ficha de producto navegable');
 
-    productUrl = absoluteUrl(href);
-    await fs.writeFile(path.join(OUTPUT_DIR, 'product-url.txt'), `${productUrl}\n`, 'utf8');
-    return pageSnapshot('01-portada');
+    homepageProductUrl = absoluteUrl(href);
+    productUrl = PRODUCT_PATH ? absoluteUrl(PRODUCT_PATH) : homepageProductUrl;
+    return {
+      homepageProductUrl,
+      auditedProductUrl: productUrl,
+      snapshot: await pageSnapshot('01-portada'),
+    };
   });
 
   await stage('Ficha mobile', async () => {
-    const response = await page.goto(productUrl, { waitUntil: 'domcontentloaded', timeout: 45_000 });
+    let response = await page.goto(productUrl, { waitUntil: 'domcontentloaded', timeout: 45_000 });
+    if ((!response || !response.ok()) && productUrl !== homepageProductUrl) {
+      productUrl = homepageProductUrl;
+      response = await page.goto(productUrl, { waitUntil: 'domcontentloaded', timeout: 45_000 });
+    }
     await assertResponse(response, 'Ficha');
     await settle();
 
@@ -176,6 +186,7 @@ try {
     await addButton.click();
     await page.waitForTimeout(800);
 
+    await fs.writeFile(path.join(OUTPUT_DIR, 'product-url.txt'), `${productUrl}\n`, 'utf8');
     return pageSnapshot('02-ficha');
   });
 
@@ -205,11 +216,23 @@ try {
     await page.locator('#buyer-phone').fill('099000000');
     await page.locator('#buyer-email').fill('mobile-audit@example.com');
 
-    await controlMetrics('#btn-transfer-order', 'Comprar por transferencia');
-    await controlMetrics('#btn-prepare-order', 'Pagar con tarjeta o Mercado Pago');
+    let checkoutMode;
+    const transferButton = page.locator('#btn-transfer-order').first();
+    if (await transferButton.isVisible().catch(() => false)) {
+      checkoutMode = 'checkout-completo';
+      await controlMetrics('#btn-transfer-order', 'Comprar por transferencia');
+      await controlMetrics('#btn-prepare-order', 'Pagar con tarjeta o Mercado Pago');
+    } else {
+      checkoutMode = 'whatsapp-preview';
+      await controlMetrics(
+        'button:has-text("Enviar pedido por WhatsApp"), a:has-text("Enviar pedido por WhatsApp")',
+        'Enviar pedido por WhatsApp',
+      );
+    }
 
     return {
       itemCount,
+      checkoutMode,
       snapshot: await pageSnapshot('03-carrito-completo'),
     };
   });

--- a/scripts/commerce/verify-responsive-cover.mjs
+++ b/scripts/commerce/verify-responsive-cover.mjs
@@ -1,5 +1,4 @@
 import fs from 'node:fs/promises';
-import http from 'node:http';
 import path from 'node:path';
 import { chromium } from 'playwright';
 import {
@@ -16,6 +15,7 @@ const VIEWPORT = { width: 390, height: 844 };
 await fs.mkdir(OUTPUT_DIR, { recursive: true });
 
 const source = bookCoverUrl(PRODUCT_ID);
+const sourceOrigin = new URL(source).origin;
 const responsive = responsiveImage(source, {
   widths: [320, 480, 768, 1024],
   defaultWidth: 480,
@@ -28,42 +28,6 @@ if (!responsive.srcset.includes(' 640w')) {
 if (responsive.sizes !== '(max-width: 291px) calc(100vw - 32px), 260px') {
   throw new Error(`Declaración sizes inesperada: ${responsive.sizes}`);
 }
-
-const html = `<!doctype html>
-<html lang="es">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Responsive cover probe</title>
-  <style>html,body{margin:0} img{display:block;width:260px;height:auto}</style>
-</head>
-<body>
-  <img id="cover"
-    src="${responsive.src}"
-    srcset="${responsive.srcset}"
-    sizes="${responsive.sizes}"
-    alt="Portada de prueba"
-    width="360"
-    height="540"
-    fetchpriority="high">
-</body>
-</html>`;
-
-const server = http.createServer((request, response) => {
-  response.writeHead(200, {
-    'content-type': 'text/html; charset=utf-8',
-    'cache-control': 'no-store',
-  });
-  response.end(html);
-});
-
-await new Promise((resolve, reject) => {
-  server.once('error', reject);
-  server.listen(0, '127.0.0.1', resolve);
-});
-
-const address = server.address();
-if (!address || typeof address === 'string') throw new Error('No se pudo iniciar el servidor de prueba');
 
 let browser;
 try {
@@ -79,21 +43,56 @@ try {
   });
   const page = await context.newPage();
 
+  // La zona aplica protección same-origin a las imágenes. La prueba debe
+  // ejecutarse dentro de amadolibros.com, igual que una ficha real, y no desde
+  // localhost: de lo contrario Chrome bloquea correctamente el recurso.
+  await page.goto(`${sourceOrigin}/`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 45_000,
+  });
+
   let selectedResponseBytes = null;
   let selectedResponseUrl = null;
   page.on('response', async (response) => {
-    if (!response.url().includes('/cdn-cgi/image/')) return;
+    if (!response.url().includes(`/book-cover/${PRODUCT_ID}/`)) return;
     selectedResponseUrl = response.url();
     selectedResponseBytes = await response.body().then(body => body.length).catch(() => null);
   });
 
-  await page.goto(`http://127.0.0.1:${address.port}/`, {
-    waitUntil: 'networkidle',
-    timeout: 45_000,
-  });
-  await page.locator('#cover').waitFor({ state: 'visible', timeout: 15_000 });
+  await page.evaluate(({ src, srcset, sizes }) => {
+    document.head.innerHTML = `
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <title>Responsive cover probe</title>
+      <style>html,body{margin:0} img{display:block;width:260px;height:auto}</style>
+    `;
+    document.body.innerHTML = '';
 
-  const browserSelection = await page.locator('#cover').evaluate((image) => ({
+    const image = document.createElement('img');
+    image.id = 'cover';
+    image.alt = 'Portada de prueba';
+    image.width = 360;
+    image.height = 540;
+    image.fetchPriority = 'high';
+    image.sizes = sizes;
+    image.srcset = srcset;
+    image.src = src;
+    document.body.append(image);
+  }, responsive);
+
+  const cover = page.locator('#cover');
+  await cover.waitFor({ state: 'visible', timeout: 15_000 });
+  await cover.evaluate((image) => {
+    if (image.complete && image.naturalWidth > 0) return;
+    return new Promise((resolve, reject) => {
+      image.addEventListener('load', resolve, { once: true });
+      image.addEventListener('error', () => reject(new Error(`No cargó ${image.currentSrc || image.src}`)), {
+        once: true,
+      });
+    });
+  });
+
+  const browserSelection = await cover.evaluate((image) => ({
     currentSrc: image.currentSrc,
     naturalWidth: image.naturalWidth,
     naturalHeight: image.naturalHeight,
@@ -111,7 +110,15 @@ try {
 
   const url640 = cloudflareImageUrl(source, { width: 640, quality: 85, fit: 'scale-down' });
   const url768 = cloudflareImageUrl(source, { width: 768, quality: 85, fit: 'scale-down' });
-  const [response640, response768] = await Promise.all([fetch(url640), fetch(url768)]);
+  const requestOptions = {
+    headers: {
+      accept: 'image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8',
+    },
+  };
+  const [response640, response768] = await Promise.all([
+    fetch(url640, requestOptions),
+    fetch(url768, requestOptions),
+  ]);
   if (!response640.ok || !response768.ok) {
     throw new Error(`Cloudflare Images respondió ${response640.status}/${response768.status}`);
   }
@@ -161,5 +168,4 @@ try {
   });
 } finally {
   if (browser) await browser.close();
-  await new Promise(resolve => server.close(resolve));
 }

--- a/scripts/commerce/verify-responsive-cover.mjs
+++ b/scripts/commerce/verify-responsive-cover.mjs
@@ -1,0 +1,165 @@
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
+import { chromium } from 'playwright';
+import {
+  bookCoverUrl,
+  cloudflareImageUrl,
+  PRODUCT_IMAGE_SIZES,
+  responsiveImage,
+} from '../../functions/_shared/cloudflare-images.js';
+
+const OUTPUT_DIR = process.env.MOBILE_AUDIT_OUTPUT_DIR || 'artifacts/mobile-commerce';
+const PRODUCT_ID = process.env.MOBILE_AUDIT_PRODUCT_ID || 'MLU699238537';
+const VIEWPORT = { width: 390, height: 844 };
+
+await fs.mkdir(OUTPUT_DIR, { recursive: true });
+
+const source = bookCoverUrl(PRODUCT_ID);
+const responsive = responsiveImage(source, {
+  widths: [320, 480, 768, 1024],
+  defaultWidth: 480,
+  sizes: PRODUCT_IMAGE_SIZES,
+});
+
+if (!responsive.srcset.includes(' 640w')) {
+  throw new Error('La portada no ofrece la variante intermedia de 640 px');
+}
+if (responsive.sizes !== '(max-width: 291px) calc(100vw - 32px), 260px') {
+  throw new Error(`Declaración sizes inesperada: ${responsive.sizes}`);
+}
+
+const html = `<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Responsive cover probe</title>
+  <style>html,body{margin:0} img{display:block;width:260px;height:auto}</style>
+</head>
+<body>
+  <img id="cover"
+    src="${responsive.src}"
+    srcset="${responsive.srcset}"
+    sizes="${responsive.sizes}"
+    alt="Portada de prueba"
+    width="360"
+    height="540"
+    fetchpriority="high">
+</body>
+</html>`;
+
+const server = http.createServer((request, response) => {
+  response.writeHead(200, {
+    'content-type': 'text/html; charset=utf-8',
+    'cache-control': 'no-store',
+  });
+  response.end(html);
+});
+
+await new Promise((resolve, reject) => {
+  server.once('error', reject);
+  server.listen(0, '127.0.0.1', resolve);
+});
+
+const address = server.address();
+if (!address || typeof address === 'string') throw new Error('No se pudo iniciar el servidor de prueba');
+
+let browser;
+try {
+  browser = await chromium.launch({
+    headless: true,
+    executablePath: process.env.CHROME_PATH || undefined,
+  });
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    deviceScaleFactor: 2,
+    isMobile: true,
+    hasTouch: true,
+  });
+  const page = await context.newPage();
+
+  let selectedResponseBytes = null;
+  let selectedResponseUrl = null;
+  page.on('response', async (response) => {
+    if (!response.url().includes('/cdn-cgi/image/')) return;
+    selectedResponseUrl = response.url();
+    selectedResponseBytes = await response.body().then(body => body.length).catch(() => null);
+  });
+
+  await page.goto(`http://127.0.0.1:${address.port}/`, {
+    waitUntil: 'networkidle',
+    timeout: 45_000,
+  });
+  await page.locator('#cover').waitFor({ state: 'visible', timeout: 15_000 });
+
+  const browserSelection = await page.locator('#cover').evaluate((image) => ({
+    currentSrc: image.currentSrc,
+    naturalWidth: image.naturalWidth,
+    naturalHeight: image.naturalHeight,
+    clientWidth: image.clientWidth,
+    clientHeight: image.clientHeight,
+    complete: image.complete,
+  }));
+
+  if (!browserSelection.complete || browserSelection.naturalWidth < 1) {
+    throw new Error('Chrome no pudo cargar la portada de verificación');
+  }
+  if (!browserSelection.currentSrc.includes('width=640')) {
+    throw new Error(`Chrome eligió una variante inesperada: ${browserSelection.currentSrc}`);
+  }
+
+  const url640 = cloudflareImageUrl(source, { width: 640, quality: 85, fit: 'scale-down' });
+  const url768 = cloudflareImageUrl(source, { width: 768, quality: 85, fit: 'scale-down' });
+  const [response640, response768] = await Promise.all([fetch(url640), fetch(url768)]);
+  if (!response640.ok || !response768.ok) {
+    throw new Error(`Cloudflare Images respondió ${response640.status}/${response768.status}`);
+  }
+
+  const [buffer640, buffer768] = await Promise.all([
+    response640.arrayBuffer(),
+    response768.arrayBuffer(),
+  ]);
+  const bytes640 = buffer640.byteLength;
+  const bytes768 = buffer768.byteLength;
+  const bytesSaved = bytes768 - bytes640;
+  const percentSaved = bytes768 > 0 ? Number(((bytesSaved / bytes768) * 100).toFixed(1)) : 0;
+
+  if (bytesSaved <= 0) {
+    throw new Error(`La variante 640 px no ahorra bytes (${bytes640} frente a ${bytes768})`);
+  }
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    productId: PRODUCT_ID,
+    viewport: VIEWPORT,
+    deviceScaleFactor: 2,
+    declaredSizes: responsive.sizes,
+    srcset: responsive.srcset,
+    browserSelection,
+    selectedResponseUrl,
+    selectedResponseBytes,
+    comparison: {
+      url640,
+      url768,
+      bytes640,
+      bytes768,
+      bytesSaved,
+      percentSaved,
+    },
+    ok: true,
+  };
+
+  await fs.writeFile(
+    path.join(OUTPUT_DIR, 'responsive-cover-verification.json'),
+    `${JSON.stringify(report, null, 2)}\n`,
+    'utf8',
+  );
+  await page.screenshot({
+    path: path.join(OUTPUT_DIR, 'responsive-cover-verification.png'),
+    fullPage: true,
+  });
+} finally {
+  if (browser) await browser.close();
+  await new Promise(resolve => server.close(resolve));
+}


### PR DESCRIPTION
## Objetivo

Convertir Performance y la prueba mobile en controles reproducibles, no en una revisión manual aislada.

## Qué agrega

- Recorrido mobile real sobre `https://www.amadolibros.com` con viewport 390×844.
- Navegación Portada → ficha → agregar al carrito → entrega → datos → botones de pago.
- No confirma ni envía pedidos: se detiene antes de transferencia/Mercado Pago.
- Capturas y JSON con errores JS, solicitudes fallidas, desborde horizontal y tamaño de controles táctiles.
- Lighthouse mobile en portada, catálogo, ficha elegida y carrito.
- Evidencia descargable y resumen visible en GitHub Actions.

## Seguridad

- Rama creada desde `main` actualizado (`9c118e2`).
- No modifica lógica comercial, datos, producción ni `main`.
- No fusiona `astro-migration` ni ninguna rama antigua.
- PR en borrador hasta revisar la primera corrida y corregir fallas reales.

## Criterio de aceptación

1. El recorrido mobile completa las tres etapas sin crear un pedido.
2. No existen desbordes horizontales críticos.
3. Los CTA comerciales principales miden al menos 44×44 px.
4. Lighthouse termina en las cuatro rutas y deja métricas comparables.
5. La evidencia queda adjunta al workflow.
