### PR TITLE
B11 infra: corregir YAML del workflow de investigación por lote

### DIFF
--- a/.github/workflows/b11-batch-research.yml
+++ b/.github/workflows/b11-batch-research.yml
@@ -140,9 +140,6 @@ jobs:
             echo "Sin cambios para commitear."
             exit 0
           fi
-          git commit -m "b11(lote): investigación real ${LIMIT} ISBN + hechos verificados
-
-Genera evidencia bibliográfica (Google Books, Open Library, BNE) y el
-módulo de hechos verificados para este lote. No modifica el registry ni
-publica nada; queda para wiring y redacción en un commit revisado aparte."
+          COMMIT_MSG=$'b11(lote): investigacion real '"${LIMIT}"$' ISBN + hechos verificados\n\nGenera evidencia bibliografica (Google Books, Open Library, BNE) y el\nmodulo de hechos verificados para este lote. No modifica el registry ni\npublica nada; queda para wiring y redaccion en un commit revisado aparte.'
+          git commit -m "$COMMIT_MSG"
           git push origin "HEAD:${{ github.ref_name }}"


### PR DESCRIPTION
## Objetivo

Fix de un solo archivo sobre PR #301 (ya fusionado): el mensaje de commit
multilínea dentro del `run: |` de `.github/workflows/b11-batch-research.yml`
tenía continuaciones sin indentar, lo que rompía el bloque YAML y hacía que
GitHub no reconociera `workflow_dispatch` (confirmado al intentar
dispararlo desde la API: `Workflow does not have 'workflow_dispatch'
trigger`).

## Qué incluye

- Reemplaza el mensaje de commit multilínea por una variable bash de una
  sola línea con `\n` escapados.
- Validado localmente con `python3 -c "import yaml; yaml.safe_load(...)"`:
  ahora parsea `on: {workflow_dispatch: ...}` correctamente.

Cero cambios de producto, cero datos comerciales — mismo alcance que PR #301.

**No fusionar sin autorización explícita** — mismo criterio que #301: es
infraestructura de CI, prerrequisito directo para poder disparar la
investigación del Lote 1.


---
_Generated by [Claude Code](https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri)_