### PR TITLE
B11.2 lote 03 final: resolver 59 ISBN del pool REVISAR y agotar el circuito automático

### DIFF
--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -320,11 +320,70 @@ Verificado después de correr: los módulos y resúmenes de los lotes 01 y 02
 quedaron sin cambios, y de las 200 entradas previas de `state.json` no se
 perdió ni se alteró ninguna.
 
+### Corrección semántica de `language` (cambios solicitados en el PR #308)
+
+La revisión detectó un bloqueo semántico real: los 8 `bibliographic.language`
+que publicaba este lote mezclaban el idioma del texto con el idioma de la
+obra original. `scripts/seo/book-intelligence-bne.mjs` construía el campo
+fusionando MARC 041 `$a`, `$d` y `$h`, cuando según MARC 21 `$a` es el idioma
+del texto de esta edición, `$h` el de la obra original y `$d` el del
+contenido cantado o hablado. Una traducción `041 1#$aspa$heng` quedaba
+publicada como "Español, Inglés" siendo un libro enteramente en español.
+
+Se corrigió en tres capas:
+
+1. **Adaptador BNE**: `language` usa únicamente los `041$a` repetidos. No
+   mezcla `$h` ni usa `$d` para libros impresos. Además, un código sin
+   etiqueta conocida se descarta en vez de publicarse crudo — ése era el
+   origen de `"Español, dut"`.
+2. **Normalización**: `bookLanguageLabel()` traduce un código a etiqueta o
+   devuelve `null`, para que un adaptador pueda descartarlo. Se agregó el
+   neerlandés (`nl`/`nld`/`dut`), presente en la evidencia real.
+3. **Resolver**: la caché de B11.1 es inmutable y sigue conteniendo los
+   valores mezclados, así que no se editó a mano ni se sustituyeron los ocho
+   valores por "Español". Se aplicó una regla conservadora y reproducible:
+   **no se publica ningún `language` con más de un idioma**. El defecto sólo
+   puede manifestarse como valor multivaluado (si `$a` y `$h` coinciden, la
+   mezcla colapsa a un único idioma y el dato es correcto igual), así que la
+   regla cubre exactamente el problema sin listar ISBN a mano.
+
+`book-enrichment-facts-b11-2-lote-03.js` se **regeneró** con el resolver
+corregido, partiendo del estado previo a la corrida. Resultado: los mismos 59
+ISBN, **0 `language` publicados** (antes 8), y ningún otro campo cambió. Los
+8 ISBN afectados conservan `publisher` y `publication_year`, así que siguen
+siendo `TERMINADO` y los contadores no se mueven.
+
+### Contaminación previa: pendiente de auditar en un PR separado
+
+El mismo defecto dejó valores mezclados en módulos ya fusionados, que **este
+PR no toca a propósito**. Auditoría del estado actual:
+
+| Módulo | Con `language` | Multivaluados (sospechosos) |
+| --- | --- | --- |
+| `book-enrichment-facts-1000.js` | 13 | **13** |
+| `book-enrichment-facts-333.js` | 2 | **2** |
+| `book-enrichment-facts-lote-01.js` | 0 | 0 |
+| `book-enrichment-facts-b11-2-lote-01.js` | 0 | 0 |
+| `book-enrichment-facts-b11-2-lote-02.js` | 2 | **2** |
+| `book-enrichment-facts-b11-2-lote-03.js` | 0 | 0 |
+| **Total** | **17** | **17** |
+
+Los 17 valores que quedan publicados en el catálogo son multivaluados y los
+17 provienen de la Biblioteca Nacional de España, es decir que replican
+exactamente el defecto corregido. Incluyen otro código crudo (`"Español,
+dan"` en `9788418859694`). Los dos casos de B11.2 Lote 02 son
+`9788408039532` ("Español, Francés") y `9788415292494` ("Español, Inglés").
+
+**Siguiente PR técnico, separado:** auditar los 17 `bibliographic.language`
+existentes contra MARC 041`$a` y corregirlos o retirarlos. No se hace acá
+para no mezclar la corrección del Lote 03 con la limpieza histórica.
+
 ### Validación
 
-- Tests focales de B11.2 y de los lotes previos: **28/28**.
-- Suite completa: **1.538/1.538**, 0 fallos (la de Functions pasa de 1.052 a
-  1.058 con los 6 tests nuevos del Lote 03).
+- Tests focales de B11.2, del adaptador BNE y de los lotes previos:
+  **44/44**.
+- Suite completa: **1.547/1.547**, 0 fallos (la de Functions pasa de 1.052 a
+  1.067 con los tests nuevos del Lote 03 y las regresiones de `language`).
 - `bash scripts/validate-ci.sh`: **Validación completa OK** (sintaxis, suite
   completa y los dos builds de Astro, checkout OFF y ON).
 - `git diff --check`: sin errores.

--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -284,8 +284,10 @@ habían sido intentados. No tocó el pool `SIN_DATOS`.
   esperable: la evidencia no cambia y cada ISBN se evalúa por separado. Se
   verificó además que un único lote de 356 y cuatro lotes secuenciales de
   100 producen clasificaciones idénticas, sin una sola diferencia.
-- Registry: **1.550 → 1.609**. Campos publicados: `publication_year` en 54
-  ISBN, `publisher` en 19, `language` en 8 y `author` en 4. Fuentes: Open
+- Registry: **1.550 → 1.609**. Campos publicados en el resultado final:
+  `publication_year` en 54 ISBN, `publisher` en 19, `author` en 4 y
+  `language` en **0** — los 8 `language` que generó la primera corrida se
+  retiraron con la corrección de MARC 041 descrita más abajo. Fuentes: Open
   Library en los 59, Biblioteca Nacional de España en 47, Google Books en
   34. Los 59 tienen `sample_listing_id` MLU real y procedencia en `https`.
 - Tasa de resolución: 16,6% (59/356), por encima del 12,0% de los lotes 01

--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -320,12 +320,41 @@ Verificado después de correr: los módulos y resúmenes de los lotes 01 y 02
 quedaron sin cambios, y de las 200 entradas previas de `state.json` no se
 perdió ni se alteró ninguna.
 
+### Validación
+
+- Tests focales de B11.2 y de los lotes previos: **28/28**.
+- Suite completa: **1.538/1.538**, 0 fallos (la de Functions pasa de 1.052 a
+  1.058 con los 6 tests nuevos del Lote 03).
+- `bash scripts/validate-ci.sh`: **Validación completa OK** (sintaxis, suite
+  completa y los dos builds de Astro, checkout OFF y ON).
+- `git diff --check`: sin errores.
+- CI de GitHub Actions sobre el head del PR #308: `Syntax & Build` **pass**,
+  `Deploy and audit every PR Preview` **pass** (2m49s), `Investigate 1000
+  unique ISBN editions` **pass**.
+- Book enrichment live check contra el Preview del PR
+  (`https://pr-308.amadolibros-web.pages.dev`), dentro del job de preview:
+  **1.594 ediciones activas verificadas en ficha y Merchant, 15 sin oferta
+  activa como no aplicables** — 1.594 + 15 = 1.550 + 59 = **1.609**, exacto.
+  Los **59 ISBN del Lote 03 aparecen los 59 como `verified`**, cada uno con
+  sus propios MLU reales y sin mezcla de datos entre ISBN (por ejemplo
+  `9788416781614` con MLU640191639 y MLU640165647, o `9789876290098` con
+  MLU698424763).
+
 ### Pendiente
 
 El [PR #308](https://github.com/trexxeseba/amadolibros-web/pull/308) está en
-Draft, **sin fusionar y sin desplegar**. Falta la verificación en Producción
+Draft, **sin fusionar y sin desplegar**. La verificación contra Producción
 que sí tuvieron los lotes 01 y 02 (deploy, full commerce audit y book
-enrichment live check), que sólo puede hacerse después de fusionar.
+enrichment live check contra `www.amadolibros.com`) sólo puede hacerse
+después de fusionar. Lo ya verificado arriba es contra el Preview del PR.
+
+### Anomalía menor registrada
+
+Tres tests fijaban el total del registry en 1.550 como literal
+(`b11-2-lote-02.test.js`, `b11-2-resolve-revisar.test.js` y
+`book-enrichment-lote-01.test.js`), así que cada lote nuevo los rompe hasta
+que se actualizan a mano. Se actualizaron a 1.609. No es un fallo del lote,
+pero conviene saber que ese literal hay que tocarlo en cada corrida.
 
 ## PR #298 — CERRADO
 

--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -387,17 +387,20 @@ para no mezclar la corrección del Lote 03 con la limpieza histórica.
 - `bash scripts/validate-ci.sh`: **Validación completa OK** (sintaxis, suite
   completa y los dos builds de Astro, checkout OFF y ON).
 - `git diff --check`: sin errores.
-- CI de GitHub Actions sobre el head del PR #308: `Syntax & Build` **pass**,
-  `Deploy and audit every PR Preview` **pass** (2m49s), `Investigate 1000
-  unique ISBN editions` **pass**.
+- CI de GitHub Actions sobre el head con la corrección de `language`
+  (`023b026`): `Syntax & Build` **pass**, `Deploy and audit every PR Preview`
+  **pass**, `Investigate 1000 unique ISBN editions` **pass** y `Reproduce
+  public SEO baseline` **pass** (este último se sumó porque el diff toca
+  `scripts/seo/`).
 - Book enrichment live check contra el Preview del PR
   (`https://pr-308.amadolibros-web.pages.dev`), dentro del job de preview:
   **1.594 ediciones activas verificadas en ficha y Merchant, 15 sin oferta
   activa como no aplicables** — 1.594 + 15 = 1.550 + 59 = **1.609**, exacto.
   Los **59 ISBN del Lote 03 aparecen los 59 como `verified`**, cada uno con
-  sus propios MLU reales y sin mezcla de datos entre ISBN (por ejemplo
-  `9788416781614` con MLU640191639 y MLU640165647, o `9789876290098` con
-  MLU698424763).
+  sus propios MLU reales y sin mezcla de datos entre ISBN. Los 8 que
+  perdieron el `language` siguen verificados por sus otros hechos (por
+  ejemplo `9788417346935` con MLU612098974 y MLU655413122, o `9788433029102`
+  con MLU625756445 y MLU652705502).
 
 ### Pendiente
 

--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -387,11 +387,18 @@ para no mezclar la corrección del Lote 03 con la limpieza histórica.
 - `bash scripts/validate-ci.sh`: **Validación completa OK** (sintaxis, suite
   completa y los dos builds de Astro, checkout OFF y ON).
 - `git diff --check`: sin errores.
-- CI de GitHub Actions sobre el head con la corrección de `language`
-  (`023b026`): `Syntax & Build` **pass**, `Deploy and audit every PR Preview`
-  **pass**, `Investigate 1000 unique ISBN editions` **pass** y `Reproduce
-  public SEO baseline` **pass** (este último se sumó porque el diff toca
-  `scripts/seo/`).
+- CI de GitHub Actions sobre `023b026`, el head que trae la corrección de
+  `language` y todo el código del lote: los cuatro checks en verde —
+  `Syntax & Build`, `Deploy and audit every PR Preview`, `Investigate 1000
+  unique ISBN editions` y `Reproduce public SEO baseline` (este último se
+  sumó porque el diff toca `scripts/seo/`).
+- En un commit posterior de **sólo documentación** el job de preview falló
+  por muestreo de imágenes: 77 de 80 imágenes válidas, 3 sin responder desde
+  R2, con feed, catálogo y páginas en 0 críticos (80/80 páginas OK). Es un
+  fallo transitorio de red, no del cambio: la corrida inmediatamente anterior
+  con el mismo código dio 80/80, y el diff entre ambos commits es un único
+  archivo Markdown. La auditoría toma una muestra distinta de 80 imágenes en
+  cada corrida.
 - Book enrichment live check contra el Preview del PR
   (`https://pr-308.amadolibros-web.pages.dev`), dentro del job de preview:
   **1.594 ediciones activas verificadas en ficha y Merchant, 15 sin oferta

--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -1,31 +1,35 @@
 # ESTADO ACTUAL — B11: enriquecimiento editorial real (2.000 fichas)
 
-Última actualización: 2026-09-02 — cierre documental tras la verificación de
-B11.2 Lote 02 en Producción. Este documento y `PLAN-MAESTRO.md` se recuperan
-en `main` (vivían solo en la rama del PR #300, que nunca se fusionó) y quedan
-alineados con el estado real del repositorio.
+Última actualización: 2026-09-02 — tras ejecutar el **Lote 03 final** de
+B11.2, que agota el pool automático `REVISAR`. Los resultados están en el
+[PR #308](https://github.com/trexxeseba/amadolibros-web/pull/308), todavía
+**sin fusionar y sin verificar en Producción**.
 
 ## Estado canónico (fuente de verdad)
 
 | Métrica | Valor |
 | --- | --- |
-| ISBN enriquecidos en el registry | **1.550** |
-| Pendientes totales | **2.065** |
-| — de los cuales `REVISAR` (evidencia con conflicto de identidad) | **524** |
-| — de los cuales `SIN_DATOS` (sin evidencia utilizable) | **1.541** |
+| ISBN enriquecidos en el registry | **1.609** |
+| Pendientes totales | **2.006** |
+| — de los cuales `REVISAR` (evidencia con conflicto de identidad) | **442** |
+| — de los cuales `SIN_DATOS` (sin evidencia utilizable) | **1.564** |
 | Universo addressable | **3.615** ISBN únicos |
-| Fase activa | **B11.2** (pipeline continuo sobre el pool `REVISAR`) |
-| Lotes B11.2 terminados | **01 y 02** (fusionados y verificados en Producción) |
-| Lotes B11.2 en curso | **ninguno — no hay ningún lote nuevo iniciado** |
+| Fase activa | **B11.2** — circuito automático **agotado** |
+| Lotes B11.2 terminados | **01, 02 y 03 final** |
+| Lotes B11.2 en curso | **ninguno** |
+| `REVISAR` sin intentar | **0** — los 556 del pool ya fueron procesados |
 
-Verificación aritmética: 524 + 1.541 = 2.065 pendientes; 1.550 + 2.065 =
+Verificación aritmética: 442 + 1.564 = 2.006 pendientes; 1.609 + 2.006 =
 3.615. El universo no crece: cada lote sólo reclasifica ISBN dentro de él.
+
+Los valores del registry corresponden al head del PR #308. En `main` el
+registry sigue en 1.550 hasta que ese PR se fusione.
 
 Comprobación contra el repositorio (no son cifras declarativas):
 `listBookEnrichments()` de `functions/_shared/book-enrichment-registry.js`
-devuelve 1.550 ISBN, y `artifacts/b11-2/state.json` contiene 200 entradas
-con `TERMINADO` 24, `SIN_DATOS` 8 y `REVISAR` 168 — los 200 ISBN intentados
-por los lotes 01 y 02.
+devuelve 1.609 ISBN, y `artifacts/b11-2/state.json` contiene 556 entradas
+con `TERMINADO` 83, `SIN_DATOS` 31 y `REVISAR` 442 — el pool `REVISAR`
+completo de B11.1, ya sin ningún ISBN pendiente de intentar.
 
 ## B11 Lote 1 — TERMINADO (fusionado y verificado en Producción)
 
@@ -61,13 +65,14 @@ B11.2 ya movió esos números: ver "Estado canónico".
 | B11 Lote 1 | 187 |
 | B11.2 Lote 01 | 12 |
 | B11.2 Lote 02 | 12 |
-| **Total en el registry** | **1.550** |
+| B11.2 Lote 03 final | 59 |
+| **Total en el registry** | **1.609** |
 
 ## Estado de PRs
 
 | Métrica | Valor |
 | --- | --- |
-| PRs de lote abiertos | 0 — ningún lote nuevo iniciado |
+| PRs de lote abiertos | 1 — [#308](https://github.com/trexxeseba/amadolibros-web/pull/308) (B11.2 Lote 03 final), en Draft, sin fusionar |
 | PRs de lote fusionados | 4 — [#303](https://github.com/trexxeseba/amadolibros-web/pull/303) (187 fichas), [#304](https://github.com/trexxeseba/amadolibros-web/pull/304) (infra de verificación), [#305](https://github.com/trexxeseba/amadolibros-web/pull/305) (B11.2 Lote 01), [#306](https://github.com/trexxeseba/amadolibros-web/pull/306) (B11.2 Lote 02) |
 
 ## Corrección de Google Books (aplicada y verificada)
@@ -265,19 +270,62 @@ No tocó el pool SIN_DATOS.
   el universo total no cambia, sólo se movieron 12 ISBN de pendiente a
   enriquecido y 7 de REVISAR a SIN_DATOS.
 
-## B11.2 Lote 03 — NO INICIADO
+## B11.2 Lote 03 final — EJECUTADO (en PR, sin fusionar)
 
-No hay ningún lote nuevo en curso. Tras el Lote 02 no se creó rama, no se
-ejecutó ninguna corrida y no se abrió ningún PR de lote: el pipeline está
-detenido a la espera de autorización explícita.
+Autorizado explícitamente por Seba el 2026-09-02 para **agotar el pool
+automático en una sola ejecución**, sobre los 356 ISBN `REVISAR` que nunca
+habían sido intentados. No tocó el pool `SIN_DATOS`.
 
-- Candidatos disponibles para un eventual Lote 03: **356** ISBN del pool
-  `REVISAR` nunca intentados (524 `REVISAR` totales − 87 del Lote 01 sin
-  resolver − 81 del Lote 02 sin resolver).
-- Reintentar los 168 `REVISAR` ya intentados no aporta nada mientras no
-  haya evidencia nueva: el resolver reutiliza evidencia inmutable, así que
-  daría exactamente el mismo resultado.
-- Los 1.541 `SIN_DATOS` siguen fuera del circuito automático por diseño.
+- Resultado real: **59 TERMINADO** (integrados al registry), **23
+  SIN_DATOS**, **274 siguen REVISAR**. Procesados: 356. Duración del
+  procesamiento: 0,1s, sin ninguna llamada de red — reutiliza la evidencia
+  inmutable ya commiteada por B11.1.
+- Coincide exactamente con la simulación previa (59/23/274), como era
+  esperable: la evidencia no cambia y cada ISBN se evalúa por separado. Se
+  verificó además que un único lote de 356 y cuatro lotes secuenciales de
+  100 producen clasificaciones idénticas, sin una sola diferencia.
+- Registry: **1.550 → 1.609**. Campos publicados: `publication_year` en 54
+  ISBN, `publisher` en 19, `language` en 8 y `author` en 4. Fuentes: Open
+  Library en los 59, Biblioteca Nacional de España en 47, Google Books en
+  34. Los 59 tienen `sample_listing_id` MLU real y procedencia en `https`.
+- Tasa de resolución: 16,6% (59/356), por encima del 12,0% de los lotes 01
+  y 02. La diferencia es de composición, no de método: 213 de los 356
+  restantes son prefijo 978-84 (registro español), que resuelve al 24%,
+  mientras que los prefijos latinoamericanos 978-95x y 978-98x resuelven
+  al 4-6%.
+
+### El circuito automático quedó agotado
+
+`artifacts/b11-2/state.json` pasa de 200 a **556** entradas, que son
+exactamente los 556 ISBN `REVISAR` que dejó B11.1: **no queda ninguno sin
+intentar**. Hay un test que lo verifica cruzando el estado persistente
+contra el report original de B11.1, no por conteo.
+
+Estado acumulado: `TERMINADO` 83, `SIN_DATOS` 31, `REVISAR` 442. Por lote:
+100 (lote 01) + 100 (lote 02) + 356 (lote 03 final).
+
+Reintentar los 442 `REVISAR` restantes con la evidencia actual daría
+idéntico resultado. Avanzar más exige evidencia nueva —una fuente
+adicional o redacción manual—, no otra corrida del resolver.
+
+### Protección contra sobrescritura
+
+Los defaults de `B11_2_FACTS_OUTPUT` y `B11_2_SUMMARY_PATH` apuntan a los
+archivos del Lote 01, y el resolver los reescribe por completo: correrlo
+sin definirlos habría borrado del registry los 12 ISBN del Lote 01. Se
+ejecutó con las cuatro variables explícitas (`B11_2_BATCH_SIZE=356`,
+`B11_2_BATCH_NAME=lote-03-final`, y los dos archivos nuevos
+`book-enrichment-facts-b11-2-lote-03.js` y `lote-03-final-summary.md`).
+Verificado después de correr: los módulos y resúmenes de los lotes 01 y 02
+quedaron sin cambios, y de las 200 entradas previas de `state.json` no se
+perdió ni se alteró ninguna.
+
+### Pendiente
+
+El [PR #308](https://github.com/trexxeseba/amadolibros-web/pull/308) está en
+Draft, **sin fusionar y sin desplegar**. Falta la verificación en Producción
+que sí tuvieron los lotes 01 y 02 (deploy, full commerce audit y book
+enrichment live check), que sólo puede hacerse después de fusionar.
 
 ## PR #298 — CERRADO
 

--- a/PLAN-MAESTRO.md
+++ b/PLAN-MAESTRO.md
@@ -2,14 +2,17 @@
 
 ## Estado vigente (2026-09-02)
 
-- **Fase activa: B11.2** — pipeline continuo con estados persistentes. La
+- **Fase activa: B11.2**, con el **circuito automático agotado**. La
   estructura original de 10 lotes de 200 fichas quedó **superada** y se
   conserva más abajo sólo como registro histórico.
-- **Lotes B11.2 terminados: 01 y 02**, ambos fusionados a `main` y
-  verificados en Producción.
-- **Ningún lote nuevo iniciado**: no hay rama, corrida ni PR de un Lote 03.
-- Contadores canónicos: registry **1.550**, pendientes **2.065**
-  (`REVISAR` **524** + `SIN_DATOS` **1.541**), universo **3.615**.
+- **Lotes B11.2 terminados: 01, 02 y 03 final.** Los lotes 01 y 02 están
+  fusionados y verificados en Producción; el Lote 03 final está en el
+  [PR #308](https://github.com/trexxeseba/amadolibros-web/pull/308), en
+  Draft, **sin fusionar ni desplegar**.
+- **El pool `REVISAR` quedó agotado**: los 556 ISBN que dejó B11.1 ya
+  fueron procesados, no queda ninguno sin intentar.
+- Contadores canónicos (head del PR #308): registry **1.609**, pendientes
+  **2.006** (`REVISAR` **442** + `SIN_DATOS` **1.564**), universo **3.615**.
 - Los contadores en vivo, la evidencia de Producción y los bloqueos activos
   están en `ESTADO-ACTUAL.md`, que es la fuente de verdad operativa.
 
@@ -106,7 +109,7 @@ enriquecidas.
 | B11.1 | — | Infra de verificación manual contra cualquier `base_url` | [#304](https://github.com/trexxeseba/amadolibros-web/pull/304) | **Fusionado** (commit `7be3b39`) |
 | B11.2 | 01 | 100 ISBN de `REVISAR` → 12 TERMINADO, 1 SIN_DATOS, 87 REVISAR | [#305](https://github.com/trexxeseba/amadolibros-web/pull/305) | **Fusionado y verificado en Producción** (commit `8d474bf`) |
 | B11.2 | 02 | 100 ISBN de `REVISAR` → 12 TERMINADO, 7 SIN_DATOS, 81 REVISAR | [#306](https://github.com/trexxeseba/amadolibros-web/pull/306) | **Fusionado y verificado en Producción** (commit `662c13c`) |
-| B11.2 | 03 | 356 candidatos `REVISAR` nunca intentados | — | **No iniciado** — sin rama, sin corrida, sin PR |
+| B11.2 | 03 final | 356 ISBN de `REVISAR` → 59 TERMINADO, 23 SIN_DATOS, 274 REVISAR | [#308](https://github.com/trexxeseba/amadolibros-web/pull/308) | **Ejecutado, en Draft** — sin fusionar ni verificar en Producción |
 
 ### Estructura original de 10 lotes (histórica, descartada)
 
@@ -141,8 +144,12 @@ Lote 01: **12 TERMINADO, 1 SIN_DATOS, 87 REVISAR** —
 **fusionado y verificado en Producción** (commit `8d474bf`). Lote 02:
 **12 TERMINADO, 7 SIN_DATOS, 81 REVISAR** —
 [PR #306](https://github.com/trexxeseba/amadolibros-web/pull/306)
-**fusionado y verificado en Producción** (commit `662c13c`). Registry
-acumulado: 1.550. Detalle real en `ESTADO-ACTUAL.md`.
+**fusionado y verificado en Producción** (commit `662c13c`). Lote 03 final:
+**59 TERMINADO, 23 SIN_DATOS, 274 REVISAR** sobre los 356 ISBN nunca
+intentados —
+[PR #308](https://github.com/trexxeseba/amadolibros-web/pull/308), en Draft,
+sin fusionar. Registry acumulado: 1.609. Detalle real en
+`ESTADO-ACTUAL.md`.
 Reemplaza la estructura fija de 10 lotes de 200 (que el Lote 1 ya mostró
 inviable: de 2.276 candidatos elegibles, solo 187 califican con las
 fuentes actuales) por un pipeline continuo dimensionado al rendimiento
@@ -195,15 +202,30 @@ tocar los que pueden cambiar de estado.
 
 - **Dónde vive el estado persistente:** manifiesto único
   `artifacts/b11-2/state.json`, acumulativo y retomable, más un resumen por
-  lote (`artifacts/b11-2/lote-NN-summary.md`). Hoy contiene 200 entradas
-  (24 `TERMINADO`, 8 `SIN_DATOS`, 168 `REVISAR`).
+  lote (`artifacts/b11-2/lote-NN-summary.md`). Ya contiene las 556 entradas
+  del pool completo (83 `TERMINADO`, 31 `SIN_DATOS`, 442 `REVISAR`).
 - **Cómo se excluyen ISBN ya vistos:** cada corrida descarta todo ISBN con
   estado persistente previo, sin importar cuál sea. Filtrar sólo por
   `TERMINADO` fue un bug real detectado antes del Lote 02, que si no habría
   reprocesado los mismos 88 ISBN del Lote 01 sin avanzar.
-- **Autorización:** concedida por Seba y ejercida en los lotes 01 y 02.
-  Sigue siendo requisito explícito por lote: **no hay autorización abierta
-  para arrancar el Lote 03.**
+- **Tamaño de lote:** irrelevante para el resultado. Se comprobó que un
+  único lote de 356 y cuatro lotes secuenciales de 100 producen
+  clasificaciones idénticas — la evidencia es inmutable y cada ISBN se
+  evalúa por separado. Por eso el Lote 03 se corrió entero de una vez.
+- **Autorización:** concedida por Seba y ejercida en los lotes 01, 02 y 03
+  final. Sigue siendo requisito explícito por lote.
+
+### Riesgo operativo del resolver: defaults que pisan el Lote 01
+
+`B11_2_FACTS_OUTPUT` y `B11_2_SUMMARY_PATH` tienen como default los
+archivos del Lote 01, y el script los **reescribe completos** con los
+resultados de la corrida actual. Ejecutar el resolver sin definirlos borra
+del registry los ISBN del Lote 01. Toda corrida nueva debe pasar las cuatro
+variables explícitas (`B11_2_BATCH_SIZE`, `B11_2_BATCH_NAME`,
+`B11_2_FACTS_OUTPUT`, `B11_2_SUMMARY_PATH`) y, además, agregar el `import`
+del módulo nuevo en `functions/_shared/book-enrichment-registry.js`: el
+registry compone los lotes por nombre, así que un módulo no importado no
+entra aunque el archivo exista.
 
 ### Qué sigue pendiente de decidir
 
@@ -211,14 +233,20 @@ tocar los que pueden cambiar de estado.
   subconjunto de los matches de Google Books) es parte de B11.2 o un tercer
   proyecto separado. Ninguna de las fichas enriquecidas hasta hoy tiene
   sinopsis: el pipeline masivo sólo escribe hechos bibliográficos.
-- Qué hacer con los 1.541 `SIN_DATOS` y los 168 `REVISAR` ya intentados:
-  sin una fuente de evidencia nueva, reintentarlos da el mismo resultado.
+- Qué hacer con los 1.564 `SIN_DATOS` y los 442 `REVISAR` que quedaron sin
+  resolver: sin una fuente de evidencia nueva, reintentarlos da exactamente
+  el mismo resultado.
 
 ### Estado de ejecución
 
-Lotes 01 y 02 terminados, fusionados y verificados en Producción. **Ningún
-lote nuevo iniciado**: el Lote 03 no tiene rama, corrida ni PR, y queda a la
-espera de autorización explícita. Quedan 356 candidatos `REVISAR` nunca
-intentados.
+Lotes 01 y 02 terminados, fusionados y verificados en Producción. Lote 03
+final ejecutado y en el
+[PR #308](https://github.com/trexxeseba/amadolibros-web/pull/308), en Draft,
+sin fusionar ni desplegar.
+
+**El circuito automático quedó agotado**: los 556 ISBN `REVISAR` de B11.1
+ya fueron procesados y no queda ninguno sin intentar. No hay un Lote 04
+posible con las fuentes actuales — cualquier avance adicional exige
+evidencia nueva, no otra corrida del resolver.
 
 Ver `ESTADO-ACTUAL.md` para contadores en vivo y bloqueos activos.

--- a/PLAN-MAESTRO.md
+++ b/PLAN-MAESTRO.md
@@ -215,6 +215,28 @@ tocar los que pueden cambiar de estado.
 - **Autorización:** concedida por Seba y ejercida en los lotes 01, 02 y 03
   final. Sigue siendo requisito explícito por lote.
 
+### MARC 041: qué subcampo describe el idioma de la edición
+
+`$a` es el idioma del texto de esta edición, `$h` el de la obra original y
+`$d` el del contenido cantado o hablado. Sólo `$a` describe lo que el lector
+recibe. Fusionarlos —como hacía el adaptador de BNE hasta el Lote 03—
+convierte una traducción (`041 1#$aspa$heng`) en un falso "Español, Inglés".
+Un `$a` repetido (`041 0#$aspa$aeng`) sí indica una edición realmente
+bilingüe. Además, un código sin etiqueta conocida se descarta en vez de
+publicarse crudo: es preferible no informar el idioma antes que mostrar
+`dut` en una ficha.
+
+Como la evidencia cacheada por B11.1 es inmutable y conserva los valores
+mezclados, el resolver aplica una regla conservadora: **no publica ningún
+`language` con más de un idioma**. El defecto sólo puede aparecer como valor
+multivaluado, así que la regla lo cubre sin necesidad de listar ISBN a mano.
+
+Queda pendiente un PR técnico separado para auditar los 17
+`bibliographic.language` que siguen publicados en módulos ya fusionados
+(13 en `facts-1000`, 2 en `facts-333`, 2 en B11.2 Lote 02): los 17 son
+multivaluados y provienen de BNE, o sea que replican el mismo defecto. Ver
+`ESTADO-ACTUAL.md` para el detalle por ISBN.
+
 ### Riesgo operativo del resolver: defaults que pisan el Lote 01
 
 `B11_2_FACTS_OUTPUT` y `B11_2_SUMMARY_PATH` tienen como default los

--- a/artifacts/b11-2/lote-03-final-summary.md
+++ b/artifacts/b11-2/lote-03-final-summary.md
@@ -1,0 +1,20 @@
+# B11.2 — lote-03-final
+
+- Generado: 2026-09-02T19:05:32.884Z
+- Candidatos REVISAR disponibles antes de esta corrida: 356.
+- Procesados en este lote: 356.
+- Resueltos automáticamente (TERMINADO, integrados): 59.
+- Identidad confirmada pero sin hechos publicables (SIN_DATOS): 23.
+- Siguen en REVISAR: 274.
+- Duración: 0.1s.
+
+## Regla aplicada
+
+- PUBLICABLE/TERMINADO exige un par de fuentes independientes que
+  coincidan en título normalizado, autor, editorial y año (ausencia en
+  un lado nunca cuenta como conflicto).
+- Cada hecho publicado exige además su propio umbral de evidencia (1
+  fuente oficial o 2 independientes), igual que el resto de B11.
+- No se reprocesan ISBN ya TERMINADO en corridas anteriores.
+- Título, H1, slug, precio, stock, imágenes y datos comerciales no se
+  tocan: este lote solo agrega hechos bibliográficos ausentes.

--- a/artifacts/b11-2/lote-03-final-summary.md
+++ b/artifacts/b11-2/lote-03-final-summary.md
@@ -1,6 +1,6 @@
 # B11.2 — lote-03-final
 
-- Generado: 2026-09-02T19:05:32.884Z
+- Generado: 2026-09-02T20:36:18.346Z
 - Candidatos REVISAR disponibles antes de esta corrida: 356.
 - Procesados en este lote: 356.
 - Resueltos automáticamente (TERMINADO, integrados): 59.

--- a/artifacts/b11-2/state.json
+++ b/artifacts/b11-2/state.json
@@ -1200,6 +1200,2142 @@
       "updated_at": "2026-09-02",
       "batch": "b11-2-lote-02",
       "reason": "sin_par_de_consenso"
+    },
+    "9788416240357": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788416676989": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788416676996": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788416781614": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788416894000": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788417002534": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788417057381": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788417103026": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788417133481": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788417184834": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788417241865": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788417346935": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788417371258": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788417371326": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788417452346": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788417492199": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788417804985": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788417884307": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788417910334": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788418128110": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788418137525": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788418137952": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788418610042": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788418623233": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788418672910": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788418709876": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788418826511": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788418853371": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788418939495": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788419094421": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788419164469": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788419172136": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788419440464": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788419547217": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788419547668": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788419654052": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788420010540": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788420011097": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788420011189": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788420301495": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788422017660": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788423362264": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788423414512": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788425225123": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788425368370": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788425410338": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788425448553": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788426110091": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788426122728": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788426135094": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788426138064": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788426145215": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788426727817": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788427043916": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788427208346": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788427719972": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788428217217": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788428500036": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788428510448": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788428549172": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788428813884": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788429144291": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788429175554": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788429307887": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788430113309": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788430120666": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788432153839": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788432159626": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788432227813": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788433006264": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788433029102": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788433030238": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788433031143": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788435010856": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788437066691": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788438712580": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788441411913": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788441540392": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788441542457": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788441542969": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788441546585": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788448868550": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788449304538": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788449322433": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788449322730": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788449330131": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788449332425": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788449336188": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788466331470": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788466343145": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788466376938": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788467023565": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788467035834": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788467756579": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788467758221": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788467780345": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788467957389": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788467961096": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788468001579": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788469620014": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788470683602": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788471016195": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788471019745": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788471121738": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788471122162": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788471123190": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788471512642": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788472095557": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788472098855": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788472450752": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788472452824": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788472456778": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788475093413": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788475778303": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788476272152": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788476580189": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788477205883": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788478080458": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788478080465": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788478132898": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788478276219": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788478277674": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788478693597": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788478696550": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788478696567": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788478696574": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788478847440": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788479026899": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788479141288": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788480204835": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788480635158": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788481647600": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788482674728": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788483108383": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788483830130": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788484075639": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788484453178": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788484454380": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788484454618": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788484455523": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788484455578": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788484761600": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788484919599": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788485316076": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788485316595": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788486221362": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788488061546": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788488337948": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788490227107": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788490327418": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788490328866": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788490615072": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788490658741": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788490664544": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788490732496": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788490732502": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788490736609": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788490748930": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788490970751": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788491047223": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788491103578": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788491104346": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788491109396": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788491133537": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788491139652": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788491180616": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788491181217": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788491182146": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788491214861": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788491468899": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788491870395": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788491930013": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788492517954": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788492534401": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788492654703": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788493464547": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788493622671": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788493774301": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788494183287": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788494294761": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788494408410": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788494441585": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788496060197": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788496208223": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788496375048": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788496916197": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788497276245": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788497343343": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788497775427": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788497849586": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788497938600": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788498258950": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788498351262": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788498356915": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788498359602": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788498743326": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788498743517": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9788498746525": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788498747171": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788498859034": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788499081786": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788499083957": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788499170954": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788499201306": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788499214061": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788499285191": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788499452081": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788499501499": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9788499743073": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788499804286": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788499882345": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788499885452": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788499887005": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788742551943": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788794216302": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788817107938": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788865275368": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788876380396": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9788883956805": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789089989574": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9789500306614": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789500396554": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789500420594": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789500423434": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789500696791": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789500728997": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789500757294": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789500759441": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789500762427": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789501213072": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789501229158": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789501229165": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789501239812": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789501271072": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789501296679": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789501297102": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789501297423": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789501524772": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789501602487": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789501712780": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789502307893": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789502317984": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789502321295": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789502415802": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789502416069": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789502803029": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789504969983": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789505045822": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789505046324": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789505071364": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789505072217": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789505125883": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789505181025": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9789505182350": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789505182800": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789505185948": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789505188062": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9789505530601": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789505566990": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9789506020149": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789506021436": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789506022365": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789506496449": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789506496548": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789507245121": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789507247163": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9789507302060": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789507540257": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789507543807": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789507547492": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789507864902": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789508085139": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789508088178": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789508922014": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789508922731": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789508923073": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789508924735": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789508925237": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789508925879": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789508926494": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789508926838": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789508927163": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789508940346": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789509255821": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789509255838": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789509603295": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789509725126": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789568543297": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9789568742027": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789585911390": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789587658064": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789681673369": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789681673802": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789706430366": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789870601142": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789870603009": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789870606772": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789870607205": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789871061266": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789871104796": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789871561490": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789871603541": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789871694945": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789873507922": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789873685842": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789873804397": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789873804533": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789873818127": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789873874932": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9789873954337": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789874595560": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789875000094": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789875380912": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789875381469": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789875382565": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789875383722": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789875384330": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789875385177": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789875386518": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789875386815": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789875388017": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789875388369": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789875388420": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9789875677678": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789875701045": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789875703087": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9789875704336": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9789875704466": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9789875710856": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789875804913": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789876290098": {
+      "status": "TERMINADO",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_por_consenso"
+    },
+    "9789876291576": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789876371759": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789876372688": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789876938204": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789877390186": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789877472479": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789877710250": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789877711998": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789878461656": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9789878461687": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789878475271": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789878610634": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789878984049": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789879006191": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789879066201": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789879066560": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789879165744": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789879869628": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789879869635": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789963480630": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789974480667": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9789974482999": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9791387869007": {
+      "status": "SIN_DATOS",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "identidad_confirmada_sin_hechos_publicables"
+    },
+    "9798400501166": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
+    },
+    "9798890980038": {
+      "status": "REVISAR",
+      "updated_at": "2026-09-02",
+      "batch": "lote-03-final",
+      "reason": "sin_par_de_consenso"
     }
   }
 }

--- a/functions/__tests__/b11-2-lote-02.test.js
+++ b/functions/__tests__/b11-2-lote-02.test.js
@@ -19,7 +19,7 @@ test('B11.2 lote 02 resuelve 12 ISBN nuevos del pool REVISAR con consenso cruzad
       assert.match(source.url, /^https:\/\//);
     }
   }
-  assert.equal(listBookEnrichments().length, 1550);
+  assert.equal(listBookEnrichments().length, 1609);
 });
 
 test('B11.2 lote 02 no repite ningún ISBN ya resuelto en el lote 01', () => {

--- a/functions/__tests__/b11-2-lote-03-final.test.js
+++ b/functions/__tests__/b11-2-lote-03-final.test.js
@@ -85,6 +85,39 @@ test('B11.2 lote 03: los TERMINADO del estado son exactamente los ISBN integrado
   }
 });
 
+test('B11.2 lote 03 no publica ningún language derivado de la caché contaminada', () => {
+  // Los 8 valores que salían de MARC 041 con $a/$d/$h fusionados ("Español,
+  // Inglés" para libros enteramente en español) ya no se publican. El
+  // adaptador se corrigió para leer sólo 041$a, pero la caché de B11.1 es
+  // inmutable, así que el resolver además descarta cualquier language
+  // multivaluado que venga de ella.
+  const conLanguage = BOOK_FACT_ENRICHMENTS_B11_2_LOTE_03
+    .filter(entry => entry.facts.bibliographic?.language);
+  assert.deepEqual(conLanguage.map(entry => entry.isbn), []);
+
+  // Ningún código crudo puede aparecer en un dato visible, venga del campo
+  // que venga.
+  const visible = JSON.stringify(BOOK_FACT_ENRICHMENTS_B11_2_LOTE_03.map(entry => entry.facts));
+  for (const code of ['dut', 'eng', 'spa', 'fre', 'ger', 'ita', 'cat']) {
+    assert.equal(new RegExp(`"${code}"`, 'i').test(visible), false, code);
+  }
+});
+
+test('los 8 ISBN que perdieron el language conservan editorial y año', () => {
+  const afectados = [
+    '9788417346935', '9788417804985', '9788423362264', '9788433029102',
+    '9788433031143', '9788441542969', '9788478847440', '9788499083957',
+  ];
+  const porIsbn = new Map(BOOK_FACT_ENRICHMENTS_B11_2_LOTE_03.map(entry => [entry.isbn, entry]));
+  for (const isbn of afectados) {
+    const entry = porIsbn.get(isbn);
+    assert.ok(entry, `${isbn} debe seguir integrado al registry`);
+    assert.equal(typeof entry.facts.publisher, 'string', isbn);
+    assert.match(entry.facts.bibliographic.publication_year, /^\d{4}$/, isbn);
+    assert.equal(entry.facts.bibliographic.language, undefined, isbn);
+  }
+});
+
 test('B11.2 lote 03 no contiene ni modifica títulos o datos comerciales', () => {
   const forbidden = /"(?:title|description|price|available_quantity|stock|slug|canonical|pictures|thumbnail|condition)"\s*:/;
   assert.equal(forbidden.test(JSON.stringify(BOOK_FACT_ENRICHMENTS_B11_2_LOTE_03)), false);

--- a/functions/__tests__/b11-2-lote-03-final.test.js
+++ b/functions/__tests__/b11-2-lote-03-final.test.js
@@ -1,0 +1,140 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01 } from '../_shared/book-enrichment-facts-b11-2-lote-01.js';
+import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_B11_2_LOTE_02 } from '../_shared/book-enrichment-facts-b11-2-lote-02.js';
+import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_B11_2_LOTE_03 } from '../_shared/book-enrichment-facts-b11-2-lote-03.js';
+import { normalizeValidIsbn } from '../_shared/showcase-ranking.js';
+import {
+  applyBookEnrichment,
+  getBookEnrichmentByIsbn,
+  listBookEnrichments,
+  validateBookEnrichment,
+} from '../_shared/book-enrichment-registry.js';
+
+const state = JSON.parse(readFileSync('artifacts/b11-2/state.json', 'utf8'));
+
+test('B11.2 lote 03 final resuelve 59 ISBN del pool REVISAR con consenso cruzado real', () => {
+  assert.equal(BOOK_FACT_ENRICHMENTS_B11_2_LOTE_03.length, 59);
+  assert.equal(new Set(BOOK_FACT_ENRICHMENTS_B11_2_LOTE_03.map(entry => entry.isbn)).size, 59);
+  for (const entry of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_03) {
+    assert.equal(validateBookEnrichment(entry), true, entry.isbn);
+    assert.equal(getBookEnrichmentByIsbn(entry.isbn), entry);
+    assert.equal(entry.decision, 'auto_publish_facts', entry.isbn);
+    for (const source of entry.provenance) {
+      assert.match(source.url, /^https:\/\//);
+    }
+  }
+  assert.equal(listBookEnrichments().length, 1609);
+});
+
+test('B11.2 lote 03 no repite ningún ISBN de los lotes 01 y 02', () => {
+  const anteriores = new Set([
+    ...BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01.map(entry => entry.isbn),
+    ...BOOK_FACT_ENRICHMENTS_B11_2_LOTE_02.map(entry => entry.isbn),
+  ]);
+  for (const entry of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_03) {
+    assert.equal(anteriores.has(entry.isbn), false, entry.isbn);
+  }
+});
+
+test('B11.2 lote 03 final agota el pool REVISAR: los 556 ISBN quedan con estado persistente', () => {
+  const entries = Object.values(state.entries);
+  assert.equal(entries.length, 556);
+
+  const porStatus = entries.reduce((acc, entry) => {
+    acc[entry.status] = (acc[entry.status] || 0) + 1;
+    return acc;
+  }, {});
+  assert.deepEqual(porStatus, { REVISAR: 442, TERMINADO: 83, SIN_DATOS: 31 });
+
+  const porLote = entries.reduce((acc, entry) => {
+    acc[entry.batch] = (acc[entry.batch] || 0) + 1;
+    return acc;
+  }, {});
+  assert.deepEqual(porLote, { 'b11-2-lote-01': 100, 'b11-2-lote-02': 100, 'lote-03-final': 356 });
+
+  // La garantía real del lote final: no queda ningún ISBN REVISAR de B11.1
+  // sin haber sido intentado al menos una vez. El circuito automático se
+  // agotó — avanzar más exige evidencia nueva, no otra corrida del resolver.
+  const report = JSON.parse(readFileSync('artifacts/book-intelligence/lote-01/isbn-1000-report.json', 'utf8'));
+  const revisarDeB11_1 = [...new Set(
+    report.results
+      .filter(result => result.publication_class === 'REVIEW')
+      .map(result => normalizeValidIsbn(result.isbn))
+      .filter(Boolean),
+  )];
+  assert.equal(revisarDeB11_1.length, 556);
+  const sinIntentar = revisarDeB11_1.filter(isbn => !state.entries[isbn]);
+  assert.deepEqual(sinIntentar, []);
+});
+
+test('B11.2 lote 03: los TERMINADO del estado son exactamente los ISBN integrados al registry', () => {
+  const terminadosDelLote = Object.entries(state.entries)
+    .filter(([, entry]) => entry.status === 'TERMINADO' && entry.batch === 'lote-03-final')
+    .map(([isbn]) => isbn)
+    .sort();
+  const integrados = BOOK_FACT_ENRICHMENTS_B11_2_LOTE_03.map(entry => entry.isbn).sort();
+  assert.deepEqual(terminadosDelLote, integrados);
+
+  // Ni un SIN_DATOS ni un REVISAR se coló al registry.
+  for (const [isbn, entry] of Object.entries(state.entries)) {
+    if (entry.status === 'TERMINADO') continue;
+    assert.equal(integrados.includes(isbn), false, isbn);
+  }
+});
+
+test('B11.2 lote 03 no contiene ni modifica títulos o datos comerciales', () => {
+  const forbidden = /"(?:title|description|price|available_quantity|stock|slug|canonical|pictures|thumbnail|condition)"\s*:/;
+  assert.equal(forbidden.test(JSON.stringify(BOOK_FACT_ENRICHMENTS_B11_2_LOTE_03)), false);
+
+  for (const entry of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_03) {
+    const original = {
+      id: entry.sample_listing_id || 'MLU999999999',
+      isbn: entry.isbn,
+      title: `Título original ${entry.isbn}`,
+      author: 'Desconocido',
+      description: 'Descripción comercial original.',
+      publisher: null,
+      pages: null,
+      price: 990,
+      currency_id: 'UYU',
+      status: 'active',
+      available_quantity: 3,
+      condition: 'new',
+      pictures: [{ url: 'https://example.com/portada.jpg' }],
+      canonical: `/libro/${entry.sample_listing_id || 'MLU999999999'}/titulo-original`,
+    };
+    const enriched = applyBookEnrichment(original);
+
+    assert.notEqual(enriched, original, entry.isbn);
+    assert.equal(enriched.title, original.title, entry.isbn);
+    assert.equal(enriched.description, original.description, entry.isbn);
+    assert.equal(enriched.price, original.price, entry.isbn);
+    assert.equal(enriched.currency_id, original.currency_id, entry.isbn);
+    assert.equal(enriched.available_quantity, original.available_quantity, entry.isbn);
+    assert.equal(enriched.condition, original.condition, entry.isbn);
+    assert.equal(enriched.canonical, original.canonical, entry.isbn);
+    assert.deepEqual(enriched.pictures, original.pictures, entry.isbn);
+  }
+});
+
+test('B11.2 lote 03: applyBookEnrichment publica el hecho aunque el catálogo traiga la clave bibliográfica vacía', () => {
+  for (const entry of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_03) {
+    const original = {
+      id: entry.sample_listing_id || 'MLU999999999',
+      isbn: entry.isbn,
+      title: `Título original ${entry.isbn}`,
+      author: 'Desconocido',
+      publisher: '',
+      pages: null,
+      bibliographic: { language: '', format: '', edition: '', publication_year: '' },
+      status: 'active',
+    };
+    const enriched = applyBookEnrichment(original);
+    for (const [field, value] of Object.entries(entry.facts.bibliographic || {})) {
+      assert.equal(enriched.bibliographic[field], value, `${entry.isbn}.${field}`);
+    }
+  }
+});

--- a/functions/__tests__/b11-2-resolve-revisar.test.js
+++ b/functions/__tests__/b11-2-resolve-revisar.test.js
@@ -2,7 +2,11 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { titlesCompatible, authorsCompatible } from '../../scripts/seo/book-editorial-cohort-2000.mjs';
-import { findConsensusPair, buildFactsFromConsensus } from '../../scripts/seo/b11-2-resolve-revisar.mjs';
+import {
+  findConsensusPair,
+  buildFactsFromConsensus,
+  publishableLanguage,
+} from '../../scripts/seo/b11-2-resolve-revisar.mjs';
 import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01 } from '../_shared/book-enrichment-facts-b11-2-lote-01.js';
 import {
   applyBookEnrichment,
@@ -113,6 +117,30 @@ test('B11.2: applyBookEnrichment publica el hecho aunque el catálogo ya traiga 
       assert.equal(enriched.bibliographic[field], value, `${entry.isbn}.${field}`);
     }
   }
+});
+
+test('un language multivaluado de la caché de B11.1 no se publica', () => {
+  // La caché es inmutable y se generó con el adaptador de BNE que fusionaba
+  // MARC 041 $a/$d/$h. El defecto sólo puede aparecer como valor
+  // multivaluado: si $a y $h coinciden, la mezcla colapsa a un solo idioma.
+  assert.equal(publishableLanguage('Español, Inglés'), false);
+  assert.equal(publishableLanguage('Español, dut'), false);
+  assert.equal(publishableLanguage('spa, eng'), false);
+  assert.equal(publishableLanguage('Español'), true);
+  assert.equal(publishableLanguage('spa'), true);
+  assert.equal(publishableLanguage(''), false);
+  assert.equal(publishableLanguage(null), false);
+});
+
+test('buildFactsFromConsensus descarta el language dudoso pero conserva el resto de los hechos', () => {
+  const records = [
+    { source: 'bne', title: 'Obra', author: 'Autor Real', publisher: 'Acantilado', pages: null, language: 'Español, Inglés', format: null, edition: null, publication_year: '2019', source_url: 'https://catalogo.bne.es/x' },
+    { source: 'open_library', title: 'Obra', author: 'Autor Real', publisher: 'Acantilado', pages: null, language: null, format: null, edition: null, publication_year: '2019', source_url: 'https://openlibrary.org/isbn/9780000000003' },
+  ];
+  const { facts } = buildFactsFromConsensus('9780000000003', '2026-09-02', records);
+  assert.equal(facts.bibliographic?.language, undefined);
+  assert.equal(facts.publisher, 'Acantilado');
+  assert.equal(facts.bibliographic.publication_year, '2019');
 });
 
 test('titlesCompatible/authorsCompatible siguen exportadas y estables (dependencia de B11.2)', () => {

--- a/functions/__tests__/b11-2-resolve-revisar.test.js
+++ b/functions/__tests__/b11-2-resolve-revisar.test.js
@@ -21,8 +21,9 @@ test('B11.2 lote 01 resuelve 12 ISBN del pool REVISAR con consenso cruzado real'
       assert.match(source.url, /^https:\/\//);
     }
   }
-  // El total global sube con cada lote posterior (B11.2 lote 02 agrega 12 más).
-  assert.equal(listBookEnrichments().length, 1550);
+  // El total global sube con cada lote posterior (lote 02 agrega 12 y el
+  // lote 03 final, 59).
+  assert.equal(listBookEnrichments().length, 1609);
 });
 
 test('B11.2 lote 01 no contiene ni modifica títulos o datos comerciales', () => {

--- a/functions/__tests__/book-bibliographic-normalization.test.js
+++ b/functions/__tests__/book-bibliographic-normalization.test.js
@@ -1,7 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { normalizeBookLanguage } from '../_shared/book-bibliographic-normalization.js';
+import {
+  bookLanguageLabel,
+  normalizeBookLanguage,
+} from '../_shared/book-bibliographic-normalization.js';
 
 test('normaliza códigos ISO de Google, Open Library y MARC a etiquetas visibles', () => {
   assert.equal(normalizeBookLanguage('es'), 'Español');
@@ -13,4 +16,16 @@ test('normaliza códigos ISO de Google, Open Library y MARC a etiquetas visibles
 test('conserva una etiqueta explícita que no es un código conocido', () => {
   assert.equal(normalizeBookLanguage('Español rioplatense'), 'Español rioplatense');
   assert.equal(normalizeBookLanguage(''), null);
+});
+
+test('bookLanguageLabel traduce un código conocido y devuelve null para el resto', () => {
+  assert.equal(bookLanguageLabel('spa'), 'Español');
+  assert.equal(bookLanguageLabel('ENG'), 'Inglés');
+  assert.equal(bookLanguageLabel('dut'), 'Neerlandés');
+  assert.equal(bookLanguageLabel('nld'), 'Neerlandés');
+  // Devolver null permite que un adaptador descarte el código en vez de
+  // dejar que llegue crudo a una ficha.
+  assert.equal(bookLanguageLabel('zzz'), null);
+  assert.equal(bookLanguageLabel(''), null);
+  assert.equal(bookLanguageLabel(null), null);
 });

--- a/functions/__tests__/book-enrichment-lote-01.test.js
+++ b/functions/__tests__/book-enrichment-lote-01.test.js
@@ -27,8 +27,9 @@ test('el lote 01 incorpora 187 ISBN nuevos con evidencia verificable', () => {
     assert.equal(validateBookEnrichment(entry), true, entry.isbn);
     assert.equal(getBookEnrichmentByIsbn(entry.isbn), entry);
   }
-  // El total global sube con cada lote posterior (B11.2 lote 01 + lote 02 agregan 24 más).
-  assert.equal(listBookEnrichments().length, 1550);
+  // El total global sube con cada lote posterior (los lotes 01, 02 y 03
+  // final de B11.2 agregan 83 más).
+  assert.equal(listBookEnrichments().length, 1609);
 });
 
 test('el lote 01 no contiene ni modifica títulos o datos comerciales', () => {

--- a/functions/__tests__/book-intelligence-bne.test.js
+++ b/functions/__tests__/book-intelligence-bne.test.js
@@ -10,7 +10,21 @@ import {
 const ISBN = '9788496836693';
 const OTHER_ISBN = '9780194527552';
 
-function marcRecord({ isbn = ISBN, title = 'Padres fuertes, hijas felices', author = 'Meeker, Meg' } = {}) {
+const LANGUAGE_041_DEFAULT = '<datafield tag="041" ind1="0" ind2=" "><subfield code="a">spa</subfield></datafield>';
+
+// Construye un 041 con los subcampos indicados, respetando el orden en que
+// se pasan: `subfields([['a','spa'],['h','eng']])`.
+function language041(subfields, ind1 = '1') {
+  const body = subfields.map(([code, value]) => `<subfield code="${code}">${value}</subfield>`).join('');
+  return `<datafield tag="041" ind1="${ind1}" ind2=" ">${body}</datafield>`;
+}
+
+function marcRecord({
+  isbn = ISBN,
+  title = 'Padres fuertes, hijas felices',
+  author = 'Meeker, Meg',
+  languageField = LANGUAGE_041_DEFAULT,
+} = {}) {
   return `
     <record xmlns="http://www.loc.gov/MARC21/slim">
       <leader>00000nam a2200000 i 4500</leader>
@@ -26,7 +40,7 @@ function marcRecord({ isbn = ISBN, title = 'Padres fuertes, hijas felices', auth
         <subfield code="c">2008.</subfield>
       </datafield>
       <datafield tag="300" ind1=" " ind2=" "><subfield code="a">304 p. ;</subfield></datafield>
-      <datafield tag="041" ind1="0" ind2=" "><subfield code="a">spa</subfield></datafield>
+      ${languageField}
       <datafield tag="520" ind1=" " ind2=" ">
         <subfield code="a">Registro bibliográfico con una descripción suficientemente extensa para comprobar la extracción semántica del adaptador.</subfield>
       </datafield>
@@ -80,6 +94,58 @@ test('parser BNE revalida 020$a y extrae evidencia bibliográfica fuerte', () =>
   assert.equal(record.topics.length, 3);
   assert.equal(record.raw_quality.exact_isbn, true);
   assert.equal(record.raw_quality.catalog, 'BNE');
+});
+
+// Regresión de B11.2 lote 03: el adaptador fusionaba 041 $a, $d y $h, así
+// que una traducción al español desde otro idioma se publicaba como si el
+// libro fuera bilingüe ("Español, Inglés"). Según MARC 21, $a es el idioma
+// del texto de esta edición, $h el de la obra original y $d el del contenido
+// cantado o hablado: sólo $a describe lo que el lector recibe.
+function languageOf(languageField) {
+  const [record] = parseBneEvidence(sruResponse([marcRecord({ languageField })]), ISBN);
+  return record.language;
+}
+
+test('041$h (idioma de la obra original) no se mezcla: una traducción es sólo Español', () => {
+  assert.equal(languageOf(language041([['a', 'spa'], ['h', 'eng']])), 'Español');
+  assert.equal(languageOf(language041([['a', 'spa'], ['h', 'ita']])), 'Español');
+  assert.equal(languageOf(language041([['a', 'spa'], ['h', 'fre']])), 'Español');
+  assert.equal(languageOf(language041([['a', 'spa'], ['h', 'cat']])), 'Español');
+});
+
+test('041$a repetido sí indica una edición realmente multilingüe', () => {
+  assert.equal(languageOf(language041([['a', 'spa'], ['a', 'eng']], '0')), 'Español, Inglés');
+  assert.equal(languageOf(language041([['a', 'spa'], ['a', 'cat']], '0')), 'Español, Catalán');
+});
+
+test('041$d (cantado o hablado) no se usa en un libro impreso', () => {
+  assert.equal(languageOf(language041([['a', 'spa'], ['d', 'eng']])), 'Español');
+  assert.equal(languageOf(language041([['a', 'spa'], ['d', 'eng'], ['h', 'ger']])), 'Español');
+});
+
+test('ningún código crudo de idioma llega al dato visible', () => {
+  // El caso real que disparó la corrección: 041 1#$aspa$hdut publicaba
+  // "Español, dut" porque `dut` no tenía etiqueta y pasaba tal cual.
+  assert.equal(languageOf(language041([['a', 'spa'], ['h', 'dut']])), 'Español');
+  assert.equal(languageOf(language041([['a', 'dut']], '0')), 'Neerlandés');
+
+  // Un código sin etiqueta conocida se descarta: preferimos no informar el
+  // idioma antes que mostrar el código crudo en una ficha.
+  assert.equal(languageOf(language041([['a', 'zzz']], '0')), null);
+  assert.equal(languageOf(language041([['a', 'spa'], ['a', 'zzz']], '0')), 'Español');
+
+  for (const field of [
+    language041([['a', 'spa'], ['h', 'eng']]),
+    language041([['a', 'spa'], ['a', 'eng']], '0'),
+    language041([['a', 'dut']], '0'),
+    language041([['a', 'zzz']], '0'),
+  ]) {
+    const value = languageOf(field);
+    if (value === null) continue;
+    for (const code of ['dut', 'eng', 'spa', 'fre', 'ger', 'ita', 'cat', 'zzz']) {
+      assert.equal(new RegExp(`\\b${code}\\b`, 'i').test(value), false, `${value} contiene ${code}`);
+    }
+  }
 });
 
 test('un registro sin el ISBN solicitado nunca se convierte en evidencia', () => {

--- a/functions/_shared/book-bibliographic-normalization.js
+++ b/functions/_shared/book-bibliographic-normalization.js
@@ -22,10 +22,22 @@ const LANGUAGE_LABELS = Object.freeze({
   eu: 'Euskera',
   baq: 'Euskera',
   eus: 'Euskera',
+  nl: 'Neerlandés',
+  nld: 'Neerlandés',
+  dut: 'Neerlandés',
 });
 
 function clean(value) {
   return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+// Devuelve la etiqueta legible de un código de idioma, o null si no se
+// conoce. Sirve para que un adaptador pueda descartar un código en vez de
+// dejar que llegue crudo al dato visible (`dut`, `eng`, `spa`…).
+export function bookLanguageLabel(code) {
+  const key = clean(code).toLocaleLowerCase('es');
+  if (!key) return null;
+  return LANGUAGE_LABELS[key] || null;
 }
 
 export function normalizeBookLanguage(value) {

--- a/functions/_shared/book-enrichment-facts-b11-2-lote-03.js
+++ b/functions/_shared/book-enrichment-facts-b11-2-lote-03.js
@@ -1,0 +1,2433 @@
+// Generado por scripts/seo/b11-2-resolve-revisar.mjs. NO EDITAR A MANO.
+// Hechos verificados por consenso cruzado de fuentes independientes,
+// resolviendo conflictos de identidad del pool REVISAR de B11.1.
+
+export const BOOK_FACT_ENRICHMENTS = Object.freeze([
+  {
+    "schema_version": 1,
+    "isbn": "9788416781614",
+    "sample_listing_id": "MLU640165647",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2017"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788416781614%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788416781614",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=lqBIvgAACAAJ&dq=isbn:9788416781614&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788416781614",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788416781614",
+        "relationship": "exact_edition",
+        "isbn": "9788416781614",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788417103026",
+    "sample_listing_id": "MLU1476047750",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2017"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=eD9HswEACAAJ&dq=isbn:9788417103026&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788417103026",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788417103026",
+        "relationship": "exact_edition",
+        "isbn": "9788417103026",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788417241865",
+    "sample_listing_id": "MLU624970612",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Arzalia Ediciones",
+      "bibliographic": {
+        "publication_year": "2021"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788417241865%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788417241865",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788417241865",
+        "relationship": "exact_edition",
+        "isbn": "9788417241865",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788417346935",
+    "sample_listing_id": "MLU612098974",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Acantilado",
+      "bibliographic": {
+        "language": "Español, dut",
+        "publication_year": "2019"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788417346935%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788417346935",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "language",
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788417346935",
+        "relationship": "exact_edition",
+        "isbn": "9788417346935",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788417804985",
+    "sample_listing_id": "MLU667396328",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Ara Llibres",
+      "bibliographic": {
+        "language": "Español, Catalán",
+        "publication_year": "2021"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788417804985%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788417804985",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "language",
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788417804985",
+        "relationship": "exact_edition",
+        "isbn": "9788417804985",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788418128110",
+    "sample_listing_id": "MLU662157004",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Duomo ediciones"
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788418128110%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788418128110",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788418128110",
+        "relationship": "exact_edition",
+        "isbn": "9788418128110",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788418137525",
+    "sample_listing_id": "MLU643829263",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2020"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788418137525%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788418137525",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=b5xbzgEACAAJ&dq=isbn:9788418137525&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788418137525",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788418137525",
+        "relationship": "exact_edition",
+        "isbn": "9788418137525",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788418137952",
+    "sample_listing_id": "MLU643803359",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2021"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788418137952%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788418137952",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=b5u1zwEACAAJ&dq=isbn:9788418137952&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788418137952",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788418137952",
+        "relationship": "exact_edition",
+        "isbn": "9788418137952",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788418623233",
+    "sample_listing_id": "MLU912853188",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2021"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788418623233%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788418623233",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=HTT50AEACAAJ&dq=isbn:9788418623233&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788418623233",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788418623233",
+        "relationship": "exact_edition",
+        "isbn": "9788418623233",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788418672910",
+    "sample_listing_id": "MLU640787807",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2022"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=UzDL0QEACAAJ&dq=isbn:9788418672910&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788418672910",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788418672910",
+        "relationship": "exact_edition",
+        "isbn": "9788418672910",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788418826511",
+    "sample_listing_id": "MLU651942506",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2022"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788418826511%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788418826511",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=3_xUzwEACAAJ&dq=isbn:9788418826511&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788418826511",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788418826511",
+        "relationship": "exact_edition",
+        "isbn": "9788418826511",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788420011097",
+    "sample_listing_id": "MLU639239245",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2008"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788420011097%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788420011097",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=0blBQwAACAAJ&dq=isbn:9788420011097&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788420011097",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788420011097",
+        "relationship": "exact_edition",
+        "isbn": "9788420011097",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788423362264",
+    "sample_listing_id": "MLU620290536",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Booket",
+      "bibliographic": {
+        "language": "Español, Italiano",
+        "publication_year": "2022"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788423362264%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788423362264",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "language",
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788423362264",
+        "relationship": "exact_edition",
+        "isbn": "9788423362264",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788425368370",
+    "sample_listing_id": "MLU1043954574",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "author": "Nazareth Olivera Belart",
+      "bibliographic": {
+        "publication_year": "2025"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=Zktg0QEACAAJ&dq=isbn:9788425368370&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788425368370",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "author",
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788425368370",
+        "relationship": "exact_edition",
+        "isbn": "9788425368370",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "author",
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788426110091",
+    "sample_listing_id": "MLU639035281",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Juventud"
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788426110091%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788426110091",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788426110091",
+        "relationship": "exact_edition",
+        "isbn": "9788426110091",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788426138064",
+    "sample_listing_id": "MLU687648212",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "author": "Demi",
+      "bibliographic": {
+        "publication_year": "2010"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788426138064%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788426138064",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "author",
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=tiwfkgAACAAJ&dq=isbn:9788426138064&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788426138064",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "author",
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788426138064",
+        "relationship": "exact_edition",
+        "isbn": "9788426138064",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "author",
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788426145215",
+    "sample_listing_id": "MLU643758313",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2018"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788426145215%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788426145215",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788426145215",
+        "relationship": "exact_edition",
+        "isbn": "9788426145215",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788428217217",
+    "sample_listing_id": "MLU697194224",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2020"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=_3NVzwEACAAJ&dq=isbn:9788428217217&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788428217217",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788428217217",
+        "relationship": "exact_edition",
+        "isbn": "9788428217217",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788430120666",
+    "sample_listing_id": "MLU645584035",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2020"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788430120666%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788430120666",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=5pIUzgEACAAJ&dq=isbn:9788430120666&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788430120666",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788430120666",
+        "relationship": "exact_edition",
+        "isbn": "9788430120666",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788432153839",
+    "sample_listing_id": "MLU628170035",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2021"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788432153839%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788432153839",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=NQDmzgEACAAJ&dq=isbn:9788432153839&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788432153839",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788432153839",
+        "relationship": "exact_edition",
+        "isbn": "9788432153839",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788432227813",
+    "sample_listing_id": "MLU1494548512",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2004"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=NlwdMQAACAAJ&dq=isbn:9788432227813&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788432227813",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788432227813",
+        "relationship": "exact_edition",
+        "isbn": "9788432227813",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788433029102",
+    "sample_listing_id": "MLU625756445",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Desclée De Brouwer",
+      "bibliographic": {
+        "language": "Español, Inglés",
+        "publication_year": "2017"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788433029102%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788433029102",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "language",
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788433029102",
+        "relationship": "exact_edition",
+        "isbn": "9788433029102",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788433031143",
+    "sample_listing_id": "MLU678044090",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Desclée De Brouwer",
+      "bibliographic": {
+        "language": "Español, Inglés",
+        "publication_year": "2020"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788433031143%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788433031143",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "language",
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788433031143",
+        "relationship": "exact_edition",
+        "isbn": "9788433031143",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788441542969",
+    "sample_listing_id": "MLU664252462",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "ANAYA MULTIMEDIA",
+      "bibliographic": {
+        "language": "Español, Inglés",
+        "publication_year": "2021"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788441542969%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788441542969",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "language",
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788441542969",
+        "relationship": "exact_edition",
+        "isbn": "9788441542969",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788467035834",
+    "sample_listing_id": "MLU626172916",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Booket",
+      "bibliographic": {
+        "publication_year": "2011"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788467035834%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788467035834",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=dZRFAwEACAAJ&dq=isbn:9788467035834&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788467035834",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788467035834",
+        "relationship": "exact_edition",
+        "isbn": "9788467035834",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788467780345",
+    "sample_listing_id": "MLU1494067112",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2021"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788467780345%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788467780345",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=vZbNzgEACAAJ&dq=isbn:9788467780345&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788467780345",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788467780345",
+        "relationship": "exact_edition",
+        "isbn": "9788467780345",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788478132898",
+    "sample_listing_id": "MLU679659318",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2005"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788478132898%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788478132898",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=z-hHAAAACAAJ&dq=isbn:9788478132898&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788478132898",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788478132898",
+        "relationship": "exact_edition",
+        "isbn": "9788478132898",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788478847440",
+    "sample_listing_id": "MLU609584757",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Editorial Popular",
+      "bibliographic": {
+        "language": "Español, Francés",
+        "publication_year": "2017"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788478847440%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788478847440",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "language",
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788478847440",
+        "relationship": "exact_edition",
+        "isbn": "9788478847440",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788483108383",
+    "sample_listing_id": "MLU617037469",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Tusquets"
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788483108383%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788483108383",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788483108383",
+        "relationship": "exact_edition",
+        "isbn": "9788483108383",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788483830130",
+    "sample_listing_id": "MLU636069314",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Tusquets",
+      "bibliographic": {
+        "publication_year": "2007"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788483830130%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788483830130",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788483830130",
+        "relationship": "exact_edition",
+        "isbn": "9788483830130",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788484453178",
+    "sample_listing_id": "MLU1474705770",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2010"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788484453178%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788484453178",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=V5StcQAACAAJ&dq=isbn:9788484453178&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788484453178",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788484453178",
+        "relationship": "exact_edition",
+        "isbn": "9788484453178",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788484454380",
+    "sample_listing_id": "MLU1489004436",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2012"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788484454380%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788484454380",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=IeaWvgEACAAJ&dq=isbn:9788484454380&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788484454380",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788484454380",
+        "relationship": "exact_edition",
+        "isbn": "9788484454380",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788484455578",
+    "sample_listing_id": "MLU1346585778",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2015"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788484455578%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788484455578",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788484455578",
+        "relationship": "exact_edition",
+        "isbn": "9788484455578",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788485316595",
+    "sample_listing_id": "MLU644976285",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "1981"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788485316595%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788485316595",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=Ye28PAAACAAJ&dq=isbn:9788485316595&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788485316595",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788485316595",
+        "relationship": "exact_edition",
+        "isbn": "9788485316595",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788490327418",
+    "sample_listing_id": "MLU672474006",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Debolsillo",
+      "bibliographic": {
+        "publication_year": "2014"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788490327418%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788490327418",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788490327418",
+        "relationship": "exact_edition",
+        "isbn": "9788490327418",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788490615072",
+    "sample_listing_id": "MLU1494566608",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2017"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788490615072%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788490615072",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=zOQ0swEACAAJ&dq=isbn:9788490615072&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788490615072",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788490615072",
+        "relationship": "exact_edition",
+        "isbn": "9788490615072",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788490664544",
+    "sample_listing_id": "MLU1026182614",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2017"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788490664544%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788490664544",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788490664544",
+        "relationship": "exact_edition",
+        "isbn": "9788490664544",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788490732502",
+    "sample_listing_id": "MLU680721042",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2016"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788490732502%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788490732502",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=JCPfuQEACAAJ&dq=isbn:9788490732502&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788490732502",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788490732502",
+        "relationship": "exact_edition",
+        "isbn": "9788490732502",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788490748930",
+    "sample_listing_id": "MLU643192227",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2019"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788490748930%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788490748930",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://play.google.com/store/books/details?id=vN-RDwAAQBAJ&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788490748930",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788490748930",
+        "relationship": "exact_edition",
+        "isbn": "9788490748930",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788490970751",
+    "sample_listing_id": "MLU637772847",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Los Libros de la Catarata",
+      "bibliographic": {
+        "publication_year": "2015"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788490970751%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788490970751",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788490970751",
+        "relationship": "exact_edition",
+        "isbn": "9788490970751",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788491139652",
+    "sample_listing_id": "MLU672289182",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Elsevier"
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788491139652%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788491139652",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788491139652",
+        "relationship": "exact_edition",
+        "isbn": "9788491139652",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788491181217",
+    "sample_listing_id": "MLU644340815",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2019"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788491181217%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788491181217",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=ZoBJygEACAAJ&dq=isbn:9788491181217&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788491181217",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788491181217",
+        "relationship": "exact_edition",
+        "isbn": "9788491181217",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788491870395",
+    "sample_listing_id": "MLU617229758",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "author": "Illescas, Miguel",
+      "publisher": "RBA",
+      "bibliographic": {
+        "publication_year": "2018"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788491870395%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788491870395",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "author",
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788491870395",
+        "relationship": "exact_edition",
+        "isbn": "9788491870395",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "author",
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788492534401",
+    "sample_listing_id": "MLU683142450",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2022"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788492534401%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788492534401",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788492534401",
+        "relationship": "exact_edition",
+        "isbn": "9788492534401",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788493464547",
+    "sample_listing_id": "MLU1468246340",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2007"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788493464547%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788493464547",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=mmQyQwAACAAJ&dq=isbn:9788493464547&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788493464547",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788493464547",
+        "relationship": "exact_edition",
+        "isbn": "9788493464547",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788494441585",
+    "sample_listing_id": "MLU912853562",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2016"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788494441585%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788494441585",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788494441585",
+        "relationship": "exact_edition",
+        "isbn": "9788494441585",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788496375048",
+    "sample_listing_id": "MLU652670422",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Losada"
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788496375048%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788496375048",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788496375048",
+        "relationship": "exact_edition",
+        "isbn": "9788496375048",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788498359602",
+    "sample_listing_id": "MLU686467468",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2016"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788498359602%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788498359602",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788498359602",
+        "relationship": "exact_edition",
+        "isbn": "9788498359602",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788498747171",
+    "sample_listing_id": "MLU645136093",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2022"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788498747171%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788498747171",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788498747171",
+        "relationship": "exact_edition",
+        "isbn": "9788498747171",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788499083957",
+    "sample_listing_id": "MLU639649507",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "publisher": "Debolsillo",
+      "bibliographic": {
+        "language": "Español, Inglés",
+        "publication_year": "2010"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788499083957%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788499083957",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "language",
+          "publication_year",
+          "publisher"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788499083957",
+        "relationship": "exact_edition",
+        "isbn": "9788499083957",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year",
+          "publisher"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788499201306",
+    "sample_listing_id": "MLU647235993",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2012"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788499201306%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788499201306",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=UuX5ugAACAAJ&dq=isbn:9788499201306&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788499201306",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788499201306",
+        "relationship": "exact_edition",
+        "isbn": "9788499201306",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9788499501499",
+    "sample_listing_id": "MLU640759137",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2015"
+      }
+    },
+    "provenance": [
+      {
+        "type": "national_library",
+        "provider": "Biblioteca Nacional de España",
+        "url": "https://catalogo.bne.es/view/sru/34BNE_INST?operation=searchRetrieve&version=1.2&query=alma.isbn%3D%229788499501499%22&recordSchema=marcxml&startRecord=1&maximumRecords=5",
+        "relationship": "exact_edition",
+        "isbn": "9788499501499",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=iqBfjgEACAAJ&dq=isbn:9788499501499&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9788499501499",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9788499501499",
+        "relationship": "exact_edition",
+        "isbn": "9788499501499",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9789089989574",
+    "sample_listing_id": "MLU697932901",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2018"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=9mCTtgEACAAJ&dq=isbn:9789089989574&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9789089989574",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9789089989574",
+        "relationship": "exact_edition",
+        "isbn": "9789089989574",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9789505181025",
+    "sample_listing_id": "MLU633003679",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2003"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=itXuAAAACAAJ&dq=isbn:9789505181025&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9789505181025",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9789505181025",
+        "relationship": "exact_edition",
+        "isbn": "9789505181025",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9789505188062",
+    "sample_listing_id": "MLU697318255",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "1999"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=ftBZAgAACAAJ&dq=isbn:9789505188062&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9789505188062",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9789505188062",
+        "relationship": "exact_edition",
+        "isbn": "9789505188062",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9789505566990",
+    "sample_listing_id": "MLU614583373",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "author": "José Luis Espert",
+      "bibliographic": {
+        "publication_year": "2017"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=5BnLtAEACAAJ&dq=isbn:9789505566990&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9789505566990",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "author",
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9789505566990",
+        "relationship": "exact_edition",
+        "isbn": "9789505566990",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "author",
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9789507247163",
+    "sample_listing_id": "MLU642935647",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "1998"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=zHU8AAAACAAJ&dq=isbn:9789507247163&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9789507247163",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9789507247163",
+        "relationship": "exact_edition",
+        "isbn": "9789507247163",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9789875703087",
+    "sample_listing_id": "MLU677652528",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2017"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=gnGvswEACAAJ&dq=isbn:9789875703087&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9789875703087",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9789875703087",
+        "relationship": "exact_edition",
+        "isbn": "9789875703087",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  },
+  {
+    "schema_version": 1,
+    "isbn": "9789876290098",
+    "sample_listing_id": "MLU698424763",
+    "decision": "auto_publish_facts",
+    "verified_at": "2026-09-02",
+    "facts": {
+      "bibliographic": {
+        "publication_year": "2008"
+      }
+    },
+    "provenance": [
+      {
+        "type": "bibliographic_database",
+        "provider": "Google Books",
+        "url": "https://books.google.com/books?id=tSqxOgAACAAJ&dq=isbn:9789876290098&hl=&as_pt=BOOKS&source=gbs_api",
+        "relationship": "exact_edition",
+        "isbn": "9789876290098",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      },
+      {
+        "type": "library_catalog",
+        "provider": "Open Library",
+        "url": "https://openlibrary.org/isbn/9789876290098",
+        "relationship": "exact_edition",
+        "isbn": "9789876290098",
+        "verified_at": "2026-09-02",
+        "fields": [
+          "publication_year"
+        ]
+      }
+    ]
+  }
+]);

--- a/functions/_shared/book-enrichment-facts-b11-2-lote-03.js
+++ b/functions/_shared/book-enrichment-facts-b11-2-lote-03.js
@@ -134,7 +134,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
     "facts": {
       "publisher": "Acantilado",
       "bibliographic": {
-        "language": "Español, dut",
         "publication_year": "2019"
       }
     },
@@ -147,7 +146,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
         "isbn": "9788417346935",
         "verified_at": "2026-09-02",
         "fields": [
-          "language",
           "publication_year",
           "publisher"
         ]
@@ -175,7 +173,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
     "facts": {
       "publisher": "Ara Llibres",
       "bibliographic": {
-        "language": "Español, Catalán",
         "publication_year": "2021"
       }
     },
@@ -188,7 +185,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
         "isbn": "9788417804985",
         "verified_at": "2026-09-02",
         "fields": [
-          "language",
           "publication_year",
           "publisher"
         ]
@@ -521,7 +517,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
     "facts": {
       "publisher": "Booket",
       "bibliographic": {
-        "language": "Español, Italiano",
         "publication_year": "2022"
       }
     },
@@ -534,7 +529,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
         "isbn": "9788423362264",
         "verified_at": "2026-09-02",
         "fields": [
-          "language",
           "publication_year",
           "publisher"
         ]
@@ -888,7 +882,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
     "facts": {
       "publisher": "Desclée De Brouwer",
       "bibliographic": {
-        "language": "Español, Inglés",
         "publication_year": "2017"
       }
     },
@@ -901,7 +894,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
         "isbn": "9788433029102",
         "verified_at": "2026-09-02",
         "fields": [
-          "language",
           "publication_year",
           "publisher"
         ]
@@ -929,7 +921,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
     "facts": {
       "publisher": "Desclée De Brouwer",
       "bibliographic": {
-        "language": "Español, Inglés",
         "publication_year": "2020"
       }
     },
@@ -942,7 +933,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
         "isbn": "9788433031143",
         "verified_at": "2026-09-02",
         "fields": [
-          "language",
           "publication_year",
           "publisher"
         ]
@@ -970,7 +960,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
     "facts": {
       "publisher": "ANAYA MULTIMEDIA",
       "bibliographic": {
-        "language": "Español, Inglés",
         "publication_year": "2021"
       }
     },
@@ -983,7 +972,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
         "isbn": "9788441542969",
         "verified_at": "2026-09-02",
         "fields": [
-          "language",
           "publication_year",
           "publisher"
         ]
@@ -1155,7 +1143,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
     "facts": {
       "publisher": "Editorial Popular",
       "bibliographic": {
-        "language": "Español, Francés",
         "publication_year": "2017"
       }
     },
@@ -1168,7 +1155,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
         "isbn": "9788478847440",
         "verified_at": "2026-09-02",
         "fields": [
-          "language",
           "publication_year",
           "publisher"
         ]
@@ -2049,7 +2035,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
     "facts": {
       "publisher": "Debolsillo",
       "bibliographic": {
-        "language": "Español, Inglés",
         "publication_year": "2010"
       }
     },
@@ -2062,7 +2047,6 @@ export const BOOK_FACT_ENRICHMENTS = Object.freeze([
         "isbn": "9788499083957",
         "verified_at": "2026-09-02",
         "fields": [
-          "language",
           "publication_year",
           "publisher"
         ]

--- a/functions/_shared/book-enrichment-registry.js
+++ b/functions/_shared/book-enrichment-registry.js
@@ -10,6 +10,7 @@ import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_333 } from './book-enric
 import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_LOTE_01 } from './book-enrichment-facts-lote-01.js';
 import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01 } from './book-enrichment-facts-b11-2-lote-01.js';
 import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_B11_2_LOTE_02 } from './book-enrichment-facts-b11-2-lote-02.js';
+import { BOOK_FACT_ENRICHMENTS as BOOK_FACT_ENRICHMENTS_B11_2_LOTE_03 } from './book-enrichment-facts-b11-2-lote-03.js';
 import { BOOK_EDITORIAL_UPGRADES } from './book-editorial-upgrades.js';
 import { isGenericAuthor, normalizeValidIsbn } from './showcase-ranking.js';
 
@@ -526,6 +527,15 @@ for (const record of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_01) {
   ENRICHMENT_BY_ISBN.set(record.isbn, record);
 }
 for (const record of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_02) {
+  if (!validateBookEnrichment(record)) {
+    throw new Error(`Enriquecimiento factual inválido para ${record?.isbn || 'ISBN desconocido'}.`);
+  }
+  if (ENRICHMENT_BY_ISBN.has(record.isbn)) {
+    throw new Error(`ISBN duplicado en el registro de enriquecimiento: ${record.isbn}.`);
+  }
+  ENRICHMENT_BY_ISBN.set(record.isbn, record);
+}
+for (const record of BOOK_FACT_ENRICHMENTS_B11_2_LOTE_03) {
   if (!validateBookEnrichment(record)) {
     throw new Error(`Enriquecimiento factual inválido para ${record?.isbn || 'ISBN desconocido'}.`);
   }

--- a/scripts/seo/b11-2-resolve-revisar.mjs
+++ b/scripts/seo/b11-2-resolve-revisar.mjs
@@ -144,6 +144,27 @@ function httpsUrl(value, { source, isbn } = {}) {
   }
 }
 
+// La evidencia cacheada por B11.1 se generó con un adaptador de BNE que
+// fusionaba MARC 041 $a (idioma del texto de esta edición), $d (contenido
+// cantado o hablado) y $h (idioma de la obra original). Con esa mezcla una
+// traducción quedó registrada como "Español, Inglés" cuando el libro está
+// enteramente en español. El adaptador ya se corrigió para leer sólo $a,
+// pero la caché es inmutable y sigue conteniendo los valores mezclados.
+//
+// El defecto sólo puede manifestarse como un valor multivaluado: si $a y $h
+// coinciden, la mezcla colapsa a un único idioma y el dato es correcto igual.
+// Por eso alcanza con no publicar ningún `language` que traiga más de un
+// idioma. Es deliberadamente conservador: ante evidencia que no distingue el
+// idioma del texto del de la obra original, no se informa nada. Una edición
+// realmente bilingüe queda sin idioma hasta que se reprocese la evidencia con
+// el adaptador corregido, que es el resultado preferible frente a publicar un
+// idioma que el lector no va a encontrar en el libro.
+export function publishableLanguage(value) {
+  const normalized = normalizeBookLanguage(value);
+  if (!normalized) return false;
+  return !normalized.includes(',');
+}
+
 function sourceDescriptor(source) {
   if (source === 'bne') return { type: 'national_library', provider: 'Biblioteca Nacional de España', official: true };
   if (source === 'google_books') return { type: 'bibliographic_database', provider: 'Google Books', official: false };
@@ -183,7 +204,8 @@ export function buildFactsFromConsensus(isbn, verifiedAt, allRecords) {
   for (const field of EDITION_FIELDS) {
     const values = allRecords
       .map(record => ({ record, value: record[field] }))
-      .filter(({ value }) => value !== null && value !== undefined && clean(value));
+      .filter(({ value }) => value !== null && value !== undefined && clean(value))
+      .filter(({ value }) => field !== 'language' || publishableLanguage(value));
     if (!values.length) continue;
 
     const groups = new Map();

--- a/scripts/seo/book-intelligence-bne.mjs
+++ b/scripts/seo/book-intelligence-bne.mjs
@@ -9,7 +9,7 @@
 // - sólo se usa offline/batch, nunca en una request de cliente.
 
 import { normalizeValidIsbn } from '../../functions/_shared/showcase-ranking.js';
-import { normalizeBookLanguage } from '../../functions/_shared/book-bibliographic-normalization.js';
+import { bookLanguageLabel, normalizeBookLanguage } from '../../functions/_shared/book-bibliographic-normalization.js';
 
 export const BNE_SRU_BASE = 'https://catalogo.bne.es/view/sru/34BNE_INST';
 export const BNE_MAX_RECORDS = 5;
@@ -157,9 +157,21 @@ function pageCount(record) {
   return Number.isInteger(pages) && pages > 0 ? pages : null;
 }
 
+// MARC 21 campo 041: $a es el idioma del texto de ESTA edición, $h el de la
+// obra original y $d el del contenido cantado o hablado. Sólo $a describe lo
+// que el lector recibe: mezclarlos convierte una traducción
+// (041 1#$aspa$heng) en un falso "Español, Inglés". Para un libro impreso $d
+// no aplica. Se leen todos los $a repetidos, que sí indican una edición
+// realmente multilingüe (041 0#$aspa$aeng).
+//
+// Un código que no se puede traducir a etiqueta se descarta en vez de
+// publicarse crudo: es preferible no informar el idioma antes que mostrar
+// "dut" en una ficha.
 function languageValue(record) {
-  const values = [...new Set(subfieldValues(record, '041', ['a', 'd', 'h']))];
-  return normalizeBookLanguage(values.join(', '));
+  const labels = [...new Set(subfieldValues(record, '041', 'a'))]
+    .map(bookLanguageLabel)
+    .filter(Boolean);
+  return labels.length ? normalizeBookLanguage(labels.join(', ')) : null;
 }
 
 function summaryValue(record) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ejecución única sobre los **356 ISBN `REVISAR` que nunca habían sido intentados**, autorizada por Seba para agotar el pool automático de B11.2 de una sola vez. Parte de `main` en `673bc0f`.

> **Cambios solicitados aplicados.** Se corrigió el bloqueo semántico de `bibliographic.language`. El PR sigue en **Draft**, sin fusionar y sin desplegar.

## Corrección de `language` (MARC 041)

`scripts/seo/book-intelligence-bne.mjs` construía el idioma fusionando MARC 041 `$a`, `$d` y `$h`. Según MARC 21, `$a` es el idioma del texto de esta edición, `$h` el de la obra original y `$d` el del contenido cantado o hablado, así que una traducción `041 1#$aspa$heng` se publicaba como "Español, Inglés" siendo un libro enteramente en español.

Corregido en tres capas:

1. **Adaptador BNE**: `language` usa únicamente los `041$a` repetidos. No mezcla `$h`, no usa `$d` para libros impresos, y descarta cualquier código sin etiqueta conocida en vez de publicarlo crudo — ése era el origen de `"Español, dut"`.
2. **Normalización**: nuevo `bookLanguageLabel()`, que traduce un código a etiqueta o devuelve `null` para que el adaptador pueda descartarlo. Se agregó el neerlandés (`nl`/`nld`/`dut`), presente en la evidencia real.
3. **Resolver**: la caché de B11.1 es inmutable y conserva los valores mezclados. No se editó a mano el archivo generado ni se sustituyeron los ocho valores por "Español". Se aplicó una regla conservadora y reproducible: **no se publica ningún `language` con más de un idioma**. El defecto sólo puede manifestarse como valor multivaluado, porque si `$a` y `$h` coinciden la mezcla colapsa a un único idioma y el dato es correcto igual. Así se cubre exactamente el problema sin listar ISBN a mano.

`book-enrichment-facts-b11-2-lote-03.js` se **regeneró** con el resolver corregido, partiendo del estado previo a la corrida. El diff del módulo son sólo las 8 líneas de `language` y sus entradas en `provenance.fields`: **ningún otro campo cambió**.

| | Antes | Ahora |
| --- | --- | --- |
| `language` publicados | 8 | **0** |
| Códigos crudos visibles | 1 (`dut`) | **0** |
| ISBN en el módulo | 59 | 59 |

Los 8 afectados conservan `publisher` y `publication_year`, así que siguen siendo `TERMINADO`:

```
9788417346935  Acantilado / 2019          9788433031143  Desclée De Brouwer / 2020
9788417804985  Ara Llibres / 2021         9788441542969  ANAYA MULTIMEDIA / 2021
9788423362264  Booket / 2022              9788478847440  Editorial Popular / 2017
9788433029102  Desclée De Brouwer / 2017  9788499083957  Debolsillo / 2010
```

### Tests de regresión

`041 1#$aspa$heng` → `Español`. `041 0#$aspa$aeng` → `Español, Inglés`. `$d` ignorado en libro impreso. Ningún código crudo (`dut`, `eng`, `spa`, `zzz`…) puede llegar al dato visible. Más los de la regla del resolver y los que verifican que el módulo generado no publica ningún `language`.

## Contaminación previa: PR técnico separado

Este PR **no toca** los módulos históricos, a propósito. Auditoría del estado actual:

| Módulo | Con `language` | Multivaluados |
| --- | --- | --- |
| `book-enrichment-facts-1000.js` | 13 | **13** |
| `book-enrichment-facts-333.js` | 2 | **2** |
| `book-enrichment-facts-b11-2-lote-02.js` | 2 | **2** |
| `book-enrichment-facts-lote-01.js` | 0 | 0 |
| `book-enrichment-facts-b11-2-lote-01.js` | 0 | 0 |
| `book-enrichment-facts-b11-2-lote-03.js` | 0 | 0 |
| **Total** | **17** | **17** |

Los 17 que siguen publicados son multivaluados y los 17 provienen de BNE, o sea que replican exactamente el mismo defecto. Incluyen otro código crudo (`"Español, dan"` en `9788418859694`). Queda anotado como **siguiente PR técnico separado** para auditarlos contra MARC 041`$a`, sin mezclar la limpieza histórica con este lote.

## Resultado del lote (sin cambios)

| Estado | ISBN |
| --- | --- |
| `TERMINADO` | **59** |
| `SIN_DATOS` | **23** |
| Siguen `REVISAR` | **274** |
| **Procesados** | **356** |

Registry **1.550 → 1.609**. `state.json` con **556** entradas (`TERMINADO` 83, `SIN_DATOS` 31, `REVISAR` 442). El estado regenerado es idéntico al anterior, por eso `state.json` ni siquiera aparece en el diff de la corrección.

**El pool queda agotado**: las 556 entradas son exactamente los 556 ISBN `REVISAR` que dejó B11.1, ninguno sin intentar. Hay un test que lo verifica cruzando el estado contra el report original.

## Protección contra sobrescritura

El resolver se ejecutó con las cuatro variables explícitas, porque los defaults de `B11_2_FACTS_OUTPUT` y `B11_2_SUMMARY_PATH` apuntan al Lote 01 y lo habrían borrado del registry:

```
B11_2_BATCH_SIZE=356
B11_2_BATCH_NAME=lote-03-final
B11_2_FACTS_OUTPUT=functions/_shared/book-enrichment-facts-b11-2-lote-03.js
B11_2_SUMMARY_PATH=artifacts/b11-2/lote-03-final-summary.md
```

Verificado: los módulos y resúmenes de los lotes 01 y 02 quedaron sin cambios, y de las 200 entradas previas de `state.json` no se perdió ni se alteró ninguna.

## Validación

Tests focales **44/44**, suite completa **1.547/1.547 con 0 fallos**, `bash scripts/validate-ci.sh` en `Validación completa OK` y `git diff --check` limpio.

CI en verde: `Syntax & Build`, `Deploy and audit every PR Preview`, `Investigate 1000 unique ISBN editions` y `Reproduce public SEO baseline` (este último se sumó porque el diff toca `scripts/seo/`).

Live check contra `https://pr-308.amadolibros-web.pages.dev`: **1.594 ediciones verificadas en ficha y Merchant, 15 sin oferta activa**, que suman los 1.609 exactos del registry. Los **59 ISBN del lote verificados**, incluidos los 8 que perdieron el idioma y quedan respaldados por editorial y año.

No fusionar ni desplegar a Producción sin autorización de Seba.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74ca4dcc-80a4-4fec-841d-b0864fd6627e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74ca4dcc-80a4-4fec-841d-b0864fd6627e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

