### PR TITLE
docs(b11): cierre documental — recuperar PLAN-MAESTRO y ESTADO-ACTUAL en main y alinearlos con el estado real

### DIFF
--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -1,6 +1,31 @@
 # ESTADO ACTUAL — B11: enriquecimiento editorial real (2.000 fichas)
 
-Última actualización: 2026-09-02 (sesión `session_014vUFN9BC9DEb3Nh1B477Ri`), tras verificar B11.2 Lote 02 en Producción.
+Última actualización: 2026-09-02 — cierre documental tras la verificación de
+B11.2 Lote 02 en Producción. Este documento y `PLAN-MAESTRO.md` se recuperan
+en `main` (vivían solo en la rama del PR #300, que nunca se fusionó) y quedan
+alineados con el estado real del repositorio.
+
+## Estado canónico (fuente de verdad)
+
+| Métrica | Valor |
+| --- | --- |
+| ISBN enriquecidos en el registry | **1.550** |
+| Pendientes totales | **2.065** |
+| — de los cuales `REVISAR` (evidencia con conflicto de identidad) | **524** |
+| — de los cuales `SIN_DATOS` (sin evidencia utilizable) | **1.541** |
+| Universo addressable | **3.615** ISBN únicos |
+| Fase activa | **B11.2** (pipeline continuo sobre el pool `REVISAR`) |
+| Lotes B11.2 terminados | **01 y 02** (fusionados y verificados en Producción) |
+| Lotes B11.2 en curso | **ninguno — no hay ningún lote nuevo iniciado** |
+
+Verificación aritmética: 524 + 1.541 = 2.065 pendientes; 1.550 + 2.065 =
+3.615. El universo no crece: cada lote sólo reclasifica ISBN dentro de él.
+
+Comprobación contra el repositorio (no son cifras declarativas):
+`listBookEnrichments()` de `functions/_shared/book-enrichment-registry.js`
+devuelve 1.550 ISBN, y `artifacts/b11-2/state.json` contiene 200 entradas
+con `TERMINADO` 24, `SIN_DATOS` 8 y `REVISAR` 168 — los 200 ISBN intentados
+por los lotes 01 y 02.
 
 ## B11 Lote 1 — TERMINADO (fusionado y verificado en Producción)
 
@@ -11,29 +36,39 @@
 - Book enrichment live check contra Producción (`https://www.amadolibros.com`), `run 33545168003`: **1.517 verified, 9 not_applicable, 0 failed** sobre el registry completo de 1.526 ISBN (incluidos los 187 del Lote 1). Los 9 `not_applicable` son ISBN del registry sin ninguna publicación MLU activa hoy — no es una falla, es la conservación correcta del dato para cuando vuelva a haber oferta.
 - Muestra de 12 ISBN del Lote 1 verificados individualmente contra Producción (mezcla de los 19 de la 1ª corrida y los 168 de la 2ª): `9788401039058`, `9788408214359`, `9788425427015`, `9788446056720`, `9788467975819`, `9780006551805`, `9780142410110`, `9780194053921`, `9780198338734`, `9780307951526`, `9780230490017`, `9780199640942` — los 12 con status `verified`, cada uno con sus propios MLU reales y sin mezcla de datos entre ISBN.
 
-## Contadores acumulados
+## Contadores del Lote 1 (histórico, ya superado)
 
-| Métrica | Valor |
+Esta tabla es la foto al cierre de B11.1 y se conserva como registro. Los
+contadores vigentes son los de "Estado canónico" al principio del documento.
+
+| Métrica | Valor al cierre del Lote 1 |
 | --- | --- |
 | Universo inicial del Lote 1 (ISBN elegibles investigados) | 2.276 |
 | Fichas enriquecidas correctamente (verificadas, en `main` y Producción) | **187** (18 `GREEN_FULL` + 169 `GREEN_FACTS`) |
-| Fichas pendientes totales | **2.089** |
-| — de las cuales SIN_DATOS (sin evidencia utilizable) | 1.533 |
-| — de las cuales REVISAR (evidencia con conflicto de identidad) | 556 |
-| PRs abiertos (lotes) | 0 |
-| PRs fusionados (lotes) | 2 — [PR #303](https://github.com/trexxeseba/amadolibros-web/pull/303) (187 fichas), [PR #304](https://github.com/trexxeseba/amadolibros-web/pull/304) (infra de verificación) |
+| Fichas pendientes entonces | **2.089** |
+| — de las cuales SIN_DATOS | 1.533 |
+| — de las cuales REVISAR | 556 |
 
-Verificación: 187 + 2.089 = 2.276. 1.533 + 556 = 2.089. Los 556 REVISAR
-están **dentro** de los 2.089 pendientes, no se suman aparte.
+Verificación de esa foto: 187 + 2.089 = 2.276. 1.533 + 556 = 2.089. Los 556
+REVISAR estaban **dentro** de los 2.089 pendientes, no se sumaban aparte.
+B11.2 ya movió esos números: ver "Estado canónico".
 
-Total del catálogo (todos los lotes B11 hasta ahora, incluidos B11.2
-Lote 01 y Lote 02): 1.339 ya enriquecidos antes del Lote 1 + 187 del
-Lote 1 + 12 de B11.2 Lote 01 + 12 de B11.2 Lote 02 = **1.550 ISBN
-enriquecidos**. Universo addressable completo: 1.550 + 2.065 pendientes
-(1.541 SIN_DATOS + 524 REVISAR) = **3.615 ISBN únicos** (sin cambios —
-el universo no crece, solo se reclasifican ISBN dentro de él). Ver la
-sección "B11.2 Lote 02" más abajo para el detalle y la evidencia de
-Producción.
+## Composición del registry actual
+
+| Origen | ISBN |
+| --- | --- |
+| Enriquecidos antes del Lote 1 | 1.339 |
+| B11 Lote 1 | 187 |
+| B11.2 Lote 01 | 12 |
+| B11.2 Lote 02 | 12 |
+| **Total en el registry** | **1.550** |
+
+## Estado de PRs
+
+| Métrica | Valor |
+| --- | --- |
+| PRs de lote abiertos | 0 — ningún lote nuevo iniciado |
+| PRs de lote fusionados | 4 — [#303](https://github.com/trexxeseba/amadolibros-web/pull/303) (187 fichas), [#304](https://github.com/trexxeseba/amadolibros-web/pull/304) (infra de verificación), [#305](https://github.com/trexxeseba/amadolibros-web/pull/305) (B11.2 Lote 01), [#306](https://github.com/trexxeseba/amadolibros-web/pull/306) (B11.2 Lote 02) |
 
 ## Corrección de Google Books (aplicada y verificada)
 
@@ -229,6 +264,20 @@ No tocó el pool SIN_DATOS.
   = 2.065 pendientes; 1.550 enriquecidos + 2.065 pendientes = 3.615 —
   el universo total no cambia, sólo se movieron 12 ISBN de pendiente a
   enriquecido y 7 de REVISAR a SIN_DATOS.
+
+## B11.2 Lote 03 — NO INICIADO
+
+No hay ningún lote nuevo en curso. Tras el Lote 02 no se creó rama, no se
+ejecutó ninguna corrida y no se abrió ningún PR de lote: el pipeline está
+detenido a la espera de autorización explícita.
+
+- Candidatos disponibles para un eventual Lote 03: **356** ISBN del pool
+  `REVISAR` nunca intentados (524 `REVISAR` totales − 87 del Lote 01 sin
+  resolver − 81 del Lote 02 sin resolver).
+- Reintentar los 168 `REVISAR` ya intentados no aporta nada mientras no
+  haya evidencia nueva: el resolver reutiliza evidencia inmutable, así que
+  daría exactamente el mismo resultado.
+- Los 1.541 `SIN_DATOS` siguen fuera del circuito automático por diseño.
 
 ## PR #298 — CERRADO
 

--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -1,0 +1,236 @@
+# ESTADO ACTUAL — B11: enriquecimiento editorial real (2.000 fichas)
+
+Última actualización: 2026-09-02 (sesión `session_014vUFN9BC9DEb3Nh1B477Ri`), tras verificar B11.2 Lote 02 en Producción.
+
+## B11 Lote 1 — TERMINADO (fusionado y verificado en Producción)
+
+- [PR #303](https://github.com/trexxeseba/amadolibros-web/pull/303) fusionado a `main` por trexxeseba (squash, commit `5b46f72`), 2026-09-01T16:55:06Z.
+- [PR #304](https://github.com/trexxeseba/amadolibros-web/pull/304) fusionado (infra de verificación manual contra cualquier `base_url`), commit `7be3b3931b`.
+- Deploy to Cloudflare Pages sobre `5b46f72`: `run 33534675172`, intento 2, **success** (el intento 1 falló solo en el job "Publish production paused/active catalog" por un `Recv failure: Connection reset by peer` transitorio de red; el job "Deploy" —build, Wrangler, smoke test— fue success desde el intento 1).
+- Full commerce production audit (dispatch manual, `sample_only=true`), `run 33544377442`: **result=pass, critical=0** — catálogo 7.128 items, feed Merchant 3.707 items (0 críticos/warnings), 300/300 imágenes válidas (`r2-production`), 300/300 páginas verificadas.
+- Book enrichment live check contra Producción (`https://www.amadolibros.com`), `run 33545168003`: **1.517 verified, 9 not_applicable, 0 failed** sobre el registry completo de 1.526 ISBN (incluidos los 187 del Lote 1). Los 9 `not_applicable` son ISBN del registry sin ninguna publicación MLU activa hoy — no es una falla, es la conservación correcta del dato para cuando vuelva a haber oferta.
+- Muestra de 12 ISBN del Lote 1 verificados individualmente contra Producción (mezcla de los 19 de la 1ª corrida y los 168 de la 2ª): `9788401039058`, `9788408214359`, `9788425427015`, `9788446056720`, `9788467975819`, `9780006551805`, `9780142410110`, `9780194053921`, `9780198338734`, `9780307951526`, `9780230490017`, `9780199640942` — los 12 con status `verified`, cada uno con sus propios MLU reales y sin mezcla de datos entre ISBN.
+
+## Contadores acumulados
+
+| Métrica | Valor |
+| --- | --- |
+| Universo inicial del Lote 1 (ISBN elegibles investigados) | 2.276 |
+| Fichas enriquecidas correctamente (verificadas, en `main` y Producción) | **187** (18 `GREEN_FULL` + 169 `GREEN_FACTS`) |
+| Fichas pendientes totales | **2.089** |
+| — de las cuales SIN_DATOS (sin evidencia utilizable) | 1.533 |
+| — de las cuales REVISAR (evidencia con conflicto de identidad) | 556 |
+| PRs abiertos (lotes) | 0 |
+| PRs fusionados (lotes) | 2 — [PR #303](https://github.com/trexxeseba/amadolibros-web/pull/303) (187 fichas), [PR #304](https://github.com/trexxeseba/amadolibros-web/pull/304) (infra de verificación) |
+
+Verificación: 187 + 2.089 = 2.276. 1.533 + 556 = 2.089. Los 556 REVISAR
+están **dentro** de los 2.089 pendientes, no se suman aparte.
+
+Total del catálogo (todos los lotes B11 hasta ahora, incluidos B11.2
+Lote 01 y Lote 02): 1.339 ya enriquecidos antes del Lote 1 + 187 del
+Lote 1 + 12 de B11.2 Lote 01 + 12 de B11.2 Lote 02 = **1.550 ISBN
+enriquecidos**. Universo addressable completo: 1.550 + 2.065 pendientes
+(1.541 SIN_DATOS + 524 REVISAR) = **3.615 ISBN únicos** (sin cambios —
+el universo no crece, solo se reclasifican ISBN dentro de él). Ver la
+sección "B11.2 Lote 02" más abajo para el detalle y la evidencia de
+Producción.
+
+## Corrección de Google Books (aplicada y verificada)
+
+La corrida 1 (`33457523327`) tenía Google Books casi inutilizable: 39/40
+pedidos con `HTTP 429`, circuit-breaker cortando el resto. Causa:
+concurrencia/ritmo (2 pedidos en paralelo, 1,1s de espera) excedía la
+cuota por segundo del proyecto GCP. Corrección aplicada en
+`b11-batch-research.yml`: concurrencia 1, delay 2s, presupuestos de BNE/
+Open Library/Google Books ampliados al universo elegible completo (2.276).
+
+**Resultado de la corrida 2** (`33513707088`, éxito, 57 min): Google Books
+pasó de 1/40 a **615/2.257** coincidencias exactas (71 errores, ya no por
+cuota agotada; 2.257 = 2.276 menos las 19 ya resueltas en la corrida 1).
+Open Library: 1.071/2.257. BNE: 234/2.257. `GREEN_FULL` 1→17 nuevos,
+`GREEN_FACTS` 18→151 nuevos: de 19 a **187** ISBN verificados en total
+(+8,8×).
+
+**Bug encontrado y corregido en la propia corrida 2:** el script
+`book-intelligence-project.mjs` reescribe el archivo de hechos del lote
+desde cero con el manifest de la corrida actual — la corrida 2 pisó (no
+fusionó) los 19 ISBN de la corrida 1 en el archivo commiteado por el
+workflow. Se detectó antes de fusionar nada a `main`, se recuperaron los
+19 desde el commit `86bbec3` y se fusionaron sin ISBN duplicados: 187
+totales, verificado por test. El workflow se corrigió para que corridas
+futuras del mismo lote **acumulen** sobre el archivo existente en vez de
+pisarlo — evita que el mismo bug se repita en los lotes siguientes.
+
+## Validación (todas corridas localmente sobre el head actual del PR #303)
+
+- Tests focales (lote-01 + editorial-upgrades + 333 + boundary + 1000 +
+  cohort-2000): **20/20**.
+- Suite completa de Functions: **1.041/1.041**.
+- `bash scripts/validate-ci.sh` (build Preview + Producción, smoke
+  checkout ON/OFF): **OK**.
+- `git diff --check`: sin errores.
+- CI de GitHub Actions sobre el commit final del PR #303: verificado, ver
+  sección de checks más abajo.
+
+## Sigue sin haber sinopsis real
+
+Ninguna de las 187 fichas tiene sinopsis: el pipeline masivo
+(`book-intelligence-project.mjs`) solo escribe hechos bibliográficos
+(editorial, páginas, idioma, año, temas) — por diseño explícito del
+propio script, nunca copia una sinopsis externa. Conseguir sinopsis real
+(como el precedente Disney, PR #296) requiere lectura y redacción caso
+por caso de la evidencia ya obtenida (Google Books ahora sí trae
+`description` para varios de los 615 matches).
+
+## 🔴 El techo del catálogo sigue siendo el hallazgo crítico
+
+3.615 ISBN únicos en todo el catálogo addressable. El objetivo original
+de "2.000 fichas nuevas" sigue excediendo por mucho lo que el catálogo
+tiene para dar: incluso con Google Books funcionando, este lote convirtió
+187/2.276 (8,2%) en verificado — una mejora real de ~9× sobre el 0,8%
+anterior — pero el techo absoluto no cambia. Ver `PLAN-MAESTRO.md` para
+el rediseño (B11.2) que reemplaza el objetivo fijo de 2.000 por un
+pipeline continuo con estados persistentes sobre el universo real.
+
+## B11.2 Lote 01 — TERMINADO (fusionado y verificado en Producción)
+
+Autorizado e iniciado 2026-09-01, sobre el pool de 556 `REVISAR` dejado
+por B11.1, sin tocar los 1.533 `SIN_DATOS`. Primer lote de 100 ISBN.
+
+- Regla aplicada: un ISBN pasa a `PUBLICABLE` cuando 2 fuentes
+  independientes (Google Books/Open Library/BNE) coinciden entre sí en
+  título normalizado + autor + editorial + año (un campo ausente en un
+  lado nunca cuenta como conflicto). Reutiliza evidencia ya investigada
+  por B11.1 — 0 llamadas de red nuevas.
+- Resultado real del lote 01: **12 TERMINADO** (integrados al
+  registry), **1 SIN_DATOS** (identidad confirmada, sin hechos con
+  evidencia suficiente para publicar), **87 siguen REVISAR**. Duración
+  del procesamiento: 0,1s.
+- Estado persistente commiteado en `artifacts/b11-2/state.json`
+  (acumulativo, retomable, nunca reprocesa un `TERMINADO`).
+- [PR #305](https://github.com/trexxeseba/amadolibros-web/pull/305)
+  fusionado a `main` por trexxeseba (squash, commit `8d474bf`),
+  2026-09-01.
+- Dos bugs reales encontrados y corregidos durante la verificación
+  (ninguno tocó título/precio/stock/imágenes/datos comerciales, los
+  tres siguientes hallazgos son solo de la propia herramienta de
+  verificación/merge):
+  1. Las URLs `infoLink`/`selfLink` de Google Books a veces vienen en
+     `http://`, no `https://`, y `validateBookEnrichment` exige
+     `https`. Sin la normalización (ya usada en
+     `book-intelligence-project.mjs`, faltaba replicarla en el
+     resolver) el resolver daba 0 resueltos en vez de 12.
+  2. `applyBookEnrichment` mezclaba `bibliographic` con spread de
+     objeto: una clave ya presente en el ítem del catálogo (aunque
+     vacía, como suele traer MercadoLibre) tapaba el hecho verificado
+     en vez de sólo ganar cuando su propio valor es real —
+     inconsistente con el patrón que ya usan `publisher`/`pages`.
+     Corregido con test de regresión.
+  3. `book-enrichment-live-check.mjs` exigía que cada
+     `auto_publish_facts` introdujera al menos un campo visible nuevo
+     respecto al catálogo para considerarse "verificado". Con
+     evidencia real de CI se confirmó que no había corrupción de
+     datos: 8 de los 12 ISBN ya tenían en el catálogo el mismo valor
+     real que el hecho verificado (ej. `9780194501873`:
+     `publication_year "2015"` en ambos lados — hecho legítimamente
+     redundante), y el resto tenía un valor real distinto que el merge
+     correctamente no pisa (ej. catálogo con `"2222"`, un dato erróneo
+     del vendedor). Corregido: el gate ahora verifica que los hechos
+     que sí se aplicaron se rendericen bien, sin exigir novedad.
+- Deploy to Cloudflare Pages sobre `8d474bf`: `run 33558241703`,
+  **success** (el job "Publish production paused/active catalog" tardó
+  ~9 min pero terminó en verde; el resto —build, Wrangler, smoke
+  test— fue success desde el arranque).
+- Full commerce production audit (dispatch manual, `sample_only=true`),
+  `run 33559277806`: **result=pass, critical=0** — catálogo 7.128
+  items, feed Merchant 3.707 items (0 críticos/warnings), 300/300
+  imágenes válidas (`r2-production`), 300/300 páginas verificadas.
+- Book enrichment live check contra Producción
+  (`https://www.amadolibros.com`), `run 33559284981`: **1.529
+  verified, 9 not_applicable, 0 failed** sobre el registry completo de
+  **1.538** ISBN (1.529 + 9 = 1.538, exacto). Los 9 `not_applicable`
+  son los mismos ISBN sin publicación MLU activa ya vistos en la
+  verificación del Lote 1 — no es una falla nueva.
+- Los 12 ISBN de este lote verificados individualmente contra
+  Producción, todos `verified`, cada uno con sus propios MLU reales y
+  sin mezcla de datos entre ISBN: `9780194114226` (MLU637863473,
+  MLU674080904), `9780194419215` (MLU637824793, MLU1300310658,
+  MLU1299647170), `9780194501873` (MLU702908736, MLU702882796),
+  `9780194730952` (MLU675019228, MLU638287647), `9780230498181`
+  (MLU887472434, MLU653511723), `9781090348418` (MLU679894804),
+  `9781292268729` (MLU627781415), `9781292401133` (MLU628486908,
+  MLU636069230), `9781316627686` (MLU642033254, MLU658014430),
+  `9781456277161` (MLU684400158, MLU684374146), `9781557764256`
+  (MLU725474470, MLU730190378), `9781640951877` (MLU1467423248,
+  MLU1468208694).
+- Tests: 6/6 focales de B11.2 (+2 tests de regresión agregados durante
+  la verificación) + 1.048/1.048 suite completa + `validate-ci.sh` OK +
+  `git diff --check` limpio.
+- Pendientes de REVISAR tras este lote: 556 − 12 − 1 = **543** (444 sin
+  tocar aún + 87 reintentados sin éxito en este lote). SIN_DATOS:
+  1.533 + 1 = **1.534**. Verificación: 543 + 1.534 = 2.077 pendientes;
+  1.538 enriquecidos + 2.077 pendientes = 3.615 — el universo total no
+  cambia, sólo se movieron 12 ISBN de pendiente a enriquecido y 1 de
+  REVISAR a SIN_DATOS.
+
+## B11.2 Lote 02 — TERMINADO (fusionado y verificado en Producción)
+
+Autorizado explícitamente por Seba el 2026-09-02, sobre los **siguientes
+100 ISBN** del pool REVISAR que quedaron sin intentar tras el lote 01.
+No tocó el pool SIN_DATOS.
+
+- Bug real encontrado y corregido antes de correr este lote: el filtro
+  de candidatos de `scripts/seo/b11-2-resolve-revisar.mjs` sólo excluía
+  ISBN ya `TERMINADO`, no los que habían quedado `REVISAR` o
+  `SIN_DATOS` en el lote 01. Como el script reutiliza la misma
+  evidencia inmutable (sin nuevas consultas externas), reintentar esos
+  ISBN da exactamente el mismo resultado — sin el fix, este lote habría
+  repetido los mismos 87 `REVISAR` + 1 `SIN_DATOS` del lote 01 en vez
+  de avanzar. Corregido para excluir cualquier ISBN con un estado
+  persistente previo, sin importar su status. Verificado: candidatos
+  disponibles antes de la corrida = 456 (= 556 − 100 ya intentados en
+  el lote 01), exacto.
+- Resultado real del lote 02: **12 TERMINADO** (integrados al
+  registry), **7 SIN_DATOS**, **81 siguen REVISAR**. Duración del
+  procesamiento: 0,1s.
+- Estado persistente acumulado en `artifacts/b11-2/state.json`: **200**
+  ISBN (100 lote 01 + 100 lote 02), sin solapamiento — `TERMINADO` 24,
+  `SIN_DATOS` 8, `REVISAR` 168.
+- [PR #306](https://github.com/trexxeseba/amadolibros-web/pull/306)
+  fusionado a `main` por trexxeseba (squash, commit `662c13c`),
+  2026-09-02.
+- Deploy to Cloudflare Pages sobre `662c13c`: `run 33581187859`,
+  **success**.
+- Full commerce production audit (dispatch manual, `sample_only=true`),
+  `run 33634575851`: **result=pass, critical=0** — catálogo 7.115
+  items, feed Merchant 3.702 items (0 críticos/warnings), 300/300
+  imágenes válidas (`r2-production`), 300/300 páginas verificadas.
+- Book enrichment live check contra Producción
+  (`https://www.amadolibros.com`), `run 33634584205`: **1.535
+  verified, 15 not_applicable, 0 failed** sobre el registry completo de
+  **1.550** ISBN (1.535 + 15 = 1.550, exacto).
+- Los 12 ISBN de este lote verificados individualmente contra
+  Producción, todos `verified`, cada uno con sus propios MLU reales y
+  sin mezcla de datos entre ISBN: `9781711054490` (MLU1031375038,
+  MLU1033790258), `9786074485905` (MLU638995253, MLU676667854),
+  `9788408039532` (MLU619139873, MLU663111902), `9788408239321`
+  (MLU1494561902, MLU1494066700), `9788408249436` (MLU668636662,
+  MLU668440964), `9788408257363` (MLU625847761, MLU654868116),
+  `9788408262770` (MLU620296782, MLU649316004), `9788411323000`
+  (MLU698429827), `9788412364163` (MLU660119936, MLU660297658),
+  `9788412440843` (MLU692240645, MLU692279433), `9788415292494`
+  (MLU634314472, MLU654449602), `9788415577133` (MLU685273682,
+  MLU685118228).
+- Tests: suite completa **1.052/1.052** + `validate-ci.sh` OK +
+  `git diff --check` limpio.
+- Contadores tras este lote: REVISAR-status = 87 (lote 01, sin tocar) +
+  356 (nunca intentados, 456 − 100) + 81 (lote 02, sin resolver) =
+  **524**. SIN_DATOS: 1.534 + 7 = **1.541**. Verificación: 524 + 1.541
+  = 2.065 pendientes; 1.550 enriquecidos + 2.065 pendientes = 3.615 —
+  el universo total no cambia, sólo se movieron 12 ISBN de pendiente a
+  enriquecido y 7 de REVISAR a SIN_DATOS.
+
+## PR #298 — CERRADO
+
+Registrado como definitivamente cerrado y fusionado. Ver detalle completo en
+`PLAN-MAESTRO.md`. No requiere ninguna acción adicional.

--- a/PLAN-MAESTRO.md
+++ b/PLAN-MAESTRO.md
@@ -1,14 +1,33 @@
 # PLAN MAESTRO — B11: enriquecimiento editorial real del catálogo
 
+## Estado vigente (2026-09-02)
+
+- **Fase activa: B11.2** — pipeline continuo con estados persistentes. La
+  estructura original de 10 lotes de 200 fichas quedó **superada** y se
+  conserva más abajo sólo como registro histórico.
+- **Lotes B11.2 terminados: 01 y 02**, ambos fusionados a `main` y
+  verificados en Producción.
+- **Ningún lote nuevo iniciado**: no hay rama, corrida ni PR de un Lote 03.
+- Contadores canónicos: registry **1.550**, pendientes **2.065**
+  (`REVISAR` **524** + `SIN_DATOS` **1.541**), universo **3.615**.
+- Los contadores en vivo, la evidencia de Producción y los bloqueos activos
+  están en `ESTADO-ACTUAL.md`, que es la fuente de verdad operativa.
+
 ## Objetivo operativo
 
-Enriquecer 2.000 fichas reales del catálogo con información editorial
-verificable (sinopsis, descripción, temas, público, autoría, datos
-bibliográficos, FAQ específicas, metadatos SEO secundarios), organizado en
-**10 lotes consecutivos de 200 fichas**, cada uno en su propia rama y PR.
+Enriquecer fichas reales del catálogo con información editorial verificable
+(sinopsis, descripción, temas, público, autoría, datos bibliográficos, FAQ
+específicas, metadatos SEO secundarios).
 
-No es un piloto. El objetivo es 2.000 fichas efectivamente implementadas,
-probadas y presentadas en PRs — no un plan ni un lote testimonial.
+El objetivo original —2.000 fichas en **10 lotes consecutivos de 200**, cada
+uno en su propia rama y PR— se fijó antes de conocer el rendimiento real del
+catálogo. El Lote 1 lo desmintió: de 2.276 ISBN elegibles investigados sólo
+187 calificaron, un 8,2%. Desde B11.2 la meta ya no es un número fijo de
+fichas sino **agotar el universo real** de 3.615 ISBN hasta donde llegue la
+evidencia verificable, en lotes dimensionados a ese rendimiento efectivo.
+
+Lo que no cambió: no es un piloto. Cada lote se implementa, se prueba y se
+presenta en un PR — nada de lotes testimoniales ni de planes sin ejecución.
 
 ## Historial verificado
 
@@ -79,27 +98,33 @@ sobre `main`. Si una ficha no tiene información confiable suficiente:
 saltear y reemplazar por otra hasta completar 2.000 fichas efectivamente
 enriquecidas.
 
-## Estructura de los 10 lotes
+## Lotes ejecutados
 
-| Lote | Fichas | Rama | PR | Estado |
+| Fase | Lote | Alcance real | PR | Estado |
 | --- | --- | --- | --- | --- |
-| 1 | Universo 2.276 → 187 enriquecidos | `b11/enriquecimiento-lote-01-ci` | [#303](https://github.com/trexxeseba/amadolibros-web/pull/303) | **Fusionado y verificado en Producción** (commit `5b46f72`) |
-| 2 | 201–400 | `b11/enriquecimiento-lote-02` | pendiente | pendiente |
-| 3 | 401–600 | `b11/enriquecimiento-lote-03` | pendiente | pendiente |
-| 4 | 601–800 | `b11/enriquecimiento-lote-04` | pendiente | pendiente |
-| 5 | 801–1000 | `b11/enriquecimiento-lote-05` | pendiente | pendiente |
-| 6 | 1001–1200 | `b11/enriquecimiento-lote-06` | pendiente | pendiente |
-| 7 | 1201–1400 | `b11/enriquecimiento-lote-07` | pendiente | pendiente |
-| 8 | 1401–1600 | `b11/enriquecimiento-lote-08` | pendiente | pendiente |
-| 9 | 1601–1800 | `b11/enriquecimiento-lote-09` | pendiente | pendiente |
-| 10 | 1801–2000 | `b11/enriquecimiento-lote-10` | pendiente | pendiente |
+| B11.1 | 1 | Universo 2.276 → 187 enriquecidos | [#303](https://github.com/trexxeseba/amadolibros-web/pull/303) | **Fusionado y verificado en Producción** (commit `5b46f72`) |
+| B11.1 | — | Infra de verificación manual contra cualquier `base_url` | [#304](https://github.com/trexxeseba/amadolibros-web/pull/304) | **Fusionado** (commit `7be3b39`) |
+| B11.2 | 01 | 100 ISBN de `REVISAR` → 12 TERMINADO, 1 SIN_DATOS, 87 REVISAR | [#305](https://github.com/trexxeseba/amadolibros-web/pull/305) | **Fusionado y verificado en Producción** (commit `8d474bf`) |
+| B11.2 | 02 | 100 ISBN de `REVISAR` → 12 TERMINADO, 7 SIN_DATOS, 81 REVISAR | [#306](https://github.com/trexxeseba/amadolibros-web/pull/306) | **Fusionado y verificado en Producción** (commit `662c13c`) |
+| B11.2 | 03 | 356 candidatos `REVISAR` nunca intentados | — | **No iniciado** — sin rama, sin corrida, sin PR |
+
+### Estructura original de 10 lotes (histórica, descartada)
+
+El plan inicial preveía 10 lotes fijos de 200 fichas
+(`b11/enriquecimiento-lote-01` … `-10`) hasta llegar a 2.000. Se descartó
+tras el Lote 1: el universo elegible completo (2.276 ISBN) ya fue
+investigado de una sola vez y sólo rindió 187 fichas, así que repartir el
+mismo universo en lotes de 200 no habría agregado nada. B11.2 lo reemplaza
+por lotes de 100 sobre estados persistentes.
 
 ## Flujo obligatorio por lote
 
 1. Rama nueva desde `main` actualizado.
-2. Selección de 200 ISBN priorizando: valor comercial/tráfico, fichas
-   pobres en contenido, ISBN identificable, datos bibliográficos
-   confiables reales. Descartar y reemplazar los que no califiquen.
+2. Selección de ISBN (100 por lote desde B11.2; eran 200 en el plan
+   original) priorizando: valor comercial/tráfico, fichas pobres en
+   contenido, ISBN identificable, datos bibliográficos confiables reales.
+   Descartar y reemplazar los que no califiquen, y excluir todo ISBN que
+   ya tenga estado persistente previo.
 3. Enriquecimiento editorial real (campos verificados únicamente).
 4. Tests completos + verificación de no-duplicación con la vidriera
    automática (`editorial-showcase-boundary.test.js` u equivalente).
@@ -166,15 +191,34 @@ tocar los que pueden cambiar de estado.
   stock, imágenes y demás datos comerciales permanecen intactos en todos
   los lotes de B11.2, igual que en B11.1.
 
-### Qué falta antes de ejecutar B11.2
+### Decisiones ya resueltas al ejecutar B11.2
 
-- Definir dónde vive el estado persistente por ISBN (¿archivo commiteado
-  por lote, como hoy, o un manifiesto único que se actualiza en cada
-  corrida?) y cómo se pasa de `REVISAR`/`SIN_DATOS` a `TERMINADO`.
-- Decidir si conseguir sinopsis real (campo `description`, ahora
-  disponible en un subconjunto de los matches de Google Books) es parte
-  de B11.2 o un tercer proyecto separado.
-- Autorización explícita de Seba para arrancar — **no se ejecuta nada de
-  esto todavía.**
+- **Dónde vive el estado persistente:** manifiesto único
+  `artifacts/b11-2/state.json`, acumulativo y retomable, más un resumen por
+  lote (`artifacts/b11-2/lote-NN-summary.md`). Hoy contiene 200 entradas
+  (24 `TERMINADO`, 8 `SIN_DATOS`, 168 `REVISAR`).
+- **Cómo se excluyen ISBN ya vistos:** cada corrida descarta todo ISBN con
+  estado persistente previo, sin importar cuál sea. Filtrar sólo por
+  `TERMINADO` fue un bug real detectado antes del Lote 02, que si no habría
+  reprocesado los mismos 88 ISBN del Lote 01 sin avanzar.
+- **Autorización:** concedida por Seba y ejercida en los lotes 01 y 02.
+  Sigue siendo requisito explícito por lote: **no hay autorización abierta
+  para arrancar el Lote 03.**
+
+### Qué sigue pendiente de decidir
+
+- Si conseguir sinopsis real (campo `description`, disponible en un
+  subconjunto de los matches de Google Books) es parte de B11.2 o un tercer
+  proyecto separado. Ninguna de las fichas enriquecidas hasta hoy tiene
+  sinopsis: el pipeline masivo sólo escribe hechos bibliográficos.
+- Qué hacer con los 1.541 `SIN_DATOS` y los 168 `REVISAR` ya intentados:
+  sin una fuente de evidencia nueva, reintentarlos da el mismo resultado.
+
+### Estado de ejecución
+
+Lotes 01 y 02 terminados, fusionados y verificados en Producción. **Ningún
+lote nuevo iniciado**: el Lote 03 no tiene rama, corrida ni PR, y queda a la
+espera de autorización explícita. Quedan 356 candidatos `REVISAR` nunca
+intentados.
 
 Ver `ESTADO-ACTUAL.md` para contadores en vivo y bloqueos activos.

--- a/PLAN-MAESTRO.md
+++ b/PLAN-MAESTRO.md
@@ -1,0 +1,180 @@
+# PLAN MAESTRO — B11: enriquecimiento editorial real del catálogo
+
+## Objetivo operativo
+
+Enriquecer 2.000 fichas reales del catálogo con información editorial
+verificable (sinopsis, descripción, temas, público, autoría, datos
+bibliográficos, FAQ específicas, metadatos SEO secundarios), organizado en
+**10 lotes consecutivos de 200 fichas**, cada uno en su propia rama y PR.
+
+No es un piloto. El objetivo es 2.000 fichas efectivamente implementadas,
+probadas y presentadas en PRs — no un plan ni un lote testimonial.
+
+## Historial verificado
+
+### PR #298 — cierre definitivo (registrado 2026-08-31)
+
+- **Título:** "B11: cohorte editorial real de 2.000 ISBN + preservar SEO curado"
+- **Rama:** `b11/editorial-real-2000-1` → `main`
+- **Estado:** `closed`, `merged: true`
+- **Merge commit:** `0c0ebf3848447365b87bd38147c4bc1f943f8309`
+- **Merged por:** trexxeseba, 2026-08-31T15:16:16Z
+- **Qué entregó:**
+  - Cambió la unidad de trabajo de B11 a "2.000 ISBN únicos por cohorte":
+    investigación bibliográfica real (Google Books, Open Library, BNE) sin
+    contar metadatos aislados como fichas editoriales completas.
+  - Generó 2.000 *dossiers* de investigación (estados: listo para
+    redacción, una sola fuente, contenido estructurado, conflicto de
+    identidad, sin evidencia) con `publication_allowed: false` explícito en
+    los 2.000 — ninguno se auto-publicó.
+  - Corrigió un bug real de producción: el middleware de vidriera
+    automática reprocesaba fichas editoriales curadas después del SSR,
+    duplicando contenido y pisando el copy SEO curado con texto genérico.
+  - Evidencia de CI: cohorte de 2.000 dossiers (`run 33388882918`), CI
+    general (`run 33391392044`), preview/auditorías (`run 33391392061`),
+    SEO baseline (`run 33391392073`), enrich 1000 ISBN (`run 33391392090`).
+- **Lo que el PR #298 NO hizo:** no redactó ni publicó copy editorial para
+  los 2.000 ISBN. Dejó la investigación lista como insumo (`next_action:
+  REDACT_AND_VALIDATE_EDITORIAL_REAL_V1` en los dossiers que calificaron),
+  bloqueada a propósito para publicación.
+
+### Precedentes de redacción real (antes de este plan)
+
+- PR #296 — Disney tomo 11 (ISBN 9791388034435): primer y único
+  enriquecimiento `editorial_real_v1` completo (sinopsis, highlights,
+  copy de decisión, meta description, merchant description) con 3 fuentes
+  verificadas (2 `exact_edition` + 1 `source_edition` editorial).
+- PR #293 — 333 ISBN con enriquecimiento factual (`auto_publish_facts`):
+  autor, editorial, páginas, idioma, formato — sin redacción de sinopsis.
+- Lote SEO psicología (`docs/seo/enrichment-batch-01-psychology.md`,
+  2026-08-14): 5 fichas con sinopsis real, seleccionadas cruzando archivo
+  de ventas de Mercado Libre — proceso manual, fuentes documentadas.
+
+## Arquitectura del pipeline (repo)
+
+- `scripts/seo/book-intelligence-research-run.mjs` /
+  `book-intelligence-sources.mjs` / `book-intelligence-bne.mjs`: adaptadores
+  de investigación (Google Books, Open Library, BNE).
+- `scripts/seo/book-editorial-cohort-2000.mjs`: selección + clasificación de
+  cohortes en dossiers, sin publicar.
+- `functions/_shared/book-enrichment-registry.js`: registro por ISBN-13 con
+  `validateBookEnrichment` — exige fuentes reales, URLs verificables,
+  fecha de verificación y trazabilidad. Nunca toca precio, stock, imágenes,
+  condición, slug, canonical ni checkout.
+- `functions/_shared/book-editorial-upgrades.js`: tier `editorial_real_v1`
+  (sinopsis + highlights + copy de decisión), el más exigente.
+- `functions/_shared/book-enrichment-facts-1000.js` /
+  `book-enrichment-facts-333.js`: tier `auto_publish_facts` (datos
+  bibliográficos verificados sin redacción de sinopsis).
+- `functions/__tests__/editorial-showcase-boundary.test.js`: evita que la
+  vidriera automática duplique o pise una ficha editorial curada.
+
+## Reglas absolutas (invariantes de todos los lotes)
+
+No modificar: título original/comercial, H1, slug, precio, stock,
+condición, imágenes, permalink, canonical, carrito ni identificadores
+comerciales. No inventar sinopsis, autores, características ni datos
+bibliográficos. No usar texto genérico sin sustento específico. No trabajar
+sobre `main`. Si una ficha no tiene información confiable suficiente:
+saltear y reemplazar por otra hasta completar 2.000 fichas efectivamente
+enriquecidas.
+
+## Estructura de los 10 lotes
+
+| Lote | Fichas | Rama | PR | Estado |
+| --- | --- | --- | --- | --- |
+| 1 | Universo 2.276 → 187 enriquecidos | `b11/enriquecimiento-lote-01-ci` | [#303](https://github.com/trexxeseba/amadolibros-web/pull/303) | **Fusionado y verificado en Producción** (commit `5b46f72`) |
+| 2 | 201–400 | `b11/enriquecimiento-lote-02` | pendiente | pendiente |
+| 3 | 401–600 | `b11/enriquecimiento-lote-03` | pendiente | pendiente |
+| 4 | 601–800 | `b11/enriquecimiento-lote-04` | pendiente | pendiente |
+| 5 | 801–1000 | `b11/enriquecimiento-lote-05` | pendiente | pendiente |
+| 6 | 1001–1200 | `b11/enriquecimiento-lote-06` | pendiente | pendiente |
+| 7 | 1201–1400 | `b11/enriquecimiento-lote-07` | pendiente | pendiente |
+| 8 | 1401–1600 | `b11/enriquecimiento-lote-08` | pendiente | pendiente |
+| 9 | 1601–1800 | `b11/enriquecimiento-lote-09` | pendiente | pendiente |
+| 10 | 1801–2000 | `b11/enriquecimiento-lote-10` | pendiente | pendiente |
+
+## Flujo obligatorio por lote
+
+1. Rama nueva desde `main` actualizado.
+2. Selección de 200 ISBN priorizando: valor comercial/tráfico, fichas
+   pobres en contenido, ISBN identificable, datos bibliográficos
+   confiables reales. Descartar y reemplazar los que no califiquen.
+3. Enriquecimiento editorial real (campos verificados únicamente).
+4. Tests completos + verificación de no-duplicación con la vidriera
+   automática (`editorial-showcase-boundary.test.js` u equivalente).
+5. PR separado documentando: cantidad procesada, ISBN incluidos, fuentes
+   utilizadas, resultado de tests.
+6. No fusionar sin autorización explícita — salvo autorización previa
+   expresa para fusión automática de lotes en verde.
+
+## B11.2 — Pipeline continuo de enriquecimiento y resolución de conflictos
+
+Registrado el 2026-09-01, autorizado y ejecutado sobre el pool REVISAR.
+Lote 01: **12 TERMINADO, 1 SIN_DATOS, 87 REVISAR** —
+[PR #305](https://github.com/trexxeseba/amadolibros-web/pull/305)
+**fusionado y verificado en Producción** (commit `8d474bf`). Lote 02:
+**12 TERMINADO, 7 SIN_DATOS, 81 REVISAR** —
+[PR #306](https://github.com/trexxeseba/amadolibros-web/pull/306)
+**fusionado y verificado en Producción** (commit `662c13c`). Registry
+acumulado: 1.550. Detalle real en `ESTADO-ACTUAL.md`.
+Reemplaza la estructura fija de 10 lotes de 200 (que el Lote 1 ya mostró
+inviable: de 2.276 candidatos elegibles, solo 187 califican con las
+fuentes actuales) por un pipeline continuo dimensionado al rendimiento
+real del catálogo.
+
+### Motivación
+
+El Lote 1 investigó su universo elegible completo (2.276 ISBN) en vez de
+una muestra de 200: 187 calificaron, 1.533 quedaron sin evidencia y 556
+quedaron con evidencia en conflicto. Repetir "lotes de 200" sobre el
+mismo universo ya investigado no agrega nada — hace falta un pipeline que
+sepa qué ISBN ya se investigó, en qué estado quedó, y que solo vuelva a
+tocar los que pueden cambiar de estado.
+
+### Diseño
+
+- **Unidad de trabajo:** lotes independientes de 100 ISBN (no 200).
+- **Estados persistentes por ISBN** (se guardan, no se recalculan desde
+  cero en cada corrida):
+  - `PUBLICABLE`: evidencia suficiente, sin conflicto — listo para
+    integrar al registry (equivalente a `GREEN_FULL`/`GREEN_FACTS` hoy).
+  - `REVISAR`: hay evidencia pero con conflicto de identidad (título,
+    autor, editorial o año no coinciden entre fuentes) — requiere
+    resolución antes de publicar.
+  - `SIN_DATOS`: ninguna fuente disponible tiene evidencia utilizable.
+  - `TERMINADO`: el ISBN ya se procesó de forma definitiva (publicado o
+    descartado) — **nunca se vuelve a consultar**.
+- **Resolución automática de conflictos:** cuando dos o más fuentes
+  coinciden en ISBN exacto + título normalizado + autor + editorial + año,
+  el conflicto se resuelve automáticamente y el ISBN pasa a `PUBLICABLE`.
+  Si no coinciden en esos cuatro campos, se queda en `REVISAR` para
+  revisión humana — nunca se fuerza una resolución sin ese acuerdo.
+- **Los `SIN_DATOS` salen del circuito automático**: no se reintentan en
+  cada corrida (evita repetir consultas ya fallidas contra BNE/Open
+  Library/Google Books); quedan disponibles para una fuente adicional
+  futura o revisión manual, pero no consumen presupuesto de investigación
+  de forma repetida.
+- **Ningún lote puede sobrescribir resultados anteriores**: cada corrida
+  fusiona sobre el estado persistente existente (la causa raíz del bug
+  encontrado y corregido en la 2ª corrida del Lote 1: acumular, nunca
+  pisar).
+- **Cada lote es retomable**: un lote interrumpido (timeout, error de
+  red, cuota agotada) puede continuarse desde el estado persistido sin
+  perder lo ya resuelto.
+- **Invariante comercial sin excepción:** títulos, H1, slugs, precios,
+  stock, imágenes y demás datos comerciales permanecen intactos en todos
+  los lotes de B11.2, igual que en B11.1.
+
+### Qué falta antes de ejecutar B11.2
+
+- Definir dónde vive el estado persistente por ISBN (¿archivo commiteado
+  por lote, como hoy, o un manifiesto único que se actualiza en cada
+  corrida?) y cómo se pasa de `REVISAR`/`SIN_DATOS` a `TERMINADO`.
+- Decidir si conseguir sinopsis real (campo `description`, ahora
+  disponible en un subconjunto de los matches de Google Books) es parte
+  de B11.2 o un tercer proyecto separado.
+- Autorización explícita de Seba para arrancar — **no se ejecuta nada de
+  esto todavía.**
+
+Ver `ESTADO-ACTUAL.md` para contadores en vivo y bloqueos activos.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cierre documental de B11 tras la verificación del Lote 02 de B11.2. **Solo se tocan dos archivos Markdown**: no se modifica código, artifacts, fichas ni datos comerciales.

## Por qué

`PLAN-MAESTRO.md` y `ESTADO-ACTUAL.md` **no existían en `main`**. Vivían únicamente en la rama `claude/enriquecimiento-2000-fichas-tgu1zv`, cabeza del PR #300, que sigue abierto y nunca se fusionó. Es decir, la documentación maestra del proyecto no estaba en la rama principal, y la última copia disponible tenía contadores desactualizados.

## Qué hace

Dos commits, deliberadamente separados para que el review sea simple:

1. `454f9cb` — recupera ambos archivos en `main` **byte a byte** como están en la rama del PR #300, sin ningún cambio.
2. `52948aa` — los alinea con el estado real. Al estar aislado, este commit muestra exactamente qué se actualizó.

## Estado registrado

| Métrica | Valor |
| --- | --- |
| Registry | 1.550 |
| Pendientes | 2.065 |
| — `REVISAR` | 524 |
| — `SIN_DATOS` | 1.541 |
| Universo | 3.615 |
| Fase activa | B11.2 |
| Lotes terminados | 01 y 02 (fusionados y verificados en Producción) |
| Lote nuevo | ninguno iniciado |

Los contadores no son declarativos: se verificaron contra el repositorio antes de escribirlos. `listBookEnrichments()` de `functions/_shared/book-enrichment-registry.js` devuelve **1.550** ISBN, y `artifacts/b11-2/state.json` tiene **200** entradas con `TERMINADO` 24, `SIN_DATOS` 8 y `REVISAR` 168 — los 200 ISBN intentados entre los lotes 01 y 02. La aritmética cierra: 524 + 1.541 = 2.065, y 1.550 + 2.065 = 3.615.

## Contradicciones corregidas

`ESTADO-ACTUAL.md` publicaba como vigente una tabla "Contadores acumulados" con los números de B11.1 (2.089 pendientes, 1.533 `SIN_DATOS`, 556 `REVISAR`), mientras el cuerpo del documento ya narraba los valores reales más abajo. Ahora la tabla canónica va al principio y la anterior queda etiquetada como foto histórica del Lote 1. Además se agrega la composición del registry, se actualizan los PRs de lote fusionados a 4 (#303, #304, #305, #306) y se deja asentado que el Lote 03 no está iniciado, con sus 356 candidatos disponibles.

`PLAN-MAESTRO.md` seguía presentando la estructura de 10 lotes de 200 fichas como vigente, con los lotes 2 a 10 "pendientes", y cerraba con una sección "Qué falta antes de ejecutar B11.2" que afirmaba **"no se ejecuta nada de esto todavía"** — cuando los lotes 01 y 02 ya están fusionados y verificados en Producción. Ahora la estructura de 10 lotes está marcada como histórica y descartada, se reemplaza por una tabla de lotes efectivamente ejecutados, y la sección de pendientes distingue lo ya resuelto (dónde vive el estado persistente, cómo se excluyen ISBN ya vistos) de lo que sigue abierto (sinopsis real, qué hacer con `SIN_DATOS`).

## Alcance

`git diff --name-status main` devuelve exactamente dos entradas, ambas altas:

```
A	ESTADO-ACTUAL.md
A	PLAN-MAESTRO.md
```

`git diff --check` limpio.

## Checks

- **CI / Syntax & Build: pass.**
- **Deploy and audit every PR Preview: fail**, por una carrera de propagación ajena a este cambio. El deploy y el gate de propagación pasaron; la auditoría falló inmediatamente después con `https://pr-307.amadolibros-web.pages.dev/sitemap-books-active.xml respondió HTTP 404`. El gate "Wait for Preview propagation" sólo comprueba `/` y `/feed.xml`, así que no cubre las rutas de sitemap que la auditoría pide acto seguido en un alias `pr-NNN` recién creado. Ese mismo preview ya sirve la ruta con **HTTP 200** (igual que `/`, `/feed.xml`, `/sitemap.xml` y `/sitemap-books-paused.xml`), y este PR no toca una sola línea de código, así que el resultado no es reproducible ni atribuible al diff. Con volver a correr el job debería quedar en verde.
- Validación local sobre el head de la rama: `bash scripts/validate-ci.sh` termina con `Validación completa OK` (exit 0) — sintaxis, suite completa (1.052 + 270 + 117 + 63 + 30 tests, 0 fallos) y los dos builds de Astro (checkout OFF y ON).

Sugerencia aparte, fuera del alcance de este PR: convendría que el paso "Wait for Preview propagation" de `deploy-pr-preview.yml` también espere por `/sitemap-books-active.xml`, para no volver a tropezar con este flake en PRs nuevos.

No fusionar sin autorización explícita.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74ca4dcc-80a4-4fec-841d-b0864fd6627e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74ca4dcc-80a4-4fec-841d-b0864fd6627e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

