### PR TITLE
V1.1: checkout guidance + rediseño profundo de /carrito (layout, selector de pago, CTA único)

### DIFF
--- a/.github/workflows/deploy-checkout-v11-preview.yml
+++ b/.github/workflows/deploy-checkout-v11-preview.yml
@@ -1,0 +1,156 @@
+name: Deploy V1.1 checkout Preview (checkout ON)
+
+# El Preview automático de todo PR (deploy-pr-preview.yml) compila
+# deliberadamente con PUBLIC_CHECKOUT_ENABLED=false — sirve para auditar
+# SEO/catálogo, no para revisar el checkout. No existe hoy ningún pipeline
+# que despliegue un Preview con el checkout visible para esta rama (ver
+# docs/environments.md, "Pendientes antes de activar cobros LIVE", punto 3).
+# Este workflow, gateado a una sola rama de trabajo, cubre exactamente ese
+# hueco para la revisión del rediseño V1.1 — mismo patrón ya usado en
+# deploy-price-bank-preview.yml. No toca el pipeline global de PR previews
+# ni el de Producción.
+
+on:
+  push:
+    branches:
+      - v1.1/checkout-guidance
+
+permissions:
+  contents: read
+
+concurrency:
+  group: checkout-v11-preview
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Guard Preview ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Block every other branch
+        run: |
+          if [ "${GITHUB_REF}" != "refs/heads/v1.1/checkout-guidance" ]; then
+            echo "Deploy bloqueado: rama incorrecta."
+            exit 1
+          fi
+
+  validate:
+    name: Validate exact branch code
+    needs: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: astro-front/package-lock.json
+      - name: Validate shared suite
+        run: bash scripts/validate-ci.sh
+
+  deploy-preview:
+    name: Deploy isolated Preview with checkout visible
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: astro-front/package-lock.json
+
+      - name: Install Astro dependencies
+        working-directory: astro-front
+        run: npm ci --no-audit --no-fund
+
+      # Config pública de Preview (docs/environments.md), NO la de
+      # Producción: site key y hosts permitidos son los del widget
+      # `amadolibros-orders-preview`, distinto del widget de Producción.
+      - name: Build protected Preview with checkout visible
+        working-directory: astro-front
+        env:
+          PUBLIC_INDEXABLE: 'false'
+          PUBLIC_GA_ID: ''
+          PUBLIC_CHECKOUT_ENABLED: 'true'
+          PUBLIC_TURNSTILE_SITE_KEY: '0x4AAAAAAD6E9kz8K3comwjj'
+          PUBLIC_TURNSTILE_ALLOWED_HOSTS: '.amadolibros-web.pages.dev'
+        run: npm run build
+
+      - name: Deploy branch to Cloudflare Pages Preview
+        run: >
+          npx wrangler@3.114.17 pages deploy ./astro-front/dist
+          --project-name amadolibros-web
+          --branch checkout-v11-preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      # Smoke mínimo pero decisivo: si esto falla, la URL entregada a Seba
+      # NO es un checkout real navegable y no debe usarse para revisar nada
+      # de V1.1. Cubre exactamente el error que motivó este workflow: una
+      # Preview de checkout que en realidad muestra el fallback de
+      # WhatsApp porque se compiló con el flag equivocado.
+      - name: Smoke — el checkout online está realmente presente (no el fallback de WhatsApp)
+        env:
+          PREVIEW_URL: https://checkout-v11-preview.amadolibros-web.pages.dev
+        run: |
+          ready=false
+          for attempt in 1 2 3 4 5 6 7 8; do
+            code=$(curl -sSL -o /tmp/cart.html -w '%{http_code}' \
+              "$PREVIEW_URL/carrito/" || true)
+            if [ "$code" = "200" ]; then
+              ready=true
+              break
+            fi
+            echo "Preview propagándose: intento $attempt/8, HTTP $code."
+            sleep 10
+          done
+          test "$ready" = "true"
+
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const html = fs.readFileSync('/tmp/cart.html', 'utf8');
+
+          const mustContain = [
+            'data-online-checkout="enabled"',
+            'Finalizar compra',
+            'Transferencia 12% menos',
+            'Mercado Pago hasta 12 cuotas',
+            '¿Cómo querés recibir tu pedido?',
+            'Tus datos',
+            '¿Cómo querés pagar?',
+            'name="payment-method" value="transfer"',
+            'name="payment-method" value="mercadopago"',
+            'id="btn-confirm-neutral"',
+            'id="btn-transfer-order"',
+            'id="btn-prepare-order"',
+            'class="checkout-summary"',
+            'id="cart-summary-total"',
+          ];
+          const missing = mustContain.filter((needle) => !html.includes(needle));
+          if (missing.length) {
+            throw new Error(
+              'El checkout online no está realmente presente en el HTML servido. Faltan: ' +
+              missing.join(' | ')
+            );
+          }
+
+          // El fallback de WhatsApp (class="btn-wa-order") sólo existe en el
+          // build con checkout OFF — si aparece acá, esta Preview no sirve
+          // para revisar el checkout online, sin importar qué diga el flag.
+          if (html.includes('class="btn-wa-order"')) {
+            throw new Error(
+              'El CTA de WhatsApp aparece como fallback principal — esta Preview NO tiene el checkout online activo de verdad.'
+            );
+          }
+          NODE
+
+      - name: Reportar URL de la Preview de checkout V1.1
+        run: |
+          echo "### Preview de checkout V1.1 (checkout ON)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "https://checkout-v11-preview.amadolibros-web.pages.dev/carrito/" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-checkout-v11-preview.yml
+++ b/.github/workflows/deploy-checkout-v11-preview.yml
@@ -248,6 +248,25 @@ jobs:
             } catch (_) { /* seguimos igual — el resultado real (con su motivo) queda en el diagnóstico */ }
           }
 
+          // tsGetToken() en carrito.astro tiene su propio timeout de
+          // seguridad de 30s esperando el callback de Turnstile antes de
+          // rechazar. Un wait ciego más corto que eso (el intento anterior
+          // usaba 9s) no prueba nada — corta la espera antes de que el
+          // propio producto termine de intentarlo. Acá se espera, con
+          // margen, a que ocurra alguna de las dos salidas reales posibles:
+          // la respuesta de /api/orders llegó, o el checkout ya muestra un
+          // mensaje de error — lo que pase primero, hasta 35s.
+          async function waitForOutcome(page, state, timeoutMs) {
+            const start = Date.now();
+            while (Date.now() - start < timeoutMs) {
+              if (state.ordersResp) return;
+              const text = await checkoutErrorText(page);
+              if (text) { state.checkoutErrorText = text; return; }
+              await page.waitForTimeout(500);
+            }
+            state.checkoutErrorText = await checkoutErrorText(page);
+          }
+
           const results = { scenarios: [], publicCodes: [] };
           let failures = 0;
           function check(label, cond, extra) {
@@ -293,8 +312,7 @@ jobs:
               await page.locator('input[name="payment-method"][value="mercadopago"]').check();
               await waitForTurnstileWidget(page, 8000);
               await page.locator('#btn-prepare-order').click();
-              await page.waitForTimeout(9000);
-              state.checkoutErrorText = await checkoutErrorText(page);
+              await waitForOutcome(page, state, 35000);
               check('A. Retiro+MP: POST /api/orders 2xx', is2xx(state.ordersResp), { ordersResp: state.ordersResp, checkoutErrorText: state.checkoutErrorText, consoleErrors: state.consoleErrors });
               check('A. Retiro+MP: POST /api/preferences 2xx', is2xx(state.prefsResp), state.prefsResp);
               let publicCode = null, checkoutUrl = null;
@@ -323,8 +341,7 @@ jobs:
               await page.locator('input[name="payment-method"][value="mercadopago"]').check();
               await waitForTurnstileWidget(page, 8000);
               await page.locator('#btn-prepare-order').click();
-              await page.waitForTimeout(9000);
-              state.checkoutErrorText = await checkoutErrorText(page);
+              await waitForOutcome(page, state, 35000);
               check('B. Envío+MP: POST /api/orders 2xx', is2xx(state.ordersResp), { ordersResp: state.ordersResp, checkoutErrorText: state.checkoutErrorText, consoleErrors: state.consoleErrors });
               check('B. Envío+MP: POST /api/preferences 2xx', is2xx(state.prefsResp), state.prefsResp);
               let publicCode = null, checkoutUrl = null;
@@ -350,8 +367,7 @@ jobs:
               await page.locator('input[name="payment-method"][value="transfer"]').check();
               await waitForTurnstileWidget(page, 8000);
               await page.locator('#btn-transfer-order').click();
-              await page.waitForTimeout(9000);
-              state.checkoutErrorText = await checkoutErrorText(page);
+              await waitForOutcome(page, state, 35000);
               check('C. Retiro+Transferencia: POST /api/orders 2xx', is2xx(state.ordersResp), { ordersResp: state.ordersResp, checkoutErrorText: state.checkoutErrorText, consoleErrors: state.consoleErrors });
               check('C. Retiro+Transferencia: /api/transfer-options 2xx', is2xx(state.transferResp), state.transferResp);
               let publicCode = null, accountsOk = false;

--- a/.github/workflows/deploy-checkout-v11-preview.yml
+++ b/.github/workflows/deploy-checkout-v11-preview.yml
@@ -235,6 +235,19 @@ jobs:
             await page.fill('#buyer-email', 'preview-e2e-test@amadolibros.com');
           }
 
+          // El widget real de Turnstile (script externo de
+          // challenges.cloudflare.com) carga e inicializa de forma
+          // asíncrona — tsWidgetId queda null hasta que termina. Clickear
+          // antes de eso no dispara ningún fetch: el handler corta antes
+          // con "La verificación aún no cargó" (getTurnstileTokenForOrder()/
+          // el chequeo de tsWidgetId en el handler de Mercado Pago). Se
+          // espera el iframe real del widget antes de cada click.
+          async function waitForTurnstileWidget(page, timeoutMs) {
+            try {
+              await page.waitForSelector('iframe[src*="challenges.cloudflare.com"]', { timeout: timeoutMs });
+            } catch (_) { /* seguimos igual — el resultado real (con su motivo) queda en el diagnóstico */ }
+          }
+
           const results = { scenarios: [], publicCodes: [] };
           let failures = 0;
           function check(label, cond, extra) {
@@ -242,6 +255,8 @@ jobs:
             else { console.log('FAIL ' + label, extra !== undefined ? JSON.stringify(extra) : ''); failures++; }
           }
           function trackApi(page, state) {
+            state.consoleErrors = [];
+            page.on('console', (msg) => { if (msg.type() === 'error') state.consoleErrors.push(msg.text()); });
             page.on('response', async (resp) => {
               const url = resp.url();
               const method = resp.request().method();
@@ -256,6 +271,9 @@ jobs:
             });
           }
           function is2xx(r) { return !!r && r.status >= 200 && r.status < 300; }
+          async function checkoutErrorText(page) {
+            return page.locator('#checkout-error').innerText().catch(() => '');
+          }
 
           async function run() {
             const browser = await chromium.launch();
@@ -273,9 +291,11 @@ jobs:
               await page.locator('#pickup-ack').check();
               await fillBuyer(page);
               await page.locator('input[name="payment-method"][value="mercadopago"]').check();
+              await waitForTurnstileWidget(page, 8000);
               await page.locator('#btn-prepare-order').click();
               await page.waitForTimeout(9000);
-              check('A. Retiro+MP: POST /api/orders 2xx', is2xx(state.ordersResp), state.ordersResp);
+              state.checkoutErrorText = await checkoutErrorText(page);
+              check('A. Retiro+MP: POST /api/orders 2xx', is2xx(state.ordersResp), { ordersResp: state.ordersResp, checkoutErrorText: state.checkoutErrorText, consoleErrors: state.consoleErrors });
               check('A. Retiro+MP: POST /api/preferences 2xx', is2xx(state.prefsResp), state.prefsResp);
               let publicCode = null, checkoutUrl = null;
               try { publicCode = JSON.parse(state.ordersResp.body).order.public_code; } catch {}
@@ -301,9 +321,11 @@ jobs:
               await page.selectOption('#delivery-departamento', 'Montevideo');
               await fillBuyer(page);
               await page.locator('input[name="payment-method"][value="mercadopago"]').check();
+              await waitForTurnstileWidget(page, 8000);
               await page.locator('#btn-prepare-order').click();
               await page.waitForTimeout(9000);
-              check('B. Envío+MP: POST /api/orders 2xx', is2xx(state.ordersResp), state.ordersResp);
+              state.checkoutErrorText = await checkoutErrorText(page);
+              check('B. Envío+MP: POST /api/orders 2xx', is2xx(state.ordersResp), { ordersResp: state.ordersResp, checkoutErrorText: state.checkoutErrorText, consoleErrors: state.consoleErrors });
               check('B. Envío+MP: POST /api/preferences 2xx', is2xx(state.prefsResp), state.prefsResp);
               let publicCode = null, checkoutUrl = null;
               try { publicCode = JSON.parse(state.ordersResp.body).order.public_code; } catch {}
@@ -326,9 +348,11 @@ jobs:
               await page.locator('#pickup-ack').check();
               await fillBuyer(page);
               await page.locator('input[name="payment-method"][value="transfer"]').check();
+              await waitForTurnstileWidget(page, 8000);
               await page.locator('#btn-transfer-order').click();
               await page.waitForTimeout(9000);
-              check('C. Retiro+Transferencia: POST /api/orders 2xx', is2xx(state.ordersResp), state.ordersResp);
+              state.checkoutErrorText = await checkoutErrorText(page);
+              check('C. Retiro+Transferencia: POST /api/orders 2xx', is2xx(state.ordersResp), { ordersResp: state.ordersResp, checkoutErrorText: state.checkoutErrorText, consoleErrors: state.consoleErrors });
               check('C. Retiro+Transferencia: /api/transfer-options 2xx', is2xx(state.transferResp), state.transferResp);
               let publicCode = null, accountsOk = false;
               try { publicCode = JSON.parse(state.ordersResp.body).order.public_code; } catch {}

--- a/.github/workflows/deploy-checkout-v11-preview.yml
+++ b/.github/workflows/deploy-checkout-v11-preview.yml
@@ -203,7 +203,16 @@ jobs:
         run: |
           npm install --no-save playwright@1.47.2
           npx playwright install --with-deps chromium
-          cat > /tmp/e2e-checkout.mjs << 'EOF'
+          # El script se escribe DENTRO de astro-front/ (no en /tmp): la
+          # resolución de módulos ESM de Node busca node_modules/playwright
+          # subiendo desde el directorio del propio archivo que hace el
+          # import, no desde el cwd — un intento anterior escribía el
+          # script en /tmp/, que no tiene relación con
+          # astro-front/node_modules/, y el import fallaba con
+          # ERR_MODULE_NOT_FOUND antes de lanzar el navegador (el job
+          # igual seguía en verde por continue-on-error, sin haber
+          # corrido ningún escenario real).
+          cat > ./e2e-checkout.mjs << 'EOF'
           import { chromium } from 'playwright';
           import { writeFileSync } from 'node:fs';
 
@@ -340,7 +349,7 @@ jobs:
           }
           run().catch((err) => { console.error(err); process.exitCode = 1; });
           EOF
-          node /tmp/e2e-checkout.mjs
+          node ./e2e-checkout.mjs
 
       - name: Verificar en D1 Preview las órdenes de prueba creadas por el E2E
         if: always()

--- a/.github/workflows/deploy-checkout-v11-preview.yml
+++ b/.github/workflows/deploy-checkout-v11-preview.yml
@@ -67,6 +67,39 @@ jobs:
         working-directory: astro-front
         run: npm ci --no-audit --no-fund
 
+      # BLOQUEANTE reproducido en checkout-v11-preview: POST /api/orders con
+      # Mercado Pago o Transferencia fallaba con "Error al guardar el
+      # pedido" — causa raíz: el INSERT en `orders` (_orders_handler.js)
+      # referencia buyer_email (migración 0006) y ga_client_id/ga_session_id
+      # (migración 0008), pero ningún workflow aplicaba migraciones a la D1
+      # de Preview (sólo deploy.yml, y sólo --env production) — la D1 de
+      # Preview quedó atrasada. Este diagnóstico deja evidencia real del
+      # esquema en los logs antes de corregir.
+      - name: Diagnóstico — esquema real de orders en D1 Preview (antes)
+        run: >
+          npx wrangler@3.114.17 d1 execute ORDERS_DB --env preview --remote
+          --command "PRAGMA table_info(orders);"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        continue-on-error: true
+
+      - name: Apply preview D1 migrations (corrección del bloqueante)
+        run: >
+          npx wrangler@3.114.17 d1 migrations apply
+          ORDERS_DB --env preview --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Diagnóstico — esquema real de orders en D1 Preview (después)
+        run: >
+          npx wrangler@3.114.17 d1 execute ORDERS_DB --env preview --remote
+          --command "PRAGMA table_info(orders);"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       # Config pública de Preview (docs/environments.md), NO la de
       # Producción: site key y hosts permitidos son los del widget
       # `amadolibros-orders-preview`, distinto del widget de Producción.
@@ -148,6 +181,205 @@ jobs:
             );
           }
           NODE
+
+      # Verificación de punta a punta contra el checkout real (no un mock):
+      # Retiro+MP, Envío+MP, Retiro+Transferencia. NO completa ningún pago
+      # real — se detiene apenas confirma que /api/orders y /api/preferences
+      # (o /api/transfer-options) respondieron bien. Playwright se instala
+      # de forma transitoria (--no-save, nunca entra a package.json/lock ni
+      # se commitea) sólo para este paso de CI.
+      #
+      # Nota honesta sobre Turnstile: /api/orders exige un token real de
+      # Turnstile (modo managed, sin bypass para automatización — por
+      # diseño, fail-closed). Un navegador headless de CI puede o no
+      # obtenerlo según el propio criterio anti-bot de Cloudflare — eso es
+      # el comportamiento CORRECTO de Turnstile, no un bug. Por eso este
+      # paso no bloquea el job (continue-on-error) y el resultado real
+      # (pase o no) se reporta tal cual, sin inventar un resultado.
+      - name: E2E real — Retiro+MP, Envío+MP, Retiro+Transferencia (no completa pagos)
+        id: e2e
+        continue-on-error: true
+        working-directory: astro-front
+        run: |
+          npm install --no-save playwright@1.47.2
+          npx playwright install --with-deps chromium
+          cat > /tmp/e2e-checkout.mjs << 'EOF'
+          import { chromium } from 'playwright';
+          import { writeFileSync } from 'node:fs';
+
+          const BASE = 'https://checkout-v11-preview.amadolibros-web.pages.dev';
+          const PRODUCT_ID = 'MLU1001092502';
+
+          function cart() {
+            return {
+              version: 2,
+              items: [{ id: PRODUCT_ID, title: 'QA E2E test item', price: 500, quantity: 1, thumbnail: '', max_qty: 5 }],
+              idempotency_key: 'qa-e2e-' + Date.now() + '-' + Math.random().toString(36).slice(2),
+            };
+          }
+          async function seed(page, cartData) {
+            await page.addInitScript((c) => { window.localStorage.setItem('amado-cart', JSON.stringify(c)); }, cartData);
+          }
+          async function fillBuyer(page) {
+            await page.fill('#buyer-name', 'QA Preview E2E');
+            await page.fill('#buyer-phone', '099000000');
+            await page.fill('#buyer-email', 'preview-e2e-test@amadolibros.com');
+          }
+
+          const results = { scenarios: [], publicCodes: [] };
+          let failures = 0;
+          function check(label, cond, extra) {
+            if (cond) { console.log('OK   ' + label); }
+            else { console.log('FAIL ' + label, extra !== undefined ? JSON.stringify(extra) : ''); failures++; }
+          }
+          function trackApi(page, state) {
+            page.on('response', async (resp) => {
+              const url = resp.url();
+              const method = resp.request().method();
+              if (method !== 'POST') return;
+              if (url.endsWith('/api/orders')) {
+                state.ordersResp = { status: resp.status(), body: await resp.text().catch(() => '') };
+              } else if (url.endsWith('/api/preferences')) {
+                state.prefsResp = { status: resp.status(), body: await resp.text().catch(() => '') };
+              } else if (url.includes('/api/transfer-options')) {
+                state.transferResp = { status: resp.status(), body: await resp.text().catch(() => '') };
+              }
+            });
+          }
+          function is2xx(r) { return !!r && r.status >= 200 && r.status < 300; }
+
+          async function run() {
+            const browser = await chromium.launch();
+
+            // A. Retiro + Mercado Pago
+            {
+              const ctx = await browser.newContext();
+              const page = await ctx.newPage();
+              const state = {};
+              trackApi(page, state);
+              await seed(page, cart());
+              await page.goto(BASE + '/carrito/', { waitUntil: 'load' });
+              await page.waitForSelector('#cart-content:not([hidden])', { timeout: 20000 });
+              await page.locator('input[name="delivery"][value="pickup"]').check();
+              await page.locator('#pickup-ack').check();
+              await fillBuyer(page);
+              await page.locator('input[name="payment-method"][value="mercadopago"]').check();
+              await page.locator('#btn-prepare-order').click();
+              await page.waitForTimeout(9000);
+              check('A. Retiro+MP: POST /api/orders 2xx', is2xx(state.ordersResp), state.ordersResp);
+              check('A. Retiro+MP: POST /api/preferences 2xx', is2xx(state.prefsResp), state.prefsResp);
+              let publicCode = null, checkoutUrl = null;
+              try { publicCode = JSON.parse(state.ordersResp.body).order.public_code; } catch {}
+              try { checkoutUrl = JSON.parse(state.prefsResp.body).checkout_url; } catch {}
+              check('A. Retiro+MP: checkout_url es sandbox de Mercado Pago', !!checkoutUrl && /sandbox/.test(checkoutUrl), checkoutUrl);
+              if (publicCode) results.publicCodes.push(publicCode);
+              results.scenarios.push({ name: 'A-retiro-mp', ...state, publicCode, checkoutUrl });
+              await ctx.close();
+            }
+
+            // B. Envío + Mercado Pago
+            {
+              const ctx = await browser.newContext();
+              const page = await ctx.newPage();
+              const state = {};
+              trackApi(page, state);
+              await seed(page, cart());
+              await page.goto(BASE + '/carrito/', { waitUntil: 'load' });
+              await page.waitForSelector('#cart-content:not([hidden])', { timeout: 20000 });
+              await page.locator('input[name="delivery"][value="shipping"]').check();
+              await page.fill('#delivery-address', 'Av. Italia 2000');
+              await page.fill('#delivery-barrio', 'Pocitos');
+              await page.selectOption('#delivery-departamento', 'Montevideo');
+              await fillBuyer(page);
+              await page.locator('input[name="payment-method"][value="mercadopago"]').check();
+              await page.locator('#btn-prepare-order').click();
+              await page.waitForTimeout(9000);
+              check('B. Envío+MP: POST /api/orders 2xx', is2xx(state.ordersResp), state.ordersResp);
+              check('B. Envío+MP: POST /api/preferences 2xx', is2xx(state.prefsResp), state.prefsResp);
+              let publicCode = null, checkoutUrl = null;
+              try { publicCode = JSON.parse(state.ordersResp.body).order.public_code; } catch {}
+              try { checkoutUrl = JSON.parse(state.prefsResp.body).checkout_url; } catch {}
+              if (publicCode) results.publicCodes.push(publicCode);
+              results.scenarios.push({ name: 'B-envio-mp', ...state, publicCode, checkoutUrl });
+              await ctx.close();
+            }
+
+            // C. Retiro + Transferencia
+            {
+              const ctx = await browser.newContext();
+              const page = await ctx.newPage();
+              const state = {};
+              trackApi(page, state);
+              await seed(page, cart());
+              await page.goto(BASE + '/carrito/', { waitUntil: 'load' });
+              await page.waitForSelector('#cart-content:not([hidden])', { timeout: 20000 });
+              await page.locator('input[name="delivery"][value="pickup"]').check();
+              await page.locator('#pickup-ack').check();
+              await fillBuyer(page);
+              await page.locator('input[name="payment-method"][value="transfer"]').check();
+              await page.locator('#btn-transfer-order').click();
+              await page.waitForTimeout(9000);
+              check('C. Retiro+Transferencia: POST /api/orders 2xx', is2xx(state.ordersResp), state.ordersResp);
+              check('C. Retiro+Transferencia: /api/transfer-options 2xx', is2xx(state.transferResp), state.transferResp);
+              let publicCode = null, accountsOk = false;
+              try { publicCode = JSON.parse(state.ordersResp.body).order.public_code; } catch {}
+              try { accountsOk = Array.isArray(JSON.parse(state.transferResp.body).accounts) && JSON.parse(state.transferResp.body).accounts.length > 0; } catch {}
+              check('C. Retiro+Transferencia: cuentas oficiales cargadas', accountsOk);
+              const transferStepVisible = await page.locator('#transfer-payment-step').isVisible().catch(() => false);
+              check('C. Retiro+Transferencia: la UI llega a la pantalla de transferencia', transferStepVisible);
+              if (publicCode) results.publicCodes.push(publicCode);
+              results.scenarios.push({ name: 'C-retiro-transfer', ...state, publicCode });
+              await ctx.close();
+            }
+
+            await browser.close();
+            writeFileSync('/tmp/e2e-results.json', JSON.stringify(results, null, 2));
+            console.log('\npublic_codes creados:', results.publicCodes.join(', ') || '(ninguno)');
+            console.log(failures === 0 ? '\n✅ E2E TODO OK' : `\n❌ ${failures} verificación(es) fallaron`);
+            process.exitCode = failures === 0 ? 0 : 1;
+          }
+          run().catch((err) => { console.error(err); process.exitCode = 1; });
+          EOF
+          node /tmp/e2e-checkout.mjs
+
+      - name: Verificar en D1 Preview las órdenes de prueba creadas por el E2E
+        if: always()
+        run: |
+          if [ ! -f /tmp/e2e-results.json ]; then
+            echo "No hay resultados de E2E (el paso anterior no llegó a escribir el archivo)."
+            exit 0
+          fi
+          CODES=$(node -e "const r=require('/tmp/e2e-results.json'); console.log(r.publicCodes.join(','));")
+          if [ -z "$CODES" ]; then
+            echo "El E2E no creó ninguna orden (revisar el resultado del paso anterior — probablemente Turnstile bloqueó la creación en este entorno de CI, ver nota en el paso E2E)."
+            exit 0
+          fi
+          echo "Órdenes de prueba creadas por el E2E: $CODES"
+          IFS=',' read -ra CODE_ARR <<< "$CODES"
+          for CODE in "${CODE_ARR[@]}"; do
+            echo "--- $CODE ---"
+            npx wrangler@3.114.17 d1 execute ORDERS_DB --env preview --remote \
+              --command "SELECT public_code, status, delivery_type, buyer_email, ga_client_id, payable_total_uyu, created_at FROM orders WHERE public_code = '$CODE';"
+          done
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Limpiar las órdenes de prueba creadas por el E2E (D1 Preview)
+        if: always()
+        run: |
+          if [ ! -f /tmp/e2e-results.json ]; then exit 0; fi
+          CODES=$(node -e "const r=require('/tmp/e2e-results.json'); console.log(r.publicCodes.join(','));")
+          if [ -z "$CODES" ]; then exit 0; fi
+          IFS=',' read -ra CODE_ARR <<< "$CODES"
+          for CODE in "${CODE_ARR[@]}"; do
+            npx wrangler@3.114.17 d1 execute ORDERS_DB --env preview --remote \
+              --command "DELETE FROM orders WHERE public_code = '$CODE';"
+          done
+          echo "Órdenes de prueba eliminadas (order_items/order_events se borran en cascada)."
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Reportar URL de la Preview de checkout V1.1
         run: |

--- a/astro-front/public/analytics-events.js
+++ b/astro-front/public/analytics-events.js
@@ -256,6 +256,36 @@
     window.gtag('event', 'whatsapp_click', params);
   }
 
+  // BLOQUEANTE PR #310 — punto 1: mide en qué etapa se traba un comprador
+  // del checkout online, sin ningún dato personal. Sólo 4 parámetros
+  // permitidos, cada uno validado contra una lista cerrada. error_code no
+  // se "sanea" con safeToken() (que preserva dígitos literales — un
+  // teléfono pegado en un texto libre sobreviviría igual) — se exige que
+  // YA tenga forma de code interno (letras/números/guión bajo, empieza con
+  // letra); cualquier otra cosa (texto libre del error, un email, etc.) se
+  // descarta entera en vez de reenviar una versión "limpiada".
+  var CHECKOUT_ERROR_STAGES = new Set(['order_create', 'preference_create', 'transfer_options']);
+  var CHECKOUT_ERROR_PAYMENT_METHODS = new Set(['transfer', 'mercadopago']);
+  var CHECKOUT_ERROR_DELIVERY_TYPES = new Set(['pickup', 'shipping']);
+  var ERROR_CODE_SHAPE = /^[A-Za-z][A-Za-z0-9_]{0,59}$/;
+
+  function errorCodeToken(value) {
+    var str = String(value == null ? '' : value).trim();
+    return ERROR_CODE_SHAPE.test(str) ? str.toUpperCase() : '';
+  }
+
+  function trackCheckoutError(options) {
+    options = options || {};
+    if (!CHECKOUT_ERROR_STAGES.has(options.stage)) return false;
+    var params = { stage: options.stage };
+    var errorCode = errorCodeToken(options.errorCode);
+    if (errorCode) params.error_code = errorCode;
+    if (CHECKOUT_ERROR_PAYMENT_METHODS.has(options.paymentMethod)) params.payment_method = options.paymentMethod;
+    if (CHECKOUT_ERROR_DELIVERY_TYPES.has(options.deliveryType)) params.delivery_type = options.deliveryType;
+    window.gtag('event', 'checkout_error', params);
+    return true;
+  }
+
   function trackStockWaitlistCreated() {
     var context = pageContext();
     if (context.pageType !== 'product' || !context.productId) return false;
@@ -294,6 +324,7 @@
   window.AmadoAnalytics = Object.assign({}, window.AmadoAnalytics, {
     trackWhatsApp: trackWhatsApp,
     trackCommerce: trackCommerce,
+    trackCheckoutError: trackCheckoutError,
     trackStockWaitlistCreated: trackStockWaitlistCreated,
     getMeasurementContext: getMeasurementContext,
   });

--- a/astro-front/public/cart.js
+++ b/astro-front/public/cart.js
@@ -4,6 +4,7 @@
 
   var STORAGE_KEY = 'amado-cart';
   var CONTEXT_KEY = 'amado-cart-context-v1';
+  var FINGERPRINT_KEY = 'amado-cart-order-fingerprint';
   var VERSION = 2; // v2: incorpora max_qty; carritos v1 sin max_qty se descartan
 
   function uuid() {
@@ -67,6 +68,36 @@
   function save(cart) {
     try { localStorage.setItem(STORAGE_KEY, JSON.stringify(cart)); } catch (_) {}
     document.dispatchEvent(new CustomEvent('amado:cart-updated', { detail: cart }));
+  }
+
+  // Ciclo de vida de idempotency_key vs. fingerprint del pedido (BLOQUEANTE
+  // PR #310): una key representa UN fingerprint lógico de pedido (items +
+  // entrega + comprador + envío — ver generateFingerprint() en
+  // functions/api/_orders_logic.js, que es la fuente de verdad real). Acá
+  // sólo se guarda, junto a la key vigente, el último fingerprint con el que
+  // esa key se envió — para poder distinguir un reintento del mismo pedido
+  // (misma key) de un pedido que cambió después de haber sido enviado (key
+  // nueva). Nunca se rota "porque sí" en cada intento — sólo cuando el
+  // fingerprint actual difiere del último enviado CON LA KEY VIGENTE.
+  function loadLastFingerprint() {
+    try {
+      var raw = localStorage.getItem(FINGERPRINT_KEY);
+      if (!raw) return null;
+      var value = JSON.parse(raw);
+      if (!value || typeof value !== 'object' ||
+          typeof value.idempotency_key !== 'string' ||
+          typeof value.fingerprint !== 'string') return null;
+      return value;
+    } catch (_) { return null; }
+  }
+
+  function saveLastFingerprint(idempotencyKey, fingerprint) {
+    try {
+      localStorage.setItem(FINGERPRINT_KEY, JSON.stringify({
+        idempotency_key: idempotencyKey,
+        fingerprint: fingerprint,
+      }));
+    } catch (_) {}
   }
 
   function rememberShoppingContext() {
@@ -186,10 +217,35 @@
 
     clear: function () { save(emptyCart()); },
 
+    // No toca el fingerprint guardado: al dejarlo asociado a la key vieja,
+    // ensureKeyForFingerprint() ve que la key vigente cambió (sameKey da
+    // false) y sólo registra el fingerprint del próximo intento — no rota
+    // una segunda vez.
     rotateKey: function () {
       var cart = load();
       cart.idempotency_key = uuid();
       save(cart);
+      return cart.idempotency_key;
+    },
+
+    // Único punto centralizado que decide si la key vigente puede seguir
+    // usándose para `fingerprint` (mismo pedido — reintento de red, doble
+    // click, volver sin cambiar nada) o si hay que generar una nueva
+    // (el pedido cambió después de haber sido enviado con esta key). Debe
+    // llamarse con el fingerprint calculado del intento actual justo antes
+    // de cada submit a /api/orders. Cambios de items ya rotan la key por su
+    // cuenta (add/remove/setQty/syncValidated/clear) — cuando eso ya pasó,
+    // sameKey da false y acá sólo se registra el fingerprint nuevo, sin
+    // rotar una segunda vez.
+    ensureKeyForFingerprint: function (fingerprint) {
+      var cart = load();
+      var last = loadLastFingerprint();
+      var sameKey = !!last && last.idempotency_key === cart.idempotency_key;
+      if (sameKey && last.fingerprint !== fingerprint) {
+        cart.idempotency_key = uuid();
+        save(cart);
+      }
+      saveLastFingerprint(cart.idempotency_key, fingerprint);
       return cart.idempotency_key;
     },
 

--- a/astro-front/public/orders-guard.js
+++ b/astro-front/public/orders-guard.js
@@ -13,11 +13,19 @@
     if (element && typeof element.focus === 'function') element.focus();
   }
 
-  function checkoutError() {
+  // V1.1: si todavía no eligió envío/retiro, este guard no debe interceptar
+  // el click de los CTA de pago (transferencia/Mercado Pago) por nombre,
+  // teléfono o dirección — eso le tapa a carrito.astro su propio mensaje
+  // "Elegí envío o retiro para continuar". El botón de WhatsApp no cambia:
+  // sigue pidiendo nombre/teléfono primero, como siempre.
+  function checkoutError(buttonId) {
+    var delivery = document.querySelector('input[name="delivery"]:checked');
+    var isPaymentButton = buttonId === 'btn-transfer-order' || buttonId === 'btn-prepare-order';
+    if (!delivery && isPaymentButton) return null;
+
     if (!valueOf('buyer-name')) return { message: 'Por favor ingresá tu nombre.', field: 'buyer-name' };
     if (!valueOf('buyer-phone')) return { message: 'Por favor ingresá tu teléfono o WhatsApp.', field: 'buyer-phone' };
 
-    var delivery = document.querySelector('input[name="delivery"]:checked');
     if (!delivery || delivery.value !== 'shipping') return null;
 
     var required = [
@@ -62,7 +70,7 @@
   document.addEventListener('click', function (event) {
     var button = event.target.closest('#btn-wa-order, #btn-prepare-order, #btn-transfer-order');
     if (!button) return;
-    var validation = checkoutError();
+    var validation = checkoutError(button.id);
     if (!validation) return;
     event.preventDefault();
     event.stopImmediatePropagation();

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -3314,7 +3314,12 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
               resetPrepareButton();
               return;
             }
-            showCheckoutError('Error: ' + (orderData.error || 'Intentá de nuevo.'));
+            // BLOQUEANTE (revisión Preview checkout-ON): antes anteponía
+            // "Error: " al mensaje del servidor, que ya es una oración
+            // completa — mostraba "Error: Error al guardar el pedido..."
+            // duplicado. Se muestra el mensaje del servidor tal cual, igual
+            // que ya hace el camino de transferencia (línea ~3120).
+            showCheckoutError(orderData.error || 'No pudimos preparar tu pedido. Intentá de nuevo.');
             resetPrepareButton();
             return;
           }

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -216,6 +216,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
                 <span class="checkout-sticky-total-label">Total</span>
                 <strong id="checkout-sticky-total-value">$&nbsp;0</strong>
               </div>
+              <p id="cart-delivery-hint" class="cart-delivery-hint" role="status" aria-live="polite" hidden>Elegí envío o retiro para continuar.</p>
               <button type="button" id="btn-transfer-order" class="btn-transfer-primary" aria-describedby="checkout-error">
                 <span>Comprar por transferencia</span>
                 <strong>12% menos</strong>
@@ -1026,6 +1027,21 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     color: #267a42;
   }
 
+  /* V1.1: aviso de guía junto a los CTA de pago — ni error (rojo) ni éxito
+     (verde): informa una decisión pendiente, no un fallo. grid-column
+     span queda siempre declarado; en el flujo normal (flex, desktop) la
+     propiedad no tiene efecto y no rompe nada. */
+  .cart-delivery-hint {
+    background: #fff7ed;
+    border: 1px solid #fed7aa;
+    color: #9a3412;
+    border-radius: var(--r);
+    padding: 0.6rem 0.85rem;
+    font-size: 0.82rem;
+    line-height: 1.4;
+    grid-column: 1 / -1;
+  }
+
   /* ── Paso de transferencia ─────────────────────────── */
   .transfer-step[hidden] { display: none; }
   .transfer-step { background: var(--surface); border: 1px solid var(--border); border-radius: calc(var(--r) + 2px); padding: 1.25rem; }
@@ -1241,6 +1257,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     var totalShippingLineEl  = document.getElementById('cart-total-shipping-line');
     var totalShippingEl      = document.getElementById('cart-total-shipping');
     var stickyTotalEl        = document.getElementById('checkout-sticky-total-value');
+    var deliveryHintEl       = document.getElementById('cart-delivery-hint');
     var checkoutErrorEl      = document.getElementById('checkout-error');
     var cartPageEl           = document.querySelector('.cart-page');
     var checkoutEditStepEl   = document.getElementById('checkout-edit-step');
@@ -1521,14 +1538,24 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       });
     }
 
+    // V1.1: elegir entrega ya NO es requisito para habilitar el CTA — sólo
+    // los bloqueos técnicos reales (stock/validación en curso o fallida,
+    // carrito sin ítems pagables) lo dejan disabled. Sin entrega elegida el
+    // botón queda interactuable a propósito: al click, requireDeliveryType()
+    // (ya probado) muestra el aviso, hace foco+scroll y corta el flujo antes
+    // de crear ninguna orden. El aviso persistente sólo se muestra cuando
+    // la entrega es lo ÚNICO que falta, para no confundirlo con un bloqueo
+    // técnico real (que ya tiene su propio mensaje vía showCheckoutError).
     function syncPaymentAvailability() {
       var cart = window.AmadoCart ? window.AmadoCart.get() : { items: [] };
-      var canPay = cartValidationReady && !cartValidationFailed &&
-        !validationRequest && getSellableItems(cart).length > 0 && !!getDeliveryType();
+      var technicallyReady = cartValidationReady && !cartValidationFailed &&
+        !validationRequest && getSellableItems(cart).length > 0;
+      var hasDelivery = !!getDeliveryType();
       var transferButton = document.getElementById('btn-transfer-order');
       var mercadoPagoButton = document.getElementById('btn-prepare-order');
-      if (transferButton && !transferButton.hasAttribute('aria-busy')) transferButton.disabled = !canPay;
-      if (mercadoPagoButton && !mercadoPagoButton.hasAttribute('aria-busy')) mercadoPagoButton.disabled = !canPay;
+      if (transferButton && !transferButton.hasAttribute('aria-busy')) transferButton.disabled = !technicallyReady;
+      if (mercadoPagoButton && !mercadoPagoButton.hasAttribute('aria-busy')) mercadoPagoButton.disabled = !technicallyReady;
+      if (deliveryHintEl) deliveryHintEl.hidden = !(technicallyReady && !hasDelivery);
     }
 
     function buildCartValidationPayload(cart) {
@@ -1636,7 +1663,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         if (transferNoteEl)      transferNoteEl.hidden      = true;
         if (shippingCostLineEl)  shippingCostLineEl.hidden  = true;
         if (totalShippingLineEl) totalShippingLineEl.hidden = true;
-        if (shippingMsgEl)       shippingMsgEl.hidden       = true;
+        if (shippingMsgEl)       { shippingMsgEl.hidden = true; shippingMsgEl.textContent = ''; }
         if (stickyTotalEl)       stickyTotalEl.textContent  = fmt.format(subtotal);
         return;
       }
@@ -1651,7 +1678,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         if (transferNoteEl)      transferNoteEl.hidden      = false;
         if (shippingCostLineEl)  shippingCostLineEl.hidden  = true;
         if (totalShippingLineEl) totalShippingLineEl.hidden = true;
-        if (shippingMsgEl)       shippingMsgEl.hidden       = true;
+        if (shippingMsgEl)       { shippingMsgEl.hidden = true; shippingMsgEl.textContent = ''; }
         if (stickyTotalEl)       stickyTotalEl.textContent  = fmt.format(total);
       } else {
         var shippingCost      = subtotal < FREE_SHIPPING_THRESHOLD_UYU ? SHIPPING_COST : 0;
@@ -1668,7 +1695,12 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
           totalShippingLineEl.hidden = false;
           if (totalShippingEl) totalShippingEl.textContent = fmt.format(totalWithShipping);
         }
-        if (shippingMsgEl) shippingMsgEl.hidden = true;
+        if (shippingMsgEl) {
+          shippingMsgEl.hidden = false;
+          shippingMsgEl.textContent = shippingCost === 0
+            ? 'Tu envío es gratis'
+            : 'Te faltan ' + fmt.format(FREE_SHIPPING_THRESHOLD_UYU - subtotal) + ' para obtener envío gratis';
+        }
         if (stickyTotalEl) stickyTotalEl.textContent = fmt.format(totalWithShipping);
       }
     }

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -2034,6 +2034,21 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       });
     }
 
+    // BLOQUEANTE PR #310 — punto 1: mide cuántos compradores se traban en
+    // el checkout online y en qué etapa, sin ningún dato personal. stage
+    // sólo puede ser order_create/preference_create/transfer_options;
+    // errorCode es siempre un code interno ya saneado (nunca el texto del
+    // error ni el public_code de la orden).
+    function trackCheckoutErrorEvent(stage, errorCode, paymentMethod) {
+      if (!window.AmadoAnalytics || typeof window.AmadoAnalytics.trackCheckoutError !== 'function') return;
+      window.AmadoAnalytics.trackCheckoutError({
+        stage: stage,
+        errorCode: errorCode || '',
+        paymentMethod: paymentMethod || '',
+        deliveryType: getDeliveryType(),
+      });
+    }
+
     // V1.1: elegir entrega ya NO es requisito para habilitar el CTA — sólo
     // los bloqueos técnicos reales (stock/validación en curso o fallida,
     // carrito sin ítems pagables) lo dejan disabled. Sin entrega elegida el
@@ -3101,7 +3116,11 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         await refreshCartAvailability({ beforePayment: true });
         return null;
       }
-      if (!response.ok) throw new Error(orderData.error || 'No pudimos preparar el pedido.');
+      if (!response.ok) {
+        var orderCreateError = new Error(orderData.error || 'No pudimos preparar el pedido.');
+        orderCreateError.code = orderData.code || 'ORDER_CREATE_FAILED';
+        throw orderCreateError;
+      }
       transferIdempotencyKey = cart.idempotency_key;
       return orderData.order;
     }
@@ -3109,15 +3128,18 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     if (btnTransfer) {
       btnTransfer.addEventListener('click', async function () {
         if (btnTransfer.disabled || !window.AmadoCart || window.AmadoCart.get().items.length === 0) return;
+        var checkoutErrorStage = 'order_create';
         try {
           var order = await createTransferOrder();
           if (!order) { resetTransferButton(); return; }
           trackCommerce('begin_checkout', order, 'bank_transfer', 'begin_checkout_transfer');
           btnTransfer.textContent = 'Cargando cuentas oficiales…';
+          checkoutErrorStage = 'transfer_options';
           transferData = await fetchTransferOptions(order.public_code, transferIdempotencyKey);
           showTransferStep();
         } catch (error) {
           showCheckoutError(error.message || 'No pudimos preparar la transferencia. Intentá de nuevo.');
+          trackCheckoutErrorEvent(checkoutErrorStage, error && error.code, 'transfer');
         } finally {
           resetTransferButton();
         }
@@ -3320,12 +3342,14 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
             // duplicado. Se muestra el mensaje del servidor tal cual, igual
             // que ya hace el camino de transferencia (línea ~3120).
             showCheckoutError(orderData.error || 'No pudimos preparar tu pedido. Intentá de nuevo.');
+            trackCheckoutErrorEvent('order_create', orderData.code || 'ORDER_CREATE_FAILED', 'mercadopago');
             resetPrepareButton();
             return;
           }
           trackCommerce('begin_checkout', orderData.order, 'mercado_pago', 'begin_checkout_mp');
         } catch (_fetchErr) {
           showCheckoutError('Error de conexión. Verificá tu internet e intentá de nuevo.');
+          trackCheckoutErrorEvent('order_create', 'NETWORK_ERROR', 'mercadopago');
           resetPrepareButton();
           return;
         }
@@ -3360,9 +3384,11 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
             return;
           }
           showCheckoutError('Error al iniciar el pago: ' + (mpData.error || 'Intentá de nuevo.'));
+          trackCheckoutErrorEvent('preference_create', mpData.code || 'PREFERENCE_CREATE_FAILED', 'mercadopago');
           resetPrepareButton();
         } catch (_err) {
           showCheckoutError('Error de conexión. Verificá tu internet e intentá de nuevo.');
+          trackCheckoutErrorEvent('preference_create', 'NETWORK_ERROR', 'mercadopago');
           resetPrepareButton();
         }
       });

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -250,6 +250,9 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
                 Consultá <a href="/envios" target="_blank">envíos</a> y
                 <a href="/devoluciones" target="_blank">devoluciones</a>.
               </p>
+              <p class="checkout-personal-note">
+                Somos una librería familiar y esta web también la hacemos nosotros. Si necesitás ayuda para completar tu compra, escribinos por WhatsApp. Te atendemos personalmente.
+              </p>
               <button type="button" id="btn-wa-order" class="btn-wa-secondary">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                   <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z"/>
@@ -799,6 +802,17 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     color: #8f4436;
     text-decoration: underline;
     text-underline-offset: 0.15em;
+  }
+
+  /* V1.1: nota personal antes del WhatsApp secundario — mismo tono discreto
+     que checkout-reassurance/checkout-policy-links, no compite visualmente
+     con los CTA de pago ni se confunde con un mensaje de error. */
+  .checkout-personal-note {
+    font-size: 0.78rem;
+    color: var(--ink-2);
+    line-height: 1.5;
+    text-align: center;
+    margin-top: 0.65rem;
   }
 
   /* ── Items creados por JS ──────────────────────── */

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -26,10 +26,15 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
 
   <main class="cart-page" data-online-checkout={checkoutEnabled ? 'enabled' : 'disabled'}>
     <div class="cart-wrap">
-      <h1 class="cart-h1">Tu carrito</h1>
-      <button type="button" id="btn-back-to-shopping" class="btn-context-back">
-        ← Seguir comprando
-      </button>
+      <div class="cart-header">
+        <button type="button" id="btn-back-to-shopping" class="btn-context-back">
+          ← Seguir comprando
+        </button>
+        <h1 class="cart-h1">Finalizar compra</h1>
+        {checkoutEnabled && (
+          <p class="cart-commercial-line">Transferencia 12% menos · Mercado Pago hasta 12 cuotas</p>
+        )}
+      </div>
 
       <!-- Región de anuncios accesibles -->
       <div id="cart-announce" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
@@ -49,238 +54,298 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       <!-- Contenido con items -->
       <div id="cart-content" hidden>
         <div id="checkout-edit-step">
+        <div class="checkout-layout">
 
-        <!-- Lista de items (llenada por JS) -->
-        <div id="cart-items" role="list" aria-label="Artículos en el carrito"></div>
+          <!-- V1.1 REDESIGN: resumen — primero en el DOM (así en mobile,
+               una sola columna, aparece antes que Entrega, como pide el
+               flujo lineal) y reubicado a la columna derecha sólo por CSS
+               Grid (grid-column) a partir de 960px, sin alterar el orden
+               real de lectura/tab. -->
+          <aside class="checkout-summary" aria-label="Resumen de tu compra">
+            <details id="cart-summary-panel" class="cart-summary-panel">
+              <summary class="cart-summary-toggle">
+                <span class="cart-summary-toggle-text">
+                  🛒 Tu compra · <span id="cart-summary-count">0</span> libro(s) · <span id="cart-summary-total">$&nbsp;0</span>
+                </span>
+                <span class="cart-summary-chevron" aria-hidden="true">Ver resumen</span>
+              </summary>
+              <div class="cart-summary-body">
+                <!-- Fila compacta por producto — miniatura/título/cantidad/precio.
+                     No reescribe buildItemRow(): es una función nueva y mínima,
+                     separada, sólo para esta vista de resumen. -->
+                <div id="cart-items-compact" class="cart-items-compact"></div>
+                <button type="button" id="btn-toggle-editor" class="cart-summary-edit-toggle" aria-expanded="false">
+                  Editar
+                </button>
 
-        <!-- Barra de resumen -->
-        <div class="cart-summary-bar">
-          <button type="button" id="btn-clear" class="btn-clear">
-            Vaciar carrito
-          </button>
-          <div class="cart-totals">
-            <p class="cart-subtotal-line">Total de productos:&nbsp;<strong id="cart-subtotal">$&nbsp;0</strong></p>
-            <p class="cart-discount-line" id="cart-discount-line" hidden>Ahorro por retiro:&nbsp;<strong>−&nbsp;$150</strong></p>
-            <p class="cart-total-line" id="cart-total-line" hidden>Total con retiro:&nbsp;<strong id="cart-total">$&nbsp;0</strong></p>
-            <p class="cart-shipping-note" id="cart-shipping-note" hidden>Envío: a coordinar según destino</p>
-            <p class="cart-shipping-cost-line" id="cart-shipping-cost-line" hidden>Envío:&nbsp;<strong id="cart-shipping-cost">$&nbsp;250</strong></p>
-            <p class="cart-total-shipping-line" id="cart-total-shipping-line" hidden>Total con envío:&nbsp;<strong id="cart-total-shipping">$&nbsp;0</strong></p>
-            <p class="cart-transfer-note" id="cart-transfer-note" hidden>Pagando por transferencia se aplica además 12&nbsp;% de descuento.</p>
-            <p class="cart-shipping-msg" id="cart-shipping-msg" hidden></p>
-          </div>
-        </div>
+                <!-- Lista completa editable (llenada por JS con buildItemRow(),
+                     sin cambios) — oculta hasta tocar "Editar". -->
+                <div id="cart-items" role="list" aria-label="Artículos en el carrito" class="cart-items-full" hidden></div>
 
-        <p class="cart-price-note">
-          Los precios corresponden al catálogo vigente. El total se actualiza
-          según la forma de entrega y los descuentos aplicables.
-          Pagando por transferencia bancaria obtenés&nbsp;12&nbsp;% de descuento.
-        </p>
-
-        <!-- Entrega -->
-        <section class="cart-section">
-          <h2 class="cart-section-h2">¿Cómo querés recibir tu pedido?</h2>
-          <div class="delivery-opts" role="radiogroup" aria-describedby="err-delivery">
-            <label class="delivery-opt">
-              <input type="radio" name="delivery" value="pickup">
-              <span class="delivery-opt-content">
-                <strong class="delivery-opt-name">Pick up a pasos de Plaza Matriz</strong>
-                <span class="delivery-opt-meta">Lunes a viernes, de 8 a 17 h</span>
-                <span class="delivery-opt-badge">Ahorrás $150 en compras desde $1.300</span>
-              </span>
-            </label>
-          </div>
-
-          <!-- PICKUP-CX-1: aviso y aceptación obligatoria. Solo visible con
-               retiro seleccionado; al pasar a envío se oculta y se limpia. -->
-          <div id="pickup-ack-box" class="pickup-ack" hidden>
-            <p class="pickup-ack-notice">
-              Para evitar que vengas en vano, esperá nuestra confirmación por
-              WhatsApp antes de venir. Te avisaremos apenas tu pedido esté
-              pronto para retirar.
-            </p>
-            <label class="pickup-ack-label" for="pickup-ack">
-              <input type="checkbox" id="pickup-ack" aria-describedby="err-pickup-ack">
-              <span>Entiendo que debo esperar la confirmación por WhatsApp antes de ir a retirar.</span>
-            </label>
-            <span class="field-error" id="err-pickup-ack" role="alert" hidden></span>
-          </div>
-
-          <div class="delivery-opts-rest">
-            <label class="delivery-opt">
-              <input type="radio" name="delivery" value="shipping">
-              <span class="delivery-opt-content">
-                <strong class="delivery-opt-name">Envío a domicilio</strong>
-                <span class="delivery-opt-meta">Coordinamos contigo y el cadete entrega en una franja horaria de tu conveniencia.</span>
-                <span class="delivery-opt-badge">Envío gratis en compras desde $1.500</span>
-              </span>
-            </label>
-          </div>
-          <span class="field-error delivery-error" id="err-delivery" role="alert" hidden></span>
-          <div id="shipping-fields" class="shipping-fields" hidden>
-            <div class="form-field">
-              <label for="delivery-address" class="form-label">Dirección <span class="form-req" aria-hidden="true">*</span></label>
-              <input type="text" id="delivery-address" class="form-input"
-                placeholder="Ej: Av. Italia 2000, Apto 3"
-                autocomplete="shipping street-address"
-                aria-describedby="err-delivery-address">
-              <span class="field-error" id="err-delivery-address" role="alert" hidden></span>
-            </div>
-            <div class="form-field">
-              <label for="delivery-barrio" class="form-label">Barrio / Localidad</label>
-              <input type="text" id="delivery-barrio" class="form-input"
-                placeholder="Ej: Pocitos, Centro, Malvín"
-                autocomplete="shipping address-level3"
-                aria-describedby="err-delivery-barrio">
-              <span class="field-error" id="err-delivery-barrio" role="alert" hidden></span>
-            </div>
-            <div class="form-field">
-              <label for="delivery-departamento" class="form-label">Departamento <span class="form-req" aria-hidden="true">*</span></label>
-              <select id="delivery-departamento" class="form-input"
-                autocomplete="shipping address-level1"
-                aria-describedby="err-delivery-departamento">
-                <option value="">Seleccioná tu departamento</option>
-                <option>Artigas</option>
-                <option>Canelones</option>
-                <option>Cerro Largo</option>
-                <option>Colonia</option>
-                <option>Durazno</option>
-                <option>Flores</option>
-                <option>Florida</option>
-                <option>Lavalleja</option>
-                <option>Maldonado</option>
-                <option>Montevideo</option>
-                <option>Paysandú</option>
-                <option>Río Negro</option>
-                <option>Rivera</option>
-                <option>Rocha</option>
-                <option>Salto</option>
-                <option>San José</option>
-                <option>Soriano</option>
-                <option>Tacuarembó</option>
-                <option>Treinta y Tres</option>
-              </select>
-              <span class="field-error" id="err-delivery-departamento" role="alert" hidden></span>
-            </div>
-            <div class="form-field">
-              <label for="delivery-notes" class="form-label">Notas para la entrega</label>
-              <textarea id="delivery-notes" class="form-input form-textarea" rows="2" placeholder="Ej: timbre 2B, dejar con portero"></textarea>
-            </div>
-            <p class="delivery-confirm-note">Después del pago coordinamos el día y el horario por WhatsApp.</p>
-          </div>
-        </section>
-
-        <!-- Datos del comprador -->
-        <section class="cart-section">
-          <h2 class="cart-section-h2">Datos para coordinar</h2>
-          <p class="buyer-note">Mientras completás el pedido, recordamos estos datos sólo en esta pestaña para que no los pierdas si abrís el banco o WhatsApp.</p>
-          <div class="form-grid">
-            <div class="form-field">
-              <label for="buyer-name" class="form-label">Nombre</label>
-              <input type="text" id="buyer-name" class="form-input" autocomplete="name"
-                aria-describedby="err-buyer-name">
-              <span class="field-error" id="err-buyer-name" role="alert" hidden></span>
-            </div>
-            <div class="form-field">
-              <label for="buyer-phone" class="form-label">WhatsApp / Teléfono</label>
-              <input type="tel" id="buyer-phone" class="form-input"
-                placeholder="Ej: 099 123 456"
-                autocomplete="tel"
-                inputmode="tel"
-                aria-describedby="err-buyer-phone">
-              <span class="field-error" id="err-buyer-phone" role="alert" hidden></span>
-            </div>
-            <div class="form-field">
-              <label for="buyer-email" class="form-label">Correo electrónico <span class="form-req" aria-hidden="true">*</span></label>
-              <input type="email" id="buyer-email" class="form-input"
-                placeholder="tu@email.com"
-                autocomplete="email"
-                inputmode="email"
-                maxlength="254"
-                required
-                aria-describedby="buyer-email-help err-buyer-email">
-              <span class="field-help" id="buyer-email-help">Ahí te enviamos la confirmación y el número de pedido.</span>
-              <span class="field-error" id="err-buyer-email" role="alert" hidden></span>
-            </div>
-          </div>
-        </section>
-
-        <!-- Acciones de pago -->
-        <section class="cart-pay-section" aria-label="Confirmar y pagar">
-          {checkoutEnabled && <div id="cf-ts-container"></div>}
-
-          <div id="checkout-error" class="checkout-error" role="alert" hidden></div>
-
-          {checkoutEnabled ? (
-            <div class="checkout-mobile-bar">
-              <div class="checkout-sticky-total" aria-hidden="true">
-                <span class="checkout-sticky-total-label">Total</span>
-                <strong id="checkout-sticky-total-value">$&nbsp;0</strong>
+                <div class="cart-totals-card">
+                  <div class="cart-totals">
+                    <p class="cart-subtotal-line">Total de productos:&nbsp;<strong id="cart-subtotal">$&nbsp;0</strong></p>
+                    <p class="cart-discount-line" id="cart-discount-line" hidden>Ahorro por retiro:&nbsp;<strong>−&nbsp;$150</strong></p>
+                    <p class="cart-total-line" id="cart-total-line" hidden>Total con retiro:&nbsp;<strong id="cart-total">$&nbsp;0</strong></p>
+                    <p class="cart-shipping-note" id="cart-shipping-note" hidden>Envío: a coordinar según destino</p>
+                    <p class="cart-shipping-cost-line" id="cart-shipping-cost-line" hidden>Envío:&nbsp;<strong id="cart-shipping-cost">$&nbsp;250</strong></p>
+                    <p class="cart-total-shipping-line" id="cart-total-shipping-line" hidden>Total con envío:&nbsp;<strong id="cart-total-shipping">$&nbsp;0</strong></p>
+                    <p class="cart-transfer-note" id="cart-transfer-note" hidden>Pagando por transferencia se aplica además 12&nbsp;% de descuento.</p>
+                    <p class="cart-shipping-msg" id="cart-shipping-msg" hidden></p>
+                  </div>
+                  <button type="button" id="btn-clear" class="btn-clear">
+                    Vaciar carrito
+                  </button>
+                  <p class="cart-price-note">Los precios corresponden al catálogo vigente.</p>
+                </div>
               </div>
-              <p id="cart-delivery-hint" class="cart-delivery-hint" role="status" aria-live="polite" hidden>Elegí envío o retiro para continuar.</p>
-              <button type="button" id="btn-transfer-order" class="btn-transfer-primary" aria-describedby="checkout-error">
-                <span>Comprar por transferencia</span>
-                <strong>12% menos</strong>
-              </button>
-              <button type="button" id="btn-prepare-order" class="btn-checkout-primary" aria-describedby="checkout-error">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
-                  stroke="currentColor" stroke-width="2" aria-hidden="true">
-                  <rect x="1" y="4" width="22" height="16" rx="2" ry="2"/>
-                  <line x1="1" y1="10" x2="23" y2="10"/>
-                </svg>
-                <span class="btn-checkout-primary-text">Pagar con tarjeta o Mercado Pago</span>
-              </button>
-            </div>
-          ) : (
-            <button type="button" id="btn-wa-order" class="btn-wa-order">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z"/>
-              </svg>
-              Enviar pedido por WhatsApp
-            </button>
-          )}
+            </details>
+          </aside>
 
-          {checkoutEnabled && (
-            <>
-              <p class="checkout-reassurance">
-                Primero verificamos precio y stock. Tu carrito no se vacía hasta
-                que el pago quede confirmado.
+          <div class="checkout-left">
+
+          <!-- Entrega -->
+          <section class="cart-section cart-section-card">
+            <h2 class="cart-section-h2">¿Cómo querés recibir tu pedido?</h2>
+            <div class="delivery-opts" role="radiogroup" aria-describedby="err-delivery">
+              <label class="delivery-opt">
+                <input type="radio" name="delivery" value="pickup">
+                <span class="delivery-opt-content">
+                  <strong class="delivery-opt-name">Retiro en Ciudad Vieja</strong>
+                  <span class="delivery-opt-meta">A pasos de Plaza Matriz · Lunes a viernes, de 8 a 17 h</span>
+                  <span class="delivery-opt-badge">Ahorrás $150 en compras desde $1.300</span>
+                </span>
+              </label>
+            </div>
+
+            <!-- PICKUP-CX-1: aviso y aceptación obligatoria. Solo visible con
+                 retiro seleccionado; al pasar a envío se oculta y se limpia. -->
+            <div id="pickup-ack-box" class="pickup-ack" hidden>
+              <p class="pickup-ack-notice">
+                Para evitar que vengas en vano, esperá nuestra confirmación por
+                WhatsApp antes de venir. Te avisaremos apenas tu pedido esté
+                pronto para retirar.
               </p>
-              <p class="checkout-policy-links">
-                Al continuar aceptás los <a href="/terminos" target="_blank">términos de compra</a>.
-                Consultá <a href="/envios" target="_blank">envíos</a> y
-                <a href="/devoluciones" target="_blank">devoluciones</a>.
-              </p>
-              <p class="checkout-personal-note">
-                Somos una librería familiar y esta web también la hacemos nosotros. Si necesitás ayuda para completar tu compra, escribinos por WhatsApp. Te atendemos personalmente.
-              </p>
-              <button type="button" id="btn-wa-order" class="btn-wa-secondary">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <label class="pickup-ack-label" for="pickup-ack">
+                <input type="checkbox" id="pickup-ack" aria-describedby="err-pickup-ack">
+                <span>Entiendo que debo esperar la confirmación por WhatsApp antes de ir a retirar.</span>
+              </label>
+              <span class="field-error" id="err-pickup-ack" role="alert" hidden></span>
+            </div>
+
+            <div class="delivery-opts-rest">
+              <label class="delivery-opt">
+                <input type="radio" name="delivery" value="shipping">
+                <span class="delivery-opt-content">
+                  <strong class="delivery-opt-name">Envío a domicilio</strong>
+                  <span class="delivery-opt-meta">Entregas de lunes a viernes · coordinamos día y franja contigo</span>
+                  <span class="delivery-opt-badge">Gratis desde $1.500</span>
+                </span>
+              </label>
+            </div>
+            <span class="field-error delivery-error" id="err-delivery" role="alert" hidden></span>
+            <div id="shipping-fields" class="shipping-fields" hidden>
+              <div class="form-field">
+                <label for="delivery-address" class="form-label">Dirección <span class="form-req" aria-hidden="true">*</span></label>
+                <input type="text" id="delivery-address" class="form-input"
+                  placeholder="Ej: Av. Italia 2000, Apto 3"
+                  autocomplete="shipping street-address"
+                  aria-describedby="err-delivery-address">
+                <span class="field-error" id="err-delivery-address" role="alert" hidden></span>
+              </div>
+              <div class="form-field">
+                <label for="delivery-barrio" class="form-label">Barrio / Localidad <span class="form-req" aria-hidden="true">*</span></label>
+                <input type="text" id="delivery-barrio" class="form-input"
+                  placeholder="Ej: Pocitos, Centro, Malvín"
+                  autocomplete="shipping address-level3"
+                  aria-describedby="err-delivery-barrio">
+                <span class="field-error" id="err-delivery-barrio" role="alert" hidden></span>
+              </div>
+              <div class="form-field">
+                <label for="delivery-departamento" class="form-label">Departamento <span class="form-req" aria-hidden="true">*</span></label>
+                <select id="delivery-departamento" class="form-input"
+                  autocomplete="shipping address-level1"
+                  aria-describedby="err-delivery-departamento">
+                  <option value="">Seleccioná tu departamento</option>
+                  <option>Artigas</option>
+                  <option>Canelones</option>
+                  <option>Cerro Largo</option>
+                  <option>Colonia</option>
+                  <option>Durazno</option>
+                  <option>Flores</option>
+                  <option>Florida</option>
+                  <option>Lavalleja</option>
+                  <option>Maldonado</option>
+                  <option>Montevideo</option>
+                  <option>Paysandú</option>
+                  <option>Río Negro</option>
+                  <option>Rivera</option>
+                  <option>Rocha</option>
+                  <option>Salto</option>
+                  <option>San José</option>
+                  <option>Soriano</option>
+                  <option>Tacuarembó</option>
+                  <option>Treinta y Tres</option>
+                </select>
+                <span class="field-error" id="err-delivery-departamento" role="alert" hidden></span>
+              </div>
+              <div class="form-field">
+                <label for="delivery-notes" class="form-label">Indicaciones para la entrega (opcional)</label>
+                <textarea id="delivery-notes" class="form-input form-textarea" rows="2" placeholder="Ej: timbre 2B, dejar con portero"></textarea>
+              </div>
+              <p class="delivery-confirm-note">Después del pago coordinamos el día y el horario por WhatsApp.</p>
+            </div>
+          </section>
+
+          <!-- Datos del comprador -->
+          <section class="cart-section">
+            <h2 class="cart-section-h2">Tus datos</h2>
+            <p class="buyer-note">Mientras completás el pedido, recordamos estos datos sólo en esta pestaña para que no los pierdas si abrís el banco o WhatsApp.</p>
+            <div class="form-grid">
+              <div class="form-field">
+                <label for="buyer-name" class="form-label">Nombre <span class="form-req" aria-hidden="true">*</span></label>
+                <input type="text" id="buyer-name" class="form-input" autocomplete="name"
+                  aria-describedby="err-buyer-name">
+                <span class="field-error" id="err-buyer-name" role="alert" hidden></span>
+              </div>
+              <div class="form-field">
+                <label for="buyer-phone" class="form-label">WhatsApp / Teléfono <span class="form-req" aria-hidden="true">*</span></label>
+                <input type="tel" id="buyer-phone" class="form-input"
+                  placeholder="Ej: 099 123 456"
+                  autocomplete="tel"
+                  inputmode="tel"
+                  aria-describedby="buyer-phone-help err-buyer-phone">
+                <span class="field-help" id="buyer-phone-help">Lo usamos únicamente para coordinar tu pedido y la entrega.</span>
+                <span class="field-error" id="err-buyer-phone" role="alert" hidden></span>
+              </div>
+              <div class="form-field">
+                <label for="buyer-email" class="form-label">Correo electrónico <span class="form-req" aria-hidden="true">*</span></label>
+                <input type="email" id="buyer-email" class="form-input"
+                  placeholder="tu@email.com"
+                  autocomplete="email"
+                  inputmode="email"
+                  maxlength="254"
+                  required
+                  aria-describedby="buyer-email-help err-buyer-email">
+                <span class="field-help" id="buyer-email-help">Ahí te enviamos la confirmación y el número de pedido.</span>
+                <span class="field-error" id="err-buyer-email" role="alert" hidden></span>
+              </div>
+            </div>
+          </section>
+
+          <!-- Acciones de pago -->
+          <section class="cart-pay-section" aria-label="Confirmar y pagar">
+            {checkoutEnabled && <div id="cf-ts-container"></div>}
+
+            <div id="checkout-error" class="checkout-error" role="alert" hidden></div>
+
+            {checkoutEnabled && (
+              <div class="payment-method-section cart-section-card">
+                <h2 class="cart-section-h2">¿Cómo querés pagar?</h2>
+                <div class="payment-opts" role="radiogroup" aria-describedby="err-payment-method">
+                  <label class="payment-opt">
+                    <input type="radio" name="payment-method" value="transfer" id="payment-method-transfer">
+                    <span class="payment-opt-content">
+                      <span class="payment-opt-head">
+                        <strong class="payment-opt-name">Transferencia bancaria</strong>
+                        <span class="payment-opt-badge">12% menos</span>
+                      </span>
+                      <span class="payment-opt-preview" id="transfer-preview-line" hidden></span>
+                    </span>
+                  </label>
+                  <label class="payment-opt">
+                    <input type="radio" name="payment-method" value="mercadopago" id="payment-method-mercadopago">
+                    <span class="payment-opt-content">
+                      <strong class="payment-opt-name">Mercado Pago</strong>
+                      <span class="payment-opt-meta">Tarjetas, débito y hasta 12 cuotas</span>
+                      <span class="payment-opt-preview" id="mp-preview-line" hidden></span>
+                    </span>
+                  </label>
+                </div>
+                <span class="field-error" id="err-payment-method" role="alert" hidden></span>
+              </div>
+            )}
+
+            {checkoutEnabled ? (
+              <div class="checkout-mobile-bar">
+                <div class="checkout-sticky-total" aria-hidden="true">
+                  <span class="checkout-sticky-total-label">Total</span>
+                  <strong id="checkout-sticky-total-value">$&nbsp;0</strong>
+                </div>
+                <p id="cart-delivery-hint" class="cart-delivery-hint" role="status" aria-live="polite" hidden>Elegí envío o retiro para continuar.</p>
+                <p id="cart-payment-hint" class="cart-delivery-hint" role="status" aria-live="polite" hidden>Elegí cómo querés pagar.</p>
+                <button type="button" id="btn-confirm-neutral" class="btn-checkout-primary">
+                  Finalizar compra
+                </button>
+                <button type="button" id="btn-transfer-order" class="btn-transfer-primary" aria-describedby="checkout-error" hidden>
+                  Confirmar compra con 12% OFF
+                </button>
+                <button type="button" id="btn-prepare-order" class="btn-checkout-primary" aria-describedby="checkout-error" hidden>
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" stroke-width="2" aria-hidden="true">
+                    <rect x="1" y="4" width="22" height="16" rx="2" ry="2"/>
+                    <line x1="1" y1="10" x2="23" y2="10"/>
+                  </svg>
+                  <span class="btn-checkout-primary-text">Pagar con Mercado Pago</span>
+                </button>
+              </div>
+            ) : (
+              <button type="button" id="btn-wa-order" class="btn-wa-order">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                   <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z"/>
                 </svg>
-                O coordinar por WhatsApp
+                Enviar pedido por WhatsApp
               </button>
-            </>
-          )}
+            )}
 
-          {!checkoutEnabled && (
-            <>
-              <p class="checkout-reassurance">
-                No pagás ahora. Te enviamos los datos para transferencia o un link de Mercado Pago.
-              </p>
-              <p class="checkout-policy-links">
-                Al enviar el pedido aceptás los <a href="/terminos" target="_blank">términos de compra</a>.
-                Consultá <a href="/envios" target="_blank">envíos</a> y
-                <a href="/devoluciones" target="_blank">devoluciones</a>.
-              </p>
-            </>
-          )}
-        </section>
+            {checkoutEnabled && (
+              <>
+                <p class="checkout-reassurance">
+                  Primero verificamos precio y stock. Tu carrito no se vacía hasta
+                  que el pago quede confirmado.
+                </p>
+                <p class="checkout-policy-links">
+                  Al continuar aceptás los <a href="/terminos" target="_blank">términos de compra</a>.
+                  Consultá <a href="/envios" target="_blank">envíos</a> y
+                  <a href="/devoluciones" target="_blank">devoluciones</a>.
+                </p>
+                <p class="checkout-personal-note">
+                  Somos una librería familiar y esta web también la hacemos nosotros. Si necesitás ayuda, escribinos por WhatsApp y te ayudamos a completar la compra.
+                </p>
+                <button type="button" id="btn-wa-order" class="btn-wa-secondary">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347zM12 2C6.477 2 2 6.477 2 12c0 1.89.525 3.663 1.437 5.17L2.057 22.5l5.373-1.408A9.953 9.953 0 0 0 12 22c5.523 0 10-4.477 10-10S17.523 2 12 2z"/>
+                  </svg>
+                  O coordinar por WhatsApp
+                </button>
+              </>
+            )}
+
+            {!checkoutEnabled && (
+              <>
+                <p class="checkout-reassurance">
+                  No pagás ahora. Te enviamos los datos para transferencia o un link de Mercado Pago.
+                </p>
+                <p class="checkout-policy-links">
+                  Al enviar el pedido aceptás los <a href="/terminos" target="_blank">términos de compra</a>.
+                  Consultá <a href="/envios" target="_blank">envíos</a> y
+                  <a href="/devoluciones" target="_blank">devoluciones</a>.
+                </p>
+              </>
+            )}
+          </section>
+
+          </div><!-- /.checkout-left -->
+
+        </div><!-- /.checkout-layout -->
         </div><!-- /#checkout-edit-step -->
 
         {checkoutEnabled && (
         <>
           <!-- Paso de pago por transferencia. Los datos se cargan desde un
-               endpoint no-cache después de validar y guardar la orden. -->
+               endpoint no-cache después de validar y guardar la orden.
+               V1.1 REDESIGN: no se toca — sigue siendo el reemplazo de
+               pantalla completa posterior a la creación de la orden. -->
           <section id="transfer-payment-step" class="transfer-step" aria-labelledby="transfer-step-title" hidden>
           <button type="button" id="btn-edit-order" class="btn-context-back">← Volver a revisar el pedido</button>
           <p class="transfer-step-kicker">Pedido <strong id="transfer-order-code">—</strong></p>
@@ -356,11 +421,33 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     margin: 0 auto;
   }
 
+  /* V1.1 REDESIGN: sólo desde ~960px el contenido crece al ancho pensado
+     para el layout de 2 columnas — por debajo, todo sigue en una sola
+     columna angosta, sin tocar el breakpoint mobile existente (640px). */
+  @media (min-width: 960px) {
+    .cart-wrap {
+      max-width: 1200px;
+    }
+  }
+
+  .cart-header {
+    margin-bottom: 1.25rem;
+  }
+
   .cart-h1 {
     font-family: var(--font-display);
     font-size: 1.75rem;
     color: var(--ink);
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.35rem;
+  }
+
+  /* V1.1 REDESIGN: visible desde el primer viewport, sin tener que llenar
+     datos para descubrir cómo se puede pagar. */
+  .cart-commercial-line {
+    font-family: var(--font-ui);
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: #8f4436;
   }
 
   .btn-context-back {
@@ -370,7 +457,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     color: var(--ink-2);
     cursor: pointer;
     font: 600 0.82rem/1.4 var(--font-ui);
-    margin: 0 0 1.5rem;
+    margin: 0 0 0.5rem;
     padding: 0.6rem 0;
     text-decoration: underline;
     text-underline-offset: 0.2em;
@@ -408,26 +495,200 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
   }
   .btn-empty-back:hover { background: var(--salmon-hover); }
 
-  /* ── Barra de resumen ──────────────────────────── */
-  .cart-summary-bar {
+  /* ── V1.1 REDESIGN: layout de checkout ──────────────────────────────
+     Mobile (por defecto): una columna, orden natural del DOM — el resumen
+     va primero (aside), después Entrega/Datos/Pago (checkout-left).
+     Desktop (>=960px): grid de 2 columnas; el resumen se reubica a la
+     derecha SOLO con grid-column, sin cambiar el orden real del DOM. */
+  .checkout-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  @media (min-width: 960px) {
+    .checkout-layout {
+      display: grid;
+      grid-template-columns: 60fr 38fr;
+      gap: 2rem;
+      align-items: start;
+    }
+    .checkout-left {
+      grid-column: 1;
+      grid-row: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .checkout-summary {
+      grid-column: 2;
+      grid-row: 1;
+      position: sticky;
+      top: 1.5rem;
+    }
+  }
+
+  /* ── Resumen de compra (aside) ──────────────────────────────────────── */
+  .cart-summary-panel {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 0;
+  }
+
+  .cart-summary-toggle {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 1rem;
-    flex-wrap: wrap;
-    padding: 1rem 0;
-    border-top: 1px solid var(--border);
-    margin-top: 1rem;
+    gap: 0.75rem;
+    padding: 1rem 1.1rem;
+    cursor: pointer;
+    list-style: none;
+    font-weight: 700;
+    font-size: 0.9rem;
+    color: var(--ink);
+  }
+  .cart-summary-toggle::-webkit-details-marker { display: none; }
+  .cart-summary-toggle::marker { content: ''; }
+  .cart-summary-toggle:focus-visible { outline: 2px solid var(--salmon); outline-offset: 2px; }
+
+  .cart-summary-chevron {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #8f4436;
+    text-decoration: underline;
+    white-space: nowrap;
   }
 
+  .cart-summary-body {
+    padding: 0 1.1rem 1.1rem;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+
+  /* El <details> nativo ya oculta este contenido cuando no está [open] (UA
+     stylesheet) — sólo declaramos flex para el estado abierto, así el
+     colapso real de mobile no queda pisado por esta regla. */
+  .cart-summary-panel[open] .cart-summary-body {
+    display: flex;
+  }
+
+  /* Desktop: el resumen siempre está expandido — el <details> deja de
+     comportarse como colapsable y el toggle se vuelve decorativo. */
+  @media (min-width: 960px) {
+    .cart-summary-panel:not([open]) .cart-summary-body {
+      display: flex;
+    }
+    /* Chromium colapsa el contenido de un <details> cerrado a través de un
+       pseudo-elemento interno (::details-content), no sólo con display en
+       sus hijos — sin este override el <details> sigue midiendo 0 de alto
+       en desktop aunque .cart-summary-body ya diga display:flex. */
+    .cart-summary-panel:not([open])::details-content {
+      content-visibility: visible;
+      display: block;
+    }
+    .cart-summary-toggle {
+      cursor: default;
+      pointer-events: none;
+    }
+    .cart-summary-chevron { display: none; }
+  }
+
+  .cart-items-compact {
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+  }
+  .cart-items-compact[hidden] { display: none; }
+
+  :global(.cart-item-compact) {
+    display: flex;
+    gap: 0.7rem;
+    align-items: flex-start;
+  }
+
+  :global(.cart-item-compact-img),
+  :global(.cart-item-compact-img-placeholder) {
+    width: 40px;
+    height: 56px;
+    border-radius: 4px;
+    background: #ede9e1;
+    object-fit: cover;
+    flex: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.1rem;
+    color: var(--ink-2);
+  }
+
+  :global(.cart-item-compact-info) {
+    flex: 1;
+    min-width: 0;
+  }
+
+  :global(.cart-item-compact-title) {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: var(--ink);
+    line-height: 1.3;
+    margin: 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  :global(.cart-item-compact-meta) {
+    font-size: 0.76rem;
+    color: var(--ink-2);
+    margin: 0.2rem 0 0;
+  }
+
+  :global(.cart-item-compact-unavailable) {
+    display: inline-block;
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: #7f2f20;
+    background: #fff8f5;
+    border: 1px solid #efc7ba;
+    border-radius: 999px;
+    padding: 0.1rem 0.5rem;
+    margin-top: 0.25rem;
+  }
+
+  .cart-summary-edit-toggle {
+    align-self: flex-start;
+    background: transparent;
+    border: 0;
+    color: #8f4436;
+    cursor: pointer;
+    font: 700 0.78rem/1.4 var(--font-ui);
+    padding: 0;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .cart-items-full[hidden] { display: none; }
+
+  .cart-totals-card {
+    border-top: 1px solid var(--border);
+    padding-top: 0.85rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  /* ── Barra de resumen (compat, ya no se usa como wrapper propio) ──── */
   .btn-clear {
-    padding: 0.45rem 1rem;
+    align-self: flex-start;
+    padding: 0.4rem 0.85rem;
     border: 1px solid var(--border);
     border-radius: var(--r);
     background: transparent;
     color: var(--ink-2);
     font-family: var(--font-ui);
-    font-size: 0.8rem;
+    font-size: 0.76rem;
     cursor: pointer;
     transition: background 0.15s, color 0.15s;
   }
@@ -435,14 +696,9 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
 
   /* ── Nota de precios ───────────────────────────── */
   .cart-price-note {
-    font-size: 0.8rem;
+    font-size: 0.75rem;
     color: var(--ink-2);
-    line-height: 1.6;
-    padding: 0.875rem 1rem;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--r);
-    margin-bottom: 1.5rem;
+    line-height: 1.5;
   }
 
   /* ── Secciones de formulario ───────────────────── */
@@ -473,7 +729,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     display: flex;
     align-items: flex-start;
     gap: 0.6rem;
-    min-height: 44px;
+    min-height: 48px;
     padding: 0.85rem;
     border: 1px solid var(--border);
     border-radius: var(--r);
@@ -485,13 +741,15 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
 
   .delivery-opt:has(input[type="radio"]:checked) {
     border-color: #267a42;
+    border-width: 2px;
     background: rgba(37, 160, 80, 0.06);
-    box-shadow: 0 0 0 1px rgba(37, 160, 80, 0.18);
   }
 
   .delivery-opt input[type="radio"] {
     margin-top: 0.2rem;
     flex-shrink: 0;
+    width: 20px;
+    height: 20px;
     accent-color: #267a42;
   }
 
@@ -583,6 +841,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     background: var(--bg);
     transition: border-color 0.15s;
     width: 100%;
+    min-height: 44px;
   }
   .form-input:focus {
     outline: 2px solid var(--salmon);
@@ -632,6 +891,90 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     gap: 0.75rem;
     padding-top: 0.5rem;
   }
+
+  /* V1.1 REDESIGN: "¿Cómo querés pagar?" — mismo lenguaje visual que las
+     cards de Entrega (delivery-opt), duplicado a propósito en vez de
+     compartir selector: cero riesgo de que un cambio futuro en una card
+     afecte a la otra sin querer. */
+  .payment-method-section {
+    margin-bottom: 0;
+  }
+
+  .payment-opts {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  .payment-opt {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.6rem;
+    min-height: 48px;
+    padding: 0.85rem;
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    background: #fff;
+    font-size: 0.9rem;
+    color: var(--ink);
+    cursor: pointer;
+  }
+
+  .payment-opt:has(input[type="radio"]:checked) {
+    border-color: var(--salmon);
+    border-width: 2px;
+    background: rgba(191, 87, 60, 0.06);
+  }
+
+  .payment-opt input[type="radio"] {
+    margin-top: 0.2rem;
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    accent-color: var(--salmon);
+  }
+
+  .payment-opt-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    flex: 1;
+  }
+
+  .payment-opt-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .payment-opt-name {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--ink);
+  }
+
+  .payment-opt-badge {
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #fff;
+    background: #177a43;
+    border-radius: 999px;
+    padding: 0.12rem 0.55rem;
+  }
+
+  .payment-opt-meta {
+    font-size: 0.78rem;
+    color: var(--ink-2);
+    line-height: 1.4;
+  }
+
+  .payment-opt-preview {
+    font-size: 0.82rem;
+    font-weight: 700;
+    color: #177a43;
+  }
+  .payment-opt-preview[hidden] { display: none; }
 
   .checkout-error {
     background: #fef2f2;
@@ -691,6 +1034,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     outline: 3px solid var(--ink);
     outline-offset: 3px;
   }
+  .btn-checkout-primary[hidden] { display: none; }
 
   .btn-transfer-primary {
     width: 100%;
@@ -702,22 +1046,16 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     cursor: pointer;
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: center;
     gap: 0.75rem;
     padding: 0.85rem 1rem;
     font: 700 0.93rem/1.2 var(--font-ui);
     box-shadow: 0 2px 7px rgba(23, 122, 67, 0.2);
   }
-  .btn-transfer-primary strong {
-    white-space: nowrap;
-    font-size: 0.78rem;
-    background: rgba(255,255,255,.18);
-    border-radius: 999px;
-    padding: 0.3rem 0.55rem;
-  }
   .btn-transfer-primary:hover:not(:disabled) { background: #126536; }
   .btn-transfer-primary:disabled { cursor: wait; opacity: .68; }
   .btn-transfer-primary:focus-visible { outline: 3px solid #8de4b2; outline-offset: 2px; }
+  .btn-transfer-primary[hidden] { display: none; }
 
   /* WhatsApp como alternativa secundaria — nunca compite visualmente con el
      botón principal de pago. */
@@ -1127,9 +1465,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     }
 
     .cart-page[data-online-checkout="enabled"] .btn-transfer-primary,
-    .cart-page[data-online-checkout="enabled"] .btn-checkout-primary { min-height: 50px; padding: .7rem .75rem; }
-    .cart-page[data-online-checkout="enabled"] .btn-transfer-primary { flex-direction: column; align-items: flex-start; gap: .2rem; }
-    .cart-page[data-online-checkout="enabled"] .btn-transfer-primary strong { background: transparent; padding: 0; }
+    .cart-page[data-online-checkout="enabled"] .btn-checkout-primary { min-height: 50px; padding: .7rem .75rem; grid-column: 1 / -1; }
     .transfer-accounts { grid-template-columns: 1fr; }
 
     /* La burbuja flotante de WhatsApp (WAFloat, fuera de <main>) competiría
@@ -1249,6 +1585,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     var PICKUP_DISCOUNT_MIN_PRODUCTS_TOTAL_UYU = 1300;
     var SHIPPING_COST               = 250;
     var FREE_SHIPPING_THRESHOLD_UYU = 1500;
+    var TRANSFER_FACTOR             = 0.88;
     var CHECKOUT_DRAFT_KEY           = 'amado-checkout-draft-v2';
     var WHATSAPP_NUMBER              = '59899841325';
 
@@ -1257,6 +1594,10 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     var emptyEl          = document.getElementById('cart-empty');
     var contentEl        = document.getElementById('cart-content');
     var itemsList        = document.getElementById('cart-items');
+    var itemsCompactList = document.getElementById('cart-items-compact');
+    var btnToggleEditor  = document.getElementById('btn-toggle-editor');
+    var cartSummaryCountEl = document.getElementById('cart-summary-count');
+    var cartSummaryTotalEl = document.getElementById('cart-summary-total');
     var subtotalEl       = document.getElementById('cart-subtotal');
     var discountLineEl   = document.getElementById('cart-discount-line');
     var totalLineEl      = document.getElementById('cart-total-line');
@@ -1272,6 +1613,9 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     var totalShippingEl      = document.getElementById('cart-total-shipping');
     var stickyTotalEl        = document.getElementById('checkout-sticky-total-value');
     var deliveryHintEl       = document.getElementById('cart-delivery-hint');
+    var paymentHintEl        = document.getElementById('cart-payment-hint');
+    var transferPreviewEl    = document.getElementById('transfer-preview-line');
+    var mpPreviewEl          = document.getElementById('mp-preview-line');
     var checkoutErrorEl      = document.getElementById('checkout-error');
     var cartPageEl           = document.querySelector('.cart-page');
     var checkoutEditStepEl   = document.getElementById('checkout-edit-step');
@@ -1371,6 +1715,42 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       });
     }
 
+    // ── V1.1 REDESIGN: medio de pago ─────────────────────────────────────
+    // Mismo patrón exacto que getDeliveryType()/requireDeliveryType(): un
+    // radio-group real, sin preselección, con su propio mensaje/foco/scroll
+    // cuando falta elegir. btn-transfer-order y btn-prepare-order NO se
+    // fusionan — sólo se decide cuál de los dos (o el CTA neutro) queda
+    // visible según esta elección.
+    function getPaymentMethod() {
+      var checked = document.querySelector('input[name="payment-method"]:checked');
+      return checked ? checked.value : '';
+    }
+
+    function requirePaymentMethod() {
+      var method = getPaymentMethod();
+      if (method) return method;
+      var errEl = document.getElementById('err-payment-method');
+      if (errEl) {
+        errEl.textContent = 'Elegí cómo querés pagar.';
+        errEl.hidden = false;
+      }
+      var firstMethod = document.querySelector('input[name="payment-method"]');
+      if (firstMethod) {
+        firstMethod.setAttribute('aria-invalid', 'true');
+        firstMethod.focus();
+        firstMethod.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+      return '';
+    }
+
+    function clearPaymentMethodError() {
+      var errEl = document.getElementById('err-payment-method');
+      if (errEl) { errEl.textContent = ''; errEl.hidden = true; }
+      document.querySelectorAll('input[name="payment-method"]').forEach(function (radio) {
+        radio.removeAttribute('aria-invalid');
+      });
+    }
+
     // ── Persistencia de la etapa y los datos mínimos ─────────────────────
     // sessionStorage sobrevive a recargas y al salto a WhatsApp, pero
     // se elimina al cerrar la pestaña. Así no guardamos PII indefinidamente.
@@ -1407,6 +1787,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
           idempotency_key: cart.idempotency_key,
           values: values,
           delivery_type: getDeliveryType(),
+          payment_method: getPaymentMethod(),
           pickup_ack: isPickupAccepted(),
           step: transferStepEl && !transferStepEl.hidden ? 'transfer' : 'edit',
           transfer_auth: transferAuth,
@@ -1432,6 +1813,10 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       }
       var delivery = document.querySelector('input[name="delivery"][value="' + draft.delivery_type + '"]');
       if (delivery) delivery.checked = true;
+      if (typeof draft.payment_method === 'string' && draft.payment_method) {
+        var paymentMethodRadio = document.querySelector('input[name="payment-method"][value="' + draft.payment_method + '"]');
+        if (paymentMethodRadio) paymentMethodRadio.checked = true;
+      }
       if (pickupAck) pickupAck.checked = draft.pickup_ack === true;
       if (typeof draft.selected_account_id === 'string') selectedAccountId = draft.selected_account_id;
       return draft;
@@ -1560,16 +1945,33 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     // de crear ninguna orden. El aviso persistente sólo se muestra cuando
     // la entrega es lo ÚNICO que falta, para no confundirlo con un bloqueo
     // técnico real (que ya tiene su propio mensaje vía showCheckoutError).
+    //
+    // V1.1 REDESIGN: mismo principio extendido al medio de pago. Ahora hay
+    // tres botones posibles en el DOM (neutro / transferencia / Mercado
+    // Pago) pero sólo UNO visible a la vez, según getPaymentMethod() — la
+    // lógica interna de cada botón (createTransferOrder(), el handler de
+    // btnPrepare) no cambia en absoluto, sólo su visibilidad.
     function syncPaymentAvailability() {
       var cart = window.AmadoCart ? window.AmadoCart.get() : { items: [] };
       var technicallyReady = cartValidationReady && !cartValidationFailed &&
         !validationRequest && getSellableItems(cart).length > 0;
       var hasDelivery = !!getDeliveryType();
+      var paymentMethod = getPaymentMethod();
+      var hasPaymentMethod = !!paymentMethod;
       var transferButton = document.getElementById('btn-transfer-order');
       var mercadoPagoButton = document.getElementById('btn-prepare-order');
+      var neutralButton = document.getElementById('btn-confirm-neutral');
+
       if (transferButton && !transferButton.hasAttribute('aria-busy')) transferButton.disabled = !technicallyReady;
       if (mercadoPagoButton && !mercadoPagoButton.hasAttribute('aria-busy')) mercadoPagoButton.disabled = !technicallyReady;
+      if (neutralButton) neutralButton.disabled = !technicallyReady;
+
+      if (transferButton) transferButton.hidden = paymentMethod !== 'transfer';
+      if (mercadoPagoButton) mercadoPagoButton.hidden = paymentMethod !== 'mercadopago';
+      if (neutralButton) neutralButton.hidden = hasPaymentMethod;
+
       if (deliveryHintEl) deliveryHintEl.hidden = !(technicallyReady && !hasDelivery);
+      if (paymentHintEl) paymentHintEl.hidden = !(technicallyReady && hasDelivery && !hasPaymentMethod);
     }
 
     function buildCartValidationPayload(cart) {
@@ -1679,6 +2081,12 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         if (totalShippingLineEl) totalShippingLineEl.hidden = true;
         if (shippingMsgEl)       { shippingMsgEl.hidden = true; shippingMsgEl.textContent = ''; }
         if (stickyTotalEl)       stickyTotalEl.textContent  = fmt.format(subtotal);
+        if (cartSummaryTotalEl)  cartSummaryTotalEl.textContent = fmt.format(subtotal);
+        // V1.1 REDESIGN: sin entrega elegida todavía no hay total real que
+        // previsualizar por medio de pago — se ocultan ambas líneas en vez
+        // de mostrar un importe que después cambiaría.
+        if (transferPreviewEl) { transferPreviewEl.hidden = true; transferPreviewEl.textContent = ''; }
+        if (mpPreviewEl)        { mpPreviewEl.hidden = true; mpPreviewEl.textContent = ''; }
         return;
       }
 
@@ -1694,6 +2102,23 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         if (totalShippingLineEl) totalShippingLineEl.hidden = true;
         if (shippingMsgEl)       { shippingMsgEl.hidden = true; shippingMsgEl.textContent = ''; }
         if (stickyTotalEl)       stickyTotalEl.textContent  = fmt.format(total);
+        if (cartSummaryTotalEl)  cartSummaryTotalEl.textContent = fmt.format(total);
+
+        // V1.1 REDESIGN: preview de "Pagás $X" — espejo EXACTO de
+        // calculateTransferTotals() en functions/api/_orders_logic.js
+        // (mismo TRANSFER_FACTOR, mismo pickupDiscount ya calculado acá
+        // mismo, sin envío). Sólo de presentación: el backend recalcula
+        // todo desde cero al crear la orden, esto nunca se envía.
+        var transferProductsTotal = Math.round(subtotal * TRANSFER_FACTOR);
+        var transferPayable = Math.max(0, transferProductsTotal - pickupDiscount);
+        if (transferPreviewEl) {
+          transferPreviewEl.hidden = false;
+          transferPreviewEl.textContent = 'Precio normal ' + fmt.format(subtotal) + ' · Pagás ' + fmt.format(transferPayable);
+        }
+        if (mpPreviewEl) {
+          mpPreviewEl.hidden = false;
+          mpPreviewEl.textContent = 'Pagás ' + fmt.format(total);
+        }
       } else {
         var shippingCost      = subtotal < FREE_SHIPPING_THRESHOLD_UYU ? SHIPPING_COST : 0;
         var totalWithShipping = subtotal + shippingCost;
@@ -1716,6 +2141,21 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
             : 'Te faltan ' + fmt.format(FREE_SHIPPING_THRESHOLD_UYU - subtotal) + ' para obtener envío gratis';
         }
         if (stickyTotalEl) stickyTotalEl.textContent = fmt.format(totalWithShipping);
+        if (cartSummaryTotalEl) cartSummaryTotalEl.textContent = fmt.format(totalWithShipping);
+
+        // V1.1 REDESIGN: mismo espejo que en la rama de retiro, ahora con
+        // shippingCost (sin pickupDiscount) — igual que
+        // calculateTransferTotals() del servidor.
+        var transferProductsTotalShip = Math.round(subtotal * TRANSFER_FACTOR);
+        var transferPayableShip = Math.max(0, transferProductsTotalShip + shippingCost);
+        if (transferPreviewEl) {
+          transferPreviewEl.hidden = false;
+          transferPreviewEl.textContent = 'Precio normal ' + fmt.format(subtotal) + ' · Pagás ' + fmt.format(transferPayableShip);
+        }
+        if (mpPreviewEl) {
+          mpPreviewEl.hidden = false;
+          mpPreviewEl.textContent = 'Pagás ' + fmt.format(totalWithShipping);
+        }
       }
     }
 
@@ -1896,6 +2336,55 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       return art;
     }
 
+    // ── V1.1 REDESIGN: fila compacta del resumen ─────────────────────────
+    // Función nueva y mínima, separada de buildItemRow() (que NO se toca):
+    // sólo miniatura + título + cantidad + precio para la vista colapsada
+    // del resumen. Los estados detallados (última unidad, precio
+    // actualizado, cantidad ajustada, quitar) siguen viviendo únicamente
+    // en la fila completa de buildItemRow(), detrás de "Editar".
+    function buildCompactItemRow(item, validation) {
+      var row = document.createElement('div');
+      row.className = 'cart-item-compact';
+
+      if (item.thumbnail) {
+        var img = document.createElement('img');
+        img.src = item.thumbnail;
+        img.alt = '';
+        img.loading = 'lazy';
+        img.className = 'cart-item-compact-img';
+        row.appendChild(img);
+      } else {
+        var ph = document.createElement('div');
+        ph.className = 'cart-item-compact-img-placeholder';
+        ph.setAttribute('aria-hidden', 'true');
+        ph.textContent = '📚';
+        row.appendChild(ph);
+      }
+
+      var info = document.createElement('div');
+      info.className = 'cart-item-compact-info';
+
+      var t = document.createElement('p');
+      t.className = 'cart-item-compact-title';
+      t.textContent = item.title;
+      info.appendChild(t);
+
+      if (validation && isUnavailableStatus(validation.status)) {
+        var badge = document.createElement('span');
+        badge.className = 'cart-item-compact-unavailable';
+        badge.textContent = 'No disponible';
+        info.appendChild(badge);
+      } else {
+        var meta = document.createElement('p');
+        meta.className = 'cart-item-compact-meta';
+        meta.textContent = 'Cant. ' + item.quantity + ' · ' + fmt.format(item.price * item.quantity);
+        info.appendChild(meta);
+      }
+
+      row.appendChild(info);
+      return row;
+    }
+
     // ── Render completo ──────────────────────────────────────────────────
     function renderCart() {
       if (!window.AmadoCart) return;
@@ -1916,6 +2405,17 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       while (itemsList.firstChild) itemsList.removeChild(itemsList.firstChild);
       for (var i = 0; i < cart.items.length; i++) {
         itemsList.appendChild(buildItemRow(cart.items[i], validationFor(cart.items[i])));
+      }
+
+      if (itemsCompactList) {
+        while (itemsCompactList.firstChild) itemsCompactList.removeChild(itemsCompactList.firstChild);
+        for (var c = 0; c < cart.items.length; c++) {
+          itemsCompactList.appendChild(buildCompactItemRow(cart.items[c], validationFor(cart.items[c])));
+        }
+      }
+      if (cartSummaryCountEl) {
+        var totalQty = cart.items.reduce(function (s, it) { return s + (it.quantity || 0); }, 0);
+        cartSummaryCountEl.textContent = String(totalQty);
       }
 
       updateTotals();
@@ -1978,6 +2478,49 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       });
     });
     syncShippingFields();
+
+    // ── V1.1 REDESIGN: toggle medio de pago ──────────────────────────────
+    var paymentMethodRadios = document.querySelectorAll('input[name="payment-method"]');
+    paymentMethodRadios.forEach(function (radio) {
+      radio.addEventListener('change', function () {
+        clearPaymentMethodError();
+        updateTotals();
+        syncPaymentAvailability();
+        saveDraft();
+      });
+    });
+
+    // ── V1.1 REDESIGN: CTA neutro cuando todavía no se eligió pago ───────
+    var btnConfirmNeutral = document.getElementById('btn-confirm-neutral');
+    if (btnConfirmNeutral) {
+      btnConfirmNeutral.addEventListener('click', function () {
+        if (btnConfirmNeutral.disabled) return;
+        if (!requireDeliveryType()) return;
+        requirePaymentMethod();
+      });
+    }
+
+    // ── V1.1 REDESIGN: texto del disclosure del resumen (colapsado/expandido) ─
+    // <details> ya dispara "toggle" nativamente al abrir/cerrar — se usa acá
+    // en vez de un truco de CSS con contenido dinámico en ::before.
+    var cartSummaryPanelEl = document.getElementById('cart-summary-panel');
+    var cartSummaryChevronEl = document.querySelector('.cart-summary-chevron');
+    if (cartSummaryPanelEl && cartSummaryChevronEl) {
+      cartSummaryPanelEl.addEventListener('toggle', function () {
+        cartSummaryChevronEl.textContent = cartSummaryPanelEl.open ? 'Ocultar' : 'Ver resumen';
+      });
+    }
+
+    // ── V1.1 REDESIGN: mostrar/ocultar el editor completo del carrito ────
+    if (btnToggleEditor) {
+      btnToggleEditor.addEventListener('click', function () {
+        var expanded = itemsList && !itemsList.hidden;
+        if (itemsList) itemsList.hidden = expanded;
+        if (itemsCompactList) itemsCompactList.hidden = !expanded;
+        btnToggleEditor.textContent = expanded ? 'Editar' : 'Listo';
+        btnToggleEditor.setAttribute('aria-expanded', String(!expanded));
+      });
+    }
 
     // ── Barra mobile: no tapar teclado ni footer ─────────────────────────
     if (onlineCheckoutEnabled && cartPageEl) {

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -2004,6 +2004,39 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       });
     }
 
+    // Espejo en el cliente de generateFingerprint() (functions/api/
+    // _orders_logic.js, fuente de verdad real) — sólo para decidir acá,
+    // ANTES de enviar, si la key vigente sigue representando el mismo
+    // pedido o si hay que rotar (evita el 409 en vez de reaccionar a él).
+    // Mismos campos, mismo orden de consolidación por product_id.
+    function checkoutFingerprint(cart, deliveryType, buyer, shipping) {
+      var items = paymentItemsPayload(cart)
+        .slice()
+        .sort(function (a, b) { return a.product_id < b.product_id ? -1 : a.product_id > b.product_id ? 1 : 0; });
+      var fp = {
+        items: items,
+        delivery_type: deliveryType,
+        pickup_ack: deliveryType === 'pickup' ? true : undefined,
+        buyer: {
+          name: (buyer.name || '').trim(),
+          phone: (buyer.phone || '').trim(),
+          email: (buyer.email || '').trim().toLowerCase(),
+        },
+      };
+      if (deliveryType === 'shipping' && shipping) {
+        fp.shipping = {
+          address: (shipping.address || '').trim(),
+          locality: (shipping.locality || '').trim(),
+          department: (shipping.department || '').trim(),
+          requested_date: '',
+          requested_from: '',
+          requested_to: '',
+          notes: (shipping.notes || '').trim(),
+        };
+      }
+      return JSON.stringify(fp);
+    }
+
     function commerceItems(cart) {
       return getSellableItems(cart).map(function (item) {
         return {
@@ -3091,6 +3124,17 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       if (!availabilityOk) return null;
       cart = window.AmadoCart.get();
 
+      var shippingForFp = deliveryType === 'shipping'
+        ? { address: address, locality: locality, department: department, notes: notes }
+        : null;
+      var fingerprint = checkoutFingerprint(
+        cart, deliveryType, { name: name, phone: phone, email: email }, shippingForFp
+      );
+      if (window.AmadoCart.ensureKeyForFingerprint) {
+        window.AmadoCart.ensureKeyForFingerprint(fingerprint);
+        cart = window.AmadoCart.get();
+      }
+
       var token = await getTurnstileTokenForOrder();
       var payload = {
         idempotency_key: cart.idempotency_key,
@@ -3115,6 +3159,20 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       if (!response.ok && orderData.code === 'CART_CHANGED') {
         await refreshCartAvailability({ beforePayment: true });
         return null;
+      }
+      if (!response.ok && (orderData.code === 'IDEMPOTENCY_CONFLICT' || orderData.code === 'ORDER_EXPIRED')) {
+        // Recuperación segura: la key vigente quedó inservible para este
+        // pedido (chocó con uno anterior, o el anterior venció) — se rota
+        // acá mismo para que el próximo intento del comprador ya salga con
+        // una identidad limpia, sin que tenga que hacer nada raro.
+        if (window.AmadoCart.rotateKey) window.AmadoCart.rotateKey();
+        var recoverableError = new Error(
+          orderData.code === 'IDEMPOTENCY_CONFLICT'
+            ? 'Actualizamos tu pedido para poder continuar. Intentá nuevamente.'
+            : (orderData.error || 'La orden anterior venció. Volvé a preparar el pedido.')
+        );
+        recoverableError.code = orderData.code;
+        throw recoverableError;
       }
       if (!response.ok) {
         var orderCreateError = new Error(orderData.error || 'No pudimos preparar el pedido.');
@@ -3304,6 +3362,17 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
 
         btnPrepare.textContent = 'Preparando tu pedido…';
 
+        var prepShippingForFp = deliveryType === 'shipping'
+          ? { address: prepAddress, locality: prepBarrio, department: prepDepto, notes: prepNotes }
+          : null;
+        var prepFingerprint = checkoutFingerprint(
+          cart, deliveryType, { name: prepName, phone: prepPhone, email: prepEmail }, prepShippingForFp
+        );
+        if (window.AmadoCart.ensureKeyForFingerprint) {
+          window.AmadoCart.ensureKeyForFingerprint(prepFingerprint);
+          cart = window.AmadoCart.get();
+        }
+
         var payload = {
           idempotency_key: cart.idempotency_key,
           cf_turnstile_response: cfTsResponse,
@@ -3333,6 +3402,22 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
           if (!resp.ok) {
             if (orderData.code === 'CART_CHANGED') {
               await refreshCartAvailability({ beforePayment: true });
+              resetPrepareButton();
+              return;
+            }
+            if (orderData.code === 'IDEMPOTENCY_CONFLICT' || orderData.code === 'ORDER_EXPIRED') {
+              // Recuperación segura: la key vigente quedó inservible para
+              // este pedido — se rota acá mismo para que el próximo intento
+              // ya salga limpio. Nunca se muestra el texto técnico del
+              // servidor ("idempotency_key"/"request_fingerprint") para
+              // IDEMPOTENCY_CONFLICT.
+              if (window.AmadoCart.rotateKey) window.AmadoCart.rotateKey();
+              showCheckoutError(
+                orderData.code === 'IDEMPOTENCY_CONFLICT'
+                  ? 'Actualizamos tu pedido para poder continuar. Intentá nuevamente.'
+                  : (orderData.error || 'La orden anterior venció. Volvé a preparar el pedido.')
+              );
+              trackCheckoutErrorEvent('order_create', orderData.code, 'mercadopago');
               resetPrepareButton();
               return;
             }

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -1792,6 +1792,23 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       if (!requireDeliveryType()) return false;
       var deliveryType = getDeliveryType();
 
+      // Corrección revisión ChatGPT (ronda final): la aceptación de retiro
+      // va inmediatamente después de Entrega — mismo mensaje/foco/scroll que
+      // ya usan createTransferOrder()/btnPrepare al confirmar, para no
+      // mandar al comprador a elegir Pago y recién ahí hacerlo volver acá.
+      if (deliveryType === 'pickup' && !isPickupAccepted()) {
+        if (pickupAckErr) {
+          pickupAckErr.textContent = 'Necesitamos que confirmes esto antes de seguir.';
+          pickupAckErr.hidden = false;
+        }
+        if (pickupAck) {
+          pickupAck.setAttribute('aria-invalid', 'true');
+          pickupAck.focus();
+          pickupAck.scrollIntoView({ block: 'center' });
+        }
+        return false;
+      }
+
       var name  = ((document.getElementById('buyer-name')  || {}).value || '').trim();
       var phone = ((document.getElementById('buyer-phone') || {}).value || '').trim();
       var email = ((document.getElementById('buyer-email') || {}).value || '').trim();

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -85,6 +85,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
                 <div class="cart-totals-card">
                   <div class="cart-totals">
                     <p class="cart-subtotal-line">Total de productos:&nbsp;<strong id="cart-subtotal">$&nbsp;0</strong></p>
+                    <p class="cart-transfer-discount-line" id="cart-transfer-discount-line" hidden>Ahorro por transferencia (12%):&nbsp;<strong id="cart-transfer-discount">−&nbsp;$0</strong></p>
                     <p class="cart-discount-line" id="cart-discount-line" hidden>Ahorro por retiro:&nbsp;<strong>−&nbsp;$150</strong></p>
                     <p class="cart-total-line" id="cart-total-line" hidden>Total con retiro:&nbsp;<strong id="cart-total">$&nbsp;0</strong></p>
                     <p class="cart-shipping-note" id="cart-shipping-note" hidden>Envío: a coordinar según destino</p>
@@ -573,20 +574,16 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     display: flex;
   }
 
-  /* Desktop: el resumen siempre está expandido — el <details> deja de
-     comportarse como colapsable y el toggle se vuelve decorativo. */
+  /* Desktop: el resumen siempre está expandido. Corrección revisión
+     ChatGPT #4: ya no se fuerza visualmente vía CSS (dependía de
+     ::details-content, un pseudo-elemento interno de Chromium sin garantía
+     de comportamiento igual en WebKit/Firefox) — ahora es JS
+     (syncSummaryDesktopState) el que fuerza el atributo real "open" del
+     <details> según el viewport, así .cart-summary-panel[open]
+     .cart-summary-body (regla de arriba, sin media query) ya alcanza para
+     mostrar el contenido con el comportamiento nativo de cualquier motor.
+     Acá sólo queda lo puramente visual del toggle decorativo. */
   @media (min-width: 960px) {
-    .cart-summary-panel:not([open]) .cart-summary-body {
-      display: flex;
-    }
-    /* Chromium colapsa el contenido de un <details> cerrado a través de un
-       pseudo-elemento interno (::details-content), no sólo con display en
-       sus hijos — sin este override el <details> sigue midiendo 0 de alto
-       en desktop aunque .cart-summary-body ya diga display:flex. */
-    .cart-summary-panel:not([open])::details-content {
-      content-visibility: visible;
-      display: block;
-    }
     .cart-summary-toggle {
       cursor: default;
       pointer-events: none;
@@ -924,6 +921,13 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     border-color: var(--salmon);
     border-width: 2px;
     background: rgba(191, 87, 60, 0.06);
+  }
+
+  /* V1.1 REDESIGN (corrección revisión ChatGPT #2): medio de pago congelado
+     mientras un submit está en curso — se ve claramente no interactuable. */
+  .payment-opt:has(input[type="radio"]:disabled) {
+    opacity: 0.65;
+    cursor: not-allowed;
   }
 
   .payment-opt input[type="radio"] {
@@ -1350,6 +1354,12 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     color: var(--ink-2);
   }
 
+  .cart-transfer-discount-line {
+    font-size: 0.875rem;
+    color: #177a43;
+    font-weight: 600;
+  }
+
   .cart-discount-line {
     font-size: 0.875rem;
     color: #267a42;
@@ -1599,6 +1609,8 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     var cartSummaryCountEl = document.getElementById('cart-summary-count');
     var cartSummaryTotalEl = document.getElementById('cart-summary-total');
     var subtotalEl       = document.getElementById('cart-subtotal');
+    var transferDiscountLineEl = document.getElementById('cart-transfer-discount-line');
+    var transferDiscountEl     = document.getElementById('cart-transfer-discount');
     var discountLineEl   = document.getElementById('cart-discount-line');
     var totalLineEl      = document.getElementById('cart-total-line');
     var totalEl          = document.getElementById('cart-total');
@@ -1749,6 +1761,74 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       document.querySelectorAll('input[name="payment-method"]').forEach(function (radio) {
         radio.removeAttribute('aria-invalid');
       });
+    }
+
+    // V1.1 REDESIGN (corrección revisión ChatGPT #2): congelar el medio de
+    // pago mientras btnTransfer o btnPrepare están en curso (aria-busy). Un
+    // radio deshabilitado no dispara 'change' aunque se lo toque por mouse
+    // o teclado, así que mientras está congelado es físicamente imposible
+    // pasar de Transferencia a Mercado Pago (o viceversa) a mitad de un
+    // submit — no hace falta ninguna bandera extra: getPaymentMethod() sigue
+    // devolviendo el valor elegido porque un radio disabled sigue "checked".
+    function setPaymentMethodFrozen(frozen) {
+      document.querySelectorAll('input[name="payment-method"]').forEach(function (radio) {
+        radio.disabled = frozen;
+      });
+    }
+    function isPaymentMethodFrozen() {
+      var radio = document.querySelector('input[name="payment-method"]');
+      return !!(radio && radio.disabled);
+    }
+
+    // V1.1 REDESIGN (corrección revisión ChatGPT #3): único punto que decide
+    // a qué falta el CTA neutro debe llevar, siguiendo el mismo orden del
+    // flujo aprobado (Entrega → Nombre → WhatsApp/Teléfono → Email →
+    // [envío: Dirección/Barrio/Departamento] → Medio de pago). No duplica la
+    // validación de submit real de createTransferOrder()/btnPrepare (esas
+    // siguen intactas y se ejecutan recién al confirmar con un medio ya
+    // elegido) — esto sólo decide, antes de eso, cuál es el primer requisito
+    // incompleto para guiar foco+scroll+error inline hacia él.
+    function focusFirstMissingRequirement() {
+      if (!requireDeliveryType()) return false;
+      var deliveryType = getDeliveryType();
+
+      var name  = ((document.getElementById('buyer-name')  || {}).value || '').trim();
+      var phone = ((document.getElementById('buyer-phone') || {}).value || '').trim();
+      var email = ((document.getElementById('buyer-email') || {}).value || '').trim();
+
+      if (!name) {
+        showFieldError('buyer-name', 'Por favor ingresá tu nombre.');
+        return false;
+      }
+      if (!phone) {
+        showFieldError('buyer-phone', 'Por favor ingresá tu teléfono o WhatsApp.');
+        return false;
+      }
+      if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+        showFieldError('buyer-email', 'Ingresá un correo válido para recibir la confirmación.');
+        return false;
+      }
+
+      if (deliveryType === 'shipping') {
+        var address       = ((document.getElementById('delivery-address')     || {}).value || '').trim();
+        var barrio        = ((document.getElementById('delivery-barrio')       || {}).value || '').trim();
+        var departamento  = ((document.getElementById('delivery-departamento') || {}).value || '').trim();
+        if (!address) {
+          showFieldError('delivery-address', 'Por favor ingresá la dirección de entrega.');
+          return false;
+        }
+        if (!barrio) {
+          showFieldError('delivery-barrio', 'Por favor ingresá la localidad.');
+          return false;
+        }
+        if (!departamento) {
+          showFieldError('delivery-departamento', 'Por favor seleccioná el departamento.');
+          return false;
+        }
+      }
+
+      if (!requirePaymentMethod()) return false;
+      return true;
     }
 
     // ── Persistencia de la etapa y los datos mínimos ─────────────────────
@@ -1964,7 +2044,11 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
 
       if (transferButton && !transferButton.hasAttribute('aria-busy')) transferButton.disabled = !technicallyReady;
       if (mercadoPagoButton && !mercadoPagoButton.hasAttribute('aria-busy')) mercadoPagoButton.disabled = !technicallyReady;
-      if (neutralButton) neutralButton.disabled = !technicallyReady;
+      // V1.1 REDESIGN (corrección revisión ChatGPT #2): con el medio de pago
+      // congelado (submit en curso) el CTA neutro ya está hidden porque hay
+      // un método elegido — este disabled es una segunda barrera explícita,
+      // no el mecanismo principal.
+      if (neutralButton) neutralButton.disabled = !technicallyReady || isPaymentMethodFrozen();
 
       if (transferButton) transferButton.hidden = paymentMethod !== 'transfer';
       if (mercadoPagoButton) mercadoPagoButton.hidden = paymentMethod !== 'mercadopago';
@@ -2073,6 +2157,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       if (subtotalEl) subtotalEl.textContent = fmt.format(subtotal);
 
       if (!deliveryType || subtotal <= 0) {
+        if (transferDiscountLineEl) transferDiscountLineEl.hidden = true;
         if (discountLineEl)      discountLineEl.hidden      = true;
         if (totalLineEl)         totalLineEl.hidden         = true;
         if (shippingNoteEl)      shippingNoteEl.hidden      = true;
@@ -2093,24 +2178,38 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       if (isPickup) {
         var pickupDiscount = pickupEligible ? RETIRO_DISCOUNT : 0;
         var total = Math.max(0, subtotal - pickupDiscount);
+
+        // V1.1 REDESIGN (corrección revisión ChatGPT #1): preview de
+        // "Pagás $X" — espejo EXACTO de calculateTransferTotals() en
+        // functions/api/_orders_logic.js (mismo TRANSFER_FACTOR, mismo
+        // pickupDiscount ya calculado acá mismo, sin envío). Sólo de
+        // presentación: el backend recalcula todo desde cero al crear la
+        // orden, esto nunca se envía. El resumen y el sticky ya NO muestran
+        // siempre el total normal: si el medio elegido es transferencia,
+        // reflejan el monto real con el 12% aplicado — antes mostraban dos
+        // importes distintos a la vez (el preview de la card vs. el total
+        // del resumen), lo que confundía al comprador.
+        var transferProductsTotal = Math.round(subtotal * TRANSFER_FACTOR);
+        var transferPayable = Math.max(0, transferProductsTotal - pickupDiscount);
+        var paymentMethod = getPaymentMethod();
+        var displayTotal = paymentMethod === 'transfer' ? transferPayable : total;
+
         if (discountLineEl)      discountLineEl.hidden      = pickupDiscount === 0;
         if (totalLineEl)         totalLineEl.hidden         = false;
-        if (totalEl)             totalEl.textContent        = fmt.format(total);
+        if (totalEl)             totalEl.textContent        = fmt.format(displayTotal);
         if (shippingNoteEl)      shippingNoteEl.hidden      = true;
         if (transferNoteEl)      transferNoteEl.hidden      = false;
         if (shippingCostLineEl)  shippingCostLineEl.hidden  = true;
         if (totalShippingLineEl) totalShippingLineEl.hidden = true;
         if (shippingMsgEl)       { shippingMsgEl.hidden = true; shippingMsgEl.textContent = ''; }
-        if (stickyTotalEl)       stickyTotalEl.textContent  = fmt.format(total);
-        if (cartSummaryTotalEl)  cartSummaryTotalEl.textContent = fmt.format(total);
+        if (stickyTotalEl)       stickyTotalEl.textContent  = fmt.format(displayTotal);
+        if (cartSummaryTotalEl)  cartSummaryTotalEl.textContent = fmt.format(displayTotal);
 
-        // V1.1 REDESIGN: preview de "Pagás $X" — espejo EXACTO de
-        // calculateTransferTotals() en functions/api/_orders_logic.js
-        // (mismo TRANSFER_FACTOR, mismo pickupDiscount ya calculado acá
-        // mismo, sin envío). Sólo de presentación: el backend recalcula
-        // todo desde cero al crear la orden, esto nunca se envía.
-        var transferProductsTotal = Math.round(subtotal * TRANSFER_FACTOR);
-        var transferPayable = Math.max(0, transferProductsTotal - pickupDiscount);
+        if (transferDiscountLineEl) {
+          transferDiscountLineEl.hidden = paymentMethod !== 'transfer';
+          if (transferDiscountEl) transferDiscountEl.textContent = '− ' + fmt.format(subtotal - transferProductsTotal);
+        }
+
         if (transferPreviewEl) {
           transferPreviewEl.hidden = false;
           transferPreviewEl.textContent = 'Precio normal ' + fmt.format(subtotal) + ' · Pagás ' + fmt.format(transferPayable);
@@ -2122,6 +2221,17 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       } else {
         var shippingCost      = subtotal < FREE_SHIPPING_THRESHOLD_UYU ? SHIPPING_COST : 0;
         var totalWithShipping = subtotal + shippingCost;
+
+        // V1.1 REDESIGN (corrección revisión ChatGPT #1): mismo espejo que
+        // en la rama de retiro, ahora con shippingCost (sin pickupDiscount)
+        // — igual que calculateTransferTotals() del servidor. displayTotal
+        // decide qué importe real mostrar en resumen/sticky según el medio
+        // de pago elegido, para que nunca difiera del importe de la card.
+        var transferProductsTotalShip = Math.round(subtotal * TRANSFER_FACTOR);
+        var transferPayableShip = Math.max(0, transferProductsTotalShip + shippingCost);
+        var paymentMethod = getPaymentMethod();
+        var displayTotalShip = paymentMethod === 'transfer' ? transferPayableShip : totalWithShipping;
+
         if (discountLineEl)     discountLineEl.hidden     = true;
         if (totalLineEl)        totalLineEl.hidden        = true;
         if (shippingNoteEl)     shippingNoteEl.hidden     = true;
@@ -2132,7 +2242,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
         }
         if (totalShippingLineEl) {
           totalShippingLineEl.hidden = false;
-          if (totalShippingEl) totalShippingEl.textContent = fmt.format(totalWithShipping);
+          if (totalShippingEl) totalShippingEl.textContent = fmt.format(displayTotalShip);
         }
         if (shippingMsgEl) {
           shippingMsgEl.hidden = false;
@@ -2140,14 +2250,14 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
             ? 'Tu envío es gratis'
             : 'Te faltan ' + fmt.format(FREE_SHIPPING_THRESHOLD_UYU - subtotal) + ' para obtener envío gratis';
         }
-        if (stickyTotalEl) stickyTotalEl.textContent = fmt.format(totalWithShipping);
-        if (cartSummaryTotalEl) cartSummaryTotalEl.textContent = fmt.format(totalWithShipping);
+        if (stickyTotalEl) stickyTotalEl.textContent = fmt.format(displayTotalShip);
+        if (cartSummaryTotalEl) cartSummaryTotalEl.textContent = fmt.format(displayTotalShip);
 
-        // V1.1 REDESIGN: mismo espejo que en la rama de retiro, ahora con
-        // shippingCost (sin pickupDiscount) — igual que
-        // calculateTransferTotals() del servidor.
-        var transferProductsTotalShip = Math.round(subtotal * TRANSFER_FACTOR);
-        var transferPayableShip = Math.max(0, transferProductsTotalShip + shippingCost);
+        if (transferDiscountLineEl) {
+          transferDiscountLineEl.hidden = paymentMethod !== 'transfer';
+          if (transferDiscountEl) transferDiscountEl.textContent = '− ' + fmt.format(subtotal - transferProductsTotalShip);
+        }
+
         if (transferPreviewEl) {
           transferPreviewEl.hidden = false;
           transferPreviewEl.textContent = 'Precio normal ' + fmt.format(subtotal) + ' · Pagás ' + fmt.format(transferPayableShip);
@@ -2491,22 +2601,56 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
     });
 
     // ── V1.1 REDESIGN: CTA neutro cuando todavía no se eligió pago ───────
+    // Corrección revisión ChatGPT #3: ya no salta directo de Entrega a
+    // Pago — sigue el orden completo vía focusFirstMissingRequirement().
     var btnConfirmNeutral = document.getElementById('btn-confirm-neutral');
     if (btnConfirmNeutral) {
       btnConfirmNeutral.addEventListener('click', function () {
         if (btnConfirmNeutral.disabled) return;
-        if (!requireDeliveryType()) return;
-        requirePaymentMethod();
+        focusFirstMissingRequirement();
       });
     }
 
     // ── V1.1 REDESIGN: texto del disclosure del resumen (colapsado/expandido) ─
     // <details> ya dispara "toggle" nativamente al abrir/cerrar — se usa acá
     // en vez de un truco de CSS con contenido dinámico en ::before.
+    //
+    // Corrección revisión ChatGPT #4: en desktop el resumen se fuerza
+    // realmente abierto por JS (atributo "open" genuino, no un efecto
+    // visual de CSS) según el viewport — comportamiento nativo del
+    // navegador, sin depender de ::details-content. Además, en desktop el
+    // <summary> sale del orden de tabulación (tabindex="-1") para que no
+    // quede como un control alcanzable por teclado que activa un toggle sin
+    // ningún cambio visible (o peor, que colapsa el resumen si el usuario
+    // logra activarlo antes de que el listener de "toggle" lo re-force
+    // abierto).
     var cartSummaryPanelEl = document.getElementById('cart-summary-panel');
     var cartSummaryChevronEl = document.querySelector('.cart-summary-chevron');
+    var cartSummaryToggleEl = document.querySelector('.cart-summary-toggle');
+    var summaryDesktopMq = window.matchMedia('(min-width: 960px)');
+
+    function syncSummaryDesktopState() {
+      if (!cartSummaryPanelEl) return;
+      if (summaryDesktopMq.matches) {
+        cartSummaryPanelEl.open = true;
+        if (cartSummaryToggleEl) cartSummaryToggleEl.setAttribute('tabindex', '-1');
+      } else if (cartSummaryToggleEl) {
+        cartSummaryToggleEl.removeAttribute('tabindex');
+      }
+    }
+    syncSummaryDesktopState();
+    if (typeof summaryDesktopMq.addEventListener === 'function') {
+      summaryDesktopMq.addEventListener('change', syncSummaryDesktopState);
+    } else if (typeof summaryDesktopMq.addListener === 'function') {
+      summaryDesktopMq.addListener(syncSummaryDesktopState);
+    }
+
     if (cartSummaryPanelEl && cartSummaryChevronEl) {
       cartSummaryPanelEl.addEventListener('toggle', function () {
+        if (summaryDesktopMq.matches && !cartSummaryPanelEl.open) {
+          cartSummaryPanelEl.open = true;
+          return;
+        }
         cartSummaryChevronEl.textContent = cartSummaryPanelEl.open ? 'Ocultar' : 'Ver resumen';
       });
     }
@@ -2672,6 +2816,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       btnTransfer.disabled = false;
       btnTransfer.removeAttribute('aria-busy');
       btnTransfer.innerHTML = btnTransferOriginalHtml;
+      setPaymentMethodFrozen(false);
       syncPaymentAvailability();
     }
 
@@ -2908,6 +3053,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       btnTransfer.disabled = true;
       btnTransfer.setAttribute('aria-busy', 'true');
       btnTransfer.textContent = 'Verificando precio y stock…';
+      setPaymentMethodFrozen(true);
 
       var availabilityOk = await refreshCartAvailability({ beforePayment: true });
       if (!availabilityOk) return null;
@@ -3012,6 +3158,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       btnPrepare.disabled = false;
       btnPrepare.removeAttribute('aria-busy');
       btnPrepare.innerHTML = origBtnHTML;
+      setPaymentMethodFrozen(false);
       syncPaymentAvailability();
     }
 
@@ -3063,6 +3210,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
 
         btnPrepare.disabled = true;
         btnPrepare.setAttribute('aria-busy', 'true');
+        setPaymentMethodFrozen(true);
 
         var availabilityOk = await refreshCartAvailability({ beforePayment: true });
         if (!availabilityOk) {

--- a/functions/__tests__/analytics-events.test.js
+++ b/functions/__tests__/analytics-events.test.js
@@ -141,6 +141,89 @@ test('trackCommerce normaliza el producto y no duplica purchase al recargar', ()
   assert.equal(params.items[0].price, 1100);
 });
 
+// BLOQUEANTE PR #310 — punto 1: checkout_error mide en qué etapa se traba
+// un comprador, sin ningún dato personal. stage/payment_method/
+// delivery_type sólo aceptan valores de una lista cerrada; error_code pasa
+// por el mismo safeToken() ya usado en cta_location/topic — nunca se envía
+// public_code, nombre, email, teléfono, dirección ni el texto del error.
+
+test('carrito.astro sólo pasa codes internos a trackCheckoutError, nunca error.message ni datos de la orden', () => {
+  assert.match(analytics, /'checkout_error'/);
+  assert.match(analytics, /CHECKOUT_ERROR_STAGES/);
+  assert.match(analytics, /order_create.*preference_create.*transfer_options/);
+  assert.match(cart, /trackCheckoutErrorEvent\('order_create', orderData\.code \|\| 'ORDER_CREATE_FAILED', 'mercadopago'\)/);
+  assert.match(cart, /trackCheckoutErrorEvent\('order_create', 'NETWORK_ERROR', 'mercadopago'\)/);
+  assert.match(cart, /trackCheckoutErrorEvent\('preference_create', mpData\.code \|\| 'PREFERENCE_CREATE_FAILED', 'mercadopago'\)/);
+  assert.match(cart, /trackCheckoutErrorEvent\('preference_create', 'NETWORK_ERROR', 'mercadopago'\)/);
+  assert.match(cart, /trackCheckoutErrorEvent\(checkoutErrorStage, error && error\.code, 'transfer'\)/);
+  // Ninguno de esos llamados pasa error.message, public_code ni datos del comprador.
+  const wrapperStart = cart.indexOf('function trackCheckoutErrorEvent');
+  const wrapperEnd = cart.indexOf('\n    }', wrapperStart);
+  const wrapperBody = cart.slice(wrapperStart, wrapperEnd);
+  assert.doesNotMatch(wrapperBody, /\.message|public_code|buyer|email|phone|address/i);
+});
+
+test('trackCheckoutError sólo emite con un stage de la lista cerrada, y satura/sanea todo lo demás', () => {
+  const window = {
+    location: { hostname: 'www.amadolibros.com', pathname: '/carrito', href: 'https://www.amadolibros.com/carrito' },
+    dataLayer: [],
+  };
+  const document = {
+    querySelector: () => null,
+    createElement: () => ({}),
+    head: { appendChild: () => {} },
+    addEventListener: () => {},
+  };
+  runInNewContext(analytics, { document, window, URL, Set, Date, Object, String, encodeURIComponent });
+
+  // stage inválido: no emite nada.
+  assert.equal(
+    window.AmadoAnalytics.trackCheckoutError({ stage: 'not_a_real_stage', errorCode: 'X' }),
+    false,
+  );
+  assert.equal(window.dataLayer.filter((e) => Array.from(e)[1] === 'checkout_error').length, 0);
+
+  // stage válido, con errorCode/paymentMethod/deliveryType válidos: pasan tal cual.
+  assert.equal(window.AmadoAnalytics.trackCheckoutError({
+    stage: 'order_create',
+    errorCode: 'ORDERS_DB_WRITE_FAILED',
+    paymentMethod: 'mercadopago',
+    deliveryType: 'pickup',
+  }), true);
+  const [, eventName, params] = Array.from(window.dataLayer.at(-1));
+  assert.equal(eventName, 'checkout_error');
+  assert.deepEqual({ ...params }, {
+    stage: 'order_create',
+    error_code: 'ORDERS_DB_WRITE_FAILED',
+    payment_method: 'mercadopago',
+    delivery_type: 'pickup',
+  });
+
+  // payment_method/delivery_type fuera de la lista cerrada: se omiten, no se inventan.
+  window.AmadoAnalytics.trackCheckoutError({
+    stage: 'transfer_options',
+    errorCode: 'TRANSFER_OPTIONS_FAILED',
+    paymentMethod: 'bitcoin',
+    deliveryType: 'teletransporte',
+  });
+  const [, , params2] = Array.from(window.dataLayer.at(-1));
+  assert.deepEqual({ ...params2 }, { stage: 'transfer_options', error_code: 'TRANSFER_OPTIONS_FAILED' });
+
+  // Texto libre (no tiene forma de code interno) se descarta ENTERO, no se
+  // "limpia" — un sanitizador que preserva dígitos dejaría pasar un
+  // teléfono pegado en el medio del texto; acá directamente no hay
+  // error_code en el evento.
+  window.AmadoAnalytics.trackCheckoutError({
+    stage: 'preference_create',
+    errorCode: 'no such column: buyer_email at ana@example.com, tel 099123456',
+  });
+  const [, , params3] = Array.from(window.dataLayer.at(-1));
+  assert.equal(JSON.stringify(params3).includes('@'), false);
+  assert.equal(JSON.stringify(params3).includes('099123456'), false);
+  assert.deepEqual({ ...params3 }, { stage: 'preference_create' });
+  assert.equal('error_code' in params3, false);
+});
+
 test('expone client_id y session_id anónimos para atribuir la compra server-side', async () => {
   const window = {
     location: {

--- a/functions/__tests__/checkout-single-step.test.js
+++ b/functions/__tests__/checkout-single-step.test.js
@@ -58,9 +58,12 @@ test('carrito.astro: Mercado Pago conserva un único CTA id="btn-prepare-order"'
 });
 
 test('carrito.astro: muestra transferencia destacada y Mercado Pago separado', () => {
+  // V1.1 REDESIGN: el copy exacto de los CTA cambió ("Confirmar compra con
+  // 12% OFF" / "Pagar con Mercado Pago"), pero la garantía sigue siendo la
+  // misma: dos botones con texto distinto para cada medio de pago.
   assert.match(carritoAstro, /id="btn-transfer-order"[^>]*class="btn-transfer-primary"/);
-  assert.match(carritoAstro, /Comprar por transferencia/);
-  assert.match(carritoAstro, /Pagar con tarjeta o Mercado Pago/);
+  assert.match(carritoAstro, /Confirmar compra con 12% OFF/);
+  assert.match(carritoAstro, /Pagar con Mercado Pago/);
 });
 
 test('carrito.astro: un solo listener de click maneja todo el pago (no hay un segundo botón/handler de "pagar")', () => {
@@ -261,7 +264,12 @@ test('carrito.astro: retiro oculta y deshabilita todos los controles de envío',
   assert.match(fnBody, /querySelectorAll\('input, select, textarea'\)/);
   assert.match(fnBody, /controls\[i\]\.disabled\s*=\s*!shippingSelected/);
   assert.match(carritoAstro, /syncShippingFields\(\);\s*\n\s*updateTotals\(\);/);
-  assert.match(carritoAstro, /syncShippingFields\(\);\s*\n\s*\n\s*\/\/ ── Barra mobile/);
+  // V1.1 REDESIGN: el bloque de "Barra mobile" ya no es lo primero que sigue
+  // a la llamada inicial de syncShippingFields() (ahora hay wiring de medio
+  // de pago en el medio) — lo que sigue garantizado es que se llama tanto en
+  // cada cambio de entrega como una vez más al cargar la página.
+  const callSites = (carritoAstro.match(/\bsyncShippingFields\(\);/g) || []).length;
+  assert.ok(callSites >= 2, 'debe llamarse tanto en el listener de cambio como al cargar la página');
 });
 
 // ── Carrito conservado antes de pago aprobado (2-N-I1 v2) ───────────────────

--- a/functions/__tests__/idempotency-lifecycle.test.js
+++ b/functions/__tests__/idempotency-lifecycle.test.js
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { runInNewContext } from 'node:vm';
+
+// BLOQUEANTE PR #310 — prueba humana: "Conflicto: el mismo idempotency_key
+// fue usado con un pedido diferente." al crear una orden, volver al
+// checkout y cambiar el pedido (entrega/datos) antes de reintentar.
+//
+// Causa raíz: cart.js sólo rotaba idempotency_key ante cambios de ITEMS
+// (add/remove/setQty/syncValidated/clear) — nunca ante cambios de
+// delivery_type/buyer/shipping, que también forman parte del
+// request_fingerprint real (generateFingerprint() en _orders_logic.js).
+// carrito.astro sólo rotaba explícitamente al volver desde la pantalla de
+// transferencia (btnEditOrder) — cualquier otro camino de vuelta al
+// checkout (volver de Mercado Pago, recargar la página) dejaba la MISMA
+// key asociada a un fingerprint viejo, y un pedido distinto con esa key
+// chocaba con el fail-safe del backend (409).
+//
+// Esta suite cubre el ciclo de vida centralizado: AmadoCart.
+// ensureKeyForFingerprint(fingerprint) decide, antes de cada submit, si la
+// key vigente sigue sirviendo para el fingerprint actual o si hay que
+// rotar — sin rotar en cada intento (retry de red / doble click deben
+// conservar la misma key).
+
+const cartJs = readFileSync('astro-front/public/cart.js', 'utf8');
+const carrito = readFileSync('astro-front/src/pages/carrito.astro', 'utf8');
+const ordersHandler = readFileSync('functions/api/_orders_handler.js', 'utf8');
+
+function makeStorage() {
+  const store = new Map();
+  return {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => { store.set(k, String(v)); },
+    removeItem: (k) => { store.delete(k); },
+    _store: store,
+  };
+}
+
+function loadCart(sharedLocalStorage) {
+  const window_ = { location: { pathname: '/carrito' }, addEventListener: () => {} };
+  const document_ = {
+    dispatchEvent: () => {},
+    addEventListener: () => {},
+    readyState: 'complete',
+  };
+  const localStorage = sharedLocalStorage || makeStorage();
+  const sessionStorage = makeStorage();
+  let uuidCounter = 0;
+  const sandbox = {
+    window: window_,
+    document: document_,
+    localStorage,
+    sessionStorage,
+    crypto: { randomUUID: () => 'uuid-' + (++uuidCounter) },
+    CustomEvent: function CustomEvent(name, opts) { this.type = name; this.detail = opts && opts.detail; },
+    requestAnimationFrame: () => {},
+    Date, Math, Array, JSON, Object, String, Number, isFinite,
+  };
+  runInNewContext(cartJs, sandbox);
+  return { AmadoCart: window_.AmadoCart, localStorage };
+}
+
+test('A/B — retry del mismo pedido (red o doble click): misma key, sin rotar', () => {
+  const { AmadoCart } = loadCart();
+  AmadoCart.add({ id: 'MLU1', price: 500 });
+  const key0 = AmadoCart.get().idempotency_key;
+
+  const fp = 'fingerprint-fijo-1';
+  const k1 = AmadoCart.ensureKeyForFingerprint(fp);
+  assert.equal(k1, key0, 'primer submit: conserva la key con la que se creó el carrito');
+
+  // Reintentos repetidos con el fingerprint idéntico (red, doble click) no
+  // deben rotar nunca — ni una sola vez de más.
+  for (let i = 0; i < 4; i++) {
+    assert.equal(AmadoCart.ensureKeyForFingerprint(fp), key0);
+  }
+});
+
+test('C/D/E — orden ya creada + cambia entrega/datos/dirección: nueva key', () => {
+  const { AmadoCart } = loadCart();
+  AmadoCart.add({ id: 'MLU1', price: 500 });
+  const key0 = AmadoCart.get().idempotency_key;
+
+  const fpPickup = 'fp-retiro-juan';
+  assert.equal(AmadoCart.ensureKeyForFingerprint(fpPickup), key0);
+
+  // C: cambia delivery_type (retiro -> envío)
+  const fpShipping = 'fp-envio-juan';
+  const keyAfterDeliveryChange = AmadoCart.ensureKeyForFingerprint(fpShipping);
+  assert.notEqual(keyAfterDeliveryChange, key0, 'delivery_type distinto debe rotar');
+
+  // Retry inmediato del MISMO fingerprint nuevo: no rota de nuevo.
+  assert.equal(AmadoCart.ensureKeyForFingerprint(fpShipping), keyAfterDeliveryChange);
+
+  // D: cambia comprador (nombre/teléfono/email)
+  const fpBuyerChanged = 'fp-envio-maria';
+  const keyAfterBuyerChange = AmadoCart.ensureKeyForFingerprint(fpBuyerChanged);
+  assert.notEqual(keyAfterBuyerChange, keyAfterDeliveryChange, 'comprador distinto debe rotar');
+
+  // E: cambia dirección/barrio/departamento/notas
+  const fpAddressChanged = 'fp-envio-maria-direccion-2';
+  const keyAfterAddressChange = AmadoCart.ensureKeyForFingerprint(fpAddressChanged);
+  assert.notEqual(keyAfterAddressChange, keyAfterBuyerChange, 'dirección distinta debe rotar');
+});
+
+test('F — cambiar items ya rota por su cuenta (cart.js); ensureKeyForFingerprint no rota una segunda vez', () => {
+  const { AmadoCart } = loadCart();
+  AmadoCart.add({ id: 'MLU1', price: 500 });
+  const fp1 = 'fp-un-item';
+  const key1 = AmadoCart.ensureKeyForFingerprint(fp1);
+
+  // Cambiar el carrito rota la key por su cuenta (ya existía antes de este
+  // fix) — sin pasar por ensureKeyForFingerprint todavía.
+  AmadoCart.add({ id: 'MLU2', price: 300 });
+  const keyAfterItemChange = AmadoCart.get().idempotency_key;
+  assert.notEqual(keyAfterItemChange, key1);
+
+  // El siguiente submit calcula un fingerprint distinto (dos items) — pero
+  // como la key YA cambió por el propio cart.js, no debe rotar de nuevo.
+  const fp2 = 'fp-dos-items';
+  const key2 = AmadoCart.ensureKeyForFingerprint(fp2);
+  assert.equal(key2, keyAfterItemChange, 'no debe haber una segunda rotación redundante');
+});
+
+test('G — volver sin cambiar nada (recarga de página incluida): misma key, reutiliza la orden', () => {
+  const shared = makeStorage();
+  const { AmadoCart: cartA } = loadCart(shared);
+  cartA.add({ id: 'MLU1', price: 500 });
+  const fp = 'fp-sin-cambios';
+  const key1 = cartA.ensureKeyForFingerprint(fp);
+
+  // Simula un reload: nueva instancia de cart.js sobre el MISMO localStorage.
+  const { AmadoCart: cartB } = loadCart(shared);
+  const key2 = cartB.ensureKeyForFingerprint(fp);
+  assert.equal(key2, key1, 'tras un reload, el mismo fingerprint debe conservar la key');
+});
+
+test('I — orden expirada / conflicto inesperado: rotateKey() dispara una key nueva sin doble rotación', () => {
+  const { AmadoCart } = loadCart();
+  AmadoCart.add({ id: 'MLU1', price: 500 });
+  const fp = 'fp-orden-vencida';
+  const keyBefore = AmadoCart.ensureKeyForFingerprint(fp);
+
+  // El cliente detecta ORDER_EXPIRED / IDEMPOTENCY_CONFLICT y llama
+  // rotateKey() explícitamente (ver carrito.astro).
+  const rotated = AmadoCart.rotateKey();
+  assert.notEqual(rotated, keyBefore);
+
+  // El próximo intento, aunque calcule el MISMO fingerprint que antes (el
+  // comprador no cambió nada, sólo reintenta), no debe rotar una segunda
+  // vez — la key ya es nueva.
+  const keyRetry = AmadoCart.ensureKeyForFingerprint(fp);
+  assert.equal(keyRetry, rotated);
+});
+
+test('el fingerprint del cliente nunca incluye el medio de pago (paridad con el backend)', () => {
+  // H: cambiar Mercado Pago <-> Transferencia sin tocar el resto del pedido
+  // no debe afectar el fingerprint (igual que generateFingerprint() en el
+  // backend, que tampoco lo incluye) — así el servidor reconoce el mismo
+  // pedido y lo reutiliza en vez de generar un 409.
+  assert.match(carrito, /function checkoutFingerprint\(cart, deliveryType, buyer, shipping\)/);
+  const start = carrito.indexOf('function checkoutFingerprint(cart, deliveryType, buyer, shipping)');
+  const end = carrito.indexOf('\n    }', start);
+  const body = carrito.slice(start, end);
+  assert.doesNotMatch(body, /payment.?method/i);
+});
+
+test('carrito.astro llama a ensureKeyForFingerprint antes de CADA submit a /api/orders (MP y transferencia)', () => {
+  assert.match(carrito, /window\.AmadoCart\.ensureKeyForFingerprint\(fingerprint\)/);
+  assert.match(carrito, /window\.AmadoCart\.ensureKeyForFingerprint\(prepFingerprint\)/);
+  // Ambas llamadas releen el carrito después, para que el payload use la
+  // key (posiblemente rotada) y no una copia vieja en memoria.
+  const calls = carrito.match(/ensureKeyForFingerprint\([a-zA-Z]+\);\s*\n\s*cart = window\.AmadoCart\.get\(\);/g) || [];
+  assert.equal(calls.length, 2);
+});
+
+test('backend: 409 por fingerprint distinto trae un code interno de recuperación', () => {
+  assert.match(
+    ordersHandler,
+    /error: 'Conflicto: el mismo idempotency_key fue usado con un pedido diferente\.', code: 'IDEMPOTENCY_CONFLICT'/
+  );
+});
+
+test('cliente: IDEMPOTENCY_CONFLICT y ORDER_EXPIRED rotan la key y muestran un mensaje humano — nunca el término técnico', () => {
+  for (const marker of ["orderData.code === 'IDEMPOTENCY_CONFLICT'", "orderData.code === 'IDEMPOTENCY_CONFLICT' || orderData.code === 'ORDER_EXPIRED'"]) {
+    assert.ok(carrito.includes(marker), `falta manejar: ${marker}`);
+  }
+  assert.match(carrito, /Actualizamos tu pedido para poder continuar\. Intentá nuevamente\./);
+  assert.equal((carrito.match(/window\.AmadoCart\.rotateKey\(\)/g) || []).length >= 3, true);
+
+  // El texto técnico del backend nunca debe llegar al cliente para este
+  // caso puntual: se reemplaza siempre por el mensaje humano, nunca se
+  // reenvía orderData.error cuando code === 'IDEMPOTENCY_CONFLICT'.
+  const idempBlockRe = /IDEMPOTENCY_CONFLICT'[\s\S]{0,650}/g;
+  const blocks = carrito.match(idempBlockRe) || [];
+  assert.ok(blocks.length >= 2);
+  for (const block of blocks) {
+    assert.doesNotMatch(block.slice(0, 500), /idempotency_key['"]?\s*fue usado/);
+  }
+});
+
+test('checkout_error se instrumenta para el conflicto de idempotencia, sin PII', () => {
+  assert.match(carrito, /trackCheckoutErrorEvent\('order_create', orderData\.code, 'mercadopago'\)/);
+  // El code que viaja a GA4 es siempre el code interno (IDEMPOTENCY_CONFLICT
+  // / ORDER_EXPIRED), nunca el mensaje ni datos del comprador — mismo
+  // contrato que ya prueba functions/__tests__/analytics-events.test.js
+  // para trackCheckoutError().
+});

--- a/functions/__tests__/pickup-cx-2.test.js
+++ b/functions/__tests__/pickup-cx-2.test.js
@@ -37,8 +37,8 @@ test('pickup-cx-2: sin selección o sin productos comprables no muestra descuent
   assert.match(fn, /discountLineEl\.hidden\s*=\s*pickupDiscount === 0/);
 });
 
-test('pickup-cx-2: elegir entrega recalcula y habilita el pago', () => {
-  assert.match(carrito, /getSellableItems\(cart\)\.length > 0 && !!getDeliveryType\(\)/);
+test('pickup-cx-2: elegir entrega recalcula totales y el aviso de guía (V1.1: la entrega ya no bloquea el CTA, sólo oculta el aviso)', () => {
+  assert.match(carrito, /var hasDelivery = !!getDeliveryType\(\);/);
   const start = carrito.indexOf("radio.addEventListener('change', function () {");
   const listener = carrito.slice(start, start + 300);
   assert.match(listener, /updateTotals\(\)/);

--- a/functions/__tests__/pickup-cx-2.test.js
+++ b/functions/__tests__/pickup-cx-2.test.js
@@ -21,7 +21,9 @@ test('pickup-cx-2: el beneficio de retiro se aplica desde $1.300 de compra total
   assert.match(carrito, /value="pickup"[\s\S]*?Ahorrás \$150 en compras desde \$1\.300/);
   assert.match(carrito, /PICKUP_DISCOUNT_MIN_PRODUCTS_TOTAL_UYU = 1300/);
   assert.match(carrito, /Number\(subtotal\) >= PICKUP_DISCOUNT_MIN_PRODUCTS_TOTAL_UYU/);
-  assert.match(carrito, /value="shipping"[\s\S]*?Envío gratis en compras desde \$1\.500/);
+  // V1.1 REDESIGN: copy más corto aprobado ("Gratis desde $1.500" en vez de
+  // "Envío gratis en compras desde $1.500"), mismo importe real.
+  assert.match(carrito, /value="shipping"[\s\S]*?Gratis desde \$1\.500/);
 });
 
 test('pickup-cx-2: sin selección o sin productos comprables no muestra descuentos', () => {

--- a/functions/__tests__/preview-orders-checkout-blocker.test.js
+++ b/functions/__tests__/preview-orders-checkout-blocker.test.js
@@ -40,7 +40,7 @@ test('deploy-checkout-v11-preview.yml aplica migraciones a la D1 de Preview ante
 test('el handler de Mercado Pago ya no antepone "Error: " al mensaje del servidor (evita el "Error: Error..." duplicado)', () => {
   const start = CARRITO.indexOf("btnPrepare.addEventListener('click'");
   assert.notEqual(start, -1);
-  const block = CARRITO.slice(start, start + 6000);
+  const block = CARRITO.slice(start, start + 8000);
   assert.doesNotMatch(block, /showCheckoutError\('Error: '/);
   assert.match(block, /showCheckoutError\(orderData\.error \|\|/);
 });

--- a/functions/__tests__/preview-orders-checkout-blocker.test.js
+++ b/functions/__tests__/preview-orders-checkout-blocker.test.js
@@ -1,0 +1,46 @@
+// BLOQUEANTE reproducido en la Preview checkout-ON (checkout-v11-preview):
+// con datos válidos y Mercado Pago elegido, POST /api/orders fallaba con
+// "Error: Error al guardar el pedido. Intentá de nuevo." — el batch de
+// INSERT en `orders` referencia buyer_email (migración 0006) y
+// ga_client_id/ga_session_id (migración 0008), pero ningún workflow aplica
+// migraciones a la D1 de Preview (sólo deploy.yml, y sólo --env production)
+// — la D1 de Preview (amadolibros-orders-preview) nunca las tenía.
+//
+// Cubre: (1) el nuevo paso que aplica migraciones a la D1 de Preview en el
+// workflow dedicado; (2) que el frontend ya no antepone "Error: " al
+// mensaje del servidor (que generaba el "Error: Error..." duplicado
+// reportado). La causa raíz del guardado en sí (mensaje/code/logging del
+// backend) está cubierta en functions/api/__tests__/orders.test.js.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const WORKFLOW = readFileSync(
+  path.join(ROOT, '.github', 'workflows', 'deploy-checkout-v11-preview.yml'),
+  'utf8',
+);
+const CARRITO = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'pages', 'carrito.astro'),
+  'utf8',
+);
+
+test('deploy-checkout-v11-preview.yml aplica migraciones a la D1 de Preview antes de desplegar', () => {
+  assert.match(WORKFLOW, /d1 migrations apply\s*\n?\s*ORDERS_DB --env preview --remote/);
+  // Debe ejecutarse antes del deploy/smoke, no después — si no, el primer
+  // pedido de prueba contra un deploy recién hecho podría volver a fallar.
+  const migrateIdx = WORKFLOW.indexOf('d1 migrations apply');
+  const deployIdx = WORKFLOW.indexOf('pages deploy ./astro-front/dist');
+  const smokeIdx = WORKFLOW.indexOf('Smoke — el checkout online');
+  assert.ok(migrateIdx !== -1 && migrateIdx < deployIdx && deployIdx < smokeIdx);
+});
+
+test('el handler de Mercado Pago ya no antepone "Error: " al mensaje del servidor (evita el "Error: Error..." duplicado)', () => {
+  const start = CARRITO.indexOf("btnPrepare.addEventListener('click'");
+  assert.notEqual(start, -1);
+  const block = CARRITO.slice(start, start + 6000);
+  assert.doesNotMatch(block, /showCheckoutError\('Error: '/);
+  assert.match(block, /showCheckoutError\(orderData\.error \|\|/);
+});

--- a/functions/__tests__/v1.1-checkout-guidance.test.js
+++ b/functions/__tests__/v1.1-checkout-guidance.test.js
@@ -263,15 +263,19 @@ test('19. Transferencia: se deshabilita antes de cualquier await, con guarda exp
 
 test('20. seguir deshabilitado (aria-busy) evita que syncPaymentAvailability lo reactive a mitad de una operación', () => {
   const start = CARRITO.indexOf('function syncPaymentAvailability');
-  const fn = CARRITO.slice(start, start + 700);
+  // V1.1 REDESIGN: la función creció (medio de pago, CTA neutro) — la
+  // ventana necesita cubrir hasta después de mercadoPagoButton.hasAttribute.
+  const fn = CARRITO.slice(start, start + 1400);
   assert.match(fn, /!transferButton\.hasAttribute\('aria-busy'\)/);
   assert.match(fn, /!mercadoPagoButton\.hasAttribute\('aria-busy'\)/);
 });
 
 // ── 6. Microcopy "librería familiar" junto al WhatsApp secundario ──────────
 
+// V1.1 REDESIGN: texto final confirmado por Seba, reemplaza "Te atendemos
+// personalmente." por "y te ayudamos a completar la compra."
 const PERSONAL_NOTE_TEXT = 'Somos una librería familiar y esta web también la hacemos nosotros. ' +
-  'Si necesitás ayuda para completar tu compra, escribinos por WhatsApp. Te atendemos personalmente.';
+  'Si necesitás ayuda, escribinos por WhatsApp y te ayudamos a completar la compra.';
 
 test('21. la microcopy aparece con el texto exacto solicitado', () => {
   assert.match(CARRITO, /class="checkout-personal-note"/);

--- a/functions/__tests__/v1.1-checkout-guidance.test.js
+++ b/functions/__tests__/v1.1-checkout-guidance.test.js
@@ -1,0 +1,269 @@
+// V1.1 — CHECKOUT GUIDANCE.
+//
+// Dos cambios sobre el carrito, ambos puramente de guía/UX:
+//
+//   1. Elegir entrega deja de ser condición para que el CTA de pago esté
+//      "disabled" — antes, sin entrega, el click ni siquiera llegaba a
+//      requireDeliveryType() (que ya mostraba mensaje/foco/scroll) porque el
+//      navegador no dispara "click" en un <button disabled>. Ahora el CTA
+//      sigue interactuable cuando la entrega es lo único que falta, y
+//      orders-guard.js (que corre en fase capture, antes que el handler de
+//      carrito.astro) tampoco debe taparlo pidiendo nombre/teléfono primero.
+//   2. #cart-shipping-msg, que existía pero quedaba siempre hidden, ahora se
+//      conecta dentro de updateTotals() reusando el subtotal/umbral/fmt ya
+//      calculados — sin duplicar la lógica de envío gratis.
+//
+// Mismo criterio que pickup-cx-1/2 y checkout-single-step: sin DOM real,
+// se verifica la estructura del código fuente con regex sobre el archivo.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const CARRITO = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'pages', 'carrito.astro'),
+  'utf8',
+);
+const GUARD = readFileSync(
+  path.join(ROOT, 'astro-front', 'public', 'orders-guard.js'),
+  'utf8',
+);
+
+// ── 1. Sin entrega elegida, el CTA no queda inerte ──────────────────────────
+
+test('1a. la falta de entrega ya no forma parte del criterio "disabled" de los CTA de pago', () => {
+  const start = CARRITO.indexOf('function syncPaymentAvailability');
+  assert.notEqual(start, -1);
+  const end = CARRITO.indexOf('\n    }', CARRITO.indexOf('deliveryHintEl.hidden', start));
+  const fn = CARRITO.slice(start, end);
+
+  // El bloqueo real (validación de stock/carrito vacío) sigue existiendo...
+  assert.match(fn, /var technicallyReady = cartValidationReady && !cartValidationFailed &&\s*\n\s*!validationRequest && getSellableItems\(cart\)\.length > 0;/);
+  // ...pero ya no exige getDeliveryType() para habilitar el botón.
+  assert.doesNotMatch(fn, /technicallyReady[\s\S]{0,40}getDeliveryType/);
+  assert.match(fn, /transferButton\.disabled = !technicallyReady/);
+  assert.match(fn, /mercadoPagoButton\.disabled = !technicallyReady/);
+});
+
+test('1b. los bloqueos técnicos reales (carrito vacío, stock inválido, envío en curso) siguen deshabilitando el CTA', () => {
+  const start = CARRITO.indexOf('function syncPaymentAvailability');
+  const fn = CARRITO.slice(start, start + 700);
+  assert.match(fn, /cartValidationReady && !cartValidationFailed/, 'validación de stock pendiente/inválida');
+  assert.match(fn, /getSellableItems\(cart\)\.length > 0/, 'carrito sin ítems pagables');
+  assert.match(fn, /!validationRequest/, 'operación de envío/validación ya en curso');
+});
+
+test('1c. no se usa cursor:wait para representar una decisión pendiente del cliente', () => {
+  assert.doesNotMatch(CARRITO, /cart-delivery-hint[^}]*cursor:\s*wait/s);
+  const cssStart = CARRITO.indexOf('.cart-delivery-hint {');
+  const cssBlock = CARRITO.slice(cssStart, CARRITO.indexOf('}', cssStart));
+  assert.doesNotMatch(cssBlock, /cursor:\s*wait/);
+});
+
+test('2. al click sin entrega, requireDeliveryType() corta el flujo antes de cualquier await/fetch — Mercado Pago', () => {
+  const handlerStart = CARRITO.indexOf("btnPrepare.addEventListener('click'");
+  assert.notEqual(handlerStart, -1);
+  const handlerBlock = CARRITO.slice(handlerStart, handlerStart + 3000);
+
+  const guardIdx = handlerBlock.search(/if\s*\(\s*!deliveryType\s*\)\s*\{\s*\n\s*requireDeliveryType\(\);\s*\n\s*return;\s*\n\s*\}/);
+  assert.notEqual(guardIdx, -1, 'no se encontró el corte temprano por falta de entrega');
+
+  const firstAwaitIdx = handlerBlock.indexOf('await ');
+  const firstOrdersFetchIdx = handlerBlock.indexOf("fetch('/api/orders'");
+  const firstPrefsFetchIdx = handlerBlock.indexOf("fetch('/api/preferences'");
+
+  assert.ok(firstAwaitIdx === -1 || guardIdx < firstAwaitIdx, 'requireDeliveryType debe ejecutarse antes de cualquier await');
+  assert.ok(firstOrdersFetchIdx === -1 || guardIdx < firstOrdersFetchIdx, 'no debe llamarse /api/orders antes de elegir entrega');
+  assert.ok(firstPrefsFetchIdx === -1 || guardIdx < firstPrefsFetchIdx, 'no debe llamarse /api/preferences antes de elegir entrega');
+});
+
+test('3. al click sin entrega, requireDeliveryType() corta el flujo antes de cualquier await/fetch — transferencia', () => {
+  const fnStart = CARRITO.indexOf('async function createTransferOrder');
+  assert.notEqual(fnStart, -1);
+  const fnEnd = CARRITO.indexOf('async function getTurnstileTokenForOrder', fnStart);
+  const fn = CARRITO.slice(fnStart, fnEnd);
+
+  const guardIdx = fn.indexOf("if (!deliveryType) { requireDeliveryType(); return null; }");
+  assert.notEqual(guardIdx, -1);
+
+  const firstAwaitIdx = fn.indexOf('await ');
+  const firstOrdersFetchIdx = fn.indexOf("fetch('/api/orders'");
+
+  assert.ok(firstAwaitIdx === -1 || guardIdx < firstAwaitIdx, 'requireDeliveryType debe ejecutarse antes de cualquier await');
+  assert.ok(firstOrdersFetchIdx === -1 || guardIdx < firstOrdersFetchIdx, 'no debe llamarse /api/orders antes de elegir entrega');
+  assert.doesNotMatch(fn.slice(0, guardIdx), /fetchTransferOptions|transferIdempotencyKey =/, 'no debe pedirse ninguna cuenta antes de elegir entrega');
+});
+
+test('4. requireDeliveryType(): mensaje, foco y scroll a la opción de entrega', () => {
+  const start = CARRITO.indexOf('function requireDeliveryType');
+  const fn = CARRITO.slice(start, start + 700);
+  assert.match(fn, /errEl\.textContent = 'Elegí envío o retiro para continuar\.'/);
+  assert.match(fn, /errEl\.hidden = false/);
+  assert.match(fn, /firstDelivery\.setAttribute\('aria-invalid', 'true'\)/);
+  assert.match(fn, /firstDelivery\.focus\(\)/);
+  assert.match(fn, /firstDelivery\.scrollIntoView/);
+});
+
+test('5. la ayuda visible junto a los CTA existe, es accesible y funciona en desktop y en la barra fija mobile', () => {
+  assert.match(CARRITO, /id="cart-delivery-hint"[^>]*role="status"[^>]*aria-live="polite"[^>]*hidden/);
+  assert.match(CARRITO, /Elegí envío o retiro para continuar\./);
+  // Vive dentro de .checkout-mobile-bar: en flujo normal (desktop) es un
+  // <p> más en el flex; en mobile ese contenedor pasa a fixed+grid, así
+  // que el mismo elemento se ve en ambos casos sin markup duplicado.
+  const barStart = CARRITO.indexOf('class="checkout-mobile-bar"');
+  const hintIdx = CARRITO.indexOf('id="cart-delivery-hint"');
+  const transferBtnIdx = CARRITO.indexOf('id="btn-transfer-order"');
+  assert.ok(barStart !== -1 && barStart < hintIdx && hintIdx < transferBtnIdx,
+    'el aviso debe estar dentro de .checkout-mobile-bar, antes de los CTA de pago');
+});
+
+test('6. la ayuda no se confunde visualmente con un error real (rojo) ni con éxito (verde)', () => {
+  const cssStart = CARRITO.indexOf('.cart-delivery-hint {');
+  const cssBlock = CARRITO.slice(cssStart, CARRITO.indexOf('}', cssStart));
+  assert.doesNotMatch(cssBlock, /#b42318|#fef2f2|#fecaca/, 'no debe reutilizar la paleta de error');
+  assert.doesNotMatch(cssBlock, /#267a42/, 'no debe reutilizar la paleta de éxito de envío gratis');
+});
+
+// ── 2. Con retiro o envío elegidos, la ayuda desaparece y el CTA sigue la
+//       disponibilidad técnica normal ──────────────────────────────────────
+
+test('7. syncPaymentAvailability oculta la ayuda apenas hay entrega elegida', () => {
+  const start = CARRITO.indexOf('function syncPaymentAvailability');
+  const end = CARRITO.indexOf('\n    }', start);
+  const fn = CARRITO.slice(start, end);
+  assert.match(fn, /var hasDelivery = !!getDeliveryType\(\);/);
+  assert.match(fn, /deliveryHintEl\.hidden = !\(technicallyReady && !hasDelivery\)/);
+});
+
+test('8. cambiar la entrega vuelve a evaluar disponibilidad (retiro y envío, no sólo un caso)', () => {
+  const start = CARRITO.indexOf("radio.addEventListener('change', function () {");
+  const listener = CARRITO.slice(start, start + 300);
+  assert.match(listener, /updateTotals\(\)/);
+  assert.match(listener, /syncPaymentAvailability\(\)/);
+});
+
+// ── 3. Mensaje de envío gratis ──────────────────────────────────────────────
+
+test('9. #cart-shipping-msg existe en el markup y arranca hidden', () => {
+  assert.match(CARRITO, /<p class="cart-shipping-msg" id="cart-shipping-msg" hidden><\/p>/);
+});
+
+test('10. carrito vacío / sin entrega: el mensaje de envío gratis queda oculto y sin texto', () => {
+  const start = CARRITO.indexOf('function updateTotals');
+  const branchEnd = CARRITO.indexOf('if (isPickup)', start);
+  const branch = CARRITO.slice(start, branchEnd);
+  assert.match(branch, /if \(!deliveryType \|\| subtotal <= 0\)/);
+  assert.match(branch, /shippingMsgEl\.hidden = true; shippingMsgEl\.textContent = '';/);
+});
+
+test('11. retiro: el mensaje de envío gratis queda oculto y sin texto', () => {
+  const start = CARRITO.indexOf('if (isPickup)');
+  const end = CARRITO.indexOf('} else {', start);
+  const branch = CARRITO.slice(start, end);
+  assert.match(branch, /shippingMsgEl\.hidden = true; shippingMsgEl\.textContent = '';/);
+});
+
+test('12. envío: reusa exactamente shippingCost/subtotal/FREE_SHIPPING_THRESHOLD_UYU/fmt ya calculados, sin duplicar la lógica', () => {
+  const start = CARRITO.indexOf('} else {', CARRITO.indexOf('if (isPickup)'));
+  const end = CARRITO.indexOf('\n      }\n    }', start);
+  const branch = CARRITO.slice(start, end);
+
+  // El mismo shippingCost que ya decide la línea de costo de envío / total.
+  assert.match(branch, /var shippingCost\s*=\s*subtotal < FREE_SHIPPING_THRESHOLD_UYU \? SHIPPING_COST : 0;/);
+  assert.match(branch, /shippingMsgEl\.hidden = false;/);
+  assert.match(branch, /shippingMsgEl\.textContent = shippingCost === 0/);
+  assert.match(branch, /'Tu envío es gratis'/);
+  assert.match(branch, /'Te faltan ' \+ fmt\.format\(FREE_SHIPPING_THRESHOLD_UYU - subtotal\) \+ ' para obtener envío gratis'/);
+
+  // No aparece ningún otro umbral/constante hardcodeada dentro de esta rama.
+  assert.doesNotMatch(branch, /1500|1\.500/);
+
+  // fmt es el mismo formateador monetario que usa el resto del carrito (no
+  // se declara un Intl.NumberFormat nuevo para este mensaje).
+  const fmtDeclarations = CARRITO.match(/new Intl\.NumberFormat\('es-UY'/g) || [];
+  assert.equal(fmtDeclarations.length, 1, 'debe existir un único formateador monetario, reusado en todo el carrito');
+});
+
+test('13. FREE_SHIPPING_THRESHOLD_UYU es la única fuente del umbral (no se hardcodea $1.500 en el nuevo mensaje)', () => {
+  assert.match(CARRITO, /FREE_SHIPPING_THRESHOLD_UYU = 1500/);
+  const msgIdx = CARRITO.indexOf("shippingMsgEl.textContent = shippingCost === 0");
+  const msgBlock = CARRITO.slice(msgIdx, msgIdx + 250);
+  assert.match(msgBlock, /FREE_SHIPPING_THRESHOLD_UYU/);
+  assert.doesNotMatch(msgBlock, /\$\s*1[.,]?500/);
+});
+
+// ── 4. orders-guard.js no debe tapar el aviso de entrega en los CTA de pago ─
+
+test('14. sin entrega elegida, orders-guard.js no intercepta el click de transferencia/Mercado Pago por nombre, teléfono o dirección', () => {
+  const fnStart = GUARD.indexOf('function checkoutError');
+  assert.notEqual(fnStart, -1);
+  const fnBody = GUARD.slice(fnStart, GUARD.indexOf('\n  }', fnStart));
+
+  const bypassIdx = fnBody.search(/if\s*\(\s*!delivery\s*&&\s*isPaymentButton\s*\)\s*return null;/);
+  assert.notEqual(bypassIdx, -1, 'debe existir un corte temprano cuando no hay entrega y el botón es uno de pago');
+
+  const nameCheckIdx = fnBody.indexOf("valueOf('buyer-name')");
+  assert.ok(nameCheckIdx === -1 || bypassIdx < nameCheckIdx,
+    'el corte por falta de entrega debe evaluarse antes que nombre/teléfono/dirección');
+
+  assert.match(fnBody, /isPaymentButton = buttonId === 'btn-transfer-order' \|\| buttonId === 'btn-prepare-order'/);
+});
+
+test('15. el click handler global le pasa el id del botón a checkoutError()', () => {
+  const idx = GUARD.indexOf("document.addEventListener('click'");
+  const block = GUARD.slice(idx, idx + 400);
+  assert.match(block, /checkoutError\(button\.id\)/);
+});
+
+test('16. el botón de WhatsApp no cambia: sigue pidiendo nombre y teléfono como hasta ahora', () => {
+  const fnStart = GUARD.indexOf('function checkoutError');
+  const fnBody = GUARD.slice(fnStart, GUARD.indexOf('\n  }', fnStart));
+  // btn-wa-order nunca es "isPaymentButton" → nunca activa el bypass; sigue
+  // cayendo en las mismas validaciones de nombre/teléfono/dirección.
+  assert.doesNotMatch(fnBody, /buttonId === 'btn-wa-order'/);
+});
+
+test('17. con entrega ya elegida, orders-guard.js sigue validando nombre/teléfono/dirección exactamente como antes', () => {
+  const fnStart = GUARD.indexOf('function checkoutError');
+  const fnBody = GUARD.slice(fnStart, GUARD.indexOf('\n  }', fnStart));
+  assert.match(fnBody, /if \(!valueOf\('buyer-name'\)\) return \{ message: 'Por favor ingresá tu nombre\.', field: 'buyer-name' \};/);
+  assert.match(fnBody, /if \(!valueOf\('buyer-phone'\)\) return \{ message: 'Por favor ingresá tu teléfono o WhatsApp\.', field: 'buyer-phone' \};/);
+  assert.match(fnBody, /if \(!delivery \|\| delivery\.value !== 'shipping'\) return null;/);
+  assert.match(fnBody, /delivery-address.*Por favor ingresá la dirección de entrega/);
+});
+
+// ── 5. Ambos caminos de pago siguen protegidos contra doble envío ──────────
+
+test('18. Mercado Pago: se deshabilita antes de cualquier await, con guarda explícita de reentrancia', () => {
+  const handlerStart = CARRITO.indexOf("btnPrepare.addEventListener('click'");
+  const handlerBlock = CARRITO.slice(handlerStart, handlerStart + 4000);
+  const reentryGuard = CARRITO.slice(handlerStart, handlerStart + 300);
+  assert.match(reentryGuard, /if\s*\(\s*btnPrepare\.disabled\s*\)\s*return;/);
+  const disableIdx = handlerBlock.indexOf('btnPrepare.disabled = true;');
+  const firstAwaitIdx = handlerBlock.indexOf('await ');
+  assert.notEqual(disableIdx, -1);
+  assert.ok(disableIdx < firstAwaitIdx);
+});
+
+test('19. Transferencia: se deshabilita antes de cualquier await, con guarda explícita de reentrancia', () => {
+  const handlerStart = CARRITO.indexOf("btnTransfer.addEventListener('click'");
+  assert.notEqual(handlerStart, -1);
+  const reentryGuard = CARRITO.slice(handlerStart, handlerStart + 200);
+  assert.match(reentryGuard, /if\s*\(\s*btnTransfer\.disabled\s*\|\|/);
+
+  const fnStart = CARRITO.indexOf('async function createTransferOrder');
+  const fnBlock = CARRITO.slice(fnStart, fnStart + 3000);
+  const disableIdx = fnBlock.indexOf('btnTransfer.disabled = true;');
+  const firstAwaitIdx = fnBlock.indexOf('await ');
+  assert.notEqual(disableIdx, -1);
+  assert.ok(disableIdx < firstAwaitIdx);
+});
+
+test('20. seguir deshabilitado (aria-busy) evita que syncPaymentAvailability lo reactive a mitad de una operación', () => {
+  const start = CARRITO.indexOf('function syncPaymentAvailability');
+  const fn = CARRITO.slice(start, start + 700);
+  assert.match(fn, /!transferButton\.hasAttribute\('aria-busy'\)/);
+  assert.match(fn, /!mercadoPagoButton\.hasAttribute\('aria-busy'\)/);
+});

--- a/functions/__tests__/v1.1-checkout-guidance.test.js
+++ b/functions/__tests__/v1.1-checkout-guidance.test.js
@@ -267,3 +267,64 @@ test('20. seguir deshabilitado (aria-busy) evita que syncPaymentAvailability lo 
   assert.match(fn, /!transferButton\.hasAttribute\('aria-busy'\)/);
   assert.match(fn, /!mercadoPagoButton\.hasAttribute\('aria-busy'\)/);
 });
+
+// ── 6. Microcopy "librería familiar" junto al WhatsApp secundario ──────────
+
+const PERSONAL_NOTE_TEXT = 'Somos una librería familiar y esta web también la hacemos nosotros. ' +
+  'Si necesitás ayuda para completar tu compra, escribinos por WhatsApp. Te atendemos personalmente.';
+
+test('21. la microcopy aparece con el texto exacto solicitado', () => {
+  assert.match(CARRITO, /class="checkout-personal-note"/);
+  const normalized = CARRITO.replace(/\s+/g, ' ');
+  assert.ok(normalized.includes(PERSONAL_NOTE_TEXT), 'el texto de la nota debe coincidir exactamente');
+});
+
+test('22. la nota está fuera de .checkout-mobile-bar, inmediatamente antes del botón "O coordinar por WhatsApp"', () => {
+  const mobileBarStart = CARRITO.indexOf('class="checkout-mobile-bar"');
+  const mobileBarEnd = CARRITO.indexOf('</div>', mobileBarStart);
+  const noteIdx = CARRITO.indexOf('class="checkout-personal-note"');
+  const waSecondaryIdx = CARRITO.indexOf('id="btn-wa-order" class="btn-wa-secondary"');
+
+  assert.notEqual(noteIdx, -1);
+  assert.notEqual(waSecondaryIdx, -1);
+  assert.ok(mobileBarEnd < noteIdx, 'la nota debe estar fuera (después del cierre) de .checkout-mobile-bar');
+  assert.ok(noteIdx < waSecondaryIdx, 'la nota debe preceder al botón secundario de WhatsApp');
+
+  // Nada más (otro tag que no sea el cierre del <p>) se interpone entre la
+  // nota y el botón — confirma "inmediatamente antes".
+  const between = CARRITO.slice(noteIdx, waSecondaryIdx);
+  const tagsBetween = (between.match(/<[a-zA-Z][^>]*>/g) || []).filter((tag) => !/^<\/?p[ >]/.test(tag));
+  assert.equal(tagsBetween.length, 0, `no debe haber otros elementos entre la nota y el botón: ${tagsBetween.join(', ')}`);
+});
+
+test('23. reutiliza el botón de WhatsApp existente — no se crea un botón ni un id nuevo', () => {
+  const waButtonIds = (CARRITO.match(/id="btn-wa-order"/g) || []).length;
+  assert.equal(waButtonIds, 2, 'sólo deben existir los dos btn-wa-order ya existentes (checkout ON/OFF), ninguno nuevo');
+
+  // La nota es un <p> plano, sin su propio <button>/<a> ni atributos de
+  // interacción — el único control que le sigue es el btn-wa-order ya
+  // existente, no uno nuevo envolviendo la nota.
+  const noteStart = CARRITO.indexOf('class="checkout-personal-note"');
+  const pOpenStart = CARRITO.lastIndexOf('<p', noteStart);
+  const pCloseEnd = CARRITO.indexOf('</p>', noteStart) + '</p>'.length;
+  const noteTag = CARRITO.slice(pOpenStart, pCloseEnd);
+  assert.match(noteTag, /^<p class="checkout-personal-note">[\s\S]*<\/p>$/);
+  assert.doesNotMatch(noteTag, /<button|<a\s|onclick|data-action/);
+});
+
+test('24. sin popup ni lógica JS nueva atada a la nota', () => {
+  const scriptStart = CARRITO.indexOf('<script is:inline');
+  assert.notEqual(scriptStart, -1);
+  const scriptBlock = CARRITO.slice(scriptStart);
+  assert.doesNotMatch(scriptBlock, /checkout-personal-note/, 'el script no debe referenciar la nota (sin JS nuevo)');
+  assert.doesNotMatch(scriptBlock, /window\.(alert|confirm)\(['"`][^'"`]*librería familiar/i);
+});
+
+test('25. presentación discreta: no reutiliza la paleta de error ni compite con los CTA de pago', () => {
+  const cssStart = CARRITO.indexOf('.checkout-personal-note {');
+  assert.notEqual(cssStart, -1);
+  const cssBlock = CARRITO.slice(cssStart, CARRITO.indexOf('}', cssStart));
+  assert.doesNotMatch(cssBlock, /#b42318|#fef2f2|#fecaca/, 'no debe reutilizar la paleta de error');
+  assert.doesNotMatch(cssBlock, /background/, 'debe seguir siendo texto discreto, sin fondo propio');
+  assert.match(cssBlock, /color:\s*var\(--ink-2\)/, 'mismo tono secundario que checkout-reassurance/checkout-policy-links');
+});

--- a/functions/__tests__/v1.1-checkout-redesign.test.js
+++ b/functions/__tests__/v1.1-checkout-redesign.test.js
@@ -149,6 +149,7 @@ test('11b. focusFirstMissingRequirement() sigue el orden completo, no salta dire
 
   const order = [
     'requireDeliveryType()',
+    '!isPickupAccepted()',
     "showFieldError('buyer-name'",
     "showFieldError('buyer-phone'",
     "showFieldError('buyer-email'",
@@ -167,6 +168,46 @@ test('11b. focusFirstMissingRequirement() sigue el orden completo, no salta dire
   const shippingGateIdx = fn.indexOf("deliveryType === 'shipping'");
   const addressIdx = fn.indexOf("showFieldError('delivery-address'");
   assert.ok(shippingGateIdx !== -1 && shippingGateIdx < addressIdx);
+});
+
+// Corrección revisión ChatGPT (ronda final): la aceptación de retiro
+// (pickup-ack) faltaba en focusFirstMissingRequirement() — permitía llegar
+// hasta Pago con retiro elegido y el checkbox sin marcar, para recién ahí
+// (al confirmar de verdad) volver arriba al pickup-ack. Ahora se exige
+// justo después de Entrega, sólo cuando deliveryType === 'pickup', con el
+// mismo mensaje/foco/scroll que ya usan createTransferOrder()/btnPrepare.
+
+test('11b2. focusFirstMissingRequirement() exige pickup-ack inmediatamente después de Entrega, sólo si es retiro', () => {
+  const start = CARRITO.indexOf('function focusFirstMissingRequirement');
+  const end = CARRITO.indexOf('// ── Persistencia de la etapa', start);
+  const fn = CARRITO.slice(start, end);
+
+  assert.match(fn, /if \(deliveryType === 'pickup' && !isPickupAccepted\(\)\) \{/);
+  assert.match(fn, /pickupAckErr\.textContent = 'Necesitamos que confirmes esto antes de seguir\.';/);
+  assert.match(fn, /pickupAckErr\.hidden = false;/);
+  assert.match(fn, /pickupAck\.setAttribute\('aria-invalid', 'true'\);/);
+  assert.match(fn, /pickupAck\.focus\(\);/);
+  assert.match(fn, /pickupAck\.scrollIntoView\(\{ block: 'center' \}\);/);
+
+  // El gate de pickup-ack va antes que el de Nombre, no después.
+  const pickupGateIdx = fn.indexOf("deliveryType === 'pickup' && !isPickupAccepted()");
+  const nameIdx = fn.indexOf("showFieldError('buyer-name'");
+  assert.ok(pickupGateIdx !== -1 && pickupGateIdx < nameIdx);
+});
+
+test('11b3. el mensaje/foco/scroll de pickup-ack en el CTA neutro es un espejo textual del que ya usa createTransferOrder()', () => {
+  const neutralStart = CARRITO.indexOf('function focusFirstMissingRequirement');
+  const neutralEnd = CARRITO.indexOf('// ── Persistencia de la etapa', neutralStart);
+  const neutralBlock = CARRITO.slice(neutralStart, neutralEnd);
+
+  const transferStart = CARRITO.indexOf('async function createTransferOrder');
+  const transferEnd = CARRITO.indexOf('if (btnTransfer) {', transferStart);
+  const transferBlock = CARRITO.slice(transferStart, transferEnd);
+  assert.match(transferBlock, /deliveryType === 'pickup' && !isPickupAccepted\(\)/);
+
+  const messageRe = /pickupAckErr\.textContent =\s*\n?\s*'Necesitamos que confirmes esto antes de seguir\.';/;
+  assert.match(neutralBlock, messageRe);
+  assert.match(transferBlock, messageRe);
 });
 
 test('11c. no duplica una segunda lógica de validación: createTransferOrder()/btnPrepare no llaman a focusFirstMissingRequirement()', () => {

--- a/functions/__tests__/v1.1-checkout-redesign.test.js
+++ b/functions/__tests__/v1.1-checkout-redesign.test.js
@@ -120,20 +120,63 @@ test('10. sólo un CTA visible a la vez: neutro, transferencia o Mercado Pago se
   assert.match(CARRITO, /id="btn-prepare-order" class="btn-checkout-primary" aria-describedby="checkout-error" hidden>/);
 
   const start = CARRITO.indexOf('function syncPaymentAvailability');
-  const fn = CARRITO.slice(start, start + 1400);
+  const fn = CARRITO.slice(start, start + 1600);
   assert.match(fn, /transferButton\.hidden = paymentMethod !== 'transfer'/);
   assert.match(fn, /mercadoPagoButton\.hidden = paymentMethod !== 'mercadopago'/);
   assert.match(fn, /neutralButton\.hidden = hasPaymentMethod/);
 });
 
-test('11. el CTA neutro no fusiona la lógica de pago: sólo exige entrega y medio, nunca llama a /api/orders', () => {
+test('11. el CTA neutro no fusiona la lógica de pago: delega en focusFirstMissingRequirement(), nunca llama a /api/orders', () => {
   const start = CARRITO.indexOf("btnConfirmNeutral.addEventListener('click'");
   assert.notEqual(start, -1);
   const block = CARRITO.slice(start, start + 400);
   assert.match(block, /if \(btnConfirmNeutral\.disabled\) return;/);
-  assert.match(block, /if \(!requireDeliveryType\(\)\) return;/);
-  assert.match(block, /requirePaymentMethod\(\);/);
+  assert.match(block, /focusFirstMissingRequirement\(\);/);
   assert.doesNotMatch(block, /fetch\(/);
+});
+
+// ── 4b. CTA neutro — corrección revisión ChatGPT #3: respeta el orden
+// completo del flujo (Entrega → Nombre → WhatsApp → Email → [envío:
+// Dirección/Barrio/Departamento] → Pago), no salta directo de Entrega a
+// Pago. No duplica la validación de submit real: es la única función que
+// decide a qué falta el CTA neutro debe llevar.
+
+test('11b. focusFirstMissingRequirement() sigue el orden completo, no salta directo de Entrega a Pago', () => {
+  const start = CARRITO.indexOf('function focusFirstMissingRequirement');
+  assert.notEqual(start, -1);
+  const end = CARRITO.indexOf('// ── Persistencia de la etapa', start);
+  const fn = CARRITO.slice(start, end);
+
+  const order = [
+    'requireDeliveryType()',
+    "showFieldError('buyer-name'",
+    "showFieldError('buyer-phone'",
+    "showFieldError('buyer-email'",
+    "showFieldError('delivery-address'",
+    "showFieldError('delivery-barrio'",
+    "showFieldError('delivery-departamento'",
+    'requirePaymentMethod()',
+  ];
+  let cursor = -1;
+  for (const token of order) {
+    const idx = fn.indexOf(token, cursor + 1);
+    assert.ok(idx > cursor, `"${token}" debe aparecer, y en este orden, dentro de focusFirstMissingRequirement()`);
+    cursor = idx;
+  }
+  // Los campos de envío sólo se piden si deliveryType === 'shipping'.
+  const shippingGateIdx = fn.indexOf("deliveryType === 'shipping'");
+  const addressIdx = fn.indexOf("showFieldError('delivery-address'");
+  assert.ok(shippingGateIdx !== -1 && shippingGateIdx < addressIdx);
+});
+
+test('11c. no duplica una segunda lógica de validación: createTransferOrder()/btnPrepare no llaman a focusFirstMissingRequirement()', () => {
+  const transferStart = CARRITO.indexOf('async function createTransferOrder');
+  const transferEnd = CARRITO.indexOf('if (btnTransfer) {', transferStart);
+  assert.doesNotMatch(CARRITO.slice(transferStart, transferEnd), /focusFirstMissingRequirement/);
+
+  const prepareStart = CARRITO.indexOf("btnPrepare.addEventListener('click'");
+  const prepareEnd = CARRITO.indexOf('refreshCartAvailability({ initial: true })', prepareStart);
+  assert.doesNotMatch(CARRITO.slice(prepareStart, prepareEnd), /focusFirstMissingRequirement/);
 });
 
 test('12. createTransferOrder() y el handler de Mercado Pago no cambiaron: cero referencias a payment-method', () => {
@@ -159,6 +202,52 @@ test('13. elegir medio de pago recalcula disponibilidad y guarda el borrador', (
 test('14. el medio de pago se persiste y restaura en el borrador de sessionStorage', () => {
   assert.match(CARRITO, /payment_method: getPaymentMethod\(\)/);
   assert.match(CARRITO, /draft\.payment_method/);
+});
+
+// ── 4c. Corrección revisión ChatGPT #2: congelar el medio de pago durante
+// submit. Antes los radios de payment-method seguían interactivos mientras
+// btnTransfer/btnPrepare estaban aria-busy — un cambio de medio a mitad de
+// un submit podía revelar el CTA alternativo. Ahora ambos radios se
+// deshabilitan al iniciar cada flujo y se rehabilitan en cada punto de
+// reset (éxito, error o cancelación) ya existente.
+
+test('14b. setPaymentMethodFrozen()/isPaymentMethodFrozen() existen y operan sobre ambos radios', () => {
+  const start = CARRITO.indexOf('function setPaymentMethodFrozen');
+  assert.notEqual(start, -1);
+  const block = CARRITO.slice(start, start + 400);
+  assert.match(block, /document\.querySelectorAll\('input\[name="payment-method"\]'\)\.forEach/);
+  assert.match(block, /radio\.disabled = frozen;/);
+  assert.match(block, /function isPaymentMethodFrozen\(\)/);
+});
+
+test('14c. createTransferOrder() congela el medio de pago al pasar a aria-busy (no antes, no en las validaciones previas)', () => {
+  const start = CARRITO.indexOf("btnTransfer.setAttribute('aria-busy', 'true');");
+  assert.notEqual(start, -1);
+  const block = CARRITO.slice(start, start + 200);
+  assert.match(block, /setPaymentMethodFrozen\(true\);/);
+});
+
+test('14d. el handler de Mercado Pago congela el medio de pago al pasar a aria-busy', () => {
+  const start = CARRITO.indexOf("btnPrepare.setAttribute('aria-busy', 'true');");
+  assert.notEqual(start, -1);
+  const block = CARRITO.slice(start, start + 200);
+  assert.match(block, /setPaymentMethodFrozen\(true\);/);
+});
+
+test('14e. resetTransferButton() y resetPrepareButton() descongelan el medio de pago en cada reset (éxito/error/cancelación)', () => {
+  const resetTransferStart = CARRITO.indexOf('function resetTransferButton');
+  const resetTransferBlock = CARRITO.slice(resetTransferStart, resetTransferStart + 300);
+  assert.match(resetTransferBlock, /setPaymentMethodFrozen\(false\);/);
+
+  const resetPrepareStart = CARRITO.indexOf('function resetPrepareButton');
+  const resetPrepareBlock = CARRITO.slice(resetPrepareStart, resetPrepareStart + 300);
+  assert.match(resetPrepareBlock, /setPaymentMethodFrozen\(false\);/);
+});
+
+test('14f. con el medio de pago congelado, syncPaymentAvailability() también bloquea el CTA neutro (no sólo lo oculta)', () => {
+  const start = CARRITO.indexOf('function syncPaymentAvailability');
+  const fn = CARRITO.slice(start, start + 1400);
+  assert.match(fn, /neutralButton\.disabled = !technicallyReady \|\| isPaymentMethodFrozen\(\);/);
 });
 
 // ── 5. Preview "Pagás $X" de transferencia — paridad real ────────────────
@@ -217,6 +306,64 @@ test('18. sin entrega elegida (o carrito vacío) el preview de transferencia que
   assert.match(block, /mpPreviewEl\.\s*\{ mpPreviewEl\.hidden = true; mpPreviewEl\.textContent = ''; \}|mpPreviewEl\.hidden = true;/);
 });
 
+// ── 5b. Corrección revisión ChatGPT #1: total consistente por medio de
+// pago. Antes el resumen y el sticky siempre mostraban el total normal,
+// incluso con transferencia elegida — dos importes distintos a la vez
+// (el preview de la card vs. el total del resumen). Ahora
+// cartSummaryTotalEl / checkout-sticky-total-value / totalEl /
+// totalShippingEl reflejan el monto real según getPaymentMethod().
+
+test('18b. rama de retiro: displayTotal usa transferPayable con transferencia elegida, y pinta resumen+sticky+total', () => {
+  const pickupBranch = CARRITO.slice(CARRITO.indexOf('if (isPickup) {'), CARRITO.indexOf('} else {'));
+  assert.match(pickupBranch, /var displayTotal = paymentMethod === 'transfer' \? transferPayable : total;/);
+  assert.match(pickupBranch, /totalEl\.textContent\s*=\s*fmt\.format\(displayTotal\)/);
+  assert.match(pickupBranch, /stickyTotalEl\.textContent\s*=\s*fmt\.format\(displayTotal\)/);
+  assert.match(pickupBranch, /cartSummaryTotalEl\.textContent\s*=\s*fmt\.format\(displayTotal\)/);
+  assert.match(pickupBranch, /transferDiscountLineEl\.hidden = paymentMethod !== 'transfer'/);
+});
+
+test('18c. rama de envío: displayTotalShip usa transferPayableShip con transferencia elegida, y pinta resumen+sticky+total', () => {
+  const shippingStart = CARRITO.indexOf('} else {', CARRITO.indexOf('if (isPickup) {'));
+  const shippingBranch = CARRITO.slice(shippingStart, CARRITO.indexOf('// ── Construir fila de item'));
+  assert.match(shippingBranch, /var displayTotalShip = paymentMethod === 'transfer' \? transferPayableShip : totalWithShipping;/);
+  assert.match(shippingBranch, /totalShippingEl\.textContent\s*=\s*fmt\.format\(displayTotalShip\)/);
+  assert.match(shippingBranch, /stickyTotalEl\.textContent\s*=\s*fmt\.format\(displayTotalShip\)/);
+  assert.match(shippingBranch, /cartSummaryTotalEl\.textContent\s*=\s*fmt\.format\(displayTotalShip\)/);
+  assert.match(shippingBranch, /transferDiscountLineEl\.hidden = paymentMethod !== 'transfer'/);
+});
+
+test('18d. sin medio de pago elegido (o Mercado Pago), el resumen/sticky muestran el total normal, no el de transferencia', () => {
+  const pickupBranch = CARRITO.slice(CARRITO.indexOf('if (isPickup) {'), CARRITO.indexOf('} else {'));
+  // displayTotal cae a "total" (no transferPayable) salvo que paymentMethod
+  // sea exactamente 'transfer' — Mercado Pago y "sin elegir" comparten rama.
+  assert.match(pickupBranch, /paymentMethod === 'transfer' \? transferPayable : total/);
+});
+
+test('18e. paridad NUMÉRICA real contra el backend en los 3 casos obligatorios del review (A/B/C)', () => {
+  const cases = [
+    { subtotal: 645,  deliveryType: 'pickup',   transfer: 568,  mercadopago: 645 },
+    { subtotal: 645,  deliveryType: 'shipping', transfer: 818,  mercadopago: 895 },
+    { subtotal: 2000, deliveryType: 'pickup',   transfer: 1610, mercadopago: 1850 },
+  ];
+  for (const c of cases) {
+    const totals = calculateTotals([{ line_total_uyu: c.subtotal }], c.deliveryType);
+    const server = calculateTransferTotals(totals);
+    assert.equal(
+      totals.payableTotal, c.mercadopago,
+      `subtotal=${c.subtotal} ${c.deliveryType}: Mercado Pago esperado ${c.mercadopago}, backend dio ${totals.payableTotal}`,
+    );
+    assert.equal(
+      server.transferPayableTotal, c.transfer,
+      `subtotal=${c.subtotal} ${c.deliveryType}: transferencia esperada ${c.transfer}, backend dio ${server.transferPayableTotal}`,
+    );
+    // displayTotal/displayTotalShip (18b/18c) usan exactamente esta misma
+    // fórmula (ver test 16, paridad de las 12 combinaciones) para pintar
+    // cart-summary-total y checkout-sticky-total-value — así que estos
+    // valores del backend son también los que terminan en pantalla según
+    // el medio elegido.
+  }
+});
+
 // ── 6. Resumen / disclosure / "Editar" ───────────────────────────────────
 
 test('19. el resumen usa <details> nativo y accesible, no un modal', () => {
@@ -225,22 +372,59 @@ test('19. el resumen usa <details> nativo y accesible, no un modal', () => {
   assert.doesNotMatch(CARRITO, /class="modal"|role="dialog"/);
 });
 
-test('20. desktop fuerza el resumen siempre expandido vía CSS, sin depender del atributo open', () => {
-  assert.match(CARRITO, /\.cart-summary-panel:not\(\[open\]\) \.cart-summary-body\s*\{\s*display:\s*flex;/);
-  // Esa regla vive dentro de un @media (min-width: 960px) cercano, no aplica en mobile.
-  const ruleIdx = CARRITO.indexOf('.cart-summary-panel:not([open]) .cart-summary-body');
-  const precedingMq = CARRITO.lastIndexOf('@media (min-width: 960px)', ruleIdx);
-  assert.ok(precedingMq !== -1 && ruleIdx - precedingMq < 300, 'la regla debe estar dentro del bloque @media, no suelta');
+// ── Corrección revisión ChatGPT #4: el resumen desktop ya no depende del
+// pseudo-elemento interno ::details-content (Chromium-only, sin garantía de
+// comportamiento igual en WebKit/Firefox) — ahora JS fuerza el atributo
+// real "open" del <details> según el viewport, y la regla base
+// .cart-summary-panel[open] .cart-summary-body (sin media query) alcanza
+// para mostrar el contenido con el comportamiento nativo del navegador.
+
+test('20. desktop ya no depende de ::details-content: CSS sólo deja el toggle decorativo', () => {
+  // No debe quedar ninguna regla CSS activa que dependa del pseudo-elemento
+  // (comentarios explicando por qué se sacó sí pueden nombrarlo).
+  assert.doesNotMatch(CARRITO, /::details-content\s*\{/);
+  assert.doesNotMatch(CARRITO, /\.cart-summary-panel:not\(\[open\]\)/);
+
+  const mqStart = CARRITO.indexOf('@media (min-width: 960px)', CARRITO.indexOf('.cart-summary-panel {'));
+  const mqBlock = CARRITO.slice(mqStart, CARRITO.indexOf('.cart-items-compact {', mqStart));
+  assert.match(mqBlock, /\.cart-summary-toggle\s*\{\s*\n\s*cursor:\s*default;\s*\n\s*pointer-events:\s*none;/);
+  assert.match(mqBlock, /\.cart-summary-chevron\s*\{\s*display:\s*none;\s*\}/);
+
+  // La regla que realmente muestra el contenido no tiene media query: ya
+  // alcanza con el atributo "open" real (forzado por JS en desktop, nativo
+  // del usuario en mobile).
+  assert.match(CARRITO, /\.cart-summary-panel\[open\] \.cart-summary-body\s*\{\s*\n\s*display:\s*flex;/);
 });
 
-test('20b. el override de desktop también alcanza ::details-content (no sólo el hijo)', () => {
-  // Regresión real encontrada con Playwright: Chromium colapsa el contenido
-  // de un <details> cerrado con un pseudo-elemento interno
-  // (::details-content), no sólo con display en los hijos. Sin este
-  // segundo override el panel medía 0 de alto en desktop aunque
-  // .cart-summary-body ya tuviera display:flex — "Editar" quedaba
-  // inalcanzable por completo en 1440×900.
-  assert.match(CARRITO, /\.cart-summary-panel:not\(\[open\]\)::details-content\s*\{\s*\n\s*content-visibility:\s*visible;\s*\n\s*display:\s*block;/);
+test('20b. JS fuerza el atributo real "open" en desktop vía matchMedia, con fallback addListener', () => {
+  const start = CARRITO.indexOf('function syncSummaryDesktopState');
+  assert.notEqual(start, -1);
+  const end = CARRITO.indexOf('syncSummaryDesktopState();', start);
+  const fn = CARRITO.slice(start, end);
+  assert.match(fn, /summaryDesktopMq\.matches/);
+  assert.match(fn, /cartSummaryPanelEl\.open = true;/);
+
+  const wireStart = CARRITO.indexOf("window.matchMedia('(min-width: 960px)')");
+  assert.notEqual(wireStart, -1);
+  const wireBlock = CARRITO.slice(wireStart, wireStart + 700);
+  assert.match(wireBlock, /summaryDesktopMq\.addEventListener\('change', syncSummaryDesktopState\)/);
+  assert.match(wireBlock, /summaryDesktopMq\.addListener\(syncSummaryDesktopState\)/);
+});
+
+test('20c. el <summary> desktop no queda como control fantasma: sale del tab order (tabindex=-1) mientras se fuerza abierto', () => {
+  const start = CARRITO.indexOf('function syncSummaryDesktopState');
+  const end = CARRITO.indexOf('syncSummaryDesktopState();', start);
+  const fn = CARRITO.slice(start, end);
+  assert.match(fn, /cartSummaryToggleEl\.setAttribute\('tabindex', '-1'\)/);
+  assert.match(fn, /cartSummaryToggleEl\.removeAttribute\('tabindex'\)/);
+});
+
+test('20d. si algo dispara "toggle" y cierra el panel en desktop, se re-fuerza abierto en el mismo evento (defensa extra)', () => {
+  const start = CARRITO.indexOf("cartSummaryPanelEl.addEventListener('toggle'");
+  assert.notEqual(start, -1);
+  const block = CARRITO.slice(start, start + 400);
+  assert.match(block, /if \(summaryDesktopMq\.matches && !cartSummaryPanelEl\.open\) \{/);
+  assert.match(block, /cartSummaryPanelEl\.open = true;/);
 });
 
 test('21. "Editar" reutiliza buildItemRow() sin reescribirla — sólo agrega una fila compacta nueva y separada', () => {

--- a/functions/__tests__/v1.1-checkout-redesign.test.js
+++ b/functions/__tests__/v1.1-checkout-redesign.test.js
@@ -1,0 +1,320 @@
+// V1.1 — REDISEÑO PROFUNDO DEL CHECKOUT.
+//
+// Cubre lo que el lote anterior (v1.1-checkout-guidance.test.js) no tocaba:
+// layout de 2 columnas, selector de medio de pago + CTA único, preview
+// "Pagás $X" de transferencia (con paridad real contra el backend, no sólo
+// regex), el disclosure del resumen, y los ajustes de copy aprobados.
+//
+// Mismo criterio que el resto de la suite para lo estructural: sin DOM real,
+// se lee el archivo fuente y se verifica con regex/índices. Para la paridad
+// del preview de transferencia SÍ se ejecuta la lógica real (importando
+// calculateTransferTotals del backend) contra la misma fórmula que declara
+// el archivo fuente — no basta con que el texto "se parezca".
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { calculateTotals, calculateTransferTotals, qualifiesForPickupDiscount } from '../api/_orders_logic.js';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const CARRITO = readFileSync(
+  path.join(ROOT, 'astro-front', 'src', 'pages', 'carrito.astro'),
+  'utf8',
+);
+
+// ── 1. Cabecera ──────────────────────────────────────────────────────────
+
+test('1. título "Finalizar compra" y línea comercial visibles desde el primer viewport (checkout ON)', () => {
+  assert.match(CARRITO, /<h1 class="cart-h1">Finalizar compra<\/h1>/);
+  assert.match(CARRITO, /class="cart-commercial-line">Transferencia 12% menos · Mercado Pago hasta 12 cuotas</);
+  // La línea comercial es condicional a checkoutEnabled, igual que el resto
+  // de la UI de pago — no debe aparecer incondicionalmente.
+  const idx = CARRITO.indexOf('cart-commercial-line');
+  const before = CARRITO.slice(Math.max(0, idx - 200), idx);
+  assert.match(before, /\{checkoutEnabled && \(/);
+});
+
+test('2. "Seguir comprando" sigue siendo un enlace secundario, no protagonista', () => {
+  assert.match(CARRITO, /id="btn-back-to-shopping" class="btn-context-back"/);
+});
+
+// ── 2. Layout de 2 columnas ──────────────────────────────────────────────
+
+test('3. grid de 2 columnas sólo a partir de ~960px; mobile es una sola columna por defecto', () => {
+  const baseStart = CARRITO.indexOf('.checkout-layout {');
+  const baseBlock = CARRITO.slice(baseStart, CARRITO.indexOf('}', baseStart));
+  assert.match(baseBlock, /display:\s*flex/, 'por defecto (mobile) es flex de una columna, no grid');
+
+  const mqStart = CARRITO.indexOf('@media (min-width: 960px)', baseStart);
+  assert.notEqual(mqStart, -1);
+  const mqBlock = CARRITO.slice(mqStart, mqStart + 600);
+  assert.match(mqBlock, /grid-template-columns:\s*60fr 38fr/);
+  assert.match(mqBlock, /\.checkout-left\s*\{[^}]*grid-column:\s*1/);
+  assert.match(mqBlock, /\.checkout-summary\s*\{[^}]*grid-column:\s*2/);
+  assert.match(mqBlock, /position:\s*sticky/);
+});
+
+test('4. el resumen va primero en el DOM (orden natural mobile) y sólo por CSS pasa a la derecha en desktop', () => {
+  const summaryIdx = CARRITO.indexOf('class="checkout-summary"');
+  const leftIdx = CARRITO.indexOf('class="checkout-left"');
+  assert.notEqual(summaryIdx, -1);
+  assert.notEqual(leftIdx, -1);
+  assert.ok(summaryIdx < leftIdx, 'en el DOM, el resumen debe preceder a Entrega/Datos/Pago (orden mobile)');
+});
+
+test('5. no se tocó el breakpoint mobile existente (640px) de la barra sticky', () => {
+  assert.match(CARRITO, /@media \(max-width: 640px\)/);
+  const mqIdx = CARRITO.indexOf('@media (max-width: 640px)');
+  const mqBlock = CARRITO.slice(mqIdx, mqIdx + 1600);
+  assert.match(mqBlock, /position:\s*fixed/);
+});
+
+// ── 3. Selector de medio de pago ─────────────────────────────────────────
+
+test('6. "¿Cómo querés pagar?" con dos radios reales, sin preselección', () => {
+  assert.match(CARRITO, /¿Cómo querés pagar\?/);
+  const sectionStart = CARRITO.indexOf('class="payment-method-section');
+  const sectionEnd = CARRITO.indexOf('</div>', CARRITO.indexOf('err-payment-method', sectionStart));
+  const section = CARRITO.slice(sectionStart, sectionEnd);
+  const radios = section.match(/<input type="radio" name="payment-method"[^>]*>/g) || [];
+  assert.equal(radios.length, 2);
+  for (const radio of radios) assert.doesNotMatch(radio, /\schecked(?:\s|>)/);
+  assert.match(section, /value="transfer"/);
+  assert.match(section, /value="mercadopago"/);
+});
+
+test('7. transferencia aparece primero (prioridad comercial) y con badge "12% menos"', () => {
+  const transferIdx = CARRITO.indexOf('value="transfer"');
+  const mpIdx = CARRITO.indexOf('value="mercadopago"');
+  assert.ok(transferIdx < mpIdx, 'transferencia debe listarse antes que Mercado Pago');
+  const badgeWindow = CARRITO.slice(transferIdx, mpIdx);
+  assert.match(badgeWindow, /class="payment-opt-badge">12% menos</);
+});
+
+test('8. Mercado Pago muestra "Tarjetas, débito y hasta 12 cuotas"', () => {
+  const mpIdx = CARRITO.indexOf('value="mercadopago"');
+  const window_ = CARRITO.slice(mpIdx, mpIdx + 400);
+  assert.match(window_, /Tarjetas, débito y hasta 12 cuotas/);
+});
+
+test('9. requirePaymentMethod(): mismo patrón que requireDeliveryType() — mensaje, foco y scroll', () => {
+  const start = CARRITO.indexOf('function requirePaymentMethod');
+  assert.notEqual(start, -1);
+  const fn = CARRITO.slice(start, start + 700);
+  assert.match(fn, /errEl\.textContent = 'Elegí cómo querés pagar\.'/);
+  assert.match(fn, /errEl\.hidden = false/);
+  assert.match(fn, /firstMethod\.setAttribute\('aria-invalid', 'true'\)/);
+  assert.match(fn, /firstMethod\.focus\(\)/);
+  assert.match(fn, /firstMethod\.scrollIntoView/);
+});
+
+// ── 4. CTA único — reutiliza los handlers existentes sin fusionarlos ────
+
+test('10. sólo un CTA visible a la vez: neutro, transferencia o Mercado Pago según el medio elegido', () => {
+  // Los tres botones arrancan hidden en el markup — la visibilidad la
+  // decide syncPaymentAvailability() en tiempo de ejecución, nunca los tres
+  // a la vez.
+  assert.match(CARRITO, /id="btn-confirm-neutral" class="btn-checkout-primary">/);
+  assert.match(CARRITO, /id="btn-transfer-order" class="btn-transfer-primary" aria-describedby="checkout-error" hidden>/);
+  assert.match(CARRITO, /id="btn-prepare-order" class="btn-checkout-primary" aria-describedby="checkout-error" hidden>/);
+
+  const start = CARRITO.indexOf('function syncPaymentAvailability');
+  const fn = CARRITO.slice(start, start + 1400);
+  assert.match(fn, /transferButton\.hidden = paymentMethod !== 'transfer'/);
+  assert.match(fn, /mercadoPagoButton\.hidden = paymentMethod !== 'mercadopago'/);
+  assert.match(fn, /neutralButton\.hidden = hasPaymentMethod/);
+});
+
+test('11. el CTA neutro no fusiona la lógica de pago: sólo exige entrega y medio, nunca llama a /api/orders', () => {
+  const start = CARRITO.indexOf("btnConfirmNeutral.addEventListener('click'");
+  assert.notEqual(start, -1);
+  const block = CARRITO.slice(start, start + 400);
+  assert.match(block, /if \(btnConfirmNeutral\.disabled\) return;/);
+  assert.match(block, /if \(!requireDeliveryType\(\)\) return;/);
+  assert.match(block, /requirePaymentMethod\(\);/);
+  assert.doesNotMatch(block, /fetch\(/);
+});
+
+test('12. createTransferOrder() y el handler de Mercado Pago no cambiaron: cero referencias a payment-method', () => {
+  const transferStart = CARRITO.indexOf('async function createTransferOrder');
+  const transferEnd = CARRITO.indexOf('if (btnTransfer) {', transferStart);
+  assert.doesNotMatch(CARRITO.slice(transferStart, transferEnd), /payment-method|getPaymentMethod|requirePaymentMethod/);
+
+  const prepareStart = CARRITO.indexOf("btnPrepare.addEventListener('click'");
+  const prepareEnd = CARRITO.indexOf('refreshCartAvailability({ initial: true })', prepareStart);
+  assert.doesNotMatch(CARRITO.slice(prepareStart, prepareEnd), /payment-method|getPaymentMethod|requirePaymentMethod/);
+});
+
+test('13. elegir medio de pago recalcula disponibilidad y guarda el borrador', () => {
+  const start = CARRITO.indexOf("var paymentMethodRadios = document.querySelectorAll('input[name=\"payment-method\"]');");
+  assert.notEqual(start, -1);
+  const block = CARRITO.slice(start, start + 400);
+  assert.match(block, /clearPaymentMethodError\(\)/);
+  assert.match(block, /updateTotals\(\)/);
+  assert.match(block, /syncPaymentAvailability\(\)/);
+  assert.match(block, /saveDraft\(\)/);
+});
+
+test('14. el medio de pago se persiste y restaura en el borrador de sessionStorage', () => {
+  assert.match(CARRITO, /payment_method: getPaymentMethod\(\)/);
+  assert.match(CARRITO, /draft\.payment_method/);
+});
+
+// ── 5. Preview "Pagás $X" de transferencia — paridad real ────────────────
+
+test('15. la fórmula del preview es un espejo textual exacto de calculateTransferTotals() (mismo factor, mismo redondeo)', () => {
+  assert.match(CARRITO, /var TRANSFER_FACTOR\s*=\s*0\.88;/);
+  const matches = CARRITO.match(/Math\.round\(subtotal \* TRANSFER_FACTOR\)/g) || [];
+  assert.equal(matches.length, 2, 'debe aparecer una vez en la rama de retiro y otra en la de envío');
+});
+
+test('16. paridad NUMÉRICA real contra calculateTransferTotals() del backend, en 12 combinaciones', () => {
+  const RETIRO_DISCOUNT = 150;
+  const SHIPPING_COST = 250;
+  const FREE_SHIPPING_THRESHOLD_UYU = 1500;
+
+  // Reimplementa EXACTAMENTE lo que ejecuta el navegador (mismas líneas que
+  // updateTotals() en carrito.astro), no una aproximación.
+  function clientPreview(subtotal, deliveryType) {
+    const isPickup = deliveryType === 'pickup';
+    const pickupEligible = qualifiesForPickupDiscount(subtotal);
+    const pickupDiscount = isPickup && pickupEligible ? RETIRO_DISCOUNT : 0;
+    const shippingCost = !isPickup && subtotal < FREE_SHIPPING_THRESHOLD_UYU ? SHIPPING_COST : 0;
+    const transferProductsTotal = Math.round(subtotal * 0.88);
+    const transferPayable = isPickup
+      ? Math.max(0, transferProductsTotal - pickupDiscount)
+      : Math.max(0, transferProductsTotal + shippingCost);
+    return transferPayable;
+  }
+
+  const cases = [
+    [2000, 'pickup'], [1000, 'shipping'], [1299, 'pickup'], [1300, 'pickup'],
+    [1301, 'pickup'], [1499, 'shipping'], [1500, 'shipping'], [1501, 'shipping'],
+    [3, 'pickup'], [645, 'pickup'], [999, 'shipping'], [1200, 'shipping'],
+  ];
+
+  for (const [subtotal, deliveryType] of cases) {
+    const totals = calculateTotals([{ line_total_uyu: subtotal }], deliveryType);
+    const server = calculateTransferTotals(totals);
+    const client = clientPreview(subtotal, deliveryType);
+    assert.equal(
+      client, server.transferPayableTotal,
+      `subtotal=${subtotal} ${deliveryType}: cliente=${client} servidor=${server.transferPayableTotal}`,
+    );
+  }
+});
+
+test('17. la línea de Mercado Pago reusa el mismo total ya mostrado (sin cálculo propio)', () => {
+  const pickupBranch = CARRITO.slice(CARRITO.indexOf('if (isPickup) {'), CARRITO.indexOf('} else {'));
+  assert.match(pickupBranch, /mpPreviewEl\.textContent = 'Pagás ' \+ fmt\.format\(total\)/);
+});
+
+test('18. sin entrega elegida (o carrito vacío) el preview de transferencia queda oculto, nunca en $0 engañoso', () => {
+  const start = CARRITO.indexOf('if (!deliveryType || subtotal <= 0) {');
+  const block = CARRITO.slice(start, CARRITO.indexOf('return;', start));
+  assert.match(block, /transferPreviewEl\.hidden = true; transferPreviewEl\.textContent = '';/);
+  assert.match(block, /mpPreviewEl\.\s*\{ mpPreviewEl\.hidden = true; mpPreviewEl\.textContent = ''; \}|mpPreviewEl\.hidden = true;/);
+});
+
+// ── 6. Resumen / disclosure / "Editar" ───────────────────────────────────
+
+test('19. el resumen usa <details> nativo y accesible, no un modal', () => {
+  assert.match(CARRITO, /<details id="cart-summary-panel" class="cart-summary-panel">/);
+  assert.match(CARRITO, /<summary class="cart-summary-toggle">/);
+  assert.doesNotMatch(CARRITO, /class="modal"|role="dialog"/);
+});
+
+test('20. desktop fuerza el resumen siempre expandido vía CSS, sin depender del atributo open', () => {
+  assert.match(CARRITO, /\.cart-summary-panel:not\(\[open\]\) \.cart-summary-body\s*\{\s*display:\s*flex;/);
+  // Esa regla vive dentro de un @media (min-width: 960px) cercano, no aplica en mobile.
+  const ruleIdx = CARRITO.indexOf('.cart-summary-panel:not([open]) .cart-summary-body');
+  const precedingMq = CARRITO.lastIndexOf('@media (min-width: 960px)', ruleIdx);
+  assert.ok(precedingMq !== -1 && ruleIdx - precedingMq < 300, 'la regla debe estar dentro del bloque @media, no suelta');
+});
+
+test('20b. el override de desktop también alcanza ::details-content (no sólo el hijo)', () => {
+  // Regresión real encontrada con Playwright: Chromium colapsa el contenido
+  // de un <details> cerrado con un pseudo-elemento interno
+  // (::details-content), no sólo con display en los hijos. Sin este
+  // segundo override el panel medía 0 de alto en desktop aunque
+  // .cart-summary-body ya tuviera display:flex — "Editar" quedaba
+  // inalcanzable por completo en 1440×900.
+  assert.match(CARRITO, /\.cart-summary-panel:not\(\[open\]\)::details-content\s*\{\s*\n\s*content-visibility:\s*visible;\s*\n\s*display:\s*block;/);
+});
+
+test('21. "Editar" reutiliza buildItemRow() sin reescribirla — sólo agrega una fila compacta nueva y separada', () => {
+  assert.match(CARRITO, /function buildItemRow\(item, validation\) \{/);
+  assert.match(CARRITO, /function buildCompactItemRow\(item, validation\) \{/);
+  // buildItemRow sigue siendo llamada exactamente igual que antes de V1.1.
+  assert.match(CARRITO, /itemsList\.appendChild\(buildItemRow\(cart\.items\[i\], validationFor\(cart\.items\[i\]\)\)\);/);
+});
+
+test('22. la lista completa arranca oculta (hidden) hasta tocar "Editar"; el toggle no borra nada, sólo alterna visibilidad', () => {
+  assert.match(CARRITO, /id="cart-items" role="list" aria-label="Artículos en el carrito" class="cart-items-full" hidden>/);
+  const start = CARRITO.indexOf('if (btnToggleEditor) {');
+  const block = CARRITO.slice(start, start + 400);
+  assert.match(block, /itemsList\.hidden = expanded/);
+  assert.match(block, /itemsCompactList\.hidden = !expanded/);
+  assert.doesNotMatch(block, /\.remove\(\)|innerHTML\s*=\s*''/);
+});
+
+test('23. "Vaciar carrito" ya no es el primer control de la página — vive dentro de la tarjeta de totales', () => {
+  const clearIdx = CARRITO.indexOf('id="btn-clear"');
+  const totalsCardIdx = CARRITO.indexOf('class="cart-totals-card"');
+  const entregaIdx = CARRITO.indexOf('¿Cómo querés recibir tu pedido?');
+  assert.ok(totalsCardIdx !== -1 && totalsCardIdx < clearIdx, 'btn-clear debe estar dentro de cart-totals-card');
+  assert.ok(clearIdx < entregaIdx, 'sigue viviendo en el resumen, no mezclado con el formulario de Entrega');
+});
+
+// ── 7. Copy aprobado: Entrega, sin promesas de ETA ───────────────────────
+
+test('24. copy de Entrega es el aprobado — sin "hoy"/"mañana"/fecha estimada', () => {
+  assert.match(CARRITO, /Retiro en Ciudad Vieja/);
+  assert.match(CARRITO, /Entregas de lunes a viernes · coordinamos día y franja contigo/);
+  assert.match(CARRITO, /class="delivery-opt-badge">Gratis desde \$1\.500</);
+
+  const entregaStart = CARRITO.indexOf('¿Cómo querés recibir tu pedido?');
+  const entregaEnd = CARRITO.indexOf('</section>', entregaStart);
+  const entregaBlock = CARRITO.slice(entregaStart, entregaEnd);
+  assert.doesNotMatch(entregaBlock, /\bhoy\b/i, 'no debe prometer "disponible/retiro/entrega hoy"');
+  assert.doesNotMatch(entregaBlock, /\bmañana\b/i, 'no debe prometer "entrega/llega mañana"');
+});
+
+test('25. el horario de retiro sigue siendo exactamente el copy canónico de PICKUP.hours', () => {
+  assert.match(CARRITO, /Lunes a viernes, de 8 a 17 h/);
+});
+
+// ── 8. "Tus datos": campos comunes, microcopy de WhatsApp, Barrio obligatorio ─
+
+test('26. Nombre, WhatsApp y Email siguen siendo el mínimo común, los tres marcados como obligatorios', () => {
+  const start = CARRITO.indexOf('<h2 class="cart-section-h2">Tus datos</h2>');
+  const end = CARRITO.indexOf('</section>', start);
+  const block = CARRITO.slice(start, end);
+  assert.match(block, /for="buyer-name" class="form-label">Nombre <span class="form-req"/);
+  assert.match(block, /for="buyer-phone" class="form-label">WhatsApp \/ Teléfono <span class="form-req"/);
+  assert.match(block, /for="buyer-email" class="form-label">Correo electrónico <span class="form-req"/);
+});
+
+test('27. microcopy debajo de WhatsApp explica para qué se usa el dato', () => {
+  assert.match(CARRITO, /id="buyer-phone-help">Lo usamos únicamente para coordinar tu pedido y la entrega\.</);
+  assert.match(CARRITO, /aria-describedby="buyer-phone-help err-buyer-phone"/);
+});
+
+test('28. Barrio queda visualmente marcado como obligatorio (backend ya lo exige para envío)', () => {
+  assert.match(CARRITO, /for="delivery-barrio" class="form-label">Barrio \/ Localidad <span class="form-req" aria-hidden="true">\*<\/span><\/label>/);
+});
+
+test('29. progressive disclosure de envío no cambió: sigue oculto con retiro, sin campos nuevos inventados', () => {
+  const shippingFieldIds = (CARRITO.match(/id="delivery-(address|barrio|departamento|notes)"/g) || []).length;
+  assert.equal(shippingFieldIds, 4, 'los mismos 4 campos de siempre, ninguno agregado ni quitado');
+  assert.match(CARRITO, /id="shipping-fields" class="shipping-fields" hidden>/);
+});
+
+// ── 9. Microcopy de respaldo humano (texto final) ────────────────────────
+
+test('30. el texto final aprobado reemplaza la versión anterior en #310', () => {
+  assert.match(CARRITO, /y te ayudamos a completar la compra\./);
+  assert.doesNotMatch(CARRITO, /Te atendemos personalmente\./);
+  assert.doesNotMatch(CARRITO, /si algo no funciona como esperabas/i);
+});

--- a/functions/api/__tests__/orders.test.js
+++ b/functions/api/__tests__/orders.test.js
@@ -169,6 +169,41 @@ test('batch fallido devuelve 500 sin commit', async()=>{
   const d=dbMock({batchError:Error('D1')}); const r=await call(pickup('fail'),d); assert.equal(r.response.status,500); assert.equal(d.committed.length,0);
 });
 
+// BLOQUEANTE (Preview checkout-ON, ronda de revisión): un batch fallido por
+// desalineación de esquema real (ej.: columna faltante por una migración no
+// aplicada en Preview) devolvía un mensaje genérico sin código, y el
+// detalle real del error de D1 (nombre de columna, etc.) nunca quedaba
+// registrado en los logs — sólo `error.name` ("Error"), inútil para
+// diagnosticar. Ahora: mensaje claro para el cliente que aclara que no se
+// cobró nada, un `code` interno para triage, y el detalle real del error
+// (sin PII, es información de esquema) sí queda en los logs del servidor.
+test('batch fallido: mensaje al cliente aclara que no se cobró nada, code interno para triage, sin exponer el detalle del error', async()=>{
+  const d=dbMock({batchError:Error('no such column: ga_client_id: SQLITE_ERROR')});
+  const r=await call(pickup('fail-schema'),d);
+  assert.equal(r.response.status,500);
+  assert.equal(r.data.code,'ORDERS_DB_WRITE_FAILED');
+  assert.match(r.data.error,/No pudimos registrar tu pedido/);
+  assert.match(r.data.error,/No se realizó ningún cobro/);
+  assert.match(r.data.error,/WhatsApp/);
+  assert.doesNotMatch(r.data.error,/ga_client_id|SQLITE_ERROR|no such column/);
+});
+
+test('batch fallido: el detalle real del error SÍ queda en los logs del servidor (para diagnosticar sin adivinar)', async()=>{
+  const originalConsoleError = console.error;
+  const logs = [];
+  console.error = (...args) => { logs.push(args); };
+  try {
+    const d=dbMock({batchError:Error('no such column: ga_client_id: SQLITE_ERROR')});
+    await call(pickup('fail-schema-logged'),d);
+  } finally {
+    console.error = originalConsoleError;
+  }
+  const batchLog = logs.find((args) => String(args[0]).includes('[orders] batch error'));
+  assert.ok(batchLog, 'debe loguear el error del batch');
+  assert.match(batchLog.join(' '), /ORDERS_DB_WRITE_FAILED/);
+  assert.match(batchLog.join(' '), /ga_client_id/);
+});
+
 test('carrera idempotente recupera orden sin depender del texto del error', async()=>{
   const b=pickup('race'), race=stored(b), d=dbMock({batchError:Error('opaque'),race}); const r=await call(b,d); assert.equal(r.response.status,200); assert.equal(r.data.order.public_code,'AL-TEST'); assert.equal(d.lookups(),2);
 });

--- a/functions/api/__tests__/orders.test.js
+++ b/functions/api/__tests__/orders.test.js
@@ -111,8 +111,10 @@ test('idempotencia idéntica responde antes de R2', async()=>{
   const r=await call(body,d,{},handler(async()=>{calls++; throw Error('R2');})); assert.equal(r.response.status,200); assert.equal(calls,0);
 });
 
-test('misma clave con pedido distinto devuelve 409', async()=>{
-  const body=pickup('conflict'); const r=await call(body,dbMock({existing:stored(body,{request_fingerprint:'otro'})})); assert.equal(r.response.status,409);
+test('misma clave con pedido distinto devuelve 409 con code de recuperación (IDEMPOTENCY_CONFLICT)', async()=>{
+  const body=pickup('conflict'); const r=await call(body,dbMock({existing:stored(body,{request_fingerprint:'otro'})}));
+  assert.equal(r.response.status,409);
+  assert.equal(r.data.code,'IDEMPOTENCY_CONFLICT');
 });
 
 test('orden vencida devuelve 410 y se marca expired', async()=>{

--- a/functions/api/_orders_handler.js
+++ b/functions/api/_orders_handler.js
@@ -290,8 +290,12 @@ async function findOrderByIdempotencyKey(db, idempotencyKey) {
 
 async function handleExistingOrder({ db, order, fingerprint, now }) {
   if (order.request_fingerprint !== fingerprint) {
+    // code interno para que el cliente pueda recuperarse (rotar identidad y
+    // reintentar) sin depender de parsear el texto — y sin que el texto
+    // técnico ("idempotency_key"/"request_fingerprint") le llegue nunca al
+    // comprador; carrito.astro nunca muestra `error` para este code.
     return json(
-      { error: 'Conflicto: el mismo idempotency_key fue usado con un pedido diferente.' },
+      { error: 'Conflicto: el mismo idempotency_key fue usado con un pedido diferente.', code: 'IDEMPOTENCY_CONFLICT' },
       409
     );
   }

--- a/functions/api/_orders_handler.js
+++ b/functions/api/_orders_handler.js
@@ -253,8 +253,18 @@ export function createOrdersHandler({ fetchCatalog, getNow = () => new Date(), v
         // Se conserva el error genérico de escritura; no se expone detalle interno.
       }
 
-      console.error('[orders] batch error', safeErrorName(batchError));
-      return json({ error: 'Error al guardar el pedido. Intentá de nuevo.' }, 500);
+      // code=ORDERS_DB_WRITE_FAILED identifica esta etapa exacta (el batch de
+      // INSERT en orders/order_items/order_events) en los logs — sin exponer
+      // el detalle del error (nombre de columna, constraint, etc.) al cliente.
+      console.error(
+        '[orders] batch error code=ORDERS_DB_WRITE_FAILED',
+        safeErrorName(batchError),
+        safeErrorMessage(batchError)
+      );
+      return json({
+        error: 'No pudimos registrar tu pedido. No se realizó ningún cobro. Intentá nuevamente; si continúa, escribinos por WhatsApp.',
+        code: 'ORDERS_DB_WRITE_FAILED',
+      }, 500);
     }
 
     return json({
@@ -333,6 +343,17 @@ function safeErrorName(error) {
   return error && typeof error === 'object' && typeof error.name === 'string'
     ? error.name
     : 'Error';
+}
+
+// El mensaje de un error de D1 (p.ej. "no such column: ga_client_id") es
+// información estructural del esquema, no PII ni datos del comprador — es
+// justo lo que hace falta para diagnosticar sin adivinar, y sólo va al log
+// del servidor (nunca a la respuesta del cliente). Mismo patrón ya usado en
+// functions/_shared/r2-access.js.
+function safeErrorMessage(error) {
+  return error && typeof error === 'object' && typeof error.message === 'string'
+    ? error.message.slice(0, 200)
+    : 'error';
 }
 
 function json(data, status = 200, extraHeaders = {}) {


### PR DESCRIPTION
## Objetivo

Este PR quedó en Draft mientras acumuló varias etapas aprobadas del plan V1.1 para `/carrito`, sobre la misma rama:

1. **Checkout guidance** (commits iniciales): guiar al cliente cuando falta elegir entrega, y activar el mensaje de envío gratis.
2. **Rediseño profundo del checkout** (commits siguientes): layout de 2 columnas en desktop, selector explícito de medio de pago, CTA único, preview de "Pagás $X" con paridad real contra el backend, y las 4 correcciones de una revisión posterior de ChatGPT sobre ese rediseño.
3. **Auditoría anti-errores-tontos de entorno/Preview**: la única Preview compartida hasta entonces (`pr-310...`) nunca tuvo el checkout activo; se agregó un pipeline dedicado (`checkout-v11-preview`) con el checkout realmente encendido.
4. **Corrección de un bloqueante real encontrado en esa Preview**: `POST /api/orders` fallaba al crear la orden — ver sección 4 abajo. Esta etapa **sí toca backend** (`functions/api/_orders_handler.js`) y agrega un evento de analítica nuevo.
5. **Corrección de un segundo bloqueante real, encontrado en la prueba humana de la sección 4**: reutilizar `idempotency_key` para un pedido que cambió (entrega/datos) chocaba con el fail-safe del backend (409). Ver sección 5 abajo. Esta etapa **sí toca la lógica de idempotencia** en frontend (`cart.js`, `carrito.astro`) y backend (`_orders_handler.js`).

## 1. Checkout guidance

- `syncPaymentAvailability()` separa el bloqueo técnico real (stock validado, sin fallos, sin validación en curso, carrito con ítems pagables) de si ya se eligió entrega — la falta de entrega, por sí sola, ya no deja el CTA `disabled`; al hacer click, `requireDeliveryType()` guía con mensaje, foco y scroll.
- `astro-front/public/orders-guard.js` (guard global en fase *capture*) deja pasar el click de los CTA de pago hacia `requireDeliveryType()` cuando lo único que falta es la entrega, en vez de bloquearlo antes con el error de nombre/teléfono.
- `#cart-shipping-msg` ahora muestra "Te faltan $X para envío gratis" / "Tu envío es gratis" según corresponda, reusando los mismos `shippingCost`/`subtotal` ya calculados.

## 2. Rediseño profundo del checkout (`#checkout-edit-step`)

Wireframe y paquete de implementación aprobados explícitamente por Seba y por el reviewer de ChatGPT antes de tocar código. Alcance:

- **Layout**: desktop ≥960px pasa a grid de 2 columnas (60/40, resumen sticky a la derecha); mobile sigue en una sola columna. El orden real del DOM no cambia (el resumen sigue primero, como corresponde al flujo lineal mobile) — el reacomodo a la derecha en desktop es sólo `grid-column`, sin duplicar markup.
- **Resumen** (`<details id="cart-summary-panel">`): fila compacta por producto (`buildCompactItemRow()`, función nueva y separada — no reescribe `buildItemRow()`), con "Editar" que revela la lista completa existente sin recrearla. "Vaciar carrito" pasa a control secundario dentro de la tarjeta de totales.
- **Entrega**: copy reescrito ("Retiro en Ciudad Vieja" / "Envío a domicilio"), sin ninguna promesa de ETA ("hoy"/"mañana"). Barrio ahora se marca visualmente obligatorio (el backend ya lo exigía; era un bug visual).
- **Tus datos**: Nombre/WhatsApp/Email como mínimo común real, con microcopy explicando para qué se usa el WhatsApp.
- **Selector de pago** ("¿Cómo querés pagar?"): radio-group nuevo, sin preselección, Transferencia primero con badge "12% menos" y preview "Pagás $X" — con **paridad numérica real** contra `calculateTransferTotals()` del backend, verificada con un test que importa la función real del backend (12 combinaciones). Mercado Pago muestra "Tarjetas, débito y hasta 12 cuotas" + su propio preview. El total del resumen, del sticky mobile y de la orden creada en el backend reflejan el medio de pago realmente elegido.
- **CTA único**: nunca dos CTA primarios visibles a la vez. `#btn-transfer-order` y `#btn-prepare-order` quedan intactos — sólo cambia su visibilidad según el medio elegido, y se congelan (radios `disabled`) mientras un envío está en curso. Un tercer botón neutro (`#btn-confirm-neutral`) aparece mientras no hay medio elegido, y sigue el orden completo del flujo vía `focusFirstMissingRequirement()`.
- **Robustez del resumen desktop**: ya no depende de `::details-content` (pseudo-elemento interno de Chromium) — JS fuerza el atributo real `open` del `<details>` según el viewport.

## 3. Auditoría anti-errores-tontos de entorno/Preview

`deploy-pr-preview.yml` (el Preview automático de todo PR) compila deliberadamente con `PUBLIC_CHECKOUT_ENABLED: 'false'` — audita SEO/catálogo, nunca mostró el checkout online. No existía ningún pipeline que desplegara un Preview con el checkout visible (`docs/environments.md` ya lo documentaba como pendiente). Se agregó `deploy-checkout-v11-preview.yml`, gateado únicamente a esta rama, que construye con la config pública **real** de Preview (Turnstile de `amadolibros-orders-preview`, no la de Producción) y despliega con un smoke que falla si el checkout no está de verdad presente:

**https://checkout-v11-preview.amadolibros-web.pages.dev/carrito/**

## 4. Corrección de bloqueante real: `POST /api/orders` fallaba en la Preview checkout-ON

Al probar la Preview de la sección 3 de punta a punta, `POST /api/orders` devolvía 500 ("Error al guardar el pedido") con datos válidos, en cualquier combinación de entrega/medio de pago.

**Causa raíz**: el INSERT en `orders` (`functions/api/_orders_handler.js`) referencia `buyer_email` (migración 0006) y `ga_client_id`/`ga_session_id` (migración 0008), pero ningún workflow aplicaba migraciones a la D1 de Preview (`amadolibros-orders-preview`) — sólo `deploy.yml` lo hace, y sólo `--env production`. La D1 de Preview quedó desactualizada desde que se agregaron esas columnas. Confirmado con evidencia real: `PRAGMA table_info(orders)` contra la D1 de Preview mostró las 3 columnas ausentes antes de la corrección y presentes después.

**Corrección**:
- `deploy-checkout-v11-preview.yml`: nuevo paso `wrangler d1 migrations apply ORDERS_DB --env preview --remote` antes de cada deploy de esta Preview, con diagnóstico antes/después. No toca Producción ni su D1 (`amadolibros-orders-production`, database_id distinto, bindeada aparte).
- **`functions/api/_orders_handler.js`**: nuevo `safeErrorMessage()` registra el detalle real del error de D1 en los logs del servidor — nunca al cliente. Nuevo `code: 'ORDERS_DB_WRITE_FAILED'` en la respuesta para triage. Mensaje al cliente: "No pudimos registrar tu pedido. No se realizó ningún cobro. Intentá nuevamente; si continúa, escribinos por WhatsApp."
- `carrito.astro`: el handler de Mercado Pago ya no antepone "Error: " al mensaje del servidor (causaba el "Error: Error al guardar el pedido..." duplicado reportado).
- **Nuevo evento GA4 `checkout_error`** (`astro-front/public/analytics-events.js` + `carrito.astro`), sin ningún dato personal: mide en qué etapa (`order_create` / `preference_create` / `transfer_options`) se traba un comprador. Sólo 4 parámetros, cada uno contra una lista cerrada; `error_code` exige forma de code interno (nunca texto libre del error). Igual que el resto del módulo, no emite nada fuera de los hosts de Producción.

## 5. Corrección de bloqueante real: reutilización de `idempotency_key` para un pedido distinto (409)

Encontrado en la prueba humana de la sección 4, sobre la misma Preview: crear una orden válida, volver al checkout, cambiar el pedido (entrega y/o datos del comprador) y reintentar devolvía "Conflicto: el mismo idempotency_key fue usado con un pedido diferente."

**Causa raíz**: `cart.js` sólo rotaba `idempotency_key` ante cambios de **items** (`add`/`remove`/`setQty`/`syncValidated`/`clear`). `delivery_type`, `buyer` y `shipping` también forman parte del `request_fingerprint` real que valida el backend (`generateFingerprint()` en `_orders_logic.js`), pero viven en el DOM del formulario — fuera del conocimiento de `cart.js`. `carrito.astro` sólo rotaba la key explícitamente al volver desde la pantalla de transferencia (`btnEditOrder`). Cualquier otro camino de vuelta al checkout (volver de Mercado Pago, recargar la página, editar campos directamente) dejaba la misma key asociada a un fingerprint viejo — y el fail-safe del backend (correcto, por diseño) respondía 409 ante un pedido distinto con esa key.

**Regla final del ciclo de vida** (implementada de forma centralizada): una `idempotency_key` representa un único fingerprint lógico de pedido. Un reintento del mismo pedido (red, doble click, volver sin cambiar nada) conserva la misma key. Si el pedido cambia después de haber sido enviado con esa key, se genera una key nueva **antes** del siguiente submit — nunca se rota indiscriminadamente en cada intento.

**Corrección**:
- `astro-front/public/cart.js`: nuevo `AmadoCart.ensureKeyForFingerprint(fingerprint)` — único punto que decide, antes de cada submit, si la key vigente sigue sirviendo para el fingerprint actual o si hay que rotar. Guarda, junto a la key, el último fingerprint con el que se envió.
- `carrito.astro`: ambos flujos de submit (Mercado Pago y Transferencia) calculan `checkoutFingerprint()` — espejo del `generateFingerprint()` real del backend, **sin** `payment_method` (igual que el backend, para que cambiar de medio de pago sin cambiar el resto del pedido reutilice la misma orden sin conflicto) — y llaman a `ensureKeyForFingerprint()` justo antes de enviar.
- `functions/api/_orders_handler.js`: el 409 por fingerprint distinto ahora trae `code: 'IDEMPOTENCY_CONFLICT'` para que el cliente se recupere sin parsear texto.
- `carrito.astro`: ante `IDEMPOTENCY_CONFLICT` u `ORDER_EXPIRED`, se rota la key (recuperación segura, listo para el próximo intento) y se muestra "Actualizamos tu pedido para poder continuar. Intentá nuevamente." — **nunca** el texto técnico del servidor ("idempotency_key"/"request_fingerprint") — instrumentando `checkout_error` con el code interno, sin PII.

Casos cubiertos explícitamente (tests + revisión de código): mismo pedido + retry de red → misma key; doble click → misma key; cambio Retiro↔Envío → nueva key; cambio de nombre/teléfono/email → nueva key; cambio de dirección/barrio/departamento/notas → nueva key; cambio de items → nueva key (ya rotaba, ahora sin doble rotación); volver desde Mercado Pago sin cambiar nada → reutiliza la orden (200); pasar de Mercado Pago a Transferencia sin cambiar el pedido → reutiliza la misma orden sin conflicto (el fingerprint no incluye el medio de pago); orden expirada → recuperación segura con key nueva.

**No modifica** precios, descuentos, stock, ni la lógica de Mercado Pago/Turnstile — sólo el ciclo de vida de la key/fingerprint alrededor de `POST /api/orders`.

## Fuera de alcance

Precios, descuentos comerciales, stock, lógica de Mercado Pago/Turnstile, SEO, canonical, ISBN/B12, buscador, Merchant, y **Producción** (código y deploy) — nada de esto se tocó en ninguna etapa. Las secciones 4 y 5 sí modifican backend (observabilidad de un error de escritura en D1, ciclo de vida de idempotencia, un evento de analítica), pero son cambios de infraestructura/diagnóstico y de robustez del propio flujo de checkout, no de lógica comercial ni de Producción.

## Tests

- `functions/__tests__/v1.1-checkout-guidance.test.js` (21 tests), `v1.1-checkout-redesign.test.js` (44 tests), `preview-orders-checkout-blocker.test.js`, `idempotency-lifecycle.test.js` (nuevo — 10 tests, ciclo de vida completo A-I ejecutado vía `node:vm` sobre el `cart.js` real).
- `functions/api/__tests__/orders.test.js`: tests para el mensaje/code/logging del error de escritura en D1, y para el `code: 'IDEMPOTENCY_CONFLICT'` del 409.
- `functions/__tests__/analytics-events.test.js`: tests ejecutables (VM real) para `checkout_error` — lista cerrada, descarte de texto libre, sin datos personales.
- Ajustes de expectativa estructural (no de garantías funcionales) en `checkout-single-step.test.js`, `pickup-cx-2.test.js` y `preview-orders-checkout-blocker.test.js` por cambios de copy/estructura aprobados.
- **Suite completa**: 1154/1154 (`functions/__tests__`) + 272/272 (`functions/api/__tests__`) + 117/117 (`worker-sync`) + 63/63 (`categorize`) + 30/30 (`astro-front/src/lib`) = **1636/1636**.
- **`bash scripts/validate-ci.sh`**: OK (incluye ambos builds, checkout ON/OFF). **`git diff --check`**: sin errores de espacios en blanco.

## Confirmación

No se tocó Producción (código ni deploy), precios, descuentos, stock, cálculo de envío, lógica de Mercado Pago/Turnstile en ninguna etapa. Rama creada desde `main` en `8ee44d54ecab02cd24415fe1208abc7a4b0a4d5b`. **PR en Draft — no fusionar ni desplegar a Producción sin autorización expresa de Seba.**

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri