### PR TITLE
B11.2 lote 02: resolver 12 ISBN del pool REVISAR por consenso cruzado

### DIFF
--- a/artifacts/b11-2/lote-02-summary.md
+++ b/artifacts/b11-2/lote-02-summary.md
@@ -1,0 +1,20 @@
+# B11.2 — b11-2-lote-02
+
+- Generado: 2026-09-02T01:26:41.025Z
+- Candidatos REVISAR disponibles antes de esta corrida: 456.
+- Procesados en este lote: 100.
+- Resueltos automáticamente (TERMINADO, integrados): 12.
+- Identidad confirmada pero sin hechos publicables (SIN_DATOS): 7.
+- Siguen en REVISAR: 81.
+- Duración: 0.1s.
+
+## Regla aplicada
+
+- PUBLICABLE/TERMINADO exige un par de fuentes independientes que
+  coincidan en título normalizado, autor, editorial y año (ausencia en
+  un lado nunca cuenta como conflicto).
+- Cada hecho publicado exige además su propio umbral de evidencia (1
+  fuente oficial o 2 independientes), igual que el resto de B11.
+- No se reprocesan ISBN ya TERMINADO en corridas anteriores.
+- Título, H1, slug, precio, stock, imágenes y datos comerciales no se
+  tocan: este lote solo agrega hechos bibliográficos ausentes.

--- a/artifacts/b11-2/state.json
+++ b/artifacts/b11-2/state.json
@@ -600,6 +600,606 @@
       "updated_at": "2026-09-01",
       "batch": "b11-2-lote-01",
       "reason": "sin_par_de_consenso"
+    },
+    "9781644733868": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781644737705": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781644738276": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781646710171": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781676305002": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781711054490": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9781717700025": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781786329486": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781797224503": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781797620985": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781800924246": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781837951666": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781910079874": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781927584149": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781931952644": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781931952651": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781951595555": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781955682268": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781974244805": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781974741229": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781974751884": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9781975360306": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9782017076698": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9782017285731": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9782017312574": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9782017312765": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9782019452384": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9782090353877": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9782764346167": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9782764346297": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9782813224637": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9782813226426": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9782813227263": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9782813227317": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9782850258275": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9783822829721": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9783836522168": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9783849903350": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9783863217662": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9783905017946": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786070747380": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786070747489": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786070747755": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786070767302": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786071512154": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786073121958": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786073241519": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786073244398": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786073244404": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786073848336": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786073903745": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786074420975": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786074480559": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786074485905": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9786075576206": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786076349694": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786079859664": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9786124890529": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788408039532": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788408055068": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788408146650": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788408166047": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788408226888": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788408236962": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788408237365": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788408239321": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788408249436": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788408257363": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788408262770": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788410489233": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788410511750": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788410512122": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788411000888": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788411206839": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788411323000": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788411323116": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788411500906": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788411500913": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788411504744": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788411580168": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788411610315": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788412250879": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788412364163": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788412405217": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788412440843": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788412496536": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788412740608": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788413146010": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788413570556": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788415241096": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788415256953": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788415292494": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788415351962": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788415428121": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788415577133": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788415732389": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788416002603": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788416004195": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788416042319": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788416233083": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "b11-2-lote-02",
+      "reason": "sin_par_de_consenso"
     }
   }
 }

--- a/functions/__tests__/b11-2-lote-02.test.js
+++ b/functions/__tests__/b11-2-lote-02.test.js
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_B11_2_LOTE_02 } from '../_shared/book-enrichment-facts-b11-2-lote-02.js';
+import {
+  applyBookEnrichment,
+  getBookEnrichmentByIsbn,
+  listBookEnrichments,
+  validateBookEnrichment,
+} from '../_shared/book-enrichment-registry.js';
+
+test('B11.2 lote 02 resuelve 12 ISBN nuevos del pool REVISAR con consenso cruzado real', () => {
+  assert.equal(BOOK_FACT_ENRICHMENTS_B11_2_LOTE_02.length, 12);
+  assert.equal(new Set(BOOK_FACT_ENRICHMENTS_B11_2_LOTE_02.map(entry => entry.isbn)).size, 12);
+  for (const entry of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_02) {
+    assert.equal(validateBookEnrichment(entry), true, entry.isbn);
+    assert.equal(getBookEnrichmentByIsbn(entry.isbn), entry);
+    for (const source of entry.provenance) {
+      assert.match(source.url, /^https:\/\//);
+    }
+  }
+  assert.equal(listBookEnrichments().length, 1550);
+});
+
+test('B11.2 lote 02 no repite ningún ISBN ya resuelto en el lote 01', () => {
+  // Regresión directa del bug encontrado antes de correr este lote: el
+  // filtro de candidatos sólo excluía TERMINADO, así que sin el fix
+  // hubiera vuelto a intentar los mismos 87 REVISAR + 1 SIN_DATOS del
+  // lote 01 (misma evidencia, mismo resultado) en vez de avanzar sobre
+  // ISBN nunca antes intentados.
+  const isbnsLote02 = new Set(BOOK_FACT_ENRICHMENTS_B11_2_LOTE_02.map(entry => entry.isbn));
+  const known = ['9780194114226', '9781316627686', '9781640951877'];
+  for (const isbn of known) {
+    assert.equal(isbnsLote02.has(isbn), false, isbn);
+  }
+});
+
+test('B11.2 lote 02 no contiene ni modifica títulos o datos comerciales', () => {
+  const forbidden = /"(?:title|description|price|available_quantity|stock|slug|canonical|pictures|thumbnail|condition)"\s*:/;
+  assert.equal(forbidden.test(JSON.stringify(BOOK_FACT_ENRICHMENTS_B11_2_LOTE_02)), false);
+
+  for (const entry of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_02) {
+    const original = {
+      id: entry.sample_listing_id || 'MLU999999999',
+      isbn: entry.isbn,
+      title: `Título original ${entry.isbn}`,
+      author: 'Desconocido',
+      description: 'Descripción comercial original.',
+      publisher: null,
+      pages: null,
+      price: 990,
+      currency_id: 'UYU',
+      status: 'active',
+      available_quantity: 3,
+      condition: 'new',
+      pictures: [{ url: 'https://example.com/portada.jpg' }],
+      canonical: `/libro/${entry.sample_listing_id || 'MLU999999999'}/titulo-original`,
+    };
+    const enriched = applyBookEnrichment(original);
+
+    assert.notEqual(enriched, original, entry.isbn);
+    assert.equal(enriched.title, original.title, entry.isbn);
+    assert.equal(enriched.description, original.description, entry.isbn);
+    assert.equal(enriched.price, original.price, entry.isbn);
+    assert.equal(enriched.available_quantity, original.available_quantity, entry.isbn);
+    assert.equal(enriched.condition, original.condition, entry.isbn);
+    assert.equal(enriched.canonical, original.canonical, entry.isbn);
+    assert.deepEqual(enriched.pictures, original.pictures, entry.isbn);
+  }
+});
+
+test('B11.2 lote 02: applyBookEnrichment publica el hecho aunque el catálogo ya traiga la clave bibliográfica vacía', () => {
+  for (const entry of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_02) {
+    const original = {
+      id: entry.sample_listing_id || 'MLU999999999',
+      isbn: entry.isbn,
+      title: `Título original ${entry.isbn}`,
+      author: 'Desconocido',
+      publisher: '',
+      pages: null,
+      bibliographic: { language: '', format: '', edition: '', publication_year: '' },
+      status: 'active',
+    };
+    const enriched = applyBookEnrichment(original);
+    for (const [field, value] of Object.entries(entry.facts.bibliographic || {})) {
+      assert.equal(enriched.bibliographic[field], value, `${entry.isbn}.${field}`);
+    }
+  }
+});

--- a/functions/__tests__/b11-2-resolve-revisar.test.js
+++ b/functions/__tests__/b11-2-resolve-revisar.test.js
@@ -21,7 +21,8 @@ test('B11.2 lote 01 resuelve 12 ISBN del pool REVISAR con consenso cruzado real'
       assert.match(source.url, /^https:\/\//);
     }
   }
-  assert.equal(listBookEnrichments().length, 1538);
+  // El total global sube con cada lote posterior (B11.2 lote 02 agrega 12 más).
+  assert.equal(listBookEnrichments().length, 1550);
 });
 
 test('B11.2 lote 01 no contiene ni modifica títulos o datos comerciales', () => {

--- a/functions/__tests__/book-enrichment-lote-01.test.js
+++ b/functions/__tests__/book-enrichment-lote-01.test.js
@@ -27,8 +27,8 @@ test('el lote 01 incorpora 187 ISBN nuevos con evidencia verificable', () => {
     assert.equal(validateBookEnrichment(entry), true, entry.isbn);
     assert.equal(getBookEnrichmentByIsbn(entry.isbn), entry);
   }
-  // El total global sube con cada lote posterior (B11.2 agrega 12 más).
-  assert.equal(listBookEnrichments().length, 1538);
+  // El total global sube con cada lote posterior (B11.2 lote 01 + lote 02 agregan 24 más).
+  assert.equal(listBookEnrichments().length, 1550);
 });
 
 test('el lote 01 no contiene ni modifica títulos o datos comerciales', () => {

--- a/functions/_shared/book-enrichment-facts-b11-2-lote-02.js
+++ b/functions/_shared/book-enrichment-facts-b11-2-lote-02.js
@@ -1,0 +1,474 @@
+// Generado por scripts/seo/b11-2-resolve-revisar.mjs. NO EDITAR A MANO.
+// Hechos verificados por consenso cruzado de fuentes independientes,
+// resolviendo conflictos de identidad del pool REVISAR de B11.1.
+
+export const BOOK_FACT_ENRICHMENTS = Object.freeze([
+  {
+    "schema_version": 1,
+    "isbn": "9781711054490",
+    "sample_listing_id": "MLU1031375038",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2019"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=TuRFzAEACAAJ&dq=isbn:9781711054490&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9781711054490",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9781711054490",
+        "relationship": "exact_edition",
+        "isbn": "9781711054490",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9786074485905",
+    "sample_listing_id": "MLU638995253",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2017"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=r6lNswEACAAJ&dq=isbn:9786074485905&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9786074485905",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9786074485905",
+        "relationship": "exact_edition",
+        "isbn": "9786074485905",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788408039532",
+    "sample_listing_id": "MLU619139873",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "language": "Español, Francés"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788408039532%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788408039532",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "language"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788408239321",
+    "sample_listing_id": "MLU1494066700",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2021"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788408239321%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788408239321",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=oDKGzgEACAAJ&dq=isbn:9788408239321&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788408239321",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788408239321",
+        "relationship": "exact_edition",
+        "isbn": "9788408239321",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788408249436",
+    "sample_listing_id": "MLU668440964",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Booket",
+      "bibliographic": {
+        "publication_year": "2021"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788408249436%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788408249436",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788408249436",
+        "relationship": "exact_edition",
+        "isbn": "9788408249436",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788408257363",
+    "sample_listing_id": "MLU625847761",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2022"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788408257363%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788408257363",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=7qZCzwEACAAJ&dq=isbn:9788408257363&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788408257363",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788408257363",
+        "relationship": "exact_edition",
+        "isbn": "9788408257363",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788408262770",
+    "sample_listing_id": "MLU620296782",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Booket",
+      "bibliographic": {
+        "publication_year": "2022"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788408262770%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788408262770",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788408262770",
+        "relationship": "exact_edition",
+        "isbn": "9788408262770",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788411323000",
+    "sample_listing_id": "MLU698429827",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2023"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788411323000%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788411323000",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788411323000",
+        "relationship": "exact_edition",
+        "isbn": "9788411323000",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788412364163",
+    "sample_listing_id": "MLU660119936",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Ediciones Arcanas",
+      "bibliographic": {
+        "publication_year": "2021"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788412364163%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788412364163",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788412364163",
+        "relationship": "exact_edition",
+        "isbn": "9788412364163",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788412440843",
+    "sample_listing_id": "MLU692240645",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2022"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788412440843%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788412440843",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788412440843",
+        "relationship": "exact_edition",
+        "isbn": "9788412440843",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788415292494",
+    "sample_listing_id": "MLU634314472",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Arkano Books",
+      "bibliographic": {
+        "language": "Español, Inglés",
+        "publication_year": "2016"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788415292494%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788415292494",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "language",
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788415292494",
+        "relationship": "exact_edition",
+        "isbn": "9788415292494",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788415577133",
+    "sample_listing_id": "MLU685273682",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2012"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788415577133%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788415577133",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=MxQrLgEACAAJ&dq=isbn:9788415577133&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788415577133",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788415577133",
+        "relationship": "exact_edition",
+        "isbn": "9788415577133",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  }
+]);

--- a/functions/_shared/book-enrichment-registry.js
+++ b/functions/_shared/book-enrichment-registry.js
@@ -9,6 +9,7 @@ import { BOOK_FACT_ENRICHMENTS } from './book-enrichment-facts-1000.js';
 import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_333 } from './book-enrichment-facts-333.js';
 import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_LOTE_01 } from './book-enrichment-facts-lote-01.js';
 import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01 } from './book-enrichment-facts-b11-2-lote-01.js';
+import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_B11_2_LOTE_02 } from './book-enrichment-facts-b11-2-lote-02.js';
 import { BOOK_EDITORIAL_UPGRADES } from './book-editorial-upgrades.js';
 import { isGenericAuthor, normalizeValidIsbn } from './showcase-ranking.js';
 
@@ -516,6 +517,15 @@ for (const record of BOOK_FACT_ENRICHMENTS_LOTE_01) {
 // B11.2: ISBN que B11.1 dejó en REVISAR, resueltos por consenso cruzado de
 // fuentes independientes (scripts/seo/b11-2-resolve-revisar.mjs).
 for (const record of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01) {
+  if (!validateBookEnrichment(record)) {
+    throw new Error(`Enriquecimiento factual inválido para ${record?.isbn || 'ISBN desconocido'}.`);
+  }
+  if (ENRICHMENT_BY_ISBN.has(record.isbn)) {
+    throw new Error(`ISBN duplicado en el registro de enriquecimiento: ${record.isbn}.`);
+  }
+  ENRICHMENT_BY_ISBN.set(record.isbn, record);
+}
+for (const record of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_02) {
   if (!validateBookEnrichment(record)) {
     throw new Error(`Enriquecimiento factual inválido para ${record?.isbn || 'ISBN desconocido'}.`);
   }

--- a/scripts/seo/b11-2-resolve-revisar.mjs
+++ b/scripts/seo/b11-2-resolve-revisar.mjs
@@ -270,12 +270,16 @@ async function main() {
   const state = loadState();
   const alreadyEnriched = new Set(listBookEnrichments().map(entry => entry.isbn));
 
+  // Sin llamadas de red nuevas, reintentar un ISBN ya evaluado en un lote
+  // anterior (REVISAR o SIN_DATOS) da exactamente el mismo resultado — la
+  // evidencia (report/cache) no cambió. Cada lote debe avanzar sobre ISBN
+  // sin ningún intento previo, no repetir los ya intentados.
   const revisarCandidates = report.results
     .filter(result => result.publication_class === 'REVIEW')
     .map(result => normalizeValidIsbn(result.isbn))
     .filter(Boolean)
     .filter(isbn => !alreadyEnriched.has(isbn))
-    .filter(isbn => state.entries[isbn]?.status !== 'TERMINADO')
+    .filter(isbn => !state.entries[isbn])
     .sort((a, b) => a.localeCompare(b));
 
   const batch = revisarCandidates.slice(0, BATCH_SIZE);


### PR DESCRIPTION
## Objetivo

Segunda ejecución de B11.2 (pipeline continuo de resolución de
conflictos), autorizada explícitamente por Seba, sobre los **siguientes
100 ISBN** del pool REVISAR que quedaron sin intentar tras el lote 01.
No toca el pool SIN_DATOS.

## Regla de resolución automática (sin cambios respecto al lote 01)

Un ISBN pasa de REVISAR a PUBLICABLE cuando existen **dos registros de
fuentes independientes** (Google Books, Open Library, BNE) que
coinciden entre sí en **título normalizado + autor + editorial + año**
— un campo ausente en un lado nunca cuenta como conflicto, solo un
valor real que contradiga al otro.

Reutiliza la evidencia **ya investigada y commiteada** por B11.1
(`artifacts/book-intelligence/lote-01/{isbn-1000-report.json,source-cache.json}`)
— esta corrida no volvió a golpear ninguna API externa.

## Bug real encontrado y corregido antes de correr este lote

El filtro de candidatos de `scripts/seo/b11-2-resolve-revisar.mjs` sólo
excluía ISBN ya `TERMINADO`, no los que habían quedado `REVISAR` o
`SIN_DATOS` en un lote anterior. Como el script no vuelve a consultar
fuentes externas, reintentar esos ISBN da exactamente el mismo
resultado (misma evidencia inmutable) — sin el fix, este "lote 02"
hubiera vuelto a intentar los mismos 87 `REVISAR` + 1 `SIN_DATOS` del
lote 01 en vez de avanzar sobre los siguientes 100 candidatos reales.

Corregido para excluir cualquier ISBN con un estado persistente previo
en `artifacts/b11-2/state.json`, sin importar su status. Verificado: los
candidatos disponibles antes de esta corrida fueron 456 (= 556 − 100 ya
intentados en el lote 01), exactamente lo esperado.

## Resultado real del lote 02 (siguientes 100 candidatos nunca antes intentados, orden determinístico por ISBN)

| Resultado | Cantidad |
| --- | --- |
| TERMINADO (integrados) | **12** |
| SIN_DATOS | 7 |
| Siguen en REVISAR | 81 |

Candidatos REVISAR disponibles antes de esta corrida: 456. Duración del
procesamiento: 0,1s (sin llamadas de red, solo evidencia ya
investigada).

## Estado persistente acumulado

`artifacts/b11-2/state.json`: **200** ISBN (100 lote 01 + 100 lote 02),
sin solapamiento — `TERMINADO` 24, `SIN_DATOS` 8, `REVISAR` 168.

## Integración

- `functions/_shared/book-enrichment-facts-b11-2-lote-02.js`: 12
  entradas `auto_publish_facts` (editorial/páginas/idioma/año/autor
  según evidencia real). Ninguna con sinopsis.
- Conectado a `book-enrichment-registry.js` (import + merge, mismo
  patrón que el lote 01). Registry total: 1.538 → **1.550**.
- Test dedicado `b11-2-lote-02.test.js`: valida las 12 entradas contra
  `validateBookEnrichment`, confirma que ninguna repite un ISBN del
  lote 01, que no tocan título/H1/slug/precio/stock/condición/
  imágenes/canonical, y que el merge de `bibliographic` sigue
  publicando el hecho aunque el catálogo ya traiga la clave vacía
  (regresión del bug real encontrado y corregido en el lote 01).
- `b11-2-resolve-revisar.test.js` y `book-enrichment-lote-01.test.js`
  actualizados (1538→1550 en el total global del registry).

## Contrato inviolable

Verificado por test: título original, H1, slug, canonical, descripción
comercial preexistente, precio, stock, condición, imágenes, carrito y
datos de Merchant permanecen intactos.

## Pruebas

- Suite completa de Functions: **1.052/1.052**.
- `bash scripts/validate-ci.sh` (build Preview + Producción, smoke checkout ON/OFF): **OK**.
- `git diff --check`: sin errores.

**Draft — no fusionar sin autorización explícita de Seba.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri

---
_Generated by [Claude Code](https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri)_