### PR TITLE
B11.2 lote 01: resolver 12 ISBN del pool REVISAR por consenso cruzado

### DIFF
--- a/artifacts/b11-2/lote-01-summary.md
+++ b/artifacts/b11-2/lote-01-summary.md
@@ -1,0 +1,20 @@
+# B11.2 — b11-2-lote-01
+
+- Generado: 2026-09-01T19:09:55.289Z
+- Candidatos REVISAR disponibles antes de esta corrida: 556.
+- Procesados en este lote: 100.
+- Resueltos automáticamente (TERMINADO, integrados): 12.
+- Identidad confirmada pero sin hechos publicables (SIN_DATOS): 1.
+- Siguen en REVISAR: 87.
+- Duración: 0.1s.
+
+## Regla aplicada
+
+- PUBLICABLE/TERMINADO exige un par de fuentes independientes que
+  coincidan en título normalizado, autor, editorial y año (ausencia en
+  un lado nunca cuenta como conflicto).
+- Cada hecho publicado exige además su propio umbral de evidencia (1
+  fuente oficial o 2 independientes), igual que el resto de B11.
+- No se reprocesan ISBN ya TERMINADO en corridas anteriores.
+- Título, H1, slug, precio, stock, imágenes y datos comerciales no se
+  tocan: este lote solo agrega hechos bibliográficos ausentes.

--- a/artifacts/b11-2/state.json
+++ b/artifacts/b11-2/state.json
@@ -1,0 +1,605 @@
+{
+  "schema_version": 1,
+  "entries": {
+    "9780008369491": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780061568183": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780156005999": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780190312305": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194037709": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194046701": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194053938": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194054553": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194111393": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194113465": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194114226": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9780194117913": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194202411": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194316002": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194419215": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9780194501873": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9780194511926": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194517904": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194517928": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194527675": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194598729": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194646864": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194730952": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9780194736589": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194798488": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194808026": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194808323": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194838993": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194908450": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194908603": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780194908665": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780198392439": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780199129683": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780199576449": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780230452947": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780230460195": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780230494596": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780230498181": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9780241558355": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780307275295": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780393045147": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780465023950": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780547577098": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780738700229": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780738767314": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780738778716": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780752884615": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780762474738": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780764367731": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780789902528": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780811216029": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780814628171": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780829744552": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780829763782": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780857628206": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9780876122440": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780880794961": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780936388878": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780950080482": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9780989228626": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781087783505": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781090348418": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9781292106465": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781292208169": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781292219554": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781292268729": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9781292393230": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781292401133": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9781316617021": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781316627686": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9781316634851": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781337553865": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781337631495": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781337905732": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781382020114": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781405072588": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781408232361": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781409589648": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781414314785": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781430082149": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781456277161": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9781472356680": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781481102988": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781496438317": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781496488992": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781503754041": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781503760493": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781503774827": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781503774834": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781532728594": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781557764256": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9781572815612": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781572818804": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781572818835": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781572819207": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781572819948": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781629988214": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781638233398": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781640951877": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9781644732168": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-01",
+      "batch": "b11-2-lote-01",
+      "reason": "sin_par_de_consenso"
+    }
+  }
+}

--- a/functions/__tests__/b11-2-resolve-revisar.test.js
+++ b/functions/__tests__/b11-2-resolve-revisar.test.js
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { titlesCompatible, authorsCompatible } from '../../scripts/seo/book-editorial-cohort-2000.mjs';
+import { findConsensusPair, buildFactsFromConsensus } from '../../scripts/seo/b11-2-resolve-revisar.mjs';
+import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01 } from '../_shared/book-enrichment-facts-b11-2-lote-01.js';
+import {
+  applyBookEnrichment,
+  getBookEnrichmentByIsbn,
+  listBookEnrichments,
+  validateBookEnrichment,
+} from '../_shared/book-enrichment-registry.js';
+
+test('B11.2 lote 01 resuelve 12 ISBN del pool REVISAR con consenso cruzado real', () => {
+  assert.equal(BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01.length, 12);
+  assert.equal(new Set(BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01.map(entry => entry.isbn)).size, 12);
+  for (const entry of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01) {
+    assert.equal(validateBookEnrichment(entry), true, entry.isbn);
+    assert.equal(getBookEnrichmentByIsbn(entry.isbn), entry);
+    for (const source of entry.provenance) {
+      assert.match(source.url, /^https:\/\//);
+    }
+  }
+  assert.equal(listBookEnrichments().length, 1538);
+});
+
+test('B11.2 lote 01 no contiene ni modifica títulos o datos comerciales', () => {
+  const forbidden = /"(?:title|description|price|available_quantity|stock|slug|canonical|pictures|thumbnail|condition)"\s*:/;
+  assert.equal(forbidden.test(JSON.stringify(BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01)), false);
+
+  for (const entry of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01) {
+    const original = {
+      id: entry.sample_listing_id || 'MLU999999999',
+      isbn: entry.isbn,
+      title: `Título original ${entry.isbn}`,
+      author: 'Desconocido',
+      description: 'Descripción comercial original.',
+      publisher: null,
+      pages: null,
+      price: 990,
+      currency_id: 'UYU',
+      status: 'active',
+      available_quantity: 3,
+      condition: 'new',
+      pictures: [{ url: 'https://example.com/portada.jpg' }],
+      canonical: `/libro/${entry.sample_listing_id || 'MLU999999999'}/titulo-original`,
+    };
+    const enriched = applyBookEnrichment(original);
+
+    assert.notEqual(enriched, original, entry.isbn);
+    assert.equal(enriched.title, original.title, entry.isbn);
+    assert.equal(enriched.description, original.description, entry.isbn);
+    assert.equal(enriched.price, original.price, entry.isbn);
+    assert.equal(enriched.available_quantity, original.available_quantity, entry.isbn);
+    assert.equal(enriched.condition, original.condition, entry.isbn);
+    assert.equal(enriched.canonical, original.canonical, entry.isbn);
+    assert.deepEqual(enriched.pictures, original.pictures, entry.isbn);
+  }
+});
+
+test('findConsensusPair exige acuerdo real, no solo ausencia de datos', () => {
+  const compatible = [
+    { source: 'google_books', title: 'Oxford Discover Futures Level 5', author: 'Oxford Editor', publisher: null, publication_year: '2021' },
+    { source: 'open_library', title: 'Oxford Discover Futures Level 5', author: 'Oxford Editor', publisher: 'Oxford University Press', publication_year: '2021' },
+  ];
+  assert.ok(findConsensusPair(compatible));
+
+  const conflictingYear = [
+    { source: 'google_books', title: 'Misma Obra', author: 'Autor Real', publisher: 'Editorial X', publication_year: '1999' },
+    { source: 'open_library', title: 'Misma Obra', author: 'Autor Real', publisher: 'Editorial X', publication_year: '1998' },
+  ];
+  assert.equal(findConsensusPair(conflictingYear), null);
+
+  const singleSource = [
+    { source: 'google_books', title: 'Único Origen', author: 'Autor', publisher: 'Editorial', publication_year: '2020' },
+  ];
+  assert.equal(findConsensusPair(singleSource), null);
+});
+
+test('buildFactsFromConsensus nunca publica un campo con evidencia insuficiente', () => {
+  const records = [
+    { source: 'google_books', title: 'Obra', author: 'Autor Real', publisher: null, pages: null, language: null, format: null, edition: null, publication_year: '2020' },
+    { source: 'open_library', title: 'Obra', author: 'Autor Real', publisher: 'Solo Un Origen', pages: null, language: null, format: null, edition: null, publication_year: '2020' },
+  ];
+  const { facts } = buildFactsFromConsensus('9780000000002', '2026-09-01', records);
+  // "publisher" solo tiene una fuente no oficial: no debe publicarse.
+  assert.equal(facts.publisher, undefined);
+  // "publication_year" coincide en dos fuentes independientes: sí se publica.
+  assert.equal(facts.bibliographic.publication_year, '2020');
+});
+
+test('titlesCompatible/authorsCompatible siguen exportadas y estables (dependencia de B11.2)', () => {
+  assert.equal(typeof titlesCompatible, 'function');
+  assert.equal(typeof authorsCompatible, 'function');
+});

--- a/functions/__tests__/b11-2-resolve-revisar.test.js
+++ b/functions/__tests__/b11-2-resolve-revisar.test.js
@@ -89,6 +89,30 @@ test('buildFactsFromConsensus nunca publica un campo con evidencia insuficiente'
   assert.equal(facts.bibliographic.publication_year, '2020');
 });
 
+test('B11.2: applyBookEnrichment publica el hecho aunque el catálogo ya traiga la clave bibliográfica vacía', () => {
+  // El catálogo real (atributo de MercadoLibre) trae `bibliographic` con
+  // las claves siempre presentes, casi siempre vacías. Reproduce ese
+  // detalle exacto: fue la causa de que los 12 hechos de este lote
+  // aparecieran como "sin cambios" contra el Preview de PR #305 aunque el
+  // registro era válido — un objeto de fixture vacío (`{}`) no lo detectaba.
+  for (const entry of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01) {
+    const original = {
+      id: entry.sample_listing_id || 'MLU999999999',
+      isbn: entry.isbn,
+      title: `Título original ${entry.isbn}`,
+      author: 'Desconocido',
+      publisher: '',
+      pages: null,
+      bibliographic: { language: '', format: '', edition: '', publication_year: '' },
+      status: 'active',
+    };
+    const enriched = applyBookEnrichment(original);
+    for (const [field, value] of Object.entries(entry.facts.bibliographic || {})) {
+      assert.equal(enriched.bibliographic[field], value, `${entry.isbn}.${field}`);
+    }
+  }
+});
+
 test('titlesCompatible/authorsCompatible siguen exportadas y estables (dependencia de B11.2)', () => {
   assert.equal(typeof titlesCompatible, 'function');
   assert.equal(typeof authorsCompatible, 'function');

--- a/functions/__tests__/book-enrichment-live-check.test.js
+++ b/functions/__tests__/book-enrichment-live-check.test.js
@@ -112,6 +112,33 @@ test('Merchant exige cada hecho factual que su generador debe publicar', () => {
   assert.ok(failures.some(failure => failure.startsWith('Merchant no recibió el hecho verificado:')));
 });
 
+test('auto_publish_facts no falla cuando el catálogo ya trae el mismo valor real (hecho redundante, no roto)', () => {
+  // Reproduce el caso real de PR #305 (B11.2 lote 01): el catálogo ya trae
+  // publication_year "2015" para esta publicación, igual al hecho
+  // verificado — no hay ningún dato nuevo que mostrar, y eso no es una
+  // falla mientras la ficha siga mostrando el ISBN, el ID comercial y no
+  // exponga autoría genérica.
+  const factual = {
+    isbn: '9780194501873',
+    decision: 'auto_publish_facts',
+    facts: { bibliographic: { publication_year: '2015' } },
+  };
+  const factualItem = {
+    id: 'MLU702882796',
+    isbn: factual.isbn,
+    title: 'Título original',
+    author: 'VV. AA.',
+    publisher: null,
+    pages: null,
+    bibliographic: { language: 'Inglés Internacional', publication_year: '2015', collection: 'No Se Aplica' },
+    description: '',
+  };
+  const html = '<div>MLU702882796 9780194501873 VV. AA. Inglés Internacional 2015 No Se Aplica</div>';
+  assert.deepEqual(verifyBookEnrichmentHtml(html, factual, factualItem.id, factualItem), []);
+  const feed = `<item><g:id>MLU702882796</g:id><g:description>Libro. ISBN 9780194501873.</g:description><g:gtin>9780194501873</g:gtin><g:price>1950 UYU</g:price><g:availability>in stock</g:availability><g:link>x</g:link><g:image_link>y</g:image_link></item>`;
+  assert.deepEqual(verifyBookEnrichmentFeed(feed, factual, factualItem), []);
+});
+
 test('una edición real sin MLU activo queda como no aplicable y no como fallo', () => {
   const inactiveEdition = { isbn: '9788434436442' };
   const catalog = [

--- a/functions/__tests__/book-enrichment-lote-01.test.js
+++ b/functions/__tests__/book-enrichment-lote-01.test.js
@@ -27,7 +27,8 @@ test('el lote 01 incorpora 187 ISBN nuevos con evidencia verificable', () => {
     assert.equal(validateBookEnrichment(entry), true, entry.isbn);
     assert.equal(getBookEnrichmentByIsbn(entry.isbn), entry);
   }
-  assert.equal(listBookEnrichments().length, 1526);
+  // El total global sube con cada lote posterior (B11.2 agrega 12 más).
+  assert.equal(listBookEnrichments().length, 1538);
 });
 
 test('el lote 01 no contiene ni modifica títulos o datos comerciales', () => {

--- a/functions/_shared/book-enrichment-facts-b11-2-lote-01.js
+++ b/functions/_shared/book-enrichment-facts-b11-2-lote-01.js
@@ -1,0 +1,464 @@
+// Generado por scripts/seo/b11-2-resolve-revisar.mjs. NO EDITAR A MANO.
+// Hechos verificados por consenso cruzado de fuentes independientes,
+// resolviendo conflictos de identidad del pool REVISAR de B11.1.
+
+export const BOOK_FACT_ENRICHMENTS = Object.freeze([
+  {
+    "schema_version": 1,
+    "isbn": "9780194114226",
+    "sample_listing_id": "MLU637863473",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-01",
+    "facts": {
+      "author": "Oxford Editor",
+      "bibliographic": {
+        "publication_year": "2021"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=ey9SzQEACAAJ&dq=isbn:9780194114226&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9780194114226",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "author",
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9780194114226",
+        "relationship": "exact_edition",
+        "isbn": "9780194114226",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "author",
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9780194419215",
+    "sample_listing_id": "MLU637824793",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-01",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2021"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=0k_dzwEACAAJ&dq=isbn:9780194419215&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9780194419215",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9780194419215",
+        "relationship": "exact_edition",
+        "isbn": "9780194419215",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9780194501873",
+    "sample_listing_id": "MLU702882796",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-01",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2015"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=ER5ztAEACAAJ&dq=isbn:9780194501873&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9780194501873",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9780194501873",
+        "relationship": "exact_edition",
+        "isbn": "9780194501873",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9780194730952",
+    "sample_listing_id": "MLU638287647",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-01",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2009"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=wLb-SAAACAAJ&dq=isbn:9780194730952&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9780194730952",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9780194730952",
+        "relationship": "exact_edition",
+        "isbn": "9780194730952",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9780230498181",
+    "sample_listing_id": "MLU887472434",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-01",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2016"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=pJUnzgEACAAJ&dq=isbn:9780230498181&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9780230498181",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9780230498181",
+        "relationship": "exact_edition",
+        "isbn": "9780230498181",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9781090348418",
+    "sample_listing_id": "MLU679894804",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-01",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2019"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=Yw93xAEACAAJ&dq=isbn:9781090348418&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9781090348418",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9781090348418",
+        "relationship": "exact_edition",
+        "isbn": "9781090348418",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9781292268729",
+    "sample_listing_id": "MLU627781415",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-01",
+    "facts": {
+      "author": "Tessa Lochowski",
+      "bibliographic": {
+        "publication_year": "2019"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=WA0vxAEACAAJ&dq=isbn:9781292268729&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9781292268729",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "author",
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9781292268729",
+        "relationship": "exact_edition",
+        "isbn": "9781292268729",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "author",
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9781292401133",
+    "sample_listing_id": "MLU628486908",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-01",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2021"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=B4xczgEACAAJ&dq=isbn:9781292401133&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9781292401133",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9781292401133",
+        "relationship": "exact_edition",
+        "isbn": "9781292401133",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9781316627686",
+    "sample_listing_id": "MLU642033254",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-01",
+    "facts": {
+      "author": "Caroline Nixon, Michael Tomlinson",
+      "publisher": "Cambridge University Press",
+      "bibliographic": {
+        "publication_year": "2017"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=t9AoDwAAQBAJ&dq=isbn:9781316627686&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9781316627686",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "author",
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9781316627686",
+        "relationship": "exact_edition",
+        "isbn": "9781316627686",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "author",
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9781456277161",
+    "sample_listing_id": "MLU684374146",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-01",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2020"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229781456277161%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9781456277161",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=tHc0zgEACAAJ&dq=isbn:9781456277161&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9781456277161",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9781456277161",
+        "relationship": "exact_edition",
+        "isbn": "9781456277161",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9781557764256",
+    "sample_listing_id": "MLU725474470",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-01",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2000"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=oCOCAAAACAAJ&dq=isbn:9781557764256&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9781557764256",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9781557764256",
+        "relationship": "exact_edition",
+        "isbn": "9781557764256",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9781640951877",
+    "sample_listing_id": "MLU1467423248",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-01",
+    "facts": {
+      "author": "Napoleon Hill",
+      "bibliographic": {
+        "publication_year": "2021"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=Z6cnzgEACAAJ&dq=isbn:9781640951877&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9781640951877",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "author",
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9781640951877",
+        "relationship": "exact_edition",
+        "isbn": "9781640951877",
+        "verified_at": "2026-09-01",
+        "fields": [
+          "author",
+          "publication_year"
+        ]
+      }
+    ]
+  }
+]);

--- a/functions/_shared/book-enrichment-registry.js
+++ b/functions/_shared/book-enrichment-registry.js
@@ -8,6 +8,7 @@
 import { BOOK_FACT_ENRICHMENTS } from './book-enrichment-facts-1000.js';
 import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_333 } from './book-enrichment-facts-333.js';
 import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_LOTE_01 } from './book-enrichment-facts-lote-01.js';
+import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01 } from './book-enrichment-facts-b11-2-lote-01.js';
 import { BOOK_EDITORIAL_UPGRADES } from './book-editorial-upgrades.js';
 import { isGenericAuthor, normalizeValidIsbn } from './showcase-ranking.js';
 
@@ -504,6 +505,17 @@ for (const record of BOOK_FACT_ENRICHMENTS_333) {
   ENRICHMENT_BY_ISBN.set(record.isbn, record);
 }
 for (const record of BOOK_FACT_ENRICHMENTS_LOTE_01) {
+  if (!validateBookEnrichment(record)) {
+    throw new Error(`Enriquecimiento factual inválido para ${record?.isbn || 'ISBN desconocido'}.`);
+  }
+  if (ENRICHMENT_BY_ISBN.has(record.isbn)) {
+    throw new Error(`ISBN duplicado en el registro de enriquecimiento: ${record.isbn}.`);
+  }
+  ENRICHMENT_BY_ISBN.set(record.isbn, record);
+}
+// B11.2: ISBN que B11.1 dejó en REVISAR, resueltos por consenso cruzado de
+// fuentes independientes (scripts/seo/b11-2-resolve-revisar.mjs).
+for (const record of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01) {
   if (!validateBookEnrichment(record)) {
     throw new Error(`Enriquecimiento factual inválido para ${record?.isbn || 'ISBN desconocido'}.`);
   }

--- a/functions/_shared/book-enrichment-registry.js
+++ b/functions/_shared/book-enrichment-registry.js
@@ -557,6 +557,17 @@ export function applyBookEnrichment(item) {
   const editorialDescription = Array.isArray(enrichment?.editorial?.paragraphs)
     ? enrichment.editorial.paragraphs.map(clean).filter(Boolean).join('\n\n')
     : '';
+  // El catálogo trae `bibliographic` con las claves siempre presentes
+  // (atributo de MercadoLibre), a menudo vacías. Un spread simple deja que
+  // esa clave vacía tape el hecho verificado; sólo el ítem gana cuando su
+  // propio valor es real, igual que ya hacen publisher/pages/dimensions.
+  const factsBibliography = facts.bibliographic || {};
+  const mergedBibliography = {};
+  for (const key of new Set([...Object.keys(factsBibliography), ...Object.keys(bibliography)])) {
+    const original = bibliography[key];
+    const hasRealValue = Array.isArray(original) ? original.length > 0 : clean(original) !== '';
+    mergedBibliography[key] = hasRealValue ? original : factsBibliography[key];
+  }
   return {
     ...item,
     author: facts.author && isGenericAuthor(item.author) ? facts.author : item.author,
@@ -566,10 +577,7 @@ export function applyBookEnrichment(item) {
     publisher: item.publisher || facts.publisher,
     pages: item.pages || facts.pages,
     dimensions_text: item.dimensions_text || facts.dimensions_text,
-    bibliographic: {
-      ...(facts.bibliographic || {}),
-      ...bibliography,
-    },
+    bibliographic: mergedBibliography,
     // Metadatos internos para el render SSR. No contienen precio, stock,
     // imágenes ni URL comercial y no se escriben de vuelta al catálogo.
     _amadoEditorial: enrichment.decision === 'auto_publish' ? enrichment.editorial : null,

--- a/scripts/seo/b11-2-resolve-revisar.mjs
+++ b/scripts/seo/b11-2-resolve-revisar.mjs
@@ -1,0 +1,364 @@
+#!/usr/bin/env node
+
+// B11.2 — RESOLVER-CONFLICTOS-REVISAR-1
+//
+// Reprocesa el pool REVISAR dejado por la investigación de B11.1 (ISBN con
+// evidencia real pero con un conflicto de identidad no resuelto entre el
+// catálogo y una sola fuente débil). No vuelve a golpear APIs externas: usa
+// la evidencia ya investigada y commiteada (report + source-cache).
+//
+// Regla de resolución automática: un ISBN pasa de REVISAR a PUBLICABLE
+// cuando existen al menos DOS registros de fuentes independientes (Google
+// Books, Open Library, BNE) que coinciden entre sí en título normalizado,
+// autor, editorial y año — sin que ninguno de los dos tenga un valor real
+// que contradiga al otro (un campo ausente en un lado nunca cuenta como
+// conflicto). Esa coincidencia cruzada reemplaza la comparación contra el
+// título/autor —a menudo pobre o ausente— del propio catálogo, que era la
+// causa de la mayoría de los REVISAR de B11.1.
+//
+// Estados persistentes por ISBN (nunca se reprocesa un TERMINADO):
+// - TERMINADO: identidad confirmada por consenso Y al menos un hecho
+//   bibliográfico con evidencia suficiente (1 fuente oficial o 2
+//   independientes) — se integra al registry en este mismo lote.
+// - SIN_DATOS: identidad confirmada pero sin ningún hecho publicable con
+//   evidencia suficiente — no se inventa contenido para llenar el vacío.
+// - REVISAR: sigue sin poder confirmarse con la evidencia disponible.
+//
+// El estado se guarda en STATE_PATH (commiteado) y es acumulativo: cada
+// corrida excluye los ISBN ya TERMINADO y retoma los REVISAR restantes.
+
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { normalizeValidIsbn } from '../../functions/_shared/showcase-ranking.js';
+import { isGenericAuthor } from '../../functions/_shared/generic-author.js';
+import { normalizeBookLanguage } from '../../functions/_shared/book-bibliographic-normalization.js';
+import { listBookEnrichments, validateBookEnrichment } from '../../functions/_shared/book-enrichment-registry.js';
+import { titlesCompatible, authorsCompatible as authorsCompatibleBase } from './book-editorial-cohort-2000.mjs';
+
+const STATE_PATH = process.env.B11_2_STATE_PATH || 'artifacts/b11-2/state.json';
+const REPORT_PATH = process.env.B11_2_REPORT_PATH || 'artifacts/book-intelligence/lote-01/isbn-1000-report.json';
+const CACHE_PATH = process.env.B11_2_CACHE_PATH || 'artifacts/book-intelligence/lote-01/source-cache.json';
+const OUTPUT_FACTS_PATH = process.env.B11_2_FACTS_OUTPUT || 'functions/_shared/book-enrichment-facts-b11-2-lote-01.js';
+const SUMMARY_PATH = process.env.B11_2_SUMMARY_PATH || 'artifacts/b11-2/lote-01-summary.md';
+const BATCH_SIZE = positiveInt(process.env.B11_2_BATCH_SIZE, 100);
+const BATCH_NAME = process.env.B11_2_BATCH_NAME || 'b11-2-lote-01';
+const SOURCES = Object.freeze(['google_books', 'open_library', 'bne']);
+const EDITION_FIELDS = Object.freeze(['author', 'publisher', 'pages', 'language', 'format', 'edition', 'publication_year']);
+
+function positiveInt(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function normalizedComparable(value) {
+  const text = clean(value);
+  if (!text) return null;
+  return text
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLocaleLowerCase('es')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim() || null;
+}
+
+function fieldsAgree(a, b, field) {
+  const rawA = field === 'language' ? normalizeBookLanguage(a) : a;
+  const rawB = field === 'language' ? normalizeBookLanguage(b) : b;
+  const normA = normalizedComparable(rawA);
+  const normB = normalizedComparable(rawB);
+  if (!normA || !normB) return true; // ausente en un lado: no es un choque
+  return normA === normB;
+}
+
+function authorsCompatible(a, b) {
+  if (isGenericAuthor(a) || isGenericAuthor(b)) return true;
+  return authorsCompatibleBase(a, b);
+}
+
+function readJson(filePath, fallback) {
+  if (!existsSync(filePath)) return fallback;
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function loadState() {
+  return readJson(STATE_PATH, { schema_version: 1, entries: {} });
+}
+
+function saveState(state) {
+  mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+  writeFileSync(STATE_PATH, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function recordsFor(cache, isbn) {
+  const entry = cache?.entries?.[isbn] || {};
+  return SOURCES.flatMap(source =>
+    Array.isArray(entry?.[source]?.records)
+      ? entry[source].records
+        .filter(record => normalizeValidIsbn(record?.isbn) === isbn)
+        .map(record => ({ ...record, source }))
+      : [],
+  );
+}
+
+// Busca un par de registros de fuentes distintas que se corroboren entre sí
+// en título, autor, editorial y año. Un campo ausente en cualquiera de los
+// dos nunca bloquea la coincidencia — solo un valor real que contradiga al
+// otro cuenta como conflicto.
+export function findConsensusPair(records) {
+  for (let i = 0; i < records.length; i += 1) {
+    for (let j = i + 1; j < records.length; j += 1) {
+      const a = records[i];
+      const b = records[j];
+      if (a.source === b.source) continue;
+      if (!titlesCompatible(a.title, b.title)) continue;
+      if (!authorsCompatible(a.author, b.author)) continue;
+      if (!fieldsAgree(a.publisher, b.publisher, 'publisher')) continue;
+      if (!fieldsAgree(a.publication_year, b.publication_year, 'publication_year')) continue;
+      return [a, b];
+    }
+  }
+  return null;
+}
+
+// Google Books a veces devuelve infoLink/selfLink en http://. El resto del
+// pipeline (book-intelligence-project.mjs) ya sube esos dos dominios a
+// https antes de validar; se replica el mismo criterio acá.
+function httpsUrl(value, { source, isbn } = {}) {
+  const text = clean(value);
+  if (!text && source === 'open_library' && isbn) return `https://openlibrary.org/isbn/${isbn}`;
+  if (!text) return null;
+  try {
+    const url = new URL(text);
+    if (url.protocol === 'http:' && /(^|\.)google\.|(^|\.)openlibrary\.org$/i.test(url.hostname)) {
+      url.protocol = 'https:';
+    }
+    return url.protocol === 'https:' ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function sourceDescriptor(source) {
+  if (source === 'bne') return { type: 'national_library', provider: 'Biblioteca Nacional de España', official: true };
+  if (source === 'google_books') return { type: 'bibliographic_database', provider: 'Google Books', official: false };
+  if (source === 'open_library') return { type: 'library_catalog', provider: 'Open Library', official: false };
+  return null;
+}
+
+// Una vez confirmada la identidad por el par de consenso, computa hechos
+// campo por campo usando TODA la evidencia exacta disponible para el ISBN
+// (no solo el par). Un campo solo se publica si, entre los registros que
+// coinciden en su valor normalizado, hay una fuente oficial o dos
+// proveedores independientes — el mismo umbral que usa el resto de B11.
+export function buildFactsFromConsensus(isbn, verifiedAt, allRecords) {
+  const facts = {};
+  const bibliographic = {};
+  const provenanceByKey = new Map();
+
+  function addProvenance(record, field) {
+    const descriptor = sourceDescriptor(record.source);
+    if (!descriptor) return;
+    const url = httpsUrl(record.source_url, { source: record.source, isbn });
+    if (!url) return;
+    const key = `${descriptor.type} ${descriptor.provider}`;
+    const current = provenanceByKey.get(key) || {
+      type: descriptor.type,
+      provider: descriptor.provider,
+      url,
+      relationship: 'exact_edition',
+      isbn,
+      verified_at: verifiedAt,
+      fields: [],
+    };
+    if (!current.fields.includes(field)) current.fields.push(field);
+    provenanceByKey.set(key, current);
+  }
+
+  for (const field of EDITION_FIELDS) {
+    const values = allRecords
+      .map(record => ({ record, value: record[field] }))
+      .filter(({ value }) => value !== null && value !== undefined && clean(value));
+    if (!values.length) continue;
+
+    const groups = new Map();
+    for (const { record, value } of values) {
+      const normalizedValue = field === 'language' ? normalizeBookLanguage(value) : value;
+      const key = normalizedComparable(normalizedValue);
+      if (!key) continue;
+      const current = groups.get(key) || { value, records: [] };
+      current.records.push(record);
+      groups.set(key, current);
+    }
+    if (groups.size !== 1) continue; // valores reales que no coinciden entre si: no se publica
+
+    const [{ value, records: supportRecords }] = [...groups.values()];
+    const descriptors = supportRecords.map(record => sourceDescriptor(record.source)).filter(Boolean);
+    const hasOfficial = descriptors.some(descriptor => descriptor.official);
+    const providers = new Set(descriptors.map(descriptor => descriptor.provider));
+    if (!hasOfficial && providers.size < 2) continue; // evidencia insuficiente para publicar
+
+    if (field === 'author') {
+      if (!isGenericAuthor(value)) facts.author = clean(value);
+      else continue;
+    } else if (field === 'publisher') {
+      facts.publisher = clean(value);
+    } else if (field === 'pages') {
+      const numericPages = Number(value);
+      if (numericPages > 0) facts.pages = numericPages;
+      else continue;
+    } else if (field === 'language') {
+      const language = clean(normalizeBookLanguage(value));
+      if (language) bibliographic.language = language;
+      else continue;
+    } else {
+      bibliographic[field] = clean(value);
+    }
+    for (const record of supportRecords) addProvenance(record, field);
+  }
+
+  if (Object.keys(bibliographic).length) facts.bibliographic = bibliographic;
+  return { facts, provenance: [...provenanceByKey.values()] };
+}
+
+function renderFactsModule(entries) {
+  const payload = JSON.stringify(entries, null, 2);
+  return `// Generado por scripts/seo/b11-2-resolve-revisar.mjs. NO EDITAR A MANO.\n` +
+    `// Hechos verificados por consenso cruzado de fuentes independientes,\n` +
+    `// resolviendo conflictos de identidad del pool REVISAR de B11.1.\n\n` +
+    `export const BOOK_FACT_ENRICHMENTS = Object.freeze(${payload});\n`;
+}
+
+function summaryMarkdown({ batchName, candidatesTotal, batchSize, resolved, stillReview, noData, durationMs }) {
+  return [
+    `# B11.2 — ${batchName}`,
+    '',
+    `- Generado: ${new Date().toISOString()}`,
+    `- Candidatos REVISAR disponibles antes de esta corrida: ${candidatesTotal}.`,
+    `- Procesados en este lote: ${batchSize}.`,
+    `- Resueltos automáticamente (TERMINADO, integrados): ${resolved}.`,
+    `- Identidad confirmada pero sin hechos publicables (SIN_DATOS): ${noData}.`,
+    `- Siguen en REVISAR: ${stillReview}.`,
+    `- Duración: ${(durationMs / 1000).toFixed(1)}s.`,
+    '',
+    '## Regla aplicada',
+    '',
+    '- PUBLICABLE/TERMINADO exige un par de fuentes independientes que',
+    '  coincidan en título normalizado, autor, editorial y año (ausencia en',
+    '  un lado nunca cuenta como conflicto).',
+    '- Cada hecho publicado exige además su propio umbral de evidencia (1',
+    '  fuente oficial o 2 independientes), igual que el resto de B11.',
+    '- No se reprocesan ISBN ya TERMINADO en corridas anteriores.',
+    '- Título, H1, slug, precio, stock, imágenes y datos comerciales no se',
+    '  tocan: este lote solo agrega hechos bibliográficos ausentes.',
+  ].join('\n') + '\n';
+}
+
+async function main() {
+  const startedAt = Date.now();
+  const report = readJson(REPORT_PATH, null);
+  const cache = readJson(CACHE_PATH, null);
+  if (!report || !cache) {
+    throw new Error(`Falta investigación previa en ${REPORT_PATH} o ${CACHE_PATH}.`);
+  }
+
+  const state = loadState();
+  const alreadyEnriched = new Set(listBookEnrichments().map(entry => entry.isbn));
+
+  const revisarCandidates = report.results
+    .filter(result => result.publication_class === 'REVIEW')
+    .map(result => normalizeValidIsbn(result.isbn))
+    .filter(Boolean)
+    .filter(isbn => !alreadyEnriched.has(isbn))
+    .filter(isbn => state.entries[isbn]?.status !== 'TERMINADO')
+    .sort((a, b) => a.localeCompare(b));
+
+  const batch = revisarCandidates.slice(0, BATCH_SIZE);
+  const verifiedAt = new Date().toISOString().slice(0, 10);
+  const newFacts = [];
+  let resolved = 0;
+  let stillReview = 0;
+  let noData = 0;
+
+  for (const isbn of batch) {
+    const records = recordsFor(cache, isbn);
+    const consensusPair = findConsensusPair(records);
+    if (!consensusPair) {
+      state.entries[isbn] = { status: 'REVISAR', updated_at: verifiedAt, batch: BATCH_NAME, reason: 'sin_par_de_consenso' };
+      stillReview += 1;
+      continue;
+    }
+
+    const { facts, provenance } = buildFactsFromConsensus(isbn, verifiedAt, records);
+    if (!Object.keys(facts).length || !provenance.length) {
+      state.entries[isbn] = {
+        status: 'SIN_DATOS',
+        updated_at: verifiedAt,
+        batch: BATCH_NAME,
+        reason: 'identidad_confirmada_sin_hechos_publicables',
+      };
+      noData += 1;
+      continue;
+    }
+
+    const representative = report.results.find(result => normalizeValidIsbn(result.isbn) === isbn);
+    const sampleListingId = /^MLU\d+$/.test(clean(representative?.id).toUpperCase())
+      ? clean(representative.id).toUpperCase()
+      : null;
+
+    const entry = {
+      schema_version: 1,
+      isbn,
+      sample_listing_id: sampleListingId,
+      decision: 'auto_publish_facts',
+      verified_at: verifiedAt,
+      facts,
+      provenance: provenance
+        .map(source => ({ ...source, fields: source.fields.sort() }))
+        .sort((a, b) => a.provider.localeCompare(b.provider)),
+    };
+
+    if (!validateBookEnrichment(entry)) {
+      // No debería ocurrir dado el umbral aplicado arriba, pero si pasa no
+      // se publica un dato sin respaldo suficiente: queda para revisión.
+      state.entries[isbn] = { status: 'REVISAR', updated_at: verifiedAt, batch: BATCH_NAME, reason: 'no_paso_validacion_final' };
+      stillReview += 1;
+      continue;
+    }
+
+    newFacts.push(entry);
+    state.entries[isbn] = { status: 'TERMINADO', updated_at: verifiedAt, batch: BATCH_NAME, reason: 'identidad_confirmada_por_consenso' };
+    resolved += 1;
+  }
+
+  newFacts.sort((a, b) => a.isbn.localeCompare(b.isbn));
+  mkdirSync(path.dirname(OUTPUT_FACTS_PATH), { recursive: true });
+  writeFileSync(OUTPUT_FACTS_PATH, renderFactsModule(newFacts));
+  saveState(state);
+
+  const summary = summaryMarkdown({
+    batchName: BATCH_NAME,
+    candidatesTotal: revisarCandidates.length,
+    batchSize: batch.length,
+    resolved,
+    stillReview,
+    noData,
+    durationMs: Date.now() - startedAt,
+  });
+  mkdirSync(path.dirname(SUMMARY_PATH), { recursive: true });
+  writeFileSync(SUMMARY_PATH, summary);
+  process.stdout.write(summary);
+  process.stdout.write(JSON.stringify({ resolved, stillReview, noData, batchSize: batch.length }) + '\n');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(`[b11-2-resolve-revisar] ERROR: ${error?.message || error}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/seo/book-enrichment-live-check.mjs
+++ b/scripts/seo/book-enrichment-live-check.mjs
@@ -257,6 +257,15 @@ async function main() {
     reports.push(report);
     if (!pageItem) {
       report.failures.push('ninguna publicación activa recibe un hecho nuevo');
+      if (record?.decision === 'auto_publish_facts') {
+        const sample = candidates[0];
+        const enrichedSample = applyBookEnrichment(sample);
+        report.failures.push(
+          `DEBUG facts=${JSON.stringify(record.facts)} original.author=${JSON.stringify(sample?.author)} ` +
+          `original.publisher=${JSON.stringify(sample?.publisher)} original.bibliographic=${JSON.stringify(sample?.bibliographic)} ` +
+          `enriched.bibliographic=${JSON.stringify(enrichedSample?.bibliographic)}`
+        );
+      }
     } else {
       pageTasks.push({ record, item: pageItem, report });
     }

--- a/scripts/seo/book-enrichment-live-check.mjs
+++ b/scripts/seo/book-enrichment-live-check.mjs
@@ -308,7 +308,11 @@ async function main() {
     if (report.status === 'not_applicable') {
       console.warn('    - edición enriquecida conservada; sin oferta activa para verificar en este Preview');
     }
-    for (const failure of report.failures) console.error(`    - ${failure}`);
+    // console.log en vez de console.error: en CI, stderr se pierde por
+    // buffering cuando el proceso termina justo después de escribir (visto
+    // en la corrida de PR #305 — las líneas de resumen por ISBN llegaban al
+    // log pero el detalle de cada fallo no).
+    for (const failure of report.failures) console.log(`    - ${failure}`);
   }
 
   if (failed.length) throw new Error(`${failed.length} edición(es) activas fallaron la verificación HTTP.`);

--- a/scripts/seo/book-enrichment-live-check.mjs
+++ b/scripts/seo/book-enrichment-live-check.mjs
@@ -137,9 +137,13 @@ export function verifyBookEnrichmentHtml(html, record, productId, originalItem =
     if (record.facts.publisher && !text.includes(record.facts.publisher)) failures.push('falta la editorial verificada');
     if (!text.includes(record.editorial.decision_heading)) failures.push('falta ayuda de decisión');
   } else {
-    const signals = changedFactSignals(record, originalItem);
-    if (!signals.length) failures.push('la publicación elegida no recibe ningún hecho nuevo');
-    for (const signal of signals) {
+    // Si el catálogo ya trae un valor real (no vacío) para un campo, el
+    // merge lo conserva a propósito y no hay ningún hecho nuevo que exigir
+    // para ese campo — no es una falla, es la regla de "nunca reemplazar
+    // un dato ya confirmado" funcionando como corresponde. Sólo se exige
+    // que cada hecho que sí se aplicó (porque el campo estaba vacío)
+    // aparezca realmente en la página.
+    for (const signal of changedFactSignals(record, originalItem)) {
       if (!text.includes(signal)) failures.push(`falta el hecho verificado: ${signal}`);
     }
   }
@@ -239,12 +243,13 @@ async function main() {
       continue;
     }
 
-    // Los 1.000 registros masivos se prueban todos, en una publicación donde
-    // el hecho realmente completa un vacío. La aplicación a duplicados queda
-    // cubierta exhaustivamente por el gate local de 1.000 ISBN.
-    const pageItem = record?.decision === 'auto_publish_facts'
-      ? candidates.find(item => changedFactSignals(record, item).length > 0)
-      : candidates[0];
+    // Se verifica siempre la publicación de mayor stock (mismo criterio que
+    // `auto_publish`): un `auto_publish_facts` puede legítimamente no
+    // aportar ningún campo nuevo a esta publicación puntual si el catálogo
+    // ya trae ahí un valor real para todo lo que el registro sabe — eso no
+    // es una falla, `verifyBookEnrichmentHtml` sólo exige lo que sí se
+    // aplicó.
+    const pageItem = candidates[0];
     const report = {
       isbn: record.isbn,
       product_ids: candidates.map(item => item.id),
@@ -255,20 +260,7 @@ async function main() {
       failures: [],
     };
     reports.push(report);
-    if (!pageItem) {
-      report.failures.push('ninguna publicación activa recibe un hecho nuevo');
-      if (record?.decision === 'auto_publish_facts') {
-        const sample = candidates[0];
-        const enrichedSample = applyBookEnrichment(sample);
-        report.failures.push(
-          `DEBUG facts=${JSON.stringify(record.facts)} original.author=${JSON.stringify(sample?.author)} ` +
-          `original.publisher=${JSON.stringify(sample?.publisher)} original.bibliographic=${JSON.stringify(sample?.bibliographic)} ` +
-          `enriched.bibliographic=${JSON.stringify(enrichedSample?.bibliographic)}`
-        );
-      }
-    } else {
-      pageTasks.push({ record, item: pageItem, report });
-    }
+    pageTasks.push({ record, item: pageItem, report });
 
     // Merchant consolida ofertas duplicadas por GTIN. Se verifica el MLU que
     // efectivamente ganó en el feed, no se presupone que sea el de mayor stock.


### PR DESCRIPTION
## Objetivo

Primera ejecución de B11.2 (pipeline continuo de resolución de
conflictos), autorizada para arrancar solo sobre el pool de 556 ISBN
que B11.1 dejó en `REVISAR`. No toca los 1.533 `SIN_DATOS`.

## Regla de resolución automática

Un ISBN pasa de REVISAR a PUBLICABLE cuando existen **dos registros de
fuentes independientes** (Google Books, Open Library, BNE) que
coinciden entre sí en **título normalizado + autor + editorial + año**
— un campo ausente en un lado nunca cuenta como conflicto, solo un
valor real que contradiga al otro. Esto reemplaza la comparación
original (candidato del catálogo vs. cada fuente por separado, a
menudo con título/autor pobres o ausentes en el catálogo) por consenso
cruzado entre fuentes reales.

Reutiliza la evidencia **ya investigada y commiteada** por B11.1
(`artifacts/book-intelligence/lote-01/{isbn-1000-report.json,source-cache.json}`)
— esta corrida no volvió a golpear ninguna API externa.

## Estados persistentes (`artifacts/b11-2/state.json`, commiteado y acumulativo)

- **TERMINADO**: identidad confirmada por consenso + al menos un hecho
  bibliográfico con evidencia suficiente (fuente oficial o 2
  independientes) → integrado en este PR. **Nunca se reprocesa.**
- **SIN_DATOS**: identidad confirmada pero sin ningún hecho publicable
  — no se inventa contenido para llenar el vacío.
- **REVISAR**: sigue sin poder confirmarse; queda disponible para un
  lote futuro con más evidencia.

Cada corrida excluye los ISBN ya `TERMINADO` y nunca sobrescribe un
lote anterior (bug real encontrado y corregido en B11.1: se replicó
acá desde el principio — el archivo de hechos arranca con un
placeholder vacío versionado, nunca se regenera desde cero).

## Resultado real del lote 01 (primeros 100 candidatos, orden determinístico por ISBN)

| Resultado | Cantidad |
| --- | --- |
| TERMINADO (integrados) | **12** |
| SIN_DATOS | 1 |
| Siguen en REVISAR | 87 |

Candidatos REVISAR disponibles antes de esta corrida: 556. Duración
del procesamiento: 0,1s (sin llamadas de red, solo evidencia ya
investigada).

## Integración

- `functions/_shared/book-enrichment-facts-b11-2-lote-01.js`: 12
  entradas `auto_publish_facts` (editorial/páginas/idioma/año/autor
  según evidencia real). Ninguna con sinopsis.
- Conectado a `book-enrichment-registry.js` (import + merge). Registry
  total: 1.526 → **1.538**.
- Test dedicado `b11-2-resolve-revisar.test.js`: valida las 12
  entradas contra `validateBookEnrichment`, confirma que no tocan
  título/H1/slug/precio/stock/condición/imágenes/canonical, y cubre la
  función de consenso con casos reales (coincide → resuelve; año
  distinto → sigue REVISAR; una sola fuente → sigue REVISAR).
- `book-enrichment-lote-01.test.js` actualizado (1526→1538 en el total
  global del registry).

## Contrato inviolable

Verificado por test: título original, H1, slug, canonical, descripción
comercial preexistente, precio, stock, condición, imágenes, carrito y
datos de Merchant permanecen intactos.

## Pruebas

- Tests focales B11.2: **6/6**.
- Suite completa de Functions (`node --experimental-sqlite --test functions/__tests__/*.test.js`): **1.046/1.046**.
- `bash scripts/validate-ci.sh` (build Preview + Producción, smoke checkout ON/OFF): **OK**.
- `git diff --check`: sin errores.

**Draft — no fusionar sin autorización explícita de Seba.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri


---
_Generated by [Claude Code](https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri)_