### PR TITLE
B11: registrar cierre de PR #298 y bloqueo de red del Lote 1 (2.000 fichas)

### DIFF
--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -6,12 +6,20 @@
 
 | Métrica | Valor |
 | --- | --- |
-| Fichas procesadas (investigadas con evidencia real, este plan) | 2.257 (corrida 2, universo elegible completo tras excluir las 19 ya resueltas en la corrida 1) |
+| Universo inicial del Lote 1 (ISBN elegibles investigados) | 2.276 |
 | Fichas enriquecidas correctamente (verificadas, integradas en PR #303) | **187** (18 `GREEN_FULL` + 169 `GREEN_FACTS`) |
-| Fichas descartadas por falta de datos confiables | 1.533 (`NO_EVIDENCE`) + 556 en revisión por conflicto de identidad |
-| Fichas pendientes (universo total restante del catálogo, tras este lote) | 2.089 (2.257 − 168 nuevas de la corrida 2) |
+| Fichas pendientes totales | **2.089** |
+| — de las cuales SIN_DATOS (sin evidencia utilizable) | 1.533 |
+| — de las cuales REVISAR (evidencia con conflicto de identidad) | 556 |
 | PRs abiertos (lotes) | 1 — [PR #303](https://github.com/trexxeseba/amadolibros-web/pull/303) (draft, "no fusionar sin autorización de Seba") |
 | PRs fusionados (lotes) | 0 |
+
+Verificación: 187 + 2.089 = 2.276. 1.533 + 556 = 2.089. Los 556 REVISAR
+están **dentro** de los 2.089 pendientes, no se suman aparte.
+
+Total del catálogo (todos los lotes B11 hasta ahora): 1.339 ya enriquecidos
+antes del Lote 1 + 187 de este lote = **1.526 ISBN enriquecidos**. Universo
+addressable completo: 1.526 + 2.089 pendientes = **3.615 ISBN únicos**.
 
 ## Corrección de Google Books (aplicada y verificada)
 
@@ -24,9 +32,10 @@ Open Library/Google Books ampliados al universo elegible completo (2.276).
 
 **Resultado de la corrida 2** (`33513707088`, éxito, 57 min): Google Books
 pasó de 1/40 a **615/2.257** coincidencias exactas (71 errores, ya no por
-cuota agotada). Open Library: 1.071/2.257. BNE: 234/2.257.
-`GREEN_FULL` 1→17 nuevos, `GREEN_FACTS` 18→151 nuevos: de 19 a **187**
-ISBN verificados en total (+8,8×).
+cuota agotada; 2.257 = 2.276 menos las 19 ya resueltas en la corrida 1).
+Open Library: 1.071/2.257. BNE: 234/2.257. `GREEN_FULL` 1→17 nuevos,
+`GREEN_FACTS` 18→151 nuevos: de 19 a **187** ISBN verificados en total
+(+8,8×).
 
 **Bug encontrado y corregido en la propia corrida 2:** el script
 `book-intelligence-project.mjs` reescribe el archivo de hechos del lote
@@ -36,7 +45,7 @@ workflow. Se detectó antes de fusionar nada a `main`, se recuperaron los
 19 desde el commit `86bbec3` y se fusionaron sin ISBN duplicados: 187
 totales, verificado por test. El workflow se corrigió para que corridas
 futuras del mismo lote **acumulen** sobre el archivo existente en vez de
-pisarlo — evita que el mismo bug se repita en los lotes 2–10.
+pisarlo — evita que el mismo bug se repita en los lotes siguientes.
 
 ## Validación (todas corridas localmente sobre el head actual del PR #303)
 
@@ -46,8 +55,8 @@ pisarlo — evita que el mismo bug se repita en los lotes 2–10.
 - `bash scripts/validate-ci.sh` (build Preview + Producción, smoke
   checkout ON/OFF): **OK**.
 - `git diff --check`: sin errores.
-- CI/FICHAS/Preview de GitHub Actions: corriendo sobre el commit final
-  (la PR tarda unos minutos en sincronizar el nuevo head después del push).
+- CI de GitHub Actions sobre el commit final del PR #303: verificado, ver
+  sección de checks más abajo.
 
 ## Sigue sin haber sinopsis real
 
@@ -57,20 +66,17 @@ Ninguna de las 187 fichas tiene sinopsis: el pipeline masivo
 propio script, nunca copia una sinopsis externa. Conseguir sinopsis real
 (como el precedente Disney, PR #296) requiere lectura y redacción caso
 por caso de la evidencia ya obtenida (Google Books ahora sí trae
-`description` para varios de los 615 matches) — es el próximo paso una
-vez cerrado el Lote 1.
+`description` para varios de los 615 matches).
 
-## 🔴 El techo del catálogo sigue siendo el mismo hallazgo crítico
+## 🔴 El techo del catálogo sigue siendo el hallazgo crítico
 
-Universo total addressable: 1.339 (ya enriquecidos antes de este lote) +
-2.257 (restantes tras el Lote 1) = **3.596 ISBN únicos en todo el
-catálogo**. El objetivo de "2.000 fichas nuevas" sigue excediendo por
-mucho lo que el catálogo tiene para dar, incluso con Google Books
-funcionando: 187/2.257 (8,3%) en esta corrida es una mejora real de casi
-9× sobre el 0,8% anterior, pero para llegar a 2.000 haría falta agotar
-varias veces el universo restante, cosa que no es posible — cada ISBN
-sólo se puede enriquecer una vez. Ver detalle completo y opciones en
-`PLAN-MAESTRO.md`.
+3.615 ISBN únicos en todo el catálogo addressable. El objetivo original
+de "2.000 fichas nuevas" sigue excediendo por mucho lo que el catálogo
+tiene para dar: incluso con Google Books funcionando, este lote convirtió
+187/2.276 (8,2%) en verificado — una mejora real de ~9× sobre el 0,8%
+anterior — pero el techo absoluto no cambia. Ver `PLAN-MAESTRO.md` para
+el rediseño (B11.2) que reemplaza el objetivo fijo de 2.000 por un
+pipeline continuo con estados persistentes sobre el universo real.
 
 ## PR #298 — CERRADO
 

--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -1,6 +1,6 @@
 # ESTADO ACTUAL — B11: enriquecimiento editorial real (2.000 fichas)
 
-Última actualización: 2026-09-01 (sesión `session_014vUFN9BC9DEb3Nh1B477Ri`), tras verificar B11.2 Lote 01 en Producción.
+Última actualización: 2026-09-02 (sesión `session_014vUFN9BC9DEb3Nh1B477Ri`), tras verificar B11.2 Lote 02 en Producción.
 
 ## B11 Lote 1 — TERMINADO (fusionado y verificado en Producción)
 
@@ -26,13 +26,14 @@
 Verificación: 187 + 2.089 = 2.276. 1.533 + 556 = 2.089. Los 556 REVISAR
 están **dentro** de los 2.089 pendientes, no se suman aparte.
 
-Total del catálogo (todos los lotes B11 hasta ahora, incluido B11.2 Lote
-01): 1.339 ya enriquecidos antes del Lote 1 + 187 del Lote 1 + 12 de
-B11.2 Lote 01 = **1.538 ISBN enriquecidos**. Universo addressable
-completo: 1.538 + 2.077 pendientes (1.534 SIN_DATOS + 543 REVISAR) =
-**3.615 ISBN únicos** (sin cambios — el universo no crece, solo se
-reclasifican ISBN dentro de él). Ver la sección "B11.2 Lote 01" más abajo
-para el detalle y la evidencia de Producción.
+Total del catálogo (todos los lotes B11 hasta ahora, incluidos B11.2
+Lote 01 y Lote 02): 1.339 ya enriquecidos antes del Lote 1 + 187 del
+Lote 1 + 12 de B11.2 Lote 01 + 12 de B11.2 Lote 02 = **1.550 ISBN
+enriquecidos**. Universo addressable completo: 1.550 + 2.065 pendientes
+(1.541 SIN_DATOS + 524 REVISAR) = **3.615 ISBN únicos** (sin cambios —
+el universo no crece, solo se reclasifican ISBN dentro de él). Ver la
+sección "B11.2 Lote 02" más abajo para el detalle y la evidencia de
+Producción.
 
 ## Corrección de Google Books (aplicada y verificada)
 
@@ -171,6 +172,63 @@ por B11.1, sin tocar los 1.533 `SIN_DATOS`. Primer lote de 100 ISBN.
   1.538 enriquecidos + 2.077 pendientes = 3.615 — el universo total no
   cambia, sólo se movieron 12 ISBN de pendiente a enriquecido y 1 de
   REVISAR a SIN_DATOS.
+
+## B11.2 Lote 02 — TERMINADO (fusionado y verificado en Producción)
+
+Autorizado explícitamente por Seba el 2026-09-02, sobre los **siguientes
+100 ISBN** del pool REVISAR que quedaron sin intentar tras el lote 01.
+No tocó el pool SIN_DATOS.
+
+- Bug real encontrado y corregido antes de correr este lote: el filtro
+  de candidatos de `scripts/seo/b11-2-resolve-revisar.mjs` sólo excluía
+  ISBN ya `TERMINADO`, no los que habían quedado `REVISAR` o
+  `SIN_DATOS` en el lote 01. Como el script reutiliza la misma
+  evidencia inmutable (sin nuevas consultas externas), reintentar esos
+  ISBN da exactamente el mismo resultado — sin el fix, este lote habría
+  repetido los mismos 87 `REVISAR` + 1 `SIN_DATOS` del lote 01 en vez
+  de avanzar. Corregido para excluir cualquier ISBN con un estado
+  persistente previo, sin importar su status. Verificado: candidatos
+  disponibles antes de la corrida = 456 (= 556 − 100 ya intentados en
+  el lote 01), exacto.
+- Resultado real del lote 02: **12 TERMINADO** (integrados al
+  registry), **7 SIN_DATOS**, **81 siguen REVISAR**. Duración del
+  procesamiento: 0,1s.
+- Estado persistente acumulado en `artifacts/b11-2/state.json`: **200**
+  ISBN (100 lote 01 + 100 lote 02), sin solapamiento — `TERMINADO` 24,
+  `SIN_DATOS` 8, `REVISAR` 168.
+- [PR #306](https://github.com/trexxeseba/amadolibros-web/pull/306)
+  fusionado a `main` por trexxeseba (squash, commit `662c13c`),
+  2026-09-02.
+- Deploy to Cloudflare Pages sobre `662c13c`: `run 33581187859`,
+  **success**.
+- Full commerce production audit (dispatch manual, `sample_only=true`),
+  `run 33634575851`: **result=pass, critical=0** — catálogo 7.115
+  items, feed Merchant 3.702 items (0 críticos/warnings), 300/300
+  imágenes válidas (`r2-production`), 300/300 páginas verificadas.
+- Book enrichment live check contra Producción
+  (`https://www.amadolibros.com`), `run 33634584205`: **1.535
+  verified, 15 not_applicable, 0 failed** sobre el registry completo de
+  **1.550** ISBN (1.535 + 15 = 1.550, exacto).
+- Los 12 ISBN de este lote verificados individualmente contra
+  Producción, todos `verified`, cada uno con sus propios MLU reales y
+  sin mezcla de datos entre ISBN: `9781711054490` (MLU1031375038,
+  MLU1033790258), `9786074485905` (MLU638995253, MLU676667854),
+  `9788408039532` (MLU619139873, MLU663111902), `9788408239321`
+  (MLU1494561902, MLU1494066700), `9788408249436` (MLU668636662,
+  MLU668440964), `9788408257363` (MLU625847761, MLU654868116),
+  `9788408262770` (MLU620296782, MLU649316004), `9788411323000`
+  (MLU698429827), `9788412364163` (MLU660119936, MLU660297658),
+  `9788412440843` (MLU692240645, MLU692279433), `9788415292494`
+  (MLU634314472, MLU654449602), `9788415577133` (MLU685273682,
+  MLU685118228).
+- Tests: suite completa **1.052/1.052** + `validate-ci.sh` OK +
+  `git diff --check` limpio.
+- Contadores tras este lote: REVISAR-status = 87 (lote 01, sin tocar) +
+  356 (nunca intentados, 456 − 100) + 81 (lote 02, sin resolver) =
+  **524**. SIN_DATOS: 1.534 + 7 = **1.541**. Verificación: 524 + 1.541
+  = 2.065 pendientes; 1.550 enriquecidos + 2.065 pendientes = 3.615 —
+  el universo total no cambia, sólo se movieron 12 ISBN de pendiente a
+  enriquecido y 7 de REVISAR a SIN_DATOS.
 
 ## PR #298 — CERRADO
 

--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -1,77 +1,71 @@
 # ESTADO ACTUAL — B11: enriquecimiento editorial real (2.000 fichas)
 
-Última actualización: 2026-08-31 (sesión `session_014vUFN9BC9DEb3Nh1B477Ri`).
+Última actualización: 2026-09-01 (sesión `session_014vUFN9BC9DEb3Nh1B477Ri`).
 
 ## Contadores acumulados
 
 | Métrica | Valor |
 | --- | --- |
-| Fichas procesadas (evaluadas para este plan de 2.000) | 0 |
-| Fichas enriquecidas correctamente (redacción real publicada en este plan) | 0 |
-| Fichas descartadas por falta de datos confiables | 0 |
-| Fichas pendientes | 2.000 |
-| PRs abiertos (lotes) | 0 |
+| Fichas procesadas (investigadas con evidencia real, este plan) | 2.276 |
+| Fichas enriquecidas correctamente (verificadas, listas en PR) | 19 (18 `auto_publish_facts` + 1 `GREEN_FULL`) |
+| Fichas descartadas por falta de datos confiables | 2.043 (`NO_EVIDENCE`) + 214 en revisión por conflicto de identidad |
+| Fichas pendientes (universo total restante del catálogo) | 2.257 (2.276 investigadas − 19 ya resueltas) |
+| PRs abiertos (lotes) | 1 — [PR #303](https://github.com/trexxeseba/amadolibros-web/pull/303) (draft, "no fusionar sin autorización de Seba") |
 | PRs fusionados (lotes) | 0 |
 
-Estos contadores son del **plan de redacción de los 10 lotes**, no de la
-investigación previa: PR #298 dejó 2.000 ISBN investigados y clasificados en
-dossiers, pero con `publication_allowed: false` — ninguno fue redactado ni
-publicado. Ese trabajo es el insumo, no el resultado.
+Bloqueo de red del PR #300 resuelto: PR #301/#302 (infraestructura CI, ya
+fusionados) permiten correr la investigación real con Google Books, Open
+Library y BNE dentro de GitHub Actions y commitear el resultado al repo.
+Detalle en `PLAN-MAESTRO.md`.
+
+## 🔴 Hallazgo crítico — el objetivo de 2.000 fichas no es alcanzable tal como está planteado
+
+La corrida real del Lote 1 (workflow `b11-batch-research.yml`, run
+`33457523327`, PR #303) investigó **todo** el universo restante del
+catálogo, no solo una muestra:
+
+- **Universo total addressable:** 1.339 ISBN ya enriquecidos en lotes
+  previos (bíblias + 1000 + 333 + Disney) + **2.276 ISBN elegibles
+  restantes** (activos, vendibles, con ISBN válido, no enriquecidos
+  todavía) = **3.615 ISBN únicos en total en todo el catálogo.**
+- De esos 2.276 restantes, se investigaron los 2.276 (no hubo corte por
+  presupuesto): Google Books devolvió 1 coincidencia exacta (39 errores —
+  la autenticación WIF probablemente no está funcionando bien, a
+  diferencia de Open Library y BNE que dieron 0 errores); Open Library
+  encontró 507 coincidencias; BNE encontró 116.
+- Después de cruzar título/autor para descartar conflictos de identidad y
+  exigir evidencia suficiente por campo: **19 ISBN (0,8%) calificaron**
+  para publicación automática. 214 (9,4%) tienen alguna evidencia pero con
+  conflictos que exigen revisión humana caso por caso. 2.043 (89,8%) no
+  tienen ninguna evidencia utilizable en estas tres fuentes gratuitas.
+- **Ninguna de las 19 tiene sinopsis** (el campo que pediste primero). Son
+  solo hechos bibliográficos verificados (editorial, páginas, año, temas).
+  Ninguna fuente gratuita consultada trajo texto de contraportada/sinopsis
+  para estos ISBN — el tier `editorial_real_v1` (con sinopsis real) exige
+  además una fuente `source_edition` de editorial, que este pipeline
+  automatizado no genera solo.
+
+### Qué significa esto en números
+
+- El **techo absoluto** del catálogo entero (ya enriquecido + investigado
+  ahora) es 3.615 ISBN. Pedir "2.000 fichas **nuevas**" sobre un resto de
+  2.276 ya exige enriquecer el 88% de todo lo que queda — con estas tres
+  fuentes gratuitas, el rendimiento real es <1%.
+- Aunque se corrija el problema de Google Books y se investigue con más
+  presupuesto, no hay más ISBN que investigar: 2.276 es el 100% del resto
+  del catálogo, no una muestra parcial.
+- Llegar a 2.000 fichas con contenido editorial real (sinopsis incluida)
+  requeriría fuentes adicionales (sitios de editoriales/librerías por
+  ISBN, investigación caso por caso) que no son automatizables en bloque
+  al mismo ritmo — el precedente real (Disney tomo 11, PR #296) llevó
+  investigación dedicada para 1 solo ISBN.
+
+**No voy a inflar estos números ni inventar contenido para simular 2.000
+fichas.** Prefiero un plan más chico pero 100% real a uno grande y falso.
+Corté acá para plantearte la decisión en vez de seguir gastando corridas
+de CI persiguiendo un número que el catálogo no puede sostener.
 
 ## PR #298 — CERRADO
 
 Registrado como definitivamente cerrado y fusionado. Ver detalle completo en
 `PLAN-MAESTRO.md`. No requiere ninguna acción adicional.
-
-## 🔴 Bloqueo activo — impide iniciar el Lote 1
-
-Al intentar iniciar el Lote 1 (selección de 200 ISBN + investigación
-bibliográfica real) se verificó que **este entorno de ejecución no tiene
-salida de red hacia ninguna de las fuentes necesarias**:
-
-| Destino | Necesario para | Resultado |
-| --- | --- | --- |
-| `pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev` (`CATALOG_URL`, catálogo real del sitio) | Seleccionar las 2.000 fichas candidatas | Bloqueado por el proxy de egreso (403, política de organización) |
-| `openlibrary.org` | Investigación bibliográfica (fuente pública, sin API key) | Bloqueado por el proxy de egreso (403) |
-| `catalogo.bne.es` (Biblioteca Nacional de España) | Investigación bibliográfica (fuente pública, sin API key) | Bloqueado por el proxy de egreso (403) |
-| `www.googleapis.com` (Google Books) | Investigación bibliográfica | Alcanzable, pero **cuota diaria agotada** (`RESOURCE_EXHAUSTED`) para el proyecto configurado; no tengo una API key propia |
-| Librerías/editoriales (Casa del Libro, sitios de editoriales, etc.) | Fuentes `commercial_reference` / `publisher` para el tier `editorial_real_v1` | Bloqueado por el proxy de egreso (403) |
-| `productionresultssa17.blob.core.windows.net` (descarga del artifact de CI con los 2.000 dossiers ya investigados por PR #298, run `33388882918`) | Reutilizar la investigación ya hecha en CI en vez de repetirla | Bloqueado por el proxy de egreso (403) |
-
-Lo único con salida de red confirmada desde esta sesión es GitHub
-(`github.com`, `api.github.com`, `raw.githubusercontent.com`) y algunos
-registries de paquetes (npm, pypi). Probé además vía el tool `WebFetch`
-(no solo `curl`) y el bloqueo es el mismo: `EGRESS_BLOCKED` a nivel de
-proxy de la organización, no un límite de la herramienta.
-
-**Consecuencia real:** no puedo obtener el catálogo real, ni investigar
-bibliografía verificable, ni reutilizar los dossiers ya investigados por CI.
-Cualquier ficha "enriquecida" que produjera en este momento tendría que
-basarse en datos no verificables desde esta sesión — lo cual viola
-directamente la regla de no inventar contenido y de usar solo fuentes
-confiables.
-
-**No voy a fabricar contenido ni simular verificación para completar el
-contador.** Prefiero reportar 0/2.000 real antes que 2.000 falsos.
-
-### Opciones para desbloquear (una sola alcanza)
-
-1. Ampliar la política de red de este entorno (`env_01LJa9rxrtnhR4pwpabC8j7q`,
-   "Default - trusted network access") para permitir `openlibrary.org`,
-   `catalogo.bne.es`, el bucket R2 del catálogo y/o los dominios de
-   descarga de artifacts de GitHub Actions (`*.blob.core.windows.net`).
-2. Proveer una API key propia de Google Books con cuota disponible
-   (variable de entorno) — con eso alcanzaría una sola fuente reachable,
-   aunque seguiría faltando una segunda fuente independiente para el tier
-   `editorial_real_v1`.
-3. Ejecutar la investigación (o volver a correr el workflow
-   `book-editorial-real-2000.yml`) en un entorno con red abierta (por
-   ejemplo, GitHub Actions, que sí tiene salida completa) y dejar el
-   resultado como archivo commiteado en el repo o accesible por HTTPS desde
-   `github.com`/`raw.githubusercontent.com`, que sí son alcanzables desde
-   aquí.
-4. Indicar otra fuente de datos bibliográficos ya disponible dentro del
-   repo o accesible por GitHub que pueda usarse en lugar de las anteriores.
-
-En cuanto se resuelva el bloqueo, el Lote 1 arranca de inmediato sin pedir
-autorización adicional, según el flujo ya definido en `PLAN-MAESTRO.md`.

--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -1,69 +1,76 @@
 # ESTADO ACTUAL — B11: enriquecimiento editorial real (2.000 fichas)
 
-Última actualización: 2026-09-01 (sesión `session_014vUFN9BC9DEb3Nh1B477Ri`).
+Última actualización: 2026-09-01 (sesión `session_014vUFN9BC9DEb3Nh1B477Ri`), tras la 2ª corrida del Lote 1 con Google Books corregido.
 
 ## Contadores acumulados
 
 | Métrica | Valor |
 | --- | --- |
-| Fichas procesadas (investigadas con evidencia real, este plan) | 2.276 |
-| Fichas enriquecidas correctamente (verificadas, listas en PR) | 19 (18 `auto_publish_facts` + 1 `GREEN_FULL`) |
-| Fichas descartadas por falta de datos confiables | 2.043 (`NO_EVIDENCE`) + 214 en revisión por conflicto de identidad |
-| Fichas pendientes (universo total restante del catálogo) | 2.257 (2.276 investigadas − 19 ya resueltas) |
+| Fichas procesadas (investigadas con evidencia real, este plan) | 2.257 (corrida 2, universo elegible completo tras excluir las 19 ya resueltas en la corrida 1) |
+| Fichas enriquecidas correctamente (verificadas, integradas en PR #303) | **187** (18 `GREEN_FULL` + 169 `GREEN_FACTS`) |
+| Fichas descartadas por falta de datos confiables | 1.533 (`NO_EVIDENCE`) + 556 en revisión por conflicto de identidad |
+| Fichas pendientes (universo total restante del catálogo, tras este lote) | 2.089 (2.257 − 168 nuevas de la corrida 2) |
 | PRs abiertos (lotes) | 1 — [PR #303](https://github.com/trexxeseba/amadolibros-web/pull/303) (draft, "no fusionar sin autorización de Seba") |
 | PRs fusionados (lotes) | 0 |
 
-Bloqueo de red del PR #300 resuelto: PR #301/#302 (infraestructura CI, ya
-fusionados) permiten correr la investigación real con Google Books, Open
-Library y BNE dentro de GitHub Actions y commitear el resultado al repo.
-Detalle en `PLAN-MAESTRO.md`.
+## Corrección de Google Books (aplicada y verificada)
 
-## 🔴 Hallazgo crítico — el objetivo de 2.000 fichas no es alcanzable tal como está planteado
+La corrida 1 (`33457523327`) tenía Google Books casi inutilizable: 39/40
+pedidos con `HTTP 429`, circuit-breaker cortando el resto. Causa:
+concurrencia/ritmo (2 pedidos en paralelo, 1,1s de espera) excedía la
+cuota por segundo del proyecto GCP. Corrección aplicada en
+`b11-batch-research.yml`: concurrencia 1, delay 2s, presupuestos de BNE/
+Open Library/Google Books ampliados al universo elegible completo (2.276).
 
-La corrida real del Lote 1 (workflow `b11-batch-research.yml`, run
-`33457523327`, PR #303) investigó **todo** el universo restante del
-catálogo, no solo una muestra:
+**Resultado de la corrida 2** (`33513707088`, éxito, 57 min): Google Books
+pasó de 1/40 a **615/2.257** coincidencias exactas (71 errores, ya no por
+cuota agotada). Open Library: 1.071/2.257. BNE: 234/2.257.
+`GREEN_FULL` 1→17 nuevos, `GREEN_FACTS` 18→151 nuevos: de 19 a **187**
+ISBN verificados en total (+8,8×).
 
-- **Universo total addressable:** 1.339 ISBN ya enriquecidos en lotes
-  previos (bíblias + 1000 + 333 + Disney) + **2.276 ISBN elegibles
-  restantes** (activos, vendibles, con ISBN válido, no enriquecidos
-  todavía) = **3.615 ISBN únicos en total en todo el catálogo.**
-- De esos 2.276 restantes, se investigaron los 2.276 (no hubo corte por
-  presupuesto): Google Books devolvió 1 coincidencia exacta (39 errores —
-  la autenticación WIF probablemente no está funcionando bien, a
-  diferencia de Open Library y BNE que dieron 0 errores); Open Library
-  encontró 507 coincidencias; BNE encontró 116.
-- Después de cruzar título/autor para descartar conflictos de identidad y
-  exigir evidencia suficiente por campo: **19 ISBN (0,8%) calificaron**
-  para publicación automática. 214 (9,4%) tienen alguna evidencia pero con
-  conflictos que exigen revisión humana caso por caso. 2.043 (89,8%) no
-  tienen ninguna evidencia utilizable en estas tres fuentes gratuitas.
-- **Ninguna de las 19 tiene sinopsis** (el campo que pediste primero). Son
-  solo hechos bibliográficos verificados (editorial, páginas, año, temas).
-  Ninguna fuente gratuita consultada trajo texto de contraportada/sinopsis
-  para estos ISBN — el tier `editorial_real_v1` (con sinopsis real) exige
-  además una fuente `source_edition` de editorial, que este pipeline
-  automatizado no genera solo.
+**Bug encontrado y corregido en la propia corrida 2:** el script
+`book-intelligence-project.mjs` reescribe el archivo de hechos del lote
+desde cero con el manifest de la corrida actual — la corrida 2 pisó (no
+fusionó) los 19 ISBN de la corrida 1 en el archivo commiteado por el
+workflow. Se detectó antes de fusionar nada a `main`, se recuperaron los
+19 desde el commit `86bbec3` y se fusionaron sin ISBN duplicados: 187
+totales, verificado por test. El workflow se corrigió para que corridas
+futuras del mismo lote **acumulen** sobre el archivo existente en vez de
+pisarlo — evita que el mismo bug se repita en los lotes 2–10.
 
-### Qué significa esto en números
+## Validación (todas corridas localmente sobre el head actual del PR #303)
 
-- El **techo absoluto** del catálogo entero (ya enriquecido + investigado
-  ahora) es 3.615 ISBN. Pedir "2.000 fichas **nuevas**" sobre un resto de
-  2.276 ya exige enriquecer el 88% de todo lo que queda — con estas tres
-  fuentes gratuitas, el rendimiento real es <1%.
-- Aunque se corrija el problema de Google Books y se investigue con más
-  presupuesto, no hay más ISBN que investigar: 2.276 es el 100% del resto
-  del catálogo, no una muestra parcial.
-- Llegar a 2.000 fichas con contenido editorial real (sinopsis incluida)
-  requeriría fuentes adicionales (sitios de editoriales/librerías por
-  ISBN, investigación caso por caso) que no son automatizables en bloque
-  al mismo ritmo — el precedente real (Disney tomo 11, PR #296) llevó
-  investigación dedicada para 1 solo ISBN.
+- Tests focales (lote-01 + editorial-upgrades + 333 + boundary + 1000 +
+  cohort-2000): **20/20**.
+- Suite completa de Functions: **1.041/1.041**.
+- `bash scripts/validate-ci.sh` (build Preview + Producción, smoke
+  checkout ON/OFF): **OK**.
+- `git diff --check`: sin errores.
+- CI/FICHAS/Preview de GitHub Actions: corriendo sobre el commit final
+  (la PR tarda unos minutos en sincronizar el nuevo head después del push).
 
-**No voy a inflar estos números ni inventar contenido para simular 2.000
-fichas.** Prefiero un plan más chico pero 100% real a uno grande y falso.
-Corté acá para plantearte la decisión en vez de seguir gastando corridas
-de CI persiguiendo un número que el catálogo no puede sostener.
+## Sigue sin haber sinopsis real
+
+Ninguna de las 187 fichas tiene sinopsis: el pipeline masivo
+(`book-intelligence-project.mjs`) solo escribe hechos bibliográficos
+(editorial, páginas, idioma, año, temas) — por diseño explícito del
+propio script, nunca copia una sinopsis externa. Conseguir sinopsis real
+(como el precedente Disney, PR #296) requiere lectura y redacción caso
+por caso de la evidencia ya obtenida (Google Books ahora sí trae
+`description` para varios de los 615 matches) — es el próximo paso una
+vez cerrado el Lote 1.
+
+## 🔴 El techo del catálogo sigue siendo el mismo hallazgo crítico
+
+Universo total addressable: 1.339 (ya enriquecidos antes de este lote) +
+2.257 (restantes tras el Lote 1) = **3.596 ISBN únicos en todo el
+catálogo**. El objetivo de "2.000 fichas nuevas" sigue excediendo por
+mucho lo que el catálogo tiene para dar, incluso con Google Books
+funcionando: 187/2.257 (8,3%) en esta corrida es una mejora real de casi
+9× sobre el 0,8% anterior, pero para llegar a 2.000 haría falta agotar
+varias veces el universo restante, cosa que no es posible — cada ISBN
+sólo se puede enriquecer una vez. Ver detalle completo y opciones en
+`PLAN-MAESTRO.md`.
 
 ## PR #298 — CERRADO
 

--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -1,18 +1,27 @@
 # ESTADO ACTUAL — B11: enriquecimiento editorial real (2.000 fichas)
 
-Última actualización: 2026-09-01 (sesión `session_014vUFN9BC9DEb3Nh1B477Ri`), tras la 2ª corrida del Lote 1 con Google Books corregido.
+Última actualización: 2026-09-01 (sesión `session_014vUFN9BC9DEb3Nh1B477Ri`), tras verificar el Lote 1 en Producción.
+
+## B11 Lote 1 — TERMINADO (fusionado y verificado en Producción)
+
+- [PR #303](https://github.com/trexxeseba/amadolibros-web/pull/303) fusionado a `main` por trexxeseba (squash, commit `5b46f72`), 2026-09-01T16:55:06Z.
+- [PR #304](https://github.com/trexxeseba/amadolibros-web/pull/304) fusionado (infra de verificación manual contra cualquier `base_url`), commit `7be3b3931b`.
+- Deploy to Cloudflare Pages sobre `5b46f72`: `run 33534675172`, intento 2, **success** (el intento 1 falló solo en el job "Publish production paused/active catalog" por un `Recv failure: Connection reset by peer` transitorio de red; el job "Deploy" —build, Wrangler, smoke test— fue success desde el intento 1).
+- Full commerce production audit (dispatch manual, `sample_only=true`), `run 33544377442`: **result=pass, critical=0** — catálogo 7.128 items, feed Merchant 3.707 items (0 críticos/warnings), 300/300 imágenes válidas (`r2-production`), 300/300 páginas verificadas.
+- Book enrichment live check contra Producción (`https://www.amadolibros.com`), `run 33545168003`: **1.517 verified, 9 not_applicable, 0 failed** sobre el registry completo de 1.526 ISBN (incluidos los 187 del Lote 1). Los 9 `not_applicable` son ISBN del registry sin ninguna publicación MLU activa hoy — no es una falla, es la conservación correcta del dato para cuando vuelva a haber oferta.
+- Muestra de 12 ISBN del Lote 1 verificados individualmente contra Producción (mezcla de los 19 de la 1ª corrida y los 168 de la 2ª): `9788401039058`, `9788408214359`, `9788425427015`, `9788446056720`, `9788467975819`, `9780006551805`, `9780142410110`, `9780194053921`, `9780198338734`, `9780307951526`, `9780230490017`, `9780199640942` — los 12 con status `verified`, cada uno con sus propios MLU reales y sin mezcla de datos entre ISBN.
 
 ## Contadores acumulados
 
 | Métrica | Valor |
 | --- | --- |
 | Universo inicial del Lote 1 (ISBN elegibles investigados) | 2.276 |
-| Fichas enriquecidas correctamente (verificadas, integradas en PR #303) | **187** (18 `GREEN_FULL` + 169 `GREEN_FACTS`) |
+| Fichas enriquecidas correctamente (verificadas, en `main` y Producción) | **187** (18 `GREEN_FULL` + 169 `GREEN_FACTS`) |
 | Fichas pendientes totales | **2.089** |
 | — de las cuales SIN_DATOS (sin evidencia utilizable) | 1.533 |
 | — de las cuales REVISAR (evidencia con conflicto de identidad) | 556 |
-| PRs abiertos (lotes) | 1 — [PR #303](https://github.com/trexxeseba/amadolibros-web/pull/303) (draft, "no fusionar sin autorización de Seba") |
-| PRs fusionados (lotes) | 0 |
+| PRs abiertos (lotes) | 0 |
+| PRs fusionados (lotes) | 2 — [PR #303](https://github.com/trexxeseba/amadolibros-web/pull/303) (187 fichas), [PR #304](https://github.com/trexxeseba/amadolibros-web/pull/304) (infra de verificación) |
 
 Verificación: 187 + 2.089 = 2.276. 1.533 + 556 = 2.089. Los 556 REVISAR
 están **dentro** de los 2.089 pendientes, no se suman aparte.

--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -1,6 +1,6 @@
 # ESTADO ACTUAL — B11: enriquecimiento editorial real (2.000 fichas)
 
-Última actualización: 2026-09-01 (sesión `session_014vUFN9BC9DEb3Nh1B477Ri`), tras verificar el Lote 1 en Producción.
+Última actualización: 2026-09-01 (sesión `session_014vUFN9BC9DEb3Nh1B477Ri`), tras verificar B11.2 Lote 01 en Producción.
 
 ## B11 Lote 1 — TERMINADO (fusionado y verificado en Producción)
 
@@ -26,9 +26,13 @@
 Verificación: 187 + 2.089 = 2.276. 1.533 + 556 = 2.089. Los 556 REVISAR
 están **dentro** de los 2.089 pendientes, no se suman aparte.
 
-Total del catálogo (todos los lotes B11 hasta ahora): 1.339 ya enriquecidos
-antes del Lote 1 + 187 de este lote = **1.526 ISBN enriquecidos**. Universo
-addressable completo: 1.526 + 2.089 pendientes = **3.615 ISBN únicos**.
+Total del catálogo (todos los lotes B11 hasta ahora, incluido B11.2 Lote
+01): 1.339 ya enriquecidos antes del Lote 1 + 187 del Lote 1 + 12 de
+B11.2 Lote 01 = **1.538 ISBN enriquecidos**. Universo addressable
+completo: 1.538 + 2.077 pendientes (1.534 SIN_DATOS + 543 REVISAR) =
+**3.615 ISBN únicos** (sin cambios — el universo no crece, solo se
+reclasifican ISBN dentro de él). Ver la sección "B11.2 Lote 01" más abajo
+para el detalle y la evidencia de Producción.
 
 ## Corrección de Google Books (aplicada y verificada)
 
@@ -87,11 +91,10 @@ anterior — pero el techo absoluto no cambia. Ver `PLAN-MAESTRO.md` para
 el rediseño (B11.2) que reemplaza el objetivo fijo de 2.000 por un
 pipeline continuo con estados persistentes sobre el universo real.
 
-## B11.2 — pipeline continuo, Lote 01 (pool REVISAR)
+## B11.2 Lote 01 — TERMINADO (fusionado y verificado en Producción)
 
-Autorizado e iniciado 2026-09-01. [PR #305](https://github.com/trexxeseba/amadolibros-web/pull/305)
-(draft, no fusionado). Primer lote de 100 ISBN tomados del pool de 556
-`REVISAR`, sin tocar los 1.533 `SIN_DATOS`.
+Autorizado e iniciado 2026-09-01, sobre el pool de 556 `REVISAR` dejado
+por B11.1, sin tocar los 1.533 `SIN_DATOS`. Primer lote de 100 ISBN.
 
 - Regla aplicada: un ISBN pasa a `PUBLICABLE` cuando 2 fuentes
   independientes (Google Books/Open Library/BNE) coinciden entre sí en
@@ -104,16 +107,70 @@ Autorizado e iniciado 2026-09-01. [PR #305](https://github.com/trexxeseba/amadol
   del procesamiento: 0,1s.
 - Estado persistente commiteado en `artifacts/b11-2/state.json`
   (acumulativo, retomable, nunca reprocesa un `TERMINADO`).
-- Registry: 1.538 (1.526 + 12).
-- Bug real encontrado y corregido durante la construcción del resolver:
-  las URLs `infoLink`/`selfLink` de Google Books a veces vienen en
-  `http://`, no `https://`, y `validateBookEnrichment` exige `https`.
-  Sin la normalización (ya usada en `book-intelligence-project.mjs`,
-  faltaba replicarla acá) el resolver daba 0 resueltos en vez de 12.
-- Tests: 6/6 focales de B11.2 + 1.046/1.046 suite completa +
-  `validate-ci.sh` OK + `git diff --check` limpio.
-- Pendientes de REVISAR tras este lote: 556 − 12 − 1 = 543 (444 sin
-  tocar aún + 87 reintentados sin éxito en este lote).
+- [PR #305](https://github.com/trexxeseba/amadolibros-web/pull/305)
+  fusionado a `main` por trexxeseba (squash, commit `8d474bf`),
+  2026-09-01.
+- Dos bugs reales encontrados y corregidos durante la verificación
+  (ninguno tocó título/precio/stock/imágenes/datos comerciales, los
+  tres siguientes hallazgos son solo de la propia herramienta de
+  verificación/merge):
+  1. Las URLs `infoLink`/`selfLink` de Google Books a veces vienen en
+     `http://`, no `https://`, y `validateBookEnrichment` exige
+     `https`. Sin la normalización (ya usada en
+     `book-intelligence-project.mjs`, faltaba replicarla en el
+     resolver) el resolver daba 0 resueltos en vez de 12.
+  2. `applyBookEnrichment` mezclaba `bibliographic` con spread de
+     objeto: una clave ya presente en el ítem del catálogo (aunque
+     vacía, como suele traer MercadoLibre) tapaba el hecho verificado
+     en vez de sólo ganar cuando su propio valor es real —
+     inconsistente con el patrón que ya usan `publisher`/`pages`.
+     Corregido con test de regresión.
+  3. `book-enrichment-live-check.mjs` exigía que cada
+     `auto_publish_facts` introdujera al menos un campo visible nuevo
+     respecto al catálogo para considerarse "verificado". Con
+     evidencia real de CI se confirmó que no había corrupción de
+     datos: 8 de los 12 ISBN ya tenían en el catálogo el mismo valor
+     real que el hecho verificado (ej. `9780194501873`:
+     `publication_year "2015"` en ambos lados — hecho legítimamente
+     redundante), y el resto tenía un valor real distinto que el merge
+     correctamente no pisa (ej. catálogo con `"2222"`, un dato erróneo
+     del vendedor). Corregido: el gate ahora verifica que los hechos
+     que sí se aplicaron se rendericen bien, sin exigir novedad.
+- Deploy to Cloudflare Pages sobre `8d474bf`: `run 33558241703`,
+  **success** (el job "Publish production paused/active catalog" tardó
+  ~9 min pero terminó en verde; el resto —build, Wrangler, smoke
+  test— fue success desde el arranque).
+- Full commerce production audit (dispatch manual, `sample_only=true`),
+  `run 33559277806`: **result=pass, critical=0** — catálogo 7.128
+  items, feed Merchant 3.707 items (0 críticos/warnings), 300/300
+  imágenes válidas (`r2-production`), 300/300 páginas verificadas.
+- Book enrichment live check contra Producción
+  (`https://www.amadolibros.com`), `run 33559284981`: **1.529
+  verified, 9 not_applicable, 0 failed** sobre el registry completo de
+  **1.538** ISBN (1.529 + 9 = 1.538, exacto). Los 9 `not_applicable`
+  son los mismos ISBN sin publicación MLU activa ya vistos en la
+  verificación del Lote 1 — no es una falla nueva.
+- Los 12 ISBN de este lote verificados individualmente contra
+  Producción, todos `verified`, cada uno con sus propios MLU reales y
+  sin mezcla de datos entre ISBN: `9780194114226` (MLU637863473,
+  MLU674080904), `9780194419215` (MLU637824793, MLU1300310658,
+  MLU1299647170), `9780194501873` (MLU702908736, MLU702882796),
+  `9780194730952` (MLU675019228, MLU638287647), `9780230498181`
+  (MLU887472434, MLU653511723), `9781090348418` (MLU679894804),
+  `9781292268729` (MLU627781415), `9781292401133` (MLU628486908,
+  MLU636069230), `9781316627686` (MLU642033254, MLU658014430),
+  `9781456277161` (MLU684400158, MLU684374146), `9781557764256`
+  (MLU725474470, MLU730190378), `9781640951877` (MLU1467423248,
+  MLU1468208694).
+- Tests: 6/6 focales de B11.2 (+2 tests de regresión agregados durante
+  la verificación) + 1.048/1.048 suite completa + `validate-ci.sh` OK +
+  `git diff --check` limpio.
+- Pendientes de REVISAR tras este lote: 556 − 12 − 1 = **543** (444 sin
+  tocar aún + 87 reintentados sin éxito en este lote). SIN_DATOS:
+  1.533 + 1 = **1.534**. Verificación: 543 + 1.534 = 2.077 pendientes;
+  1.538 enriquecidos + 2.077 pendientes = 3.615 — el universo total no
+  cambia, sólo se movieron 12 ISBN de pendiente a enriquecido y 1 de
+  REVISAR a SIN_DATOS.
 
 ## PR #298 — CERRADO
 

--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -1,0 +1,77 @@
+# ESTADO ACTUAL — B11: enriquecimiento editorial real (2.000 fichas)
+
+Última actualización: 2026-08-31 (sesión `session_014vUFN9BC9DEb3Nh1B477Ri`).
+
+## Contadores acumulados
+
+| Métrica | Valor |
+| --- | --- |
+| Fichas procesadas (evaluadas para este plan de 2.000) | 0 |
+| Fichas enriquecidas correctamente (redacción real publicada en este plan) | 0 |
+| Fichas descartadas por falta de datos confiables | 0 |
+| Fichas pendientes | 2.000 |
+| PRs abiertos (lotes) | 0 |
+| PRs fusionados (lotes) | 0 |
+
+Estos contadores son del **plan de redacción de los 10 lotes**, no de la
+investigación previa: PR #298 dejó 2.000 ISBN investigados y clasificados en
+dossiers, pero con `publication_allowed: false` — ninguno fue redactado ni
+publicado. Ese trabajo es el insumo, no el resultado.
+
+## PR #298 — CERRADO
+
+Registrado como definitivamente cerrado y fusionado. Ver detalle completo en
+`PLAN-MAESTRO.md`. No requiere ninguna acción adicional.
+
+## 🔴 Bloqueo activo — impide iniciar el Lote 1
+
+Al intentar iniciar el Lote 1 (selección de 200 ISBN + investigación
+bibliográfica real) se verificó que **este entorno de ejecución no tiene
+salida de red hacia ninguna de las fuentes necesarias**:
+
+| Destino | Necesario para | Resultado |
+| --- | --- | --- |
+| `pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev` (`CATALOG_URL`, catálogo real del sitio) | Seleccionar las 2.000 fichas candidatas | Bloqueado por el proxy de egreso (403, política de organización) |
+| `openlibrary.org` | Investigación bibliográfica (fuente pública, sin API key) | Bloqueado por el proxy de egreso (403) |
+| `catalogo.bne.es` (Biblioteca Nacional de España) | Investigación bibliográfica (fuente pública, sin API key) | Bloqueado por el proxy de egreso (403) |
+| `www.googleapis.com` (Google Books) | Investigación bibliográfica | Alcanzable, pero **cuota diaria agotada** (`RESOURCE_EXHAUSTED`) para el proyecto configurado; no tengo una API key propia |
+| Librerías/editoriales (Casa del Libro, sitios de editoriales, etc.) | Fuentes `commercial_reference` / `publisher` para el tier `editorial_real_v1` | Bloqueado por el proxy de egreso (403) |
+| `productionresultssa17.blob.core.windows.net` (descarga del artifact de CI con los 2.000 dossiers ya investigados por PR #298, run `33388882918`) | Reutilizar la investigación ya hecha en CI en vez de repetirla | Bloqueado por el proxy de egreso (403) |
+
+Lo único con salida de red confirmada desde esta sesión es GitHub
+(`github.com`, `api.github.com`, `raw.githubusercontent.com`) y algunos
+registries de paquetes (npm, pypi). Probé además vía el tool `WebFetch`
+(no solo `curl`) y el bloqueo es el mismo: `EGRESS_BLOCKED` a nivel de
+proxy de la organización, no un límite de la herramienta.
+
+**Consecuencia real:** no puedo obtener el catálogo real, ni investigar
+bibliografía verificable, ni reutilizar los dossiers ya investigados por CI.
+Cualquier ficha "enriquecida" que produjera en este momento tendría que
+basarse en datos no verificables desde esta sesión — lo cual viola
+directamente la regla de no inventar contenido y de usar solo fuentes
+confiables.
+
+**No voy a fabricar contenido ni simular verificación para completar el
+contador.** Prefiero reportar 0/2.000 real antes que 2.000 falsos.
+
+### Opciones para desbloquear (una sola alcanza)
+
+1. Ampliar la política de red de este entorno (`env_01LJa9rxrtnhR4pwpabC8j7q`,
+   "Default - trusted network access") para permitir `openlibrary.org`,
+   `catalogo.bne.es`, el bucket R2 del catálogo y/o los dominios de
+   descarga de artifacts de GitHub Actions (`*.blob.core.windows.net`).
+2. Proveer una API key propia de Google Books con cuota disponible
+   (variable de entorno) — con eso alcanzaría una sola fuente reachable,
+   aunque seguiría faltando una segunda fuente independiente para el tier
+   `editorial_real_v1`.
+3. Ejecutar la investigación (o volver a correr el workflow
+   `book-editorial-real-2000.yml`) en un entorno con red abierta (por
+   ejemplo, GitHub Actions, que sí tiene salida completa) y dejar el
+   resultado como archivo commiteado en el repo o accesible por HTTPS desde
+   `github.com`/`raw.githubusercontent.com`, que sí son alcanzables desde
+   aquí.
+4. Indicar otra fuente de datos bibliográficos ya disponible dentro del
+   repo o accesible por GitHub que pueda usarse en lugar de las anteriores.
+
+En cuanto se resuelva el bloqueo, el Lote 1 arranca de inmediato sin pedir
+autorización adicional, según el flujo ya definido en `PLAN-MAESTRO.md`.

--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -87,6 +87,34 @@ anterior — pero el techo absoluto no cambia. Ver `PLAN-MAESTRO.md` para
 el rediseño (B11.2) que reemplaza el objetivo fijo de 2.000 por un
 pipeline continuo con estados persistentes sobre el universo real.
 
+## B11.2 — pipeline continuo, Lote 01 (pool REVISAR)
+
+Autorizado e iniciado 2026-09-01. [PR #305](https://github.com/trexxeseba/amadolibros-web/pull/305)
+(draft, no fusionado). Primer lote de 100 ISBN tomados del pool de 556
+`REVISAR`, sin tocar los 1.533 `SIN_DATOS`.
+
+- Regla aplicada: un ISBN pasa a `PUBLICABLE` cuando 2 fuentes
+  independientes (Google Books/Open Library/BNE) coinciden entre sí en
+  título normalizado + autor + editorial + año (un campo ausente en un
+  lado nunca cuenta como conflicto). Reutiliza evidencia ya investigada
+  por B11.1 — 0 llamadas de red nuevas.
+- Resultado real del lote 01: **12 TERMINADO** (integrados al
+  registry), **1 SIN_DATOS** (identidad confirmada, sin hechos con
+  evidencia suficiente para publicar), **87 siguen REVISAR**. Duración
+  del procesamiento: 0,1s.
+- Estado persistente commiteado en `artifacts/b11-2/state.json`
+  (acumulativo, retomable, nunca reprocesa un `TERMINADO`).
+- Registry: 1.538 (1.526 + 12).
+- Bug real encontrado y corregido durante la construcción del resolver:
+  las URLs `infoLink`/`selfLink` de Google Books a veces vienen en
+  `http://`, no `https://`, y `validateBookEnrichment` exige `https`.
+  Sin la normalización (ya usada en `book-intelligence-project.mjs`,
+  faltaba replicarla acá) el resolver daba 0 resueltos en vez de 12.
+- Tests: 6/6 focales de B11.2 + 1.046/1.046 suite completa +
+  `validate-ci.sh` OK + `git diff --check` limpio.
+- Pendientes de REVISAR tras este lote: 556 − 12 − 1 = 543 (444 sin
+  tocar aún + 87 reintentados sin éxito en este lote).
+
 ## PR #298 — CERRADO
 
 Registrado como definitivamente cerrado y fusionado. Ver detalle completo en

--- a/PLAN-MAESTRO.md
+++ b/PLAN-MAESTRO.md
@@ -83,7 +83,7 @@ enriquecidas.
 
 | Lote | Fichas | Rama | PR | Estado |
 | --- | --- | --- | --- | --- |
-| 1 | 1–200 | `b11/enriquecimiento-lote-01` | pendiente | bloqueado (ver ESTADO-ACTUAL.md) |
+| 1 | 187 reales (no 200; ver ESTADO-ACTUAL.md) | `b11/enriquecimiento-lote-01-ci` | [#303](https://github.com/trexxeseba/amadolibros-web/pull/303) (draft) | 187 ISBN verificados, sin sinopsis; tests locales en verde; no fusionar sin autorización |
 | 2 | 201–400 | `b11/enriquecimiento-lote-02` | pendiente | pendiente |
 | 3 | 401–600 | `b11/enriquecimiento-lote-03` | pendiente | pendiente |
 | 4 | 601–800 | `b11/enriquecimiento-lote-04` | pendiente | pendiente |

--- a/PLAN-MAESTRO.md
+++ b/PLAN-MAESTRO.md
@@ -110,7 +110,10 @@ enriquecidas.
 
 ## B11.2 — Pipeline continuo de enriquecimiento y resolución de conflictos
 
-Registrado el 2026-09-01. **Diseño únicamente — no ejecutado todavía.**
+Registrado el 2026-09-01, autorizado y en ejecución sobre el pool
+REVISAR. Lote 01: **12 TERMINADO, 1 SIN_DATOS, 87 REVISAR** —
+[PR #305](https://github.com/trexxeseba/amadolibros-web/pull/305)
+(draft, no fusionado). Detalle real en `ESTADO-ACTUAL.md`.
 Reemplaza la estructura fija de 10 lotes de 200 (que el Lote 1 ya mostró
 inviable: de 2.276 candidatos elegibles, solo 187 califican con las
 fuentes actuales) por un pipeline continuo dimensionado al rendimiento

--- a/PLAN-MAESTRO.md
+++ b/PLAN-MAESTRO.md
@@ -1,0 +1,111 @@
+# PLAN MAESTRO — B11: enriquecimiento editorial real del catálogo
+
+## Objetivo operativo
+
+Enriquecer 2.000 fichas reales del catálogo con información editorial
+verificable (sinopsis, descripción, temas, público, autoría, datos
+bibliográficos, FAQ específicas, metadatos SEO secundarios), organizado en
+**10 lotes consecutivos de 200 fichas**, cada uno en su propia rama y PR.
+
+No es un piloto. El objetivo es 2.000 fichas efectivamente implementadas,
+probadas y presentadas en PRs — no un plan ni un lote testimonial.
+
+## Historial verificado
+
+### PR #298 — cierre definitivo (registrado 2026-08-31)
+
+- **Título:** "B11: cohorte editorial real de 2.000 ISBN + preservar SEO curado"
+- **Rama:** `b11/editorial-real-2000-1` → `main`
+- **Estado:** `closed`, `merged: true`
+- **Merge commit:** `0c0ebf3848447365b87bd38147c4bc1f943f8309`
+- **Merged por:** trexxeseba, 2026-08-31T15:16:16Z
+- **Qué entregó:**
+  - Cambió la unidad de trabajo de B11 a "2.000 ISBN únicos por cohorte":
+    investigación bibliográfica real (Google Books, Open Library, BNE) sin
+    contar metadatos aislados como fichas editoriales completas.
+  - Generó 2.000 *dossiers* de investigación (estados: listo para
+    redacción, una sola fuente, contenido estructurado, conflicto de
+    identidad, sin evidencia) con `publication_allowed: false` explícito en
+    los 2.000 — ninguno se auto-publicó.
+  - Corrigió un bug real de producción: el middleware de vidriera
+    automática reprocesaba fichas editoriales curadas después del SSR,
+    duplicando contenido y pisando el copy SEO curado con texto genérico.
+  - Evidencia de CI: cohorte de 2.000 dossiers (`run 33388882918`), CI
+    general (`run 33391392044`), preview/auditorías (`run 33391392061`),
+    SEO baseline (`run 33391392073`), enrich 1000 ISBN (`run 33391392090`).
+- **Lo que el PR #298 NO hizo:** no redactó ni publicó copy editorial para
+  los 2.000 ISBN. Dejó la investigación lista como insumo (`next_action:
+  REDACT_AND_VALIDATE_EDITORIAL_REAL_V1` en los dossiers que calificaron),
+  bloqueada a propósito para publicación.
+
+### Precedentes de redacción real (antes de este plan)
+
+- PR #296 — Disney tomo 11 (ISBN 9791388034435): primer y único
+  enriquecimiento `editorial_real_v1` completo (sinopsis, highlights,
+  copy de decisión, meta description, merchant description) con 3 fuentes
+  verificadas (2 `exact_edition` + 1 `source_edition` editorial).
+- PR #293 — 333 ISBN con enriquecimiento factual (`auto_publish_facts`):
+  autor, editorial, páginas, idioma, formato — sin redacción de sinopsis.
+- Lote SEO psicología (`docs/seo/enrichment-batch-01-psychology.md`,
+  2026-08-14): 5 fichas con sinopsis real, seleccionadas cruzando archivo
+  de ventas de Mercado Libre — proceso manual, fuentes documentadas.
+
+## Arquitectura del pipeline (repo)
+
+- `scripts/seo/book-intelligence-research-run.mjs` /
+  `book-intelligence-sources.mjs` / `book-intelligence-bne.mjs`: adaptadores
+  de investigación (Google Books, Open Library, BNE).
+- `scripts/seo/book-editorial-cohort-2000.mjs`: selección + clasificación de
+  cohortes en dossiers, sin publicar.
+- `functions/_shared/book-enrichment-registry.js`: registro por ISBN-13 con
+  `validateBookEnrichment` — exige fuentes reales, URLs verificables,
+  fecha de verificación y trazabilidad. Nunca toca precio, stock, imágenes,
+  condición, slug, canonical ni checkout.
+- `functions/_shared/book-editorial-upgrades.js`: tier `editorial_real_v1`
+  (sinopsis + highlights + copy de decisión), el más exigente.
+- `functions/_shared/book-enrichment-facts-1000.js` /
+  `book-enrichment-facts-333.js`: tier `auto_publish_facts` (datos
+  bibliográficos verificados sin redacción de sinopsis).
+- `functions/__tests__/editorial-showcase-boundary.test.js`: evita que la
+  vidriera automática duplique o pise una ficha editorial curada.
+
+## Reglas absolutas (invariantes de todos los lotes)
+
+No modificar: título original/comercial, H1, slug, precio, stock,
+condición, imágenes, permalink, canonical, carrito ni identificadores
+comerciales. No inventar sinopsis, autores, características ni datos
+bibliográficos. No usar texto genérico sin sustento específico. No trabajar
+sobre `main`. Si una ficha no tiene información confiable suficiente:
+saltear y reemplazar por otra hasta completar 2.000 fichas efectivamente
+enriquecidas.
+
+## Estructura de los 10 lotes
+
+| Lote | Fichas | Rama | PR | Estado |
+| --- | --- | --- | --- | --- |
+| 1 | 1–200 | `b11/enriquecimiento-lote-01` | pendiente | bloqueado (ver ESTADO-ACTUAL.md) |
+| 2 | 201–400 | `b11/enriquecimiento-lote-02` | pendiente | pendiente |
+| 3 | 401–600 | `b11/enriquecimiento-lote-03` | pendiente | pendiente |
+| 4 | 601–800 | `b11/enriquecimiento-lote-04` | pendiente | pendiente |
+| 5 | 801–1000 | `b11/enriquecimiento-lote-05` | pendiente | pendiente |
+| 6 | 1001–1200 | `b11/enriquecimiento-lote-06` | pendiente | pendiente |
+| 7 | 1201–1400 | `b11/enriquecimiento-lote-07` | pendiente | pendiente |
+| 8 | 1401–1600 | `b11/enriquecimiento-lote-08` | pendiente | pendiente |
+| 9 | 1601–1800 | `b11/enriquecimiento-lote-09` | pendiente | pendiente |
+| 10 | 1801–2000 | `b11/enriquecimiento-lote-10` | pendiente | pendiente |
+
+## Flujo obligatorio por lote
+
+1. Rama nueva desde `main` actualizado.
+2. Selección de 200 ISBN priorizando: valor comercial/tráfico, fichas
+   pobres en contenido, ISBN identificable, datos bibliográficos
+   confiables reales. Descartar y reemplazar los que no califiquen.
+3. Enriquecimiento editorial real (campos verificados únicamente).
+4. Tests completos + verificación de no-duplicación con la vidriera
+   automática (`editorial-showcase-boundary.test.js` u equivalente).
+5. PR separado documentando: cantidad procesada, ISBN incluidos, fuentes
+   utilizadas, resultado de tests.
+6. No fusionar sin autorización explícita — salvo autorización previa
+   expresa para fusión automática de lotes en verde.
+
+Ver `ESTADO-ACTUAL.md` para contadores en vivo y bloqueos activos.

--- a/PLAN-MAESTRO.md
+++ b/PLAN-MAESTRO.md
@@ -83,7 +83,7 @@ enriquecidas.
 
 | Lote | Fichas | Rama | PR | Estado |
 | --- | --- | --- | --- | --- |
-| 1 | Universo 2.276 → 187 enriquecidos, 2.089 pendientes (1.533 SIN_DATOS + 556 REVISAR) | `b11/enriquecimiento-lote-01-ci` | [#303](https://github.com/trexxeseba/amadolibros-web/pull/303) (draft) | 187 ISBN verificados, sin sinopsis; tests y CI en verde; no fusionar sin autorización |
+| 1 | Universo 2.276 → 187 enriquecidos | `b11/enriquecimiento-lote-01-ci` | [#303](https://github.com/trexxeseba/amadolibros-web/pull/303) | **Fusionado y verificado en Producción** (commit `5b46f72`) |
 | 2 | 201–400 | `b11/enriquecimiento-lote-02` | pendiente | pendiente |
 | 3 | 401–600 | `b11/enriquecimiento-lote-03` | pendiente | pendiente |
 | 4 | 601–800 | `b11/enriquecimiento-lote-04` | pendiente | pendiente |
@@ -110,10 +110,11 @@ enriquecidas.
 
 ## B11.2 — Pipeline continuo de enriquecimiento y resolución de conflictos
 
-Registrado el 2026-09-01, autorizado y en ejecución sobre el pool
-REVISAR. Lote 01: **12 TERMINADO, 1 SIN_DATOS, 87 REVISAR** —
+Registrado el 2026-09-01, autorizado y ejecutado sobre el pool REVISAR.
+Lote 01: **12 TERMINADO, 1 SIN_DATOS, 87 REVISAR** —
 [PR #305](https://github.com/trexxeseba/amadolibros-web/pull/305)
-(draft, no fusionado). Detalle real en `ESTADO-ACTUAL.md`.
+**fusionado y verificado en Producción** (commit `8d474bf`). Detalle
+real en `ESTADO-ACTUAL.md`.
 Reemplaza la estructura fija de 10 lotes de 200 (que el Lote 1 ya mostró
 inviable: de 2.276 candidatos elegibles, solo 187 califican con las
 fuentes actuales) por un pipeline continuo dimensionado al rendimiento

--- a/PLAN-MAESTRO.md
+++ b/PLAN-MAESTRO.md
@@ -113,8 +113,11 @@ enriquecidas.
 Registrado el 2026-09-01, autorizado y ejecutado sobre el pool REVISAR.
 Lote 01: **12 TERMINADO, 1 SIN_DATOS, 87 REVISAR** —
 [PR #305](https://github.com/trexxeseba/amadolibros-web/pull/305)
-**fusionado y verificado en Producción** (commit `8d474bf`). Detalle
-real en `ESTADO-ACTUAL.md`.
+**fusionado y verificado en Producción** (commit `8d474bf`). Lote 02:
+**12 TERMINADO, 7 SIN_DATOS, 81 REVISAR** —
+[PR #306](https://github.com/trexxeseba/amadolibros-web/pull/306)
+**fusionado y verificado en Producción** (commit `662c13c`). Registry
+acumulado: 1.550. Detalle real en `ESTADO-ACTUAL.md`.
 Reemplaza la estructura fija de 10 lotes de 200 (que el Lote 1 ya mostró
 inviable: de 2.276 candidatos elegibles, solo 187 califican con las
 fuentes actuales) por un pipeline continuo dimensionado al rendimiento

--- a/PLAN-MAESTRO.md
+++ b/PLAN-MAESTRO.md
@@ -83,7 +83,7 @@ enriquecidas.
 
 | Lote | Fichas | Rama | PR | Estado |
 | --- | --- | --- | --- | --- |
-| 1 | 187 reales (no 200; ver ESTADO-ACTUAL.md) | `b11/enriquecimiento-lote-01-ci` | [#303](https://github.com/trexxeseba/amadolibros-web/pull/303) (draft) | 187 ISBN verificados, sin sinopsis; tests locales en verde; no fusionar sin autorización |
+| 1 | Universo 2.276 → 187 enriquecidos, 2.089 pendientes (1.533 SIN_DATOS + 556 REVISAR) | `b11/enriquecimiento-lote-01-ci` | [#303](https://github.com/trexxeseba/amadolibros-web/pull/303) (draft) | 187 ISBN verificados, sin sinopsis; tests y CI en verde; no fusionar sin autorización |
 | 2 | 201–400 | `b11/enriquecimiento-lote-02` | pendiente | pendiente |
 | 3 | 401–600 | `b11/enriquecimiento-lote-03` | pendiente | pendiente |
 | 4 | 601–800 | `b11/enriquecimiento-lote-04` | pendiente | pendiente |
@@ -107,5 +107,67 @@ enriquecidas.
    utilizadas, resultado de tests.
 6. No fusionar sin autorización explícita — salvo autorización previa
    expresa para fusión automática de lotes en verde.
+
+## B11.2 — Pipeline continuo de enriquecimiento y resolución de conflictos
+
+Registrado el 2026-09-01. **Diseño únicamente — no ejecutado todavía.**
+Reemplaza la estructura fija de 10 lotes de 200 (que el Lote 1 ya mostró
+inviable: de 2.276 candidatos elegibles, solo 187 califican con las
+fuentes actuales) por un pipeline continuo dimensionado al rendimiento
+real del catálogo.
+
+### Motivación
+
+El Lote 1 investigó su universo elegible completo (2.276 ISBN) en vez de
+una muestra de 200: 187 calificaron, 1.533 quedaron sin evidencia y 556
+quedaron con evidencia en conflicto. Repetir "lotes de 200" sobre el
+mismo universo ya investigado no agrega nada — hace falta un pipeline que
+sepa qué ISBN ya se investigó, en qué estado quedó, y que solo vuelva a
+tocar los que pueden cambiar de estado.
+
+### Diseño
+
+- **Unidad de trabajo:** lotes independientes de 100 ISBN (no 200).
+- **Estados persistentes por ISBN** (se guardan, no se recalculan desde
+  cero en cada corrida):
+  - `PUBLICABLE`: evidencia suficiente, sin conflicto — listo para
+    integrar al registry (equivalente a `GREEN_FULL`/`GREEN_FACTS` hoy).
+  - `REVISAR`: hay evidencia pero con conflicto de identidad (título,
+    autor, editorial o año no coinciden entre fuentes) — requiere
+    resolución antes de publicar.
+  - `SIN_DATOS`: ninguna fuente disponible tiene evidencia utilizable.
+  - `TERMINADO`: el ISBN ya se procesó de forma definitiva (publicado o
+    descartado) — **nunca se vuelve a consultar**.
+- **Resolución automática de conflictos:** cuando dos o más fuentes
+  coinciden en ISBN exacto + título normalizado + autor + editorial + año,
+  el conflicto se resuelve automáticamente y el ISBN pasa a `PUBLICABLE`.
+  Si no coinciden en esos cuatro campos, se queda en `REVISAR` para
+  revisión humana — nunca se fuerza una resolución sin ese acuerdo.
+- **Los `SIN_DATOS` salen del circuito automático**: no se reintentan en
+  cada corrida (evita repetir consultas ya fallidas contra BNE/Open
+  Library/Google Books); quedan disponibles para una fuente adicional
+  futura o revisión manual, pero no consumen presupuesto de investigación
+  de forma repetida.
+- **Ningún lote puede sobrescribir resultados anteriores**: cada corrida
+  fusiona sobre el estado persistente existente (la causa raíz del bug
+  encontrado y corregido en la 2ª corrida del Lote 1: acumular, nunca
+  pisar).
+- **Cada lote es retomable**: un lote interrumpido (timeout, error de
+  red, cuota agotada) puede continuarse desde el estado persistido sin
+  perder lo ya resuelto.
+- **Invariante comercial sin excepción:** títulos, H1, slugs, precios,
+  stock, imágenes y demás datos comerciales permanecen intactos en todos
+  los lotes de B11.2, igual que en B11.1.
+
+### Qué falta antes de ejecutar B11.2
+
+- Definir dónde vive el estado persistente por ISBN (¿archivo commiteado
+  por lote, como hoy, o un manifiesto único que se actualiza en cada
+  corrida?) y cómo se pasa de `REVISAR`/`SIN_DATOS` a `TERMINADO`.
+- Decidir si conseguir sinopsis real (campo `description`, ahora
+  disponible en un subconjunto de los matches de Google Books) es parte
+  de B11.2 o un tercer proyecto separado.
+- Autorización explícita de Seba para arrancar — **no se ejecuta nada de
+  esto todavía.**
 
 Ver `ESTADO-ACTUAL.md` para contadores en vivo y bloqueos activos.


### PR DESCRIPTION
## Objetivo

Arrancar el plan de enriquecimiento editorial real de 2.000 fichas en 10
lotes de 200 (Lote 1 → Lote 10, cada uno en su propia rama y PR). Este PR
cubre el paso 1 del flujo: registrar el cierre definitivo de PR #298 y
dejar `PLAN-MAESTRO.md` / `ESTADO-ACTUAL.md` como fuente de verdad del plan
y de los contadores acumulados.

## Qué incluye

- `PLAN-MAESTRO.md`: historial verificado de PR #298 (título, rama, merge
  commit, qué entregó y qué NO entregó), arquitectura del pipeline
  existente, reglas absolutas, y la tabla de los 10 lotes.
- `ESTADO-ACTUAL.md`: contadores acumulados (procesadas, enriquecidas,
  descartadas, pendientes, PRs abiertos/fusionados) — todos en 0 salvo
  pendientes = 2.000, porque este plan mide la **redacción** de los 10
  lotes, no la investigación de PR #298 (que dejó 2.000 dossiers
  investigados pero con `publication_allowed: false`, sin redactar ni
  publicar).

## Bloqueo detectado al intentar iniciar el Lote 1

Antes de seleccionar los primeros 200 ISBN, verifiqué la salida de red de
este entorno de ejecución (`env_01LJa9rxrtnhR4pwpabC8j7q`, "Default -
trusted network access") contra cada fuente que el propio pipeline del
repo necesita:

- `pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev` (`CATALOG_URL`, el catálogo
  real del sitio) → bloqueado por el proxy de egreso (403).
- `openlibrary.org` y `catalogo.bne.es` (fuentes públicas sin API key que
  ya usa `scripts/seo/book-intelligence-*`) → bloqueadas (403).
- `www.googleapis.com` (Google Books) → alcanzable, pero cuota diaria
  agotada (`RESOURCE_EXHAUSTED`) para el proyecto configurado; no tengo
  una API key propia.
- Sitios de librerías/editoriales (Casa del Libro, etc., usados como
  `commercial_reference`/`publisher` en los enriquecimientos reales
  existentes) → bloqueados (403).
- Descarga del artifact de CI con los 2.000 dossiers ya investigados por
  PR #298 (`run 33388882918`, `productionresultssa17.blob.core.windows.net`)
  → también bloqueada (403): ni siquiera puedo reutilizar esa investigación
  ya hecha.

Lo único con salida confirmada es GitHub (`github.com`, `api.github.com`,
`raw.githubusercontent.com`) y algunos registries de paquetes. Probé tanto
con `curl` como con la herramienta `WebFetch`; el bloqueo es a nivel de
proxy de organización (`EGRESS_BLOCKED`), no una limitación de la
herramienta.

**Sin acceso al catálogo real ni a ninguna fuente bibliográfica
verificable, no puedo seleccionar ni enriquecer ninguna ficha real sin
violar la regla explícita de no inventar contenido.** Por eso este PR deja
el estado documentado como bloqueado (0/2.000) en lugar de fabricar
resultados o simular verificación. El detalle completo y las 4 opciones de
desbloqueo están en `ESTADO-ACTUAL.md`.

En cuanto se resuelva el bloqueo, el Lote 1 arranca de inmediato, sin pedir
autorización adicional, siguiendo el flujo ya definido en `PLAN-MAESTRO.md`.

## Pruebas

- Sin cambios de código; solo documentación. No aplica suite de tests.

**No fusionar sin autorización explícita.**


---
_Generated by [Claude Code](https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri)_