### PR TITLE
B11 infra: verificación manual de fichas enriquecidas contra cualquier URL

### DIFF
--- a/.github/workflows/book-enrichment-live-check-manual.yml
+++ b/.github/workflows/book-enrichment-live-check-manual.yml
@@ -1,0 +1,69 @@
+name: Book enrichment live check — manual (any base URL)
+
+# Verificación HTTP real y puntual de fichas enriquecidas contra un
+# entorno con red completa (GitHub Actions), reutilizando el mismo
+# script que corre en Preview (scripts/seo/book-enrichment-live-check.mjs)
+# pero apuntado a la URL que se indique — por defecto, Producción.
+# Solo lectura: no escribe nada en el catálogo ni en el registry.
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: URL base a verificar (sin barra final)
+        required: true
+        default: https://www.amadolibros.com
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  live-check:
+    name: Run book-enrichment-live-check against base_url
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+
+      - name: Run live check
+        env:
+          BOOK_ENRICHMENT_BASE_URL: ${{ inputs.base_url }}
+          BOOK_ENRICHMENT_OUTPUT_DIR: artifacts/book-enrichment-live-check-manual
+        run: node scripts/seo/book-enrichment-live-check.mjs
+
+      - name: Publish job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "# Book enrichment live check — ${{ inputs.base_url }}"
+            echo
+            if [ -f artifacts/book-enrichment-live-check-manual/book-enrichment-live-check.json ]; then
+              node -e "
+                const r = require('./artifacts/book-enrichment-live-check-manual/book-enrichment-live-check.json');
+                console.log('- verified:', r.verified);
+                console.log('- not_applicable:', r.not_applicable);
+                console.log('- failed:', r.failed);
+                console.log();
+                console.log('| ISBN | product_ids | status | failures |');
+                console.log('|---|---|---|---|');
+                for (const rep of r.reports) {
+                  console.log('| ' + rep.isbn + ' | ' + (rep.product_ids||[]).join(', ') + ' | ' + rep.status + ' | ' + (rep.failures||[]).join('; ') + ' |');
+                }
+              "
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: book-enrichment-live-check-manual-${{ github.run_id }}
+          path: artifacts/book-enrichment-live-check-manual/
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
## Objetivo

Prerrequisito técnico para verificar en Producción el Lote 1 recién fusionado (PR #303, 187 fichas). Este workflow reutiliza `scripts/seo/book-enrichment-live-check.mjs` (ya usado contra Preview en `deploy-pr-preview.yml`) apuntado a cualquier `base_url` vía `workflow_dispatch` — por defecto Producción.

## Qué incluye

- `.github/workflows/book-enrichment-live-check-manual.yml`: solo lectura, no toca catálogo ni registry. Verifica por HTTP real que cada ISBN del registry de enriquecimiento (1.526 total) muestra sus hechos verificados en la ficha y en Merchant, sin autoría genérica ni referencias comerciales externas.
- Igual que con PR #301/#302: GitHub solo permite disparar `workflow_dispatch` para workflows que ya existen en `main`, por eso va en su propio PR de infraestructura.

## Por qué ahora

Esta sesión no tiene salida de red hacia `www.amadolibros.com` (mismo bloqueo documentado en `ESTADO-ACTUAL.md`), así que no puedo verificar Producción con `curl`/`WebFetch` directos. Este workflow corre en GitHub Actions (red completa) y deja el resultado en el job summary + artifact.

**Infraestructura pura, cero datos comerciales — no fusionar sin autorización explícita de Seba** (mismo criterio que #301/#302).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri


---
_Generated by [Claude Code](https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri)_