### PR TITLE
diag(merchant): ampliar diagnóstico de solo lectura a todos los reportingContext

### DIFF
--- a/.github/workflows/merchant-readonly-audit.yml
+++ b/.github/workflows/merchant-readonly-audit.yml
@@ -10,6 +10,8 @@ on:
       - 'scripts/commerce/public-landing-check.mjs'
       - 'functions/__tests__/merchant-readonly-audit.test.js'
       - 'functions/__tests__/public-landing-check.test.js'
+      - 'scripts/seo/image-dimension-audit.mjs'
+      - 'functions/__tests__/image-dimension-audit.test.js'
   pull_request:
     paths:
       - '.github/workflows/merchant-readonly-audit.yml'
@@ -17,6 +19,8 @@ on:
       - 'scripts/commerce/public-landing-check.mjs'
       - 'functions/__tests__/merchant-readonly-audit.test.js'
       - 'functions/__tests__/public-landing-check.test.js'
+      - 'scripts/seo/image-dimension-audit.mjs'
+      - 'functions/__tests__/image-dimension-audit.test.js'
   workflow_dispatch:
 
 permissions:
@@ -48,6 +52,8 @@ jobs:
           node --test functions/__tests__/merchant-readonly-audit.test.js
           node --check scripts/commerce/public-landing-check.mjs
           node --test functions/__tests__/public-landing-check.test.js
+          node --check scripts/seo/image-dimension-audit.mjs
+          node --test functions/__tests__/image-dimension-audit.test.js
 
       - name: Authenticate with Google through Workload Identity
         id: google_auth
@@ -84,6 +90,15 @@ jobs:
         env:
           MERCHANT_REPORT_PATH: artifacts/merchant/merchant-readonly-report.json
         run: node scripts/commerce/public-landing-check.mjs
+
+      - name: QW2 — medir dimensiones reales de image_too_small (sólo lectura)
+        id: image_dimension_audit
+        if: steps.merchant_audit.outcome == 'success'
+        continue-on-error: true
+        env:
+          IMAGE_AUDIT_INPUT: artifacts/merchant/merchant-readonly-report.json
+          IMAGE_AUDIT_OUTPUT_DIR: artifacts/merchant
+        run: node scripts/seo/image-dimension-audit.mjs
 
       - name: Upload Merchant audit
         if: always()

--- a/.github/workflows/merchant-readonly-audit.yml
+++ b/.github/workflows/merchant-readonly-audit.yml
@@ -194,6 +194,26 @@ jobs:
           SEO_OUTPUT_DIR: artifacts/merchant
         run: node scripts/seo/catalog-coverage-effective.mjs
 
+      # Los informes completos quedan en el artefacto; este paso final imprime
+      # sólo los totales, para poder leerlos desde el log sin descargarlo.
+      - name: Resumen compacto de la evidencia QW1
+        if: always()
+        continue-on-error: true
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const read = p => { try { return JSON.parse(fs.readFileSync(p, "utf8")); } catch { return null; } };
+            const ev = read("artifacts/merchant/qw1-cohort-catalog-evidence.json");
+            const diff = read("artifacts/merchant/qw1-render-diff.json");
+            const cov = read("artifacts/merchant/catalog-coverage-effective.json");
+            console.log("=== RESUMEN COMPACTO QW1 ===");
+            console.log(JSON.stringify({
+              evidencia: ev && { fetchedAt: ev.fetchedAt, sources: ev.sources, cohortSize: ev.cohortSize, counts: ev.counts },
+              diff: diff && { before: diff.before, after: diff.after, comparedItems: diff.comparedItems, counts: diff.counts, coherence: diff.coherence },
+              cobertura: cov && { universe: cov.universe, catalogUpdatedAt: cov.catalogUpdatedAt },
+            }, null, 2));
+          '
+
       - name: Upload Merchant audit
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/merchant-readonly-audit.yml
+++ b/.github/workflows/merchant-readonly-audit.yml
@@ -14,6 +14,12 @@ on:
       - 'functions/__tests__/image-dimension-audit.test.js'
       - 'scripts/seo/qw1-preview-validation.mjs'
       - 'functions/__tests__/qw1-preview-validation.test.js'
+      - 'scripts/seo/qw1-cohort-catalog-evidence.mjs'
+      - 'scripts/seo/qw1-catalog-snapshot.mjs'
+      - 'scripts/seo/qw1-renderer-offer-report.mjs'
+      - 'scripts/seo/qw1-render-diff.mjs'
+      - 'scripts/seo/catalog-coverage-effective.mjs'
+      - 'functions/__tests__/qw1-evidence-and-diff.test.js'
   pull_request:
     paths:
       - '.github/workflows/merchant-readonly-audit.yml'
@@ -25,6 +31,12 @@ on:
       - 'functions/__tests__/image-dimension-audit.test.js'
       - 'scripts/seo/qw1-preview-validation.mjs'
       - 'functions/__tests__/qw1-preview-validation.test.js'
+      - 'scripts/seo/qw1-cohort-catalog-evidence.mjs'
+      - 'scripts/seo/qw1-catalog-snapshot.mjs'
+      - 'scripts/seo/qw1-renderer-offer-report.mjs'
+      - 'scripts/seo/qw1-render-diff.mjs'
+      - 'scripts/seo/catalog-coverage-effective.mjs'
+      - 'functions/__tests__/qw1-evidence-and-diff.test.js'
   workflow_dispatch:
 
 permissions:
@@ -60,6 +72,12 @@ jobs:
           node --test functions/__tests__/image-dimension-audit.test.js
           node --check scripts/seo/qw1-preview-validation.mjs
           node --test functions/__tests__/qw1-preview-validation.test.js
+          node --check scripts/seo/qw1-cohort-catalog-evidence.mjs
+          node --check scripts/seo/qw1-catalog-snapshot.mjs
+          node --check scripts/seo/qw1-renderer-offer-report.mjs
+          node --check scripts/seo/qw1-render-diff.mjs
+          node --check scripts/seo/catalog-coverage-effective.mjs
+          node --test functions/__tests__/qw1-evidence-and-diff.test.js
 
       - name: Authenticate with Google through Workload Identity
         id: google_auth
@@ -114,6 +132,67 @@ jobs:
           QW1_VALIDATION_INPUT: artifacts/merchant/merchant-readonly-report.json
           QW1_VALIDATION_OUTPUT_DIR: artifacts/merchant
         run: node scripts/seo/qw1-preview-validation.mjs
+
+      - name: QW1 — evidencia de catálogo por entorno (sin inferencias)
+        id: qw1_catalog_evidence
+        if: steps.merchant_audit.outcome == 'success'
+        continue-on-error: true
+        env:
+          QW1_EVIDENCE_INPUT: artifacts/merchant/merchant-readonly-report.json
+          QW1_EVIDENCE_OUTPUT_DIR: artifacts/merchant
+        run: node scripts/seo/qw1-cohort-catalog-evidence.mjs
+
+      - name: QW1 — snapshot reproducible del catálogo real
+        id: qw1_snapshot
+        if: steps.merchant_audit.outcome == 'success'
+        continue-on-error: true
+        env:
+          QW1_COHORT_INPUT: artifacts/merchant/merchant-readonly-report.json
+          QW1_SNAPSHOT: artifacts/merchant/qw1-catalog-snapshot.json
+          QW1_INCLUDE_ALL_ACTIVE: '1'
+        run: node scripts/seo/qw1-catalog-snapshot.mjs
+
+      - name: QW1 — render con el renderizador de main y con el del PR #313
+        id: qw1_render
+        if: steps.qw1_snapshot.outcome == 'success'
+        continue-on-error: true
+        env:
+          QW1_SNAPSHOT: artifacts/merchant/qw1-catalog-snapshot.json
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 origin \
+            '+refs/heads/main:refs/remotes/origin/main' \
+            '+refs/heads/agent/merchant-qw1-offer-price:refs/remotes/origin/agent/merchant-qw1-offer-price'
+          MAIN_SHA="$(git rev-parse refs/remotes/origin/main)"
+          PR313_SHA="$(git rev-parse refs/remotes/origin/agent/merchant-qw1-offer-price)"
+          cp "functions/libro/[[path]].js" /tmp/renderer-current.js
+
+          git checkout origin/main -- "functions/libro/[[path]].js"
+          QW1_RENDER_OUTPUT=artifacts/merchant/qw1-render-main.json \
+          QW1_RENDER_LABEL=main QW1_RENDER_SHA="$MAIN_SHA" \
+            node scripts/seo/qw1-renderer-offer-report.mjs
+
+          git checkout origin/agent/merchant-qw1-offer-price -- "functions/libro/[[path]].js"
+          QW1_RENDER_OUTPUT=artifacts/merchant/qw1-render-pr313.json \
+          QW1_RENDER_LABEL=pr313 QW1_RENDER_SHA="$PR313_SHA" \
+            node scripts/seo/qw1-renderer-offer-report.mjs
+
+          cp /tmp/renderer-current.js "functions/libro/[[path]].js"
+
+      - name: QW1 — diff entre ambos renderizadores
+        if: steps.qw1_render.outcome == 'success'
+        continue-on-error: true
+        env:
+          QW1_DIFF_BEFORE: artifacts/merchant/qw1-render-main.json
+          QW1_DIFF_AFTER: artifacts/merchant/qw1-render-pr313.json
+          QW1_DIFF_OUTPUT: artifacts/merchant/qw1-render-diff.json
+        run: node scripts/seo/qw1-render-diff.mjs
+
+      - name: Cobertura cruda vs efectiva del catálogo
+        continue-on-error: true
+        env:
+          SEO_OUTPUT_DIR: artifacts/merchant
+        run: node scripts/seo/catalog-coverage-effective.mjs
 
       - name: Upload Merchant audit
         if: always()

--- a/.github/workflows/merchant-readonly-audit.yml
+++ b/.github/workflows/merchant-readonly-audit.yml
@@ -12,6 +12,8 @@ on:
       - 'functions/__tests__/public-landing-check.test.js'
       - 'scripts/seo/image-dimension-audit.mjs'
       - 'functions/__tests__/image-dimension-audit.test.js'
+      - 'scripts/seo/qw1-preview-validation.mjs'
+      - 'functions/__tests__/qw1-preview-validation.test.js'
   pull_request:
     paths:
       - '.github/workflows/merchant-readonly-audit.yml'
@@ -21,6 +23,8 @@ on:
       - 'functions/__tests__/public-landing-check.test.js'
       - 'scripts/seo/image-dimension-audit.mjs'
       - 'functions/__tests__/image-dimension-audit.test.js'
+      - 'scripts/seo/qw1-preview-validation.mjs'
+      - 'functions/__tests__/qw1-preview-validation.test.js'
   workflow_dispatch:
 
 permissions:
@@ -54,6 +58,8 @@ jobs:
           node --test functions/__tests__/public-landing-check.test.js
           node --check scripts/seo/image-dimension-audit.mjs
           node --test functions/__tests__/image-dimension-audit.test.js
+          node --check scripts/seo/qw1-preview-validation.mjs
+          node --test functions/__tests__/qw1-preview-validation.test.js
 
       - name: Authenticate with Google through Workload Identity
         id: google_auth
@@ -99,6 +105,15 @@ jobs:
           IMAGE_AUDIT_INPUT: artifacts/merchant/merchant-readonly-report.json
           IMAGE_AUDIT_OUTPUT_DIR: artifacts/merchant
         run: node scripts/seo/image-dimension-audit.mjs
+
+      - name: QW1 — validar cohorte real Producción vs Preview PR #313 (sólo lectura)
+        id: qw1_preview_validation
+        if: steps.merchant_audit.outcome == 'success'
+        continue-on-error: true
+        env:
+          QW1_VALIDATION_INPUT: artifacts/merchant/merchant-readonly-report.json
+          QW1_VALIDATION_OUTPUT_DIR: artifacts/merchant
+        run: node scripts/seo/qw1-preview-validation.mjs
 
       - name: Upload Merchant audit
         if: always()

--- a/.github/workflows/merchant-readonly-audit.yml
+++ b/.github/workflows/merchant-readonly-audit.yml
@@ -7,12 +7,16 @@ on:
     paths:
       - '.github/workflows/merchant-readonly-audit.yml'
       - 'scripts/commerce/merchant-readonly-audit.mjs'
+      - 'scripts/commerce/public-landing-check.mjs'
       - 'functions/__tests__/merchant-readonly-audit.test.js'
+      - 'functions/__tests__/public-landing-check.test.js'
   pull_request:
     paths:
       - '.github/workflows/merchant-readonly-audit.yml'
       - 'scripts/commerce/merchant-readonly-audit.mjs'
+      - 'scripts/commerce/public-landing-check.mjs'
       - 'functions/__tests__/merchant-readonly-audit.test.js'
+      - 'functions/__tests__/public-landing-check.test.js'
   workflow_dispatch:
 
 permissions:
@@ -42,6 +46,8 @@ jobs:
         run: |
           node --check scripts/commerce/merchant-readonly-audit.mjs
           node --test functions/__tests__/merchant-readonly-audit.test.js
+          node --check scripts/commerce/public-landing-check.mjs
+          node --test functions/__tests__/public-landing-check.test.js
 
       - name: Authenticate with Google through Workload Identity
         id: google_auth
@@ -70,6 +76,14 @@ jobs:
           test -s artifacts/merchant/merchant-readonly-report.json
           test -s artifacts/merchant/report-summary.md
           node -e "const r=require('./artifacts/merchant/merchant-readonly-report.json'); if(r.schemaVersion!==1||r.accountId!=='5330457716') process.exit(1)"
+
+      - name: Verify public landing pages (sitio propio, sólo lectura)
+        id: public_landing_check
+        if: steps.merchant_audit.outcome == 'success'
+        continue-on-error: true
+        env:
+          MERCHANT_REPORT_PATH: artifacts/merchant/merchant-readonly-report.json
+        run: node scripts/commerce/public-landing-check.mjs
 
       - name: Upload Merchant audit
         if: always()

--- a/functions/__tests__/image-dimension-audit.test.js
+++ b/functions/__tests__/image-dimension-audit.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+test('la implementación es de solo lectura: no escribe en R2, no llama a Merchant, no usa Cloudflare Images', () => {
+  const source = readFileSync('scripts/seo/image-dimension-audit.mjs', 'utf8');
+  assert.doesNotMatch(source, /\.put\(|\.delete\(/);
+  assert.doesNotMatch(source, /merchantapi\.googleapis\.com/i);
+  assert.doesNotMatch(source, /env\.IMAGES|imagesBinding|upscale/i);
+  const fetchCalls = source.match(/\bfetch\(/g) || [];
+  assert.equal(fetchCalls.length, 1);
+});
+
+test('readImageDimensions (worker-sync/cover-mirror.js) sigue exportada y mide JPEG/PNG reales', async () => {
+  const { readImageDimensions } = await import('../../worker-sync/cover-mirror.js');
+  // JPEG 2x1 mínimo válido (marcador SOF0) — sólo se necesita el header.
+  const jpeg = new Uint8Array([
+    0xff, 0xd8, 0xff, 0xc0, 0x00, 0x11, 0x08,
+    0x00, 0x01, 0x00, 0x02, // height=1, width=2
+    0x03, 0x01, 0x11, 0x00, 0x02, 0x11, 0x01, 0x03, 0x11, 0x01,
+    0xff, 0xd9,
+  ]);
+  const dims = readImageDimensions(jpeg);
+  assert.equal(dims.width, 2);
+  assert.equal(dims.height, 1);
+  assert.equal(dims.mime, 'image/jpeg');
+});

--- a/functions/__tests__/merchant-readonly-audit.test.js
+++ b/functions/__tests__/merchant-readonly-audit.test.js
@@ -3,9 +3,13 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 import {
+  accountIssueLogSummary,
   aggregateDynamicRemarketingUy,
+  aggregateProductStatusesByContextUy,
   buildDiagnosis,
   countFeedItems,
+  finalizeContextSummary,
+  joinDataSourceProductCounts,
   summarizeDataSource,
   summarizeProducts,
 } from '../../scripts/commerce/merchant-readonly-audit.mjs';
@@ -117,10 +121,129 @@ test('el diagnóstico diferencia hechos de hipótesis', () => {
   assert.ok(diagnosis.hypotheses.some(row => row.text.includes('2 fuentes primarias')));
 });
 
+// BLOQUEANTE PR #311 — Merchant Center (Gran Apuesta): el diagnóstico
+// original filtraba deliberadamente a un solo reportingContext (Dynamic
+// remarketing / DISPLAY_ADS), así que nunca mostraba Shopping ads, Free
+// listings ni ningún otro destino que la cuenta pudiera tener. Estas
+// pruebas cubren la ampliación: agrupar TODOS los reportingContext reales
+// de Uruguay sin descartar ninguno, cruzar dataSources con su conteo real
+// de productos, y resumir accountIssues sin PII.
+
+test('agrupa TODOS los reportingContext de Uruguay, sin descartar ninguno', () => {
+  const byContext = aggregateProductStatusesByContextUy([
+    {
+      reportingContext: 'DISPLAY_ADS',
+      country: 'UY',
+      stats: { activeCount: '3381', pendingCount: '0', disapprovedCount: '318' },
+      itemLevelIssues: [{ code: 'personal_hardships_policy_violation', severity: 'DISAPPROVED', productCount: '239' }],
+    },
+    {
+      reportingContext: 'SHOPPING_ADS',
+      country: 'UY',
+      stats: { activeCount: '500', pendingCount: '10', disapprovedCount: '5' },
+      itemLevelIssues: [{ code: 'missing_gtin', severity: 'DEMOTED', productCount: '12' }],
+    },
+    {
+      reportingContext: 'FREE_LISTINGS',
+      country: 'UY',
+      stats: { activeCount: '200' },
+    },
+    {
+      // Otro país: no debe mezclarse con Uruguay.
+      reportingContext: 'DISPLAY_ADS',
+      country: 'AR',
+      stats: { activeCount: '999' },
+    },
+  ]);
+
+  assert.equal(byContext.size, 3);
+  assert.ok(byContext.has('DISPLAY_ADS'));
+  assert.ok(byContext.has('SHOPPING_ADS'));
+  assert.ok(byContext.has('FREE_LISTINGS'));
+
+  const display = byContext.get('DISPLAY_ADS');
+  assert.equal(display.active, 3381);
+  assert.equal(display.disapproved, 318);
+  assert.equal(display.issueCounts.get('personal_hardships_policy_violation').productCount, 239);
+
+  const shopping = byContext.get('SHOPPING_ADS');
+  assert.equal(shopping.active, 500);
+  assert.equal(shopping.pending, 10);
+  assert.equal(shopping.issueCounts.get('missing_gtin').productCount, 12);
+
+  const free = byContext.get('FREE_LISTINGS');
+  assert.equal(free.active, 200);
+  assert.equal(free.pending, 0);
+});
+
+test('un reportingContext desconocido/nuevo también se agrupa (no hay lista cerrada de contextos)', () => {
+  const byContext = aggregateProductStatusesByContextUy([
+    { reportingContext: 'LOCAL_INVENTORY_ADS', country: 'UY', stats: { activeCount: '3' } },
+  ]);
+  assert.equal(byContext.size, 1);
+  assert.equal(byContext.get('LOCAL_INVENTORY_ADS').active, 3);
+});
+
+test('finalizeContextSummary ordena por productCount y respeta el límite (top N)', () => {
+  const summary = {
+    reportingContext: 'SHOPPING_ADS',
+    rows: 1,
+    active: 10,
+    pending: 0,
+    disapproved: 3,
+    expiring: 0,
+    issueCounts: new Map([
+      ['a_code', { code: 'a_code', severity: 'DISAPPROVED', productCount: 1 }],
+      ['b_code', { code: 'b_code', severity: 'DISAPPROVED', productCount: 5 }],
+      ['c_code', { code: 'c_code', severity: 'DISAPPROVED', productCount: 3 }],
+    ]),
+  };
+  const finalized = finalizeContextSummary(summary, 2);
+  assert.equal(finalized.reportingContext, 'SHOPPING_ADS');
+  assert.equal(finalized.topIssues.length, 2);
+  assert.deepEqual(finalized.topIssues.map(row => row.code), ['b_code', 'c_code']);
+});
+
+test('cruza dataSources con el conteo real de productos por fuente', () => {
+  const dataSources = [
+    { name: 'accounts/533/dataSources/1', displayName: 'Feed Amado', type: 'primaryProductDataSource' },
+    { name: 'accounts/533/dataSources/2', displayName: 'Suplementaria', type: 'supplementalProductDataSource' },
+  ];
+  const byDataSource = [{ dataSource: 'accounts/533/dataSources/1', count: 6974 }];
+  const joined = joinDataSourceProductCounts(dataSources, byDataSource);
+  assert.equal(joined[0].productCount, 6974);
+  assert.equal(joined[1].productCount, 0);
+  assert.equal(joined[0].displayName, 'Feed Amado');
+});
+
+test('el resumen de accountIssues no expone PII y lista los destinos afectados sin duplicar', () => {
+  const summary = accountIssueLogSummary({
+    title: 'Cuenta pendiente de verificación',
+    severity: 'CRITICAL',
+    impactedDestinations: [
+      { reportingContext: 'SHOPPING_ADS', impacts: [] },
+      { reportingContext: 'SHOPPING_ADS', impacts: [] },
+      { reportingContext: 'FREE_LISTINGS', impacts: [] },
+    ],
+  });
+  assert.equal(summary.title, 'Cuenta pendiente de verificación');
+  assert.equal(summary.severity, 'CRITICAL');
+  assert.deepEqual(summary.destinations, ['SHOPPING_ADS', 'FREE_LISTINGS']);
+  assert.doesNotMatch(JSON.stringify(summary), /@|telefono|phone|email/i);
+});
+
 test('la implementación no contiene llamadas de escritura a Merchant API', () => {
   const source = readFileSync('scripts/commerce/merchant-readonly-audit.mjs', 'utf8');
   assert.doesNotMatch(source, /method\s*:\s*['"](?:POST|PATCH|PUT|DELETE)['"]/i);
   assert.doesNotMatch(source, /productInputs:insert|:fetch|triggeraction/i);
   assert.match(source, /merchantapi\.googleapis\.com/);
   assert.doesNotMatch(source, /\/v1beta\//);
+
+  // La ampliación del diagnóstico (reportingContexts, dataSources con
+  // conteo, accountIssues) es puro post-procesamiento en memoria de datos
+  // ya leídos — no agrega ninguna llamada de red nueva. Sólo dos fetch()
+  // deben existir en todo el archivo: el de listAll() (endpoints Merchant,
+  // todos GET) y el del feed público.
+  const fetchCalls = source.match(/\bfetch\(/g) || [];
+  assert.equal(fetchCalls.length, 2);
 });

--- a/functions/__tests__/merchant-readonly-audit.test.js
+++ b/functions/__tests__/merchant-readonly-audit.test.js
@@ -8,14 +8,18 @@ import {
   aggregateProductStatusesByContextUy,
   buildDataSourceInputMap,
   buildDiagnosis,
+  buildIdentityIndex,
   compareOfferIdsAcrossInputs,
   countByInput,
   countFeedItems,
   crossReferenceOfferIds,
   finalizeContextSummary,
+  findTwin,
   joinDataSourceProductCounts,
   listProductsByIssueCode,
+  normalizeLink,
   productDestinationStatus,
+  reconcileIdentity,
   summarizeDataSource,
   summarizeProducts,
 } from '../../scripts/commerce/merchant-readonly-audit.mjs';
@@ -367,6 +371,59 @@ test('productDestinationStatus devuelve el estado real por reportingContext, no 
   assert.equal(productDestinationStatus(product, 'SHOPPING_ADS'), 'disapproved');
   assert.equal(productDestinationStatus(product, 'FREE_LISTINGS'), 'active');
   assert.equal(productDestinationStatus(product, 'DISPLAY_ADS'), 'missing_context');
+});
+
+// BLOQUEANTE PR #312 (misma auditoría, mismo PR) — reconciliación por
+// identidad real (link normalizado / GTIN) entre AUTOFEED y FILE: dos
+// offer_id distintos pueden ser el mismo libro. Puro post-procesamiento en
+// memoria sobre productAttributes.link/gtin ya leídos por products.list.
+
+test('normalizeLink ignora query/hash/slash final y mayúsculas de host', () => {
+  assert.equal(
+    normalizeLink('https://www.AmadoLibros.com/libro/MLU1/titulo/?utm_source=x#frag'),
+    normalizeLink('https://www.amadolibros.com/libro/MLU1/titulo'),
+  );
+  assert.equal(normalizeLink(''), null);
+  assert.equal(normalizeLink(null), null);
+});
+
+test('findTwin encuentra el gemelo real por link o, si no hay, por GTIN', () => {
+  const index = buildIdentityIndex([
+    { offerId: 'FILE-1', title: 'Rayuela (FILE)', link: 'https://www.amadolibros.com/libro/rayuela', gtin: null },
+    { offerId: 'FILE-2', title: 'Cien años (FILE)', link: null, gtin: '9780307474728' },
+  ]);
+
+  const byLink = findTwin({ offerId: 'AUTO-1', link: 'https://www.amadolibros.com/libro/rayuela/', gtin: null }, index);
+  assert.equal(byLink.offerId, 'FILE-1');
+  assert.equal(byLink.matchedBy, 'link');
+
+  const byGtin = findTwin({ offerId: 'AUTO-2', link: null, gtin: '9780307474728' }, index);
+  assert.equal(byGtin.offerId, 'FILE-2');
+  assert.equal(byGtin.matchedBy, 'gtin');
+
+  const noMatch = findTwin({ offerId: 'AUTO-3', link: 'https://www.amadolibros.com/libro/otro', gtin: '000' }, index);
+  assert.equal(noMatch, null);
+});
+
+test('reconcileIdentity cuenta productos probablemente iguales aunque el offer_id no coincida', () => {
+  const fileRows = [
+    { offerId: 'FILE-1', title: 'Rayuela (FILE)', link: 'https://www.amadolibros.com/libro/rayuela', gtin: null },
+    { offerId: 'FILE-2', title: 'Cien años (FILE)', link: null, gtin: '9780307474728' },
+    { offerId: 'FILE-3', title: 'Sin relación', link: 'https://www.amadolibros.com/libro/otro-mas', gtin: null },
+  ];
+  const autofeedRows = [
+    { offerId: 'AUTO-1', title: 'Rayuela (AUTOFEED)', link: 'https://www.amadolibros.com/libro/rayuela/', gtin: null },
+    { offerId: 'AUTO-2', title: 'Cien años (AUTOFEED)', link: null, gtin: '9780307474728' },
+    { offerId: 'AUTO-3', title: 'No tiene gemelo', link: 'https://www.amadolibros.com/libro/no-existe', gtin: null },
+  ];
+
+  const index = buildIdentityIndex(fileRows);
+  const result = reconcileIdentity(autofeedRows, index, 20);
+  assert.equal(result.rowsChecked, 3);
+  assert.equal(result.linkMatches, 1);
+  assert.equal(result.gtinMatches, 1);
+  assert.equal(result.probableSameBook, 2);
+  assert.equal(result.sample.length, 2);
 });
 
 test('la implementación no contiene llamadas de escritura a Merchant API', () => {

--- a/functions/__tests__/merchant-readonly-audit.test.js
+++ b/functions/__tests__/merchant-readonly-audit.test.js
@@ -6,10 +6,16 @@ import {
   accountIssueLogSummary,
   aggregateDynamicRemarketingUy,
   aggregateProductStatusesByContextUy,
+  buildDataSourceInputMap,
   buildDiagnosis,
+  compareOfferIdsAcrossInputs,
+  countByInput,
   countFeedItems,
+  crossReferenceOfferIds,
   finalizeContextSummary,
   joinDataSourceProductCounts,
+  listProductsByIssueCode,
+  productDestinationStatus,
   summarizeDataSource,
   summarizeProducts,
 } from '../../scripts/commerce/merchant-readonly-audit.mjs';
@@ -230,6 +236,137 @@ test('el resumen de accountIssues no expone PII y lista los destinos afectados s
   assert.equal(summary.severity, 'CRITICAL');
   assert.deepEqual(summary.destinations, ['SHOPPING_ADS', 'FREE_LISTINGS']);
   assert.doesNotMatch(JSON.stringify(summary), /@|telefono|phone|email/i);
+});
+
+// BLOQUEANTE PR #312 (misma auditoría, mismo PR) — detalle producto por
+// producto de los bloqueos prioritarios (image_too_small, precio faltante,
+// ebooks, landing pages) y cruce real de offer_id entre AUTOFEED y FILE.
+// Todo puro post-procesamiento en memoria sobre products.list ya leído.
+
+function sampleProduct(overrides = {}) {
+  return {
+    offerId: 'AL-0001',
+    dataSource: 'accounts/533/dataSources/1',
+    productAttributes: {
+      title: 'Cien años de soledad',
+      link: 'https://www.amadolibros.com/producto/cien-anos-de-soledad?utm_source=x',
+      imageLink: 'https://cdn.amadolibros.com/img/cien-anos.jpg?token=secreto',
+      price: { amountMicros: '450000000', currencyCode: 'UYU' },
+      availability: 'in stock',
+    },
+    productStatus: {
+      destinationStatuses: [
+        { reportingContext: 'SHOPPING_ADS', disapprovedCountries: ['UY'] },
+        { reportingContext: 'FREE_LISTINGS', approvedCountries: ['UY'] },
+      ],
+      itemLevelIssues: [
+        { code: 'image_too_small', severity: 'DISAPPROVED', reportingContext: 'SHOPPING_ADS' },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+test('lista producto por producto los que tienen un código de issue dado, de-duplicados por offer_id', () => {
+  const products = [
+    sampleProduct(),
+    sampleProduct({
+      offerId: 'AL-0002',
+      productAttributes: { ...sampleProduct().productAttributes, title: 'Rayuela', price: undefined },
+      productStatus: {
+        destinationStatuses: [{ reportingContext: 'FREE_LISTINGS', pendingCountries: ['UY'] }],
+        itemLevelIssues: [{ code: 'item_missing_required_attribute', attribute: 'price', reportingContext: 'FREE_LISTINGS' }],
+      },
+    }),
+    sampleProduct({ offerId: 'AL-0003', productStatus: { itemLevelIssues: [{ code: 'ebooks_policy_violation', reportingContext: 'SHOPPING_ADS' }] } }),
+  ];
+
+  const tooSmall = listProductsByIssueCode(products, { code: 'image_too_small', contexts: ['SHOPPING_ADS', 'FREE_LISTINGS'] });
+  assert.equal(tooSmall.length, 1);
+  assert.equal(tooSmall[0].offerId, 'AL-0001');
+  assert.equal(tooSmall[0].title, 'Cien años de soledad');
+  assert.equal(tooSmall[0].price, '450.00 UYU');
+  assert.equal(tooSmall[0].shoppingAdsStatus, 'disapproved');
+  assert.equal(tooSmall[0].freeListingsStatus, 'active');
+  // ni la URL ni la imagen exponen credenciales o tokens de query.
+  assert.equal(JSON.stringify(tooSmall).includes('secreto'), false);
+  assert.equal(JSON.stringify(tooSmall).includes('utm_source'), false);
+
+  const missingPrice = listProductsByIssueCode(products, { code: 'item_missing_required_attribute', attribute: 'price', contexts: ['SHOPPING_ADS', 'FREE_LISTINGS'] });
+  assert.equal(missingPrice.length, 1);
+  assert.equal(missingPrice[0].offerId, 'AL-0002');
+  assert.equal(missingPrice[0].price, null);
+
+  const ebooks = listProductsByIssueCode(products, { code: 'ebooks_policy_violation', contexts: ['SHOPPING_ADS'] });
+  assert.equal(ebooks.length, 1);
+  assert.equal(ebooks[0].offerId, 'AL-0003');
+});
+
+test('el mismo offer_id con dos issues distintos no se cuenta dos veces dentro de una misma lista', () => {
+  const product = sampleProduct({
+    productStatus: {
+      destinationStatuses: [],
+      itemLevelIssues: [
+        { code: 'image_too_small', reportingContext: 'SHOPPING_ADS' },
+        { code: 'image_too_small', reportingContext: 'FREE_LISTINGS' },
+      ],
+    },
+  });
+  const result = listProductsByIssueCode([product, product], { code: 'image_too_small', contexts: ['SHOPPING_ADS', 'FREE_LISTINGS'] });
+  assert.equal(result.length, 1);
+});
+
+test('cruza offer_id exactos entre dos listas de issues (no sólo cantidades)', () => {
+  const a = [{ offerId: 'AL-1' }, { offerId: 'AL-2' }, { offerId: 'AL-3' }];
+  const b = [{ offerId: 'AL-2' }, { offerId: 'AL-4' }];
+  const overlap = crossReferenceOfferIds(a, b);
+  assert.deepEqual(overlap, { both: 1, onlyA: 2, onlyB: 1 });
+});
+
+test('countByInput agrupa filas por el input real de su dataSource', () => {
+  const map = buildDataSourceInputMap([
+    { name: 'accounts/533/dataSources/1', input: 'AUTOFEED' },
+    { name: 'accounts/533/dataSources/2', input: 'FILE' },
+  ]);
+  const rows = [
+    { dataSource: 'accounts/533/dataSources/1' },
+    { dataSource: 'accounts/533/dataSources/1' },
+    { dataSource: 'accounts/533/dataSources/2' },
+    { dataSource: 'accounts/533/dataSources/9' },
+  ];
+  assert.deepEqual(countByInput(rows, map), { AUTOFEED: 2, FILE: 1, '(desconocido)': 1 });
+});
+
+test('compara offer_id reales entre AUTOFEED y FILE, no sólo el total por fuente', () => {
+  const map = buildDataSourceInputMap([
+    { name: 'accounts/533/dataSources/autofeed', input: 'AUTOFEED' },
+    { name: 'accounts/533/dataSources/file', input: 'FILE' },
+  ]);
+  const products = [
+    sampleProduct({ offerId: 'AL-DUP', dataSource: 'accounts/533/dataSources/autofeed', productAttributes: { title: 'Duplicado (autofeed)', price: { amountMicros: '400000000', currencyCode: 'UYU' } } }),
+    sampleProduct({ offerId: 'AL-DUP', dataSource: 'accounts/533/dataSources/file', productAttributes: { title: 'Duplicado (file)', price: { amountMicros: '420000000', currencyCode: 'UYU' } } }),
+    sampleProduct({ offerId: 'AL-SOLO-AUTOFEED', dataSource: 'accounts/533/dataSources/autofeed' }),
+    sampleProduct({ offerId: 'AL-SOLO-FILE', dataSource: 'accounts/533/dataSources/file' }),
+  ];
+
+  const result = compareOfferIdsAcrossInputs(products, map, ['AUTOFEED', 'FILE'], 10);
+  assert.equal(result.totalUniqueOfferIds, 3);
+  assert.equal(result.bothCount, 1);
+  assert.equal(result.onlyACount, 1);
+  assert.equal(result.onlyBCount, 1);
+  assert.equal(result.sampleBoth.length, 1);
+  assert.equal(result.sampleBoth[0].offerId, 'AL-DUP');
+  assert.equal(result.sampleBoth[0].AUTOFEED.title, 'Duplicado (autofeed)');
+  assert.equal(result.sampleBoth[0].FILE.title, 'Duplicado (file)');
+  assert.equal(result.sampleBoth[0].AUTOFEED.price, '400.00 UYU');
+  assert.equal(result.sampleBoth[0].FILE.price, '420.00 UYU');
+});
+
+test('productDestinationStatus devuelve el estado real por reportingContext, no el de Dynamic remarketing', () => {
+  const product = sampleProduct();
+  assert.equal(productDestinationStatus(product, 'SHOPPING_ADS'), 'disapproved');
+  assert.equal(productDestinationStatus(product, 'FREE_LISTINGS'), 'active');
+  assert.equal(productDestinationStatus(product, 'DISPLAY_ADS'), 'missing_context');
 });
 
 test('la implementación no contiene llamadas de escritura a Merchant API', () => {

--- a/functions/__tests__/public-landing-check.test.js
+++ b/functions/__tests__/public-landing-check.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import { extractCanonical, extractJsonLdOffers } from '../../scripts/commerce/public-landing-check.mjs';
+
+test('la implementación es de solo lectura, no toca Merchant ni checkout', () => {
+  const source = readFileSync('scripts/commerce/public-landing-check.mjs', 'utf8');
+  assert.doesNotMatch(source, /method\s*:\s*['"](?:POST|PATCH|PUT|DELETE)['"]/i);
+  assert.doesNotMatch(source, /merchantapi\.googleapis\.com/i);
+  assert.doesNotMatch(source, /checkout/i);
+  // Sólo debe existir el fetch() a las páginas públicas del propio catálogo.
+  const fetchCalls = source.match(/\bfetch\(/g) || [];
+  assert.equal(fetchCalls.length, 1);
+});
+
+test('extractJsonLdOffers lee precio/moneda/disponibilidad de un Product válido', () => {
+  const html = `<html><head>
+    <script type="application/ld+json">
+      {"@context":"https://schema.org","@type":"Product","name":"Rayuela",
+       "offers":{"@type":"Offer","price":"1200.00","priceCurrency":"UYU","availability":"https://schema.org/InStock"}}
+    </script>
+  </head><body></body></html>`;
+  const offer = extractJsonLdOffers(html);
+  assert.equal(offer.name, 'Rayuela');
+  assert.equal(offer.price, '1200.00');
+  assert.equal(offer.priceCurrency, 'UYU');
+  assert.equal(offer.availability, 'InStock');
+});
+
+test('extractJsonLdOffers soporta @graph y descarta nodos que no son Product/Book', () => {
+  const html = `<script type="application/ld+json">
+    {"@graph":[
+      {"@type":"BreadcrumbList","itemListElement":[]},
+      {"@type":"Book","name":"Cien años de soledad","offers":{"price":"950","priceCurrency":"UYU","availability":"https://schema.org/OutOfStock"}}
+    ]}
+  </script>`;
+  const offer = extractJsonLdOffers(html);
+  assert.equal(offer.name, 'Cien años de soledad');
+  assert.equal(offer.availability, 'OutOfStock');
+});
+
+test('extractJsonLdOffers devuelve null sin JSON-LD o con JSON inválido', () => {
+  assert.equal(extractJsonLdOffers('<html></html>'), null);
+  assert.equal(extractJsonLdOffers('<script type="application/ld+json">{not valid</script>'), null);
+});
+
+test('extractCanonical toma el href de link rel=canonical', () => {
+  const html = '<head><link rel="canonical" href="https://www.amadolibros.com/libro/x"></head>';
+  assert.equal(extractCanonical(html), 'https://www.amadolibros.com/libro/x');
+  assert.equal(extractCanonical('<head></head>'), null);
+});

--- a/functions/__tests__/qw1-evidence-and-diff.test.js
+++ b/functions/__tests__/qw1-evidence-and-diff.test.js
@@ -1,0 +1,139 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import {
+  classifyCohortRow,
+  resolveItemForEnvironment,
+} from '../../scripts/seo/qw1-cohort-catalog-evidence.mjs';
+import { classifyChange, coherence } from '../../scripts/seo/qw1-render-diff.mjs';
+import { coverageFor } from '../../scripts/seo/catalog-coverage-effective.mjs';
+
+// Revisión de Astra sobre QW1: la ausencia de Offer NO prueba ausencia de
+// precio. Estas pruebas fijan el contrato de la evidencia: cada MLU se
+// resuelve contra la fuente que consume cada entorno y, cuando la fuente no
+// transporta el dato, se dice exactamente eso — no "no tiene precio".
+
+test('un ítem del catálogo activo reporta status/precio/moneda/stock reales', () => {
+  const resolved = resolveItemForEnvironment('MLU1', {
+    catalogItem: { id: 'MLU1', status: 'active', price: 1500, currency_id: 'UYU', available_quantity: 3 },
+    pausedIndex: new Map(),
+  });
+  assert.equal(resolved.source, 'catalog.json');
+  assert.equal(resolved.status, 'active');
+  assert.equal(resolved.price, 1500);
+  assert.equal(resolved.currency, 'UYU');
+  assert.equal(resolved.available_quantity, 3);
+  assert.equal(resolved.httpExpected, 200);
+});
+
+test('un pausado declara que la fuente NO transporta precio ni moneda (no que no tenga)', () => {
+  const resolved = resolveItemForEnvironment('MLU2', {
+    catalogItem: null,
+    pausedIndex: new Map([['MLU2', { id: 'MLU2' }]]),
+  });
+  assert.equal(resolved.source, 'paused-index');
+  assert.equal(resolved.status, 'paused');
+  assert.equal(resolved.price, 'no-transportado-por-la-fuente');
+  assert.equal(resolved.currency, 'no-transportado-por-la-fuente');
+  assert.equal(resolved.httpExpected, 200);
+});
+
+test('un ítem ausente de ambas fuentes del entorno espera HTTP 404', () => {
+  const resolved = resolveItemForEnvironment('MLU3', { catalogItem: null, pausedIndex: new Map() });
+  assert.equal(resolved.source, null);
+  assert.equal(resolved.httpExpected, 404);
+});
+
+test('la clasificación separa 404, pausado y activo-con-precio sin inventar causas', () => {
+  const pausadoEnAmbos = {
+    environments: {
+      produccion: { source: 'paused-index', status: 'paused', httpExpected: 200 },
+      preview: { source: 'paused-index', status: 'paused', httpExpected: 200 },
+    },
+  };
+  assert.equal(classifyCohortRow(pausadoEnAmbos), 'pausado_sin_precio_en_la_fuente');
+
+  const soloEnProduccion = {
+    environments: {
+      produccion: { source: 'paused-index', status: 'paused', httpExpected: 200 },
+      preview: { source: null, status: null, httpExpected: 404 },
+    },
+  };
+  assert.equal(classifyCohortRow(soloEnProduccion), 'no_comparable_404');
+
+  const activoConPrecio = {
+    environments: {
+      produccion: { source: 'catalog.json', status: 'active', price: 990, httpExpected: 200 },
+      preview: { source: 'catalog.json', status: 'active', price: 990, httpExpected: 200 },
+    },
+  };
+  assert.equal(classifyCohortRow(activoConPrecio), 'activo_con_precio_real');
+
+  const activoSinPrecio = {
+    environments: {
+      produccion: { source: 'catalog.json', status: 'active', price: 0, httpExpected: 200 },
+      preview: { source: 'catalog.json', status: 'active', price: 0, httpExpected: 200 },
+    },
+  };
+  assert.equal(classifyCohortRow(activoSinPrecio), 'causa_pendiente_de_verificar');
+});
+
+test('el diff entre renderizadores distingue agregado, removido, modificado y sin cambio', () => {
+  const sinOffer = { offer: null };
+  const conOffer = { offer: { price: '1500', priceCurrency: 'UYU', availability: 'InStock', url: 'u' } };
+  const conOfferOos = { offer: { price: '1500', priceCurrency: 'UYU', availability: 'OutOfStock', url: 'u' } };
+  assert.equal(classifyChange(sinOffer, conOffer), 'offer_agregado');
+  assert.equal(classifyChange(conOffer, sinOffer), 'offer_removido');
+  assert.equal(classifyChange(conOffer, conOfferOos), 'offer_modificado');
+  assert.equal(classifyChange(conOffer, conOffer), 'sin_cambio');
+  assert.equal(classifyChange(sinOffer, sinOffer), 'sin_cambio');
+});
+
+test('la coherencia detecta Offer sin precio visible y botón de compra sin stock', () => {
+  const offerSinPrecioVisible = coherence({
+    offer: { price: '1500', availability: 'OutOfStock' },
+    visiblePriceBox: false,
+    cartButton: false,
+    available_quantity: 0,
+  });
+  assert.equal(offerSinPrecioVisible.offerSinPrecioVisible, true);
+  assert.equal(offerSinPrecioVisible.botonCompraSinStock, false);
+
+  const botonSinStock = coherence({
+    offer: { price: '1500', availability: 'OutOfStock' },
+    visiblePriceBox: true,
+    cartButton: true,
+    available_quantity: 0,
+  });
+  assert.equal(botonSinStock.botonCompraSinStock, true);
+  assert.equal(botonSinStock.offerOutOfStockConBoton, true);
+});
+
+test('la cobertura separa autor no vacío de autor REAL y descripción por umbral', () => {
+  const items = [
+    { author: 'Autora Real', description: 'x'.repeat(300) },
+    { author: 'Desconocido', description: 'corta' },
+    { author: '', description: '' },
+  ];
+  const coverage = coverageFor(items);
+  assert.equal(coverage.author_no_vacio.count, 2);
+  assert.equal(coverage.author_real.count, 1);
+  assert.equal(coverage.author_generico.count, 1);
+  assert.equal(coverage.description_no_vacia.count, 2);
+  assert.equal(coverage.description_util_280.count, 1);
+});
+
+test('los scripts de evidencia son de solo lectura (sin escrituras a Merchant ni al catálogo)', () => {
+  for (const file of [
+    'scripts/seo/qw1-cohort-catalog-evidence.mjs',
+    'scripts/seo/qw1-catalog-snapshot.mjs',
+    'scripts/seo/qw1-renderer-offer-report.mjs',
+    'scripts/seo/qw1-render-diff.mjs',
+    'scripts/seo/catalog-coverage-effective.mjs',
+  ]) {
+    const source = readFileSync(file, 'utf8');
+    assert.doesNotMatch(source, /method\s*:\s*['"](?:POST|PATCH|PUT|DELETE)['"]/i, file);
+    assert.doesNotMatch(source, /merchantapi\.googleapis\.com/i, file);
+  }
+});

--- a/functions/__tests__/qw1-preview-validation.test.js
+++ b/functions/__tests__/qw1-preview-validation.test.js
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+test('la implementación es de solo lectura: sin escritura, sin Merchant, un fetch por lado', () => {
+  const source = readFileSync('scripts/seo/qw1-preview-validation.mjs', 'utf8');
+  assert.doesNotMatch(source, /method\s*:\s*['"](?:POST|PATCH|PUT|DELETE)['"]/i);
+  assert.doesNotMatch(source, /merchantapi\.googleapis\.com/i);
+  const fetchCalls = source.match(/\bfetch\(/g) || [];
+  assert.equal(fetchCalls.length, 1);
+});

--- a/functions/__tests__/qw1-preview-validation.test.js
+++ b/functions/__tests__/qw1-preview-validation.test.js
@@ -2,6 +2,35 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
+import { classify } from '../../scripts/seo/qw1-preview-validation.mjs';
+
+const OFFER_OK = {
+  httpStatus: 200,
+  canonical: 'https://www.amadolibros.com/libro/MLU1/x',
+  offer: {
+    price: '1500',
+    priceCurrency: 'UYU',
+    availability: 'InStock',
+    url: 'https://www.amadolibros.com/libro/MLU1/x',
+  },
+};
+const SIN_OFFER = { httpStatus: 200, canonical: 'https://www.amadolibros.com/libro/MLU1/x', offer: null };
+
+// Revisión de Astra: la ausencia de `Offer` en el HTML no prueba ausencia de
+// precio. Esta comparación sólo puede decir qué cambió entre entornos; la
+// causa la establece qw1-cohort-catalog-evidence.mjs contra el catálogo.
+test('no se infiere "no tiene precio" desde "no hay Offer"', () => {
+  assert.equal(classify(SIN_OFFER, SIN_OFFER), 'sin_offer_causa_pendiente_de_verificar');
+});
+
+test('se separan corregido, ya correcto en ambos, regresión y no comparable', () => {
+  assert.equal(classify(SIN_OFFER, OFFER_OK), 'corregido_por_313');
+  assert.equal(classify(OFFER_OK, OFFER_OK), 'ya_correcto_en_ambos');
+  assert.equal(classify(OFFER_OK, SIN_OFFER), 'regresion_en_313');
+  assert.equal(classify(OFFER_OK, { httpStatus: 404, offer: null }), 'no_comparable_http');
+  assert.equal(classify({ httpStatus: 404, offer: null }, OFFER_OK), 'no_comparable_http');
+});
+
 test('la implementación es de solo lectura: sin escritura, sin Merchant, un fetch por lado', () => {
   const source = readFileSync('scripts/seo/qw1-preview-validation.mjs', 'utf8');
   assert.doesNotMatch(source, /method\s*:\s*['"](?:POST|PATCH|PUT|DELETE)['"]/i);

--- a/scripts/commerce/merchant-readonly-audit.mjs
+++ b/scripts/commerce/merchant-readonly-audit.mjs
@@ -248,6 +248,138 @@ export function accountIssueLogSummary(issue = {}) {
   };
 }
 
+// Segunda ampliación (misma auditoría de solo lectura, mismo PR): las
+// secciones anteriores ya muestran cuántos productos bloquean cada código de
+// issue por reportingContext, pero no CUÁLES productos son. Estas funciones
+// recorren la lista de productos ya obtenida por products.list (sin ninguna
+// llamada nueva) y arman el detalle producto por producto para los bloqueos
+// prioritarios, más el cruce real de offer_id entre AUTOFEED y FILE.
+
+function productOfferId(product) {
+  return asText(product?.offerId) || asText(product?.productAttributes?.offerId) || null;
+}
+
+function productTitle(product) {
+  return asText(product?.productAttributes?.title) || asText(product?.title) || '(sin título)';
+}
+
+function productPriceText(product) {
+  const price = product?.productAttributes?.price;
+  if (!price || price.amountMicros == null) return null;
+  const amount = Number(price.amountMicros) / 1_000_000;
+  const currency = asText(price.currencyCode);
+  return `${Number.isFinite(amount) ? amount.toFixed(2) : price.amountMicros}${currency ? ` ${currency}` : ''}`;
+}
+
+function productAvailability(product) {
+  return asText(product?.productAttributes?.availability) || null;
+}
+
+export function productDestinationStatus(product, context) {
+  const rows = Array.isArray(product?.productStatus?.destinationStatuses) ? product.productStatus.destinationStatuses : [];
+  const row = rows.find(entry => upper(entry.reportingContext) === upper(context));
+  if (!row) return 'missing_context';
+  if ((row.approvedCountries || []).some(isUy)) return 'active';
+  if ((row.pendingCountries || []).some(isUy)) return 'pending';
+  if ((row.disapprovedCountries || []).some(isUy)) return 'disapproved';
+  return 'other_country';
+}
+
+function productRow(product) {
+  return {
+    offerId: productOfferId(product),
+    title: productTitle(product),
+    dataSource: asText(product.dataSource) || null,
+    link: safeFetchUri(product?.productAttributes?.link),
+    imageLink: safeFetchUri(product?.productAttributes?.imageLink),
+    price: productPriceText(product),
+    availability: productAvailability(product),
+    shoppingAdsStatus: productDestinationStatus(product, 'SHOPPING_ADS'),
+    freeListingsStatus: productDestinationStatus(product, 'FREE_LISTINGS'),
+  };
+}
+
+// Lista, de-duplicada por offer_id, los productos cuyo productStatus trae un
+// itemLevelIssue con ese código (y, si se pide, ese atributo y esos
+// reportingContext). Puro filtrado en memoria sobre datos ya leídos.
+export function listProductsByIssueCode(products = [], { code, attribute = null, contexts = [] } = {}) {
+  const wantedContexts = contexts.map(upper);
+  const seen = new Map();
+  for (const product of products) {
+    const issues = Array.isArray(product?.productStatus?.itemLevelIssues) ? product.productStatus.itemLevelIssues : [];
+    const matched = issues.some(issue =>
+      asText(issue.code) === code &&
+      (!attribute || upper(issue.attribute) === upper(attribute)) &&
+      (!wantedContexts.length || wantedContexts.includes(upper(issue.reportingContext)))
+    );
+    if (!matched) continue;
+    const offerId = productOfferId(product) || `(sin offerId #${seen.size})`;
+    if (!seen.has(offerId)) seen.set(offerId, productRow(product));
+  }
+  return [...seen.values()];
+}
+
+export function crossReferenceOfferIds(listA = [], listB = []) {
+  const idsA = new Set(listA.map(row => row.offerId));
+  const idsB = new Set(listB.map(row => row.offerId));
+  const both = [...idsA].filter(id => idsB.has(id));
+  return { both: both.length, onlyA: idsA.size - both.length, onlyB: idsB.size - both.length };
+}
+
+export function countByInput(rows = [], dataSourceInputMap = new Map()) {
+  const counts = {};
+  for (const row of rows) {
+    const input = dataSourceInputMap.get(row.dataSource) || '(desconocido)';
+    counts[input] = (counts[input] || 0) + 1;
+  }
+  return counts;
+}
+
+export function buildDataSourceInputMap(dataSources = []) {
+  const map = new Map();
+  for (const source of dataSources) {
+    if (source?.name) map.set(source.name, upper(source.input));
+  }
+  return map;
+}
+
+// Compara offer_id reales (no sólo cantidades) entre dos inputs de dataSource
+// (por defecto AUTOFEED vs FILE): cuántos offer_id están sólo en uno, sólo en
+// el otro, o en ambos — y para los que están en ambos, una muestra con
+// precio/imagen/disponibilidad/título de cada lado para poder compararlos.
+export function compareOfferIdsAcrossInputs(products = [], dataSourceInputMap = new Map(), inputsToCompare = ['AUTOFEED', 'FILE'], sampleSize = 10) {
+  const [inputA, inputB] = inputsToCompare;
+  const byInput = new Map(inputsToCompare.map(input => [input, new Map()]));
+  for (const product of products) {
+    const input = dataSourceInputMap.get(asText(product.dataSource));
+    const bucket = byInput.get(input);
+    if (!bucket) continue;
+    const offerId = productOfferId(product);
+    if (!offerId) continue;
+    if (!bucket.has(offerId)) bucket.set(offerId, product);
+  }
+  const mapA = byInput.get(inputA);
+  const mapB = byInput.get(inputB);
+  const idsA = new Set(mapA.keys());
+  const idsB = new Set(mapB.keys());
+  const bothIds = [...idsA].filter(id => idsB.has(id));
+  const onlyAIds = [...idsA].filter(id => !idsB.has(id));
+  const onlyBIds = [...idsB].filter(id => !idsA.has(id));
+  return {
+    inputA,
+    inputB,
+    totalUniqueOfferIds: new Set([...idsA, ...idsB]).size,
+    bothCount: bothIds.length,
+    onlyACount: onlyAIds.length,
+    onlyBCount: onlyBIds.length,
+    sampleBoth: bothIds.slice(0, sampleSize).map(offerId => ({
+      offerId,
+      [inputA]: productRow(mapA.get(offerId)),
+      [inputB]: productRow(mapB.get(offerId)),
+    })),
+  };
+}
+
 function productDestinationState(product, country = 'UY') {
   const rows = Array.isArray(product?.productStatus?.destinationStatuses)
     ? product.productStatus.destinationStatuses.filter(row => isDynamicRemarketing(row.reportingContext))
@@ -597,6 +729,32 @@ export async function main() {
 
   const dataSourcesWithCounts = joinDataSourceProductCounts(dataSources, products?.byDataSource || []);
 
+  // Tercera ampliación (mismo PR): detalle producto por producto de los
+  // bloqueos prioritarios (image_too_small, precio faltante, ebooks,
+  // landing pages) y el cruce real de offer_id entre AUTOFEED y FILE — todo
+  // en memoria sobre los mismos productos ya leídos por products.list.
+  const rawProducts = byName.products.data || [];
+  const dataSourceInputMap = buildDataSourceInputMap(dataSources);
+  const shoppingFreeContexts = ['SHOPPING_ADS', 'FREE_LISTINGS'];
+
+  const imageTooSmall = listProductsByIssueCode(rawProducts, { code: 'image_too_small', contexts: shoppingFreeContexts });
+  const missingPrice = listProductsByIssueCode(rawProducts, { code: 'item_missing_required_attribute', attribute: 'price', contexts: shoppingFreeContexts });
+  const ebooks = listProductsByIssueCode(rawProducts, { code: 'ebooks_policy_violation', contexts: ['SHOPPING_ADS'] });
+  const landingPendingCrawl = listProductsByIssueCode(rawProducts, { code: 'landing_page_pending_crawl', contexts: shoppingFreeContexts });
+  const landingError = listProductsByIssueCode(rawProducts, { code: 'landing_page_error', contexts: shoppingFreeContexts });
+
+  const productBreakdown = {
+    imageTooSmall,
+    imageTooSmallByInput: countByInput(imageTooSmall, dataSourceInputMap),
+    missingPrice,
+    missingPriceByInput: countByInput(missingPrice, dataSourceInputMap),
+    overlapImageTooSmallVsMissingPrice: crossReferenceOfferIds(imageTooSmall, missingPrice),
+    ebooks,
+    landingPendingCrawl,
+    landingError,
+    autofeedVsFile: compareOfferIdsAcrossInputs(rawProducts, dataSourceInputMap, ['AUTOFEED', 'FILE'], 10),
+  };
+
   const report = {
     schemaVersion: 1,
     generatedAt: new Date().toISOString(),
@@ -610,6 +768,7 @@ export async function main() {
     aggregateStatuses: byName.aggregateProductStatuses.ok ? byName.aggregateProductStatuses.data : null,
     dynamicRemarketingUy,
     reportingContextsUy,
+    productBreakdown,
     products,
     diagnosis: buildDiagnosis({
       alert,
@@ -666,6 +825,27 @@ export async function main() {
     total: accountIssues.length,
     issues: accountIssues.map(accountIssueLogSummary),
   }, null, 2));
+
+  // Cuarta sección de stdout: detalle producto por producto de los bloqueos
+  // prioritarios. Sin PII — son atributos de catálogo (offer_id, título,
+  // imagen, precio), no datos de compradores.
+  console.log('=== IMAGE_TOO_SMALL (producto por producto) ===');
+  console.log(JSON.stringify({ count: imageTooSmall.length, byInput: productBreakdown.imageTooSmallByInput, products: imageTooSmall }, null, 2));
+
+  console.log('=== MISSING PRICE (producto por producto) ===');
+  console.log(JSON.stringify({ count: missingPrice.length, byInput: productBreakdown.missingPriceByInput, products: missingPrice }, null, 2));
+
+  console.log('=== CRUCE image_too_small vs missing_price ===');
+  console.log(JSON.stringify(productBreakdown.overlapImageTooSmallVsMissingPrice, null, 2));
+
+  console.log('=== AUTOFEED vs FILE por offer_id ===');
+  console.log(JSON.stringify(productBreakdown.autofeedVsFile, null, 2));
+
+  console.log('=== EBOOKS policy violation (SHOPPING_ADS) ===');
+  console.log(JSON.stringify(ebooks, null, 2));
+
+  console.log('=== LANDING PAGES ===');
+  console.log(JSON.stringify({ pendingCrawl: landingPendingCrawl, error: landingError }, null, 2));
 
   if (!byName.aggregateProductStatuses.ok && !byName.products.ok) {
     process.exitCode = 1;

--- a/scripts/commerce/merchant-readonly-audit.mjs
+++ b/scripts/commerce/merchant-readonly-audit.mjs
@@ -275,6 +275,13 @@ function productAvailability(product) {
   return asText(product?.productAttributes?.availability) || null;
 }
 
+function productGtin(product) {
+  const attrs = product?.productAttributes || {};
+  if (asText(attrs.gtin)) return asText(attrs.gtin);
+  if (Array.isArray(attrs.gtins) && attrs.gtins.length) return asText(attrs.gtins[0]) || null;
+  return null;
+}
+
 export function productDestinationStatus(product, context) {
   const rows = Array.isArray(product?.productStatus?.destinationStatuses) ? product.productStatus.destinationStatuses : [];
   const row = rows.find(entry => upper(entry.reportingContext) === upper(context));
@@ -294,8 +301,81 @@ function productRow(product) {
     imageLink: safeFetchUri(product?.productAttributes?.imageLink),
     price: productPriceText(product),
     availability: productAvailability(product),
+    gtin: productGtin(product),
     shoppingAdsStatus: productDestinationStatus(product, 'SHOPPING_ADS'),
     freeListingsStatus: productDestinationStatus(product, 'FREE_LISTINGS'),
+  };
+}
+
+// Tercera ampliación (mismo PR): el cruce por offer_id (arriba) no responde
+// si dos offer_id distintos son en realidad el mismo libro — para eso hace
+// falta identidad real: mismo link (landing page) o mismo GTIN/ISBN. Ambos
+// campos ya vienen en productAttributes de products.list, así que esto
+// sigue siendo post-procesamiento en memoria, sin ninguna llamada nueva.
+export function normalizeLink(url) {
+  const raw = asText(url);
+  if (!raw) return null;
+  try {
+    const parsed = new URL(raw);
+    const path = parsed.pathname.replace(/\/+$/, '').toLowerCase();
+    return `${parsed.hostname.toLowerCase()}${path}`;
+  } catch {
+    return raw.toLowerCase();
+  }
+}
+
+export function buildIdentityIndex(rows = []) {
+  const byLink = new Map();
+  const byGtin = new Map();
+  for (const row of rows) {
+    const link = normalizeLink(row.link);
+    if (link) {
+      if (!byLink.has(link)) byLink.set(link, []);
+      byLink.get(link).push(row);
+    }
+    if (row.gtin) {
+      if (!byGtin.has(row.gtin)) byGtin.set(row.gtin, []);
+      byGtin.get(row.gtin).push(row);
+    }
+  }
+  return { byLink, byGtin };
+}
+
+// Busca, para un producto de una fuente, su probable gemelo en el índice de
+// identidad de la otra fuente: primero por link normalizado, si no por GTIN.
+export function findTwin(row, identityIndex) {
+  const link = normalizeLink(row.link);
+  const byLink = link ? identityIndex.byLink.get(link) : null;
+  if (byLink?.length) return { offerId: byLink[0].offerId, title: byLink[0].title, matchedBy: 'link' };
+  const byGtin = row.gtin ? identityIndex.byGtin.get(row.gtin) : null;
+  if (byGtin?.length) return { offerId: byGtin[0].offerId, title: byGtin[0].title, matchedBy: 'gtin' };
+  return null;
+}
+
+// Reconciliación de catálogo completo entre dos fuentes por identidad real
+// (no offer_id): cuántos productos de rowsA tienen un probable gemelo en
+// indexB, por qué campo, y una muestra para inspección manual.
+export function reconcileIdentity(rowsA = [], indexB, sampleSize = 20) {
+  let linkMatches = 0;
+  let gtinMatches = 0;
+  const sameBook = new Set();
+  const sample = [];
+  for (const row of rowsA) {
+    const twin = findTwin(row, indexB);
+    if (!twin) continue;
+    sameBook.add(row.offerId);
+    if (twin.matchedBy === 'link') linkMatches += 1;
+    else gtinMatches += 1;
+    if (sample.length < sampleSize) sample.push({ offerIdA: row.offerId, titleA: row.title, ...twin });
+  }
+  return {
+    rowsChecked: rowsA.length,
+    withLink: rowsA.filter(row => row.link).length,
+    withGtin: rowsA.filter(row => row.gtin).length,
+    linkMatches,
+    gtinMatches,
+    probableSameBook: sameBook.size,
+    sample,
   };
 }
 
@@ -743,16 +823,33 @@ export async function main() {
   const landingPendingCrawl = listProductsByIssueCode(rawProducts, { code: 'landing_page_pending_crawl', contexts: shoppingFreeContexts });
   const landingError = listProductsByIssueCode(rawProducts, { code: 'landing_page_error', contexts: shoppingFreeContexts });
 
+  // Cuarta ampliación (mismo PR): reconciliación por identidad real
+  // (link/GTIN) entre AUTOFEED y FILE — offer_id distinto puede ser el
+  // mismo libro. Se construye una vez sobre TODOS los productos ya leídos
+  // (no sólo los bloqueados) y se usa además para marcar, dentro de cada
+  // lista de bloqueos AUTOFEED, si el producto ya tiene un gemelo en FILE.
+  const allProductRows = rawProducts.map(productRow);
+  const rowsByInput = input => allProductRows.filter(row => dataSourceInputMap.get(row.dataSource) === input);
+  const autofeedRows = rowsByInput('AUTOFEED');
+  const fileRows = rowsByInput('FILE');
+  const fileIdentityIndex = buildIdentityIndex(fileRows);
+  const identityReconciliation = reconcileIdentity(autofeedRows, fileIdentityIndex, 20);
+
+  const withFileTwin = rows => rows.map(row => ({ ...row, fileTwin: findTwin(row, fileIdentityIndex) }));
+  const imageTooSmallWithTwin = withFileTwin(imageTooSmall);
+  const missingPriceWithTwin = withFileTwin(missingPrice);
+
   const productBreakdown = {
-    imageTooSmall,
+    imageTooSmall: imageTooSmallWithTwin,
     imageTooSmallByInput: countByInput(imageTooSmall, dataSourceInputMap),
-    missingPrice,
+    missingPrice: missingPriceWithTwin,
     missingPriceByInput: countByInput(missingPrice, dataSourceInputMap),
     overlapImageTooSmallVsMissingPrice: crossReferenceOfferIds(imageTooSmall, missingPrice),
     ebooks,
     landingPendingCrawl,
     landingError,
     autofeedVsFile: compareOfferIdsAcrossInputs(rawProducts, dataSourceInputMap, ['AUTOFEED', 'FILE'], 10),
+    identityReconciliationAutofeedVsFile: identityReconciliation,
   };
 
   const report = {
@@ -830,16 +927,19 @@ export async function main() {
   // prioritarios. Sin PII — son atributos de catálogo (offer_id, título,
   // imagen, precio), no datos de compradores.
   console.log('=== IMAGE_TOO_SMALL (producto por producto) ===');
-  console.log(JSON.stringify({ count: imageTooSmall.length, byInput: productBreakdown.imageTooSmallByInput, products: imageTooSmall }, null, 2));
+  console.log(JSON.stringify({ count: imageTooSmallWithTwin.length, byInput: productBreakdown.imageTooSmallByInput, products: imageTooSmallWithTwin }, null, 2));
 
   console.log('=== MISSING PRICE (producto por producto) ===');
-  console.log(JSON.stringify({ count: missingPrice.length, byInput: productBreakdown.missingPriceByInput, products: missingPrice }, null, 2));
+  console.log(JSON.stringify({ count: missingPriceWithTwin.length, byInput: productBreakdown.missingPriceByInput, products: missingPriceWithTwin }, null, 2));
 
   console.log('=== CRUCE image_too_small vs missing_price ===');
   console.log(JSON.stringify(productBreakdown.overlapImageTooSmallVsMissingPrice, null, 2));
 
   console.log('=== AUTOFEED vs FILE por offer_id ===');
   console.log(JSON.stringify(productBreakdown.autofeedVsFile, null, 2));
+
+  console.log('=== RECONCILIACIÓN DE IDENTIDAD AUTOFEED vs FILE (link/GTIN, no offer_id) ===');
+  console.log(JSON.stringify(identityReconciliation, null, 2));
 
   console.log('=== EBOOKS policy violation (SHOPPING_ADS) ===');
   console.log(JSON.stringify(ebooks, null, 2));

--- a/scripts/commerce/merchant-readonly-audit.mjs
+++ b/scripts/commerce/merchant-readonly-audit.mjs
@@ -159,6 +159,95 @@ function finalizeAggregate(summary) {
   };
 }
 
+// aggregateDynamicRemarketingUy() filtra deliberadamente a un solo destino
+// (Dynamic remarketing / DISPLAY_ADS) — así nació esta auditoría, para una
+// alerta puntual de ese destino. Eso deja ciego al resto: Shopping ads,
+// Free listings o cualquier otro reportingContext que la cuenta use nunca
+// se ven. Esta función agrupa TODOS los reportingContext reales que la API
+// devuelve para Uruguay, sin descartar ninguno — amplía el diagnóstico sin
+// tocar ni reemplazar el agregado específico de Dynamic remarketing que ya
+// existía (se mantiene igual, como campo aparte).
+export function aggregateProductStatusesByContextUy(rows = []) {
+  const byContext = new Map();
+  for (const row of rows) {
+    if (!isUy(row?.country)) continue;
+    const context = asText(row?.reportingContext) || '(sin reportingContext)';
+    const current = byContext.get(context) || {
+      reportingContext: context,
+      rows: 0,
+      active: 0,
+      pending: 0,
+      disapproved: 0,
+      expiring: 0,
+      issueCounts: new Map(),
+    };
+    const stats = row.stats || {};
+    current.rows += 1;
+    current.active += asNumber(stats.activeCount);
+    current.pending += asNumber(stats.pendingCount);
+    current.disapproved += asNumber(stats.disapprovedCount);
+    current.expiring += asNumber(stats.expiringCount);
+    for (const issue of Array.isArray(row.itemLevelIssues) ? row.itemLevelIssues : []) {
+      const key = asText(issue.code) || '(sin código)';
+      const issueCurrent = current.issueCounts.get(key) || {
+        code: key,
+        severity: asText(issue.severity) || null,
+        resolution: asText(issue.resolution) || null,
+        attribute: asText(issue.attribute) || null,
+        description: asText(issue.description) || null,
+        detail: asText(issue.detail) || null,
+        documentationUri: asText(issue.documentationUri) || null,
+        productCount: 0,
+      };
+      issueCurrent.productCount += asNumber(issue.productCount);
+      current.issueCounts.set(key, issueCurrent);
+    }
+    byContext.set(context, current);
+  }
+  return byContext;
+}
+
+export function finalizeContextSummary(summary, limit = 30) {
+  return {
+    reportingContext: summary.reportingContext,
+    rows: summary.rows,
+    active: summary.active,
+    pending: summary.pending,
+    disapproved: summary.disapproved,
+    expiring: summary.expiring,
+    topIssues: [...summary.issueCounts.values()]
+      .sort((a, b) => b.productCount - a.productCount || a.code.localeCompare(b.code))
+      .slice(0, limit),
+  };
+}
+
+// Une el conteo real de products.list (por dataSource) con los metadatos de
+// datasources.list (displayName/type/input) — ambos endpoints ya se leían
+// por separado, esto sólo los cruza para poder mostrar cantidad por fuente.
+export function joinDataSourceProductCounts(dataSources = [], byDataSource = []) {
+  const countByName = new Map(byDataSource.map(row => [row.dataSource, row.count]));
+  return dataSources.map(source => ({
+    ...source,
+    productCount: source.name ? (countByName.get(source.name) || 0) : 0,
+  }));
+}
+
+// Resumen de un accountIssue para stdout: sin PII (nunca hubo en accountIssues,
+// es información de cuenta/política, no de comprador) y sin duplicar el
+// detalle completo — sólo lo que hace falta para priorizar.
+export function accountIssueLogSummary(issue = {}) {
+  const destinations = [...new Set(
+    (Array.isArray(issue.impactedDestinations) ? issue.impactedDestinations : [])
+      .map(row => asText(row.reportingContext))
+      .filter(Boolean)
+  )];
+  return {
+    title: issue.title || '(sin título)',
+    severity: issue.severity || null,
+    destinations,
+  };
+}
+
 function productDestinationState(product, country = 'UY') {
   const rows = Array.isArray(product?.productStatus?.destinationStatuses)
     ? product.productStatus.destinationStatuses.filter(row => isDynamicRemarketing(row.reportingContext))
@@ -497,6 +586,17 @@ export async function main() {
       }
     : null;
 
+  // Ampliación del diagnóstico: dynamicRemarketingUy de arriba sigue igual
+  // (sesgado a un solo destino, a propósito, para no romper nada de lo que
+  // ya lo consume) — esto agrega TODOS los reportingContext reales que la
+  // API devolvió para Uruguay (Shopping ads, Free listings, Display ads,
+  // cualquier otro), sin descartar ninguno.
+  const reportingContextsUy = [...aggregateProductStatusesByContextUy(byName.aggregateProductStatuses.data || []).values()]
+    .map(summary => finalizeContextSummary(summary, 30))
+    .sort((a, b) => a.reportingContext.localeCompare(b.reportingContext));
+
+  const dataSourcesWithCounts = joinDataSourceProductCounts(dataSources, products?.byDataSource || []);
+
   const report = {
     schemaVersion: 1,
     generatedAt: new Date().toISOString(),
@@ -505,9 +605,11 @@ export async function main() {
     publicFeed,
     endpoints: endpoints.map(row => ({ name: row.name, ok: row.ok, error: row.error })),
     dataSources,
+    dataSourcesWithProductCounts: dataSourcesWithCounts,
     accountIssues,
     aggregateStatuses: byName.aggregateProductStatuses.ok ? byName.aggregateProductStatuses.data : null,
     dynamicRemarketingUy,
+    reportingContextsUy,
     products,
     diagnosis: buildDiagnosis({
       alert,
@@ -534,6 +636,36 @@ export async function main() {
     processedProducts: products?.processed ?? null,
     endpointFailures: endpoints.filter(row => !row.ok).map(row => row.name),
   }));
+
+  // Diagnóstico ampliado — un bloque por sección, para que quede legible
+  // directamente en el log del job (el artifact no siempre es accesible
+  // desde todos lados; el log del run sí). Top 15 issues por contexto, tal
+  // como se pidió — el archivo JSON completo (arriba) conserva hasta 30.
+  console.log('=== REPORTING CONTEXTS (Uruguay) ===');
+  console.log(JSON.stringify(
+    reportingContextsUy.map(context => ({ ...context, topIssues: context.topIssues.slice(0, 15) })),
+    null,
+    2
+  ));
+
+  console.log('=== DATA SOURCES ===');
+  console.log(JSON.stringify(
+    dataSourcesWithCounts.map(source => ({
+      displayName: source.displayName,
+      type: source.type,
+      input: source.input,
+      dataSourceId: source.dataSourceId,
+      productCount: source.productCount,
+    })),
+    null,
+    2
+  ));
+
+  console.log('=== ACCOUNT ISSUES ===');
+  console.log(JSON.stringify({
+    total: accountIssues.length,
+    issues: accountIssues.map(accountIssueLogSummary),
+  }, null, 2));
 
   if (!byName.aggregateProductStatuses.ok && !byName.products.ok) {
     process.exitCode = 1;

--- a/scripts/commerce/public-landing-check.mjs
+++ b/scripts/commerce/public-landing-check.mjs
@@ -1,0 +1,113 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// Verificación de solo lectura sobre páginas PÚBLICAS del propio catálogo
+// (amadolibros.com) — nunca Merchant API, nunca el flujo de compra del
+// sitio. Toma los links ya calculados por merchant-readonly-audit.mjs
+// (artifacts/merchant/merchant-readonly-report.json) para los bloqueos que
+// se están investigando y verifica, contra la página real, lo que Merchant
+// no puede decirnos: HTTP real, canonical, y el Offer (precio/moneda/
+// disponibilidad) que ve un crawler en el JSON-LD de la ficha.
+
+function asText(value) {
+  return String(value ?? '').trim();
+}
+
+export function extractJsonLdOffers(html) {
+  const blocks = [...String(html || '').matchAll(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)];
+  const offers = [];
+  for (const block of blocks) {
+    let parsed;
+    try { parsed = JSON.parse(block[1]); } catch { continue; }
+    const nodes = Array.isArray(parsed) ? parsed : Array.isArray(parsed?.['@graph']) ? parsed['@graph'] : [parsed];
+    for (const node of nodes) {
+      if (!node || typeof node !== 'object') continue;
+      const type = asText(node['@type']);
+      if (!/product|book/i.test(type)) continue;
+      const offer = Array.isArray(node.offers) ? node.offers[0] : node.offers;
+      offers.push({
+        name: asText(node.name) || null,
+        price: offer ? asText(offer.price) || null : null,
+        priceCurrency: offer ? asText(offer.priceCurrency) || null : null,
+        availability: offer ? asText(offer.availability).replace('https://schema.org/', '') || null : null,
+      });
+    }
+  }
+  return offers[0] || null;
+}
+
+export function extractCanonical(html) {
+  const match = String(html || '').match(/<link[^>]+rel=["']canonical["'][^>]*href=["']([^"']+)["']/i);
+  return match ? match[1] : null;
+}
+
+async function checkOne(row) {
+  const { offerId, link, bucket } = row;
+  if (!link) return { offerId, bucket, link: null, httpStatus: null, canonical: null, offer: null, error: 'sin link' };
+  try {
+    const response = await fetch(link, {
+      redirect: 'follow',
+      signal: AbortSignal.timeout(15_000),
+      headers: { 'User-Agent': 'AmadoLibros-Merchant-Diagnostics/1.0 (+solo lectura)' },
+    });
+    const html = response.status === 200 ? await response.text() : '';
+    return {
+      offerId,
+      bucket,
+      link,
+      httpStatus: response.status,
+      finalUrl: response.url !== link ? response.url : null,
+      canonical: extractCanonical(html),
+      offer: extractJsonLdOffers(html),
+      error: null,
+    };
+  } catch (error) {
+    return { offerId, bucket, link, httpStatus: null, canonical: null, offer: null, error: asText(error?.message) || 'fetch failed' };
+  }
+}
+
+async function mapWithConcurrency(items, limit, fn) {
+  const results = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (next < items.length) {
+      const index = next;
+      next += 1;
+      results[index] = await fn(items[index]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+export async function main() {
+  const reportPath = asText(process.env.MERCHANT_REPORT_PATH) || 'artifacts/merchant/merchant-readonly-report.json';
+  const outputDir = path.dirname(reportPath);
+  const raw = await readFile(reportPath, 'utf8');
+  const report = JSON.parse(raw);
+  const breakdown = report.productBreakdown || {};
+
+  const rows = [];
+  for (const row of breakdown.missingPrice || []) rows.push({ offerId: row.offerId, link: row.link, bucket: 'missingPrice' });
+  for (const row of breakdown.imageTooSmall || []) rows.push({ offerId: row.offerId, link: row.link, bucket: 'imageTooSmall' });
+  for (const row of breakdown.ebooks || []) rows.push({ offerId: row.offerId, link: row.link, bucket: 'ebooks' });
+  for (const row of breakdown.landingError || []) rows.push({ offerId: row.offerId, link: row.link, bucket: 'landingError' });
+
+  const results = await mapWithConcurrency(rows, 8, checkOne);
+
+  await writeFile(path.join(outputDir, 'public-landing-check.json'), `${JSON.stringify(results, null, 2)}\n`);
+
+  for (const bucket of ['missingPrice', 'imageTooSmall', 'ebooks', 'landingError']) {
+    const subset = results.filter(row => row.bucket === bucket);
+    console.log(`=== PUBLIC LANDING CHECK — ${bucket} (${subset.length}) ===`);
+    console.log(JSON.stringify(subset, null, 2));
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/seo/catalog-coverage-effective.mjs
+++ b/scripts/seo/catalog-coverage-effective.mjs
@@ -1,0 +1,122 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { normalizeIsbnToGtin, normalizePublisherForDescription } from '../../functions/feed.xml.js';
+import { applyBookEnrichment } from '../../functions/_shared/book-enrichment-registry.js';
+import { isGenericAuthor, realAuthor } from '../../functions/_shared/generic-author.js';
+
+// Cobertura REAL de lo que se publica, en dos capas sobre el MISMO universo y
+// el MISMO snapshot:
+//
+//   - `crudo`: el catálogo tal como llega de Mercado Libre.
+//   - `efectivo`: el mismo ítem después de applyBookEnrichment(), que es lo
+//     que realmente ve la ficha publicada, el JSON-LD y el feed.
+//
+// Además separa "campo no vacío" de "campo útil":
+//   - autor no vacío  vs  autor REAL (descarta 'Desconocido', 'Varios', etc.).
+//   - descripción no vacía vs descripción útil por umbral de longitud.
+
+const R2_BASE = 'https://pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev';
+const CATALOG_URL = `${R2_BASE}/catalog.json`;
+
+function clean(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function positiveNumber(value) {
+  return Number.isFinite(Number(value)) && Number(value) > 0;
+}
+
+function descriptionLength(item) {
+  return clean(item?.description).length;
+}
+
+function pct(count, total) {
+  return total ? Number(((count / total) * 100).toFixed(2)) : 0;
+}
+
+export function coverageFor(items) {
+  const metric = predicate => {
+    const count = items.filter(predicate).length;
+    return { count, missing: items.length - count, percent: pct(count, items.length) };
+  };
+  return {
+    author_no_vacio: metric(item => clean(item.author) !== ''),
+    author_real: metric(item => Boolean(realAuthor(item.author))),
+    author_generico: metric(item => clean(item.author) !== '' && isGenericAuthor(item.author)),
+    isbn_valido: metric(item => normalizeIsbnToGtin(item.isbn).valid),
+    publisher_real: metric(item => Boolean(normalizePublisherForDescription(item.publisher))),
+    pages: metric(item => positiveNumber(item.pages)),
+    language: metric(item => clean(item?.bibliographic?.language) !== ''),
+    format: metric(item => clean(item?.bibliographic?.format) !== ''),
+    edition: metric(item => clean(item?.bibliographic?.edition) !== ''),
+    publication_year: metric(item => clean(item?.bibliographic?.publication_year) !== ''),
+    genre: metric(item => clean(item?.bibliographic?.genre) !== ''),
+    description_no_vacia: metric(item => descriptionLength(item) > 0),
+    description_80: metric(item => descriptionLength(item) >= 80),
+    description_util_280: metric(item => descriptionLength(item) >= 280),
+    description_700: metric(item => descriptionLength(item) >= 700),
+  };
+}
+
+function deltaTable(raw, effective) {
+  const rows = {};
+  for (const key of Object.keys(raw)) {
+    rows[key] = {
+      crudo: raw[key].count,
+      efectivo: effective[key].count,
+      ganancia: effective[key].count - raw[key].count,
+      percent_crudo: raw[key].percent,
+      percent_efectivo: effective[key].percent,
+    };
+  }
+  return rows;
+}
+
+export async function main() {
+  const outputDir = process.env.SEO_OUTPUT_DIR || 'artifacts/seo';
+  const fetchedAt = new Date().toISOString();
+  const response = await fetch(CATALOG_URL, { signal: AbortSignal.timeout(60_000) });
+  if (!response.ok) throw new Error(`catalog.json respondió HTTP ${response.status}`);
+  const catalog = await response.json();
+
+  // Mismo universo que catalog-quality-audit.mjs: activos con stock.
+  const raw = (Array.isArray(catalog?.items) ? catalog.items : [])
+    .filter(item => item?.status === 'active' && Number(item.available_quantity) > 0);
+  const effective = raw.map(item => applyBookEnrichment(item));
+
+  const rawCoverage = coverageFor(raw);
+  const effectiveCoverage = coverageFor(effective);
+
+  const enrichedItems = raw.filter((item, index) => effective[index] !== item).length;
+
+  const report = {
+    schemaVersion: 1,
+    fetchedAt,
+    source: CATALOG_URL,
+    catalogUpdatedAt: catalog?.updated_at || null,
+    universe: { activeWithStock: raw.length, itemsTocadosPorEnriquecimiento: enrichedItems },
+    crudo: rawCoverage,
+    efectivo: effectiveCoverage,
+    delta: deltaTable(rawCoverage, effectiveCoverage),
+  };
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(path.join(outputDir, 'catalog-coverage-effective.json'), `${JSON.stringify(report, null, 2)}\n`);
+
+  console.log('=== COBERTURA CRUDA vs EFECTIVA (mismo universo y snapshot) ===');
+  console.log(JSON.stringify({
+    fetchedAt,
+    catalogUpdatedAt: report.catalogUpdatedAt,
+    universe: report.universe,
+    delta: report.delta,
+  }, null, 2));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/seo/image-dimension-audit.mjs
+++ b/scripts/seo/image-dimension-audit.mjs
@@ -1,0 +1,125 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { readImageDimensions } from '../../worker-sync/cover-mirror.js';
+
+// QW2 (Merchant, Gran Apuesta en curso): medición de SOLO LECTURA sobre las
+// imágenes ya identificadas como image_too_small. No modifica Merchant, no
+// escribe en R2, no activa Cloudflare Images (pago). Toma la lista de
+// productos ya calculada por merchant-readonly-audit.mjs (offer_id + link +
+// imageLink) y mide el ancho/alto REAL de la imagen que se está sirviendo
+// hoy — la misma que ve Google — clasificando por lado corto: <500, 500-999,
+// >=1000. No inventa ni corrige nada.
+
+const CONCURRENCY = 8;
+const FETCH_TIMEOUT_MS = 15_000;
+
+function asText(value) {
+  return String(value ?? '').trim();
+}
+
+function bucketFor(shortSide) {
+  if (shortSide == null) return 'sin_medir';
+  if (shortSide < 500) return '<500';
+  if (shortSide < 1000) return '500-999';
+  return '>=1000';
+}
+
+function positionFromUrl(url) {
+  const match = /\/book-cover\/[^/]+\/cover(?:-(\d+))?\.jpg$/i.exec(asText(url));
+  if (!match) return null;
+  return match[1] ? Number(match[1]) - 1 : 0;
+}
+
+async function measureOne(row) {
+  const { offerId, imageLink } = row;
+  if (!imageLink) return { offerId, imageLink: null, shortSide: null, width: null, height: null, bucket: 'sin_medir', error: 'sin imageLink' };
+  try {
+    const response = await fetch(imageLink, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { 'user-agent': 'Mozilla/5.0 (compatible; AmadoLibrosImageAudit/1.0; solo lectura)' },
+    });
+    if (!response.ok) {
+      return { offerId, imageLink, shortSide: null, width: null, height: null, bucket: 'sin_medir', error: `HTTP ${response.status}` };
+    }
+    const buffer = new Uint8Array(await response.arrayBuffer());
+    const dimensions = readImageDimensions(buffer);
+    if (!dimensions) {
+      return { offerId, imageLink, shortSide: null, width: null, height: null, bucket: 'sin_medir', error: 'no se pudo parsear la imagen' };
+    }
+    const shortSide = Math.min(dimensions.width, dimensions.height);
+    return {
+      offerId,
+      imageLink,
+      width: dimensions.width,
+      height: dimensions.height,
+      shortSide,
+      bucket: bucketFor(shortSide),
+      position: positionFromUrl(imageLink),
+      external: !/\/book-cover\//i.test(imageLink),
+      error: null,
+    };
+  } catch (error) {
+    return { offerId, imageLink, shortSide: null, width: null, height: null, bucket: 'sin_medir', error: asText(error?.message) || 'fetch failed' };
+  }
+}
+
+async function mapWithConcurrency(items, limit, fn) {
+  const results = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (next < items.length) {
+      const index = next;
+      next += 1;
+      results[index] = await fn(items[index]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+export async function main() {
+  const inputPath = asText(process.env.IMAGE_AUDIT_INPUT) || 'artifacts/merchant/merchant-readonly-report.json';
+  const outputDir = asText(process.env.IMAGE_AUDIT_OUTPUT_DIR) || 'artifacts/image-audit';
+  const raw = await readFile(inputPath, 'utf8');
+  const report = JSON.parse(raw);
+  const rows = (report.productBreakdown?.imageTooSmall || []).map(row => ({
+    offerId: row.offerId,
+    imageLink: row.imageLink,
+    dataSource: row.dataSource,
+  }));
+
+  const results = await mapWithConcurrency(rows, CONCURRENCY, measureOne);
+
+  const byBucket = {};
+  const byPosition = {};
+  for (const row of results) {
+    byBucket[row.bucket] = (byBucket[row.bucket] || 0) + 1;
+    const posKey = row.position == null ? 'externa' : `posicion_${row.position}`;
+    byPosition[posKey] = byPosition[posKey] || {};
+    byPosition[posKey][row.bucket] = (byPosition[posKey][row.bucket] || 0) + 1;
+  }
+
+  const summary = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    totalMeasured: results.length,
+    byBucket,
+    byPosition,
+    results,
+  };
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(path.join(outputDir, 'image-dimension-audit.json'), `${JSON.stringify(summary, null, 2)}\n`);
+
+  console.log('=== QW2 IMAGE DIMENSION AUDIT (solo lectura) ===');
+  console.log(JSON.stringify({ totalMeasured: summary.totalMeasured, byBucket, byPosition }, null, 2));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/seo/image-dimension-audit.mjs
+++ b/scripts/seo/image-dimension-audit.mjs
@@ -115,6 +115,20 @@ export async function main() {
 
   console.log('=== QW2 IMAGE DIMENSION AUDIT (solo lectura) ===');
   console.log(JSON.stringify({ totalMeasured: summary.totalMeasured, byBucket, byPosition }, null, 2));
+
+  console.log('=== QW2 — detalle de <500px (principal vs. secundaria) ===');
+  console.log(JSON.stringify(
+    results.filter(row => row.bucket === '<500').map(row => ({
+      offerId: row.offerId,
+      position: row.position,
+      role: row.position === 0 ? 'principal' : row.position == null ? 'externa' : 'secundaria',
+      width: row.width,
+      height: row.height,
+      imageLink: row.imageLink,
+    })),
+    null,
+    2,
+  ));
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/seo/qw1-catalog-snapshot.mjs
+++ b/scripts/seo/qw1-catalog-snapshot.mjs
@@ -1,0 +1,141 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { gunzipSync } from 'node:zlib';
+
+// QW1 — congela un snapshot reproducible de los ítems reales que hay que
+// renderizar, con su procedencia (URL, updated_at, versión de manifest y
+// fecha de lectura). El mismo archivo alimenta el render de `main` y el de
+// la rama del PR #313, para que la comparación no dependa de dos lecturas
+// distintas del catálogo vivo.
+
+const R2_BASE = 'https://pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev';
+const CATALOG_URL = `${R2_BASE}/catalog.json`;
+const PRODUCTION_MANIFEST_URL = `${R2_BASE}/catalog/manifest.json`;
+const FETCH_TIMEOUT_MS = 60_000;
+
+function asText(value) {
+  return String(value ?? '').trim();
+}
+
+function slugify(text) {
+  return (text || '')
+    .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .substring(0, 60);
+}
+
+async function getJson(url) {
+  const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+  if (!response.ok) throw new Error(`${url} respondió HTTP ${response.status}`);
+  return response.json();
+}
+
+async function getMaybeGzipJson(url) {
+  const response = await fetch(url, {
+    headers: { 'Accept-Encoding': 'identity' },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`${url} respondió HTTP ${response.status}`);
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const isGzip = buffer[0] === 0x1f && buffer[1] === 0x8b;
+  return JSON.parse((isGzip ? gunzipSync(buffer) : buffer).toString('utf8'));
+}
+
+// Reconstruye un pausado igual que expandPausedIndex() en
+// functions/_shared/catalog.js: sin price ni currency, stock 0.
+function pausedItemFromRow(row, fields) {
+  const position = Object.fromEntries(fields.map((field, i) => [field, i]));
+  const id = asText(row[position.id]).toUpperCase();
+  const title = asText(row[position.title]);
+  if (!/^MLU\d+$/.test(id) || !title) return null;
+  return {
+    id,
+    title,
+    author: row[position.author] || null,
+    isbn: row[position.isbn] || null,
+    thumbnail: row[position.image] || null,
+    slug: slugify(title),
+    status: 'paused',
+    available_quantity: 0,
+  };
+}
+
+export async function main() {
+  const cohortPath = asText(process.env.QW1_COHORT_INPUT) || 'artifacts/merchant/merchant-readonly-report.json';
+  const outputPath = asText(process.env.QW1_SNAPSHOT) || 'artifacts/qw1/catalog-snapshot.json';
+  const includeAllActive = asText(process.env.QW1_INCLUDE_ALL_ACTIVE) === '1';
+
+  const fetchedAt = new Date().toISOString();
+  const catalog = await getJson(CATALOG_URL);
+  const catalogItems = Array.isArray(catalog?.items) ? catalog.items : [];
+  const catalogById = new Map(catalogItems.map(item => [asText(item.id).toUpperCase(), item]));
+
+  const manifest = await getJson(PRODUCTION_MANIFEST_URL);
+  const descriptor = manifest?.current || null;
+  const pausedKey = descriptor?.index_gzip_key || descriptor?.index_key;
+  const pausedIndex = pausedKey ? await getMaybeGzipJson(`${R2_BASE}/${pausedKey}`) : null;
+  const pausedById = new Map();
+  if (pausedIndex && Array.isArray(pausedIndex.items) && Array.isArray(pausedIndex.fields)) {
+    for (const row of pausedIndex.items) {
+      const item = pausedItemFromRow(row, pausedIndex.fields);
+      if (item) pausedById.set(item.id, item);
+    }
+  }
+
+  const cohortIds = [];
+  try {
+    const report = JSON.parse(await readFile(cohortPath, 'utf8'));
+    for (const row of report.productBreakdown?.missingPrice || []) {
+      const id = asText(row.offerId).toUpperCase();
+      if (id) cohortIds.push(id);
+    }
+  } catch {
+    // Sin cohorte disponible el snapshot sigue siendo válido para el catálogo.
+  }
+
+  const selected = new Map();
+  for (const id of cohortIds) {
+    const item = catalogById.get(id) || pausedById.get(id) || null;
+    if (item) selected.set(id, { ...item, _qw1Cohort: true });
+  }
+  if (includeAllActive) {
+    for (const item of catalogItems) {
+      const id = asText(item.id).toUpperCase();
+      if (!selected.has(id)) selected.set(id, item);
+    }
+  }
+
+  const snapshot = {
+    schemaVersion: 1,
+    fetchedAt,
+    source: {
+      catalog: CATALOG_URL,
+      productionManifest: PRODUCTION_MANIFEST_URL,
+      manifestVersion: asText(descriptor?.version) || null,
+      pausedIndexKey: asText(pausedKey) || null,
+    },
+    catalogUpdatedAt: catalog?.updated_at || null,
+    counts: {
+      catalogItems: catalogItems.length,
+      pausedIndexItems: pausedById.size,
+      cohortRequested: cohortIds.length,
+      cohortResolved: cohortIds.filter(id => selected.has(id)).length,
+      snapshotItems: selected.size,
+    },
+    items: [...selected.values()],
+  };
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+  console.log(JSON.stringify({ ...snapshot, items: undefined }, null, 2));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/seo/qw1-cohort-catalog-evidence.mjs
+++ b/scripts/seo/qw1-cohort-catalog-evidence.mjs
@@ -1,0 +1,227 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { gunzipSync } from 'node:zlib';
+
+// QW1 — evidencia de catálogo, no inferencia. Para cada MLU del cohorte real
+// de `missing_price` cruza status, precio, moneda y stock contra el catálogo
+// que consume CADA entorno:
+//
+//   - catalog.json (activo) es COMPARTIDO por Producción y Preview.
+//   - el manifest de pausados NO: Producción usa `catalog/manifest.json` y
+//     Preview usa `stock1-preview/manifest.json` (functions/_shared/catalog.js).
+//   - el índice de pausados no transporta `price` ni `currency`: sus filas son
+//     [id, title, author, isbn, image] y se expanden con available_quantity 0.
+//
+// Todo es GET de solo lectura sobre URLs públicas. No infiere "no tiene
+// precio" desde "no hay Offer": informa el dato real de cada fuente, o
+// `desconocido` cuando la fuente no lo transporta.
+
+const R2_BASE = 'https://pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev';
+const CATALOG_URL = `${R2_BASE}/catalog.json`;
+const MANIFESTS = {
+  produccion: `${R2_BASE}/catalog/manifest.json`,
+  preview: `${R2_BASE}/stock1-preview/manifest.json`,
+};
+const FETCH_TIMEOUT_MS = 60_000;
+
+function asText(value) {
+  return String(value ?? '').trim();
+}
+
+async function getJson(url) {
+  const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+  if (!response.ok) throw new Error(`${url} respondió HTTP ${response.status}`);
+  return response.json();
+}
+
+async function getMaybeGzipJson(url) {
+  const response = await fetch(url, {
+    headers: { 'Accept-Encoding': 'identity' },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`${url} respondió HTTP ${response.status}`);
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const isGzip = buffer[0] === 0x1f && buffer[1] === 0x8b;
+  return JSON.parse((isGzip ? gunzipSync(buffer) : buffer).toString('utf8'));
+}
+
+function indexRowsToMap(index, expectedFields) {
+  const map = new Map();
+  if (!index || !Array.isArray(index.items) || !Array.isArray(index.fields)) return map;
+  const position = Object.fromEntries(index.fields.map((field, i) => [field, i]));
+  for (const row of index.items) {
+    if (!Array.isArray(row)) continue;
+    const id = asText(row[position.id]).toUpperCase();
+    if (!id) continue;
+    const entry = {};
+    for (const field of expectedFields) {
+      entry[field] = position[field] == null ? undefined : row[position[field]];
+    }
+    map.set(id, entry);
+  }
+  return map;
+}
+
+async function loadEnvironment(name, manifestUrl) {
+  const manifest = await getJson(manifestUrl);
+  const descriptor = manifest?.current || null;
+  const result = {
+    environment: name,
+    manifestUrl,
+    manifestVersion: asText(descriptor?.version) || null,
+    activeIndexKey: asText(descriptor?.active_index_key) || null,
+    pausedIndexKey: asText(descriptor?.index_key) || null,
+    active: new Map(),
+    paused: new Map(),
+  };
+  const activeKey = descriptor?.active_index_gzip_key || descriptor?.active_index_key;
+  if (activeKey) {
+    const index = await getMaybeGzipJson(`${R2_BASE}/${activeKey}`);
+    result.active = indexRowsToMap(index, ['id', 'price', 'available_quantity', 'title']);
+  }
+  const pausedKey = descriptor?.index_gzip_key || descriptor?.index_key;
+  if (pausedKey) {
+    const index = await getMaybeGzipJson(`${R2_BASE}/${pausedKey}`);
+    result.paused = indexRowsToMap(index, ['id', 'title', 'isbn']);
+  }
+  return result;
+}
+
+// El estado que resuelve functions/libro/[[path]].js: primero catalog.json
+// (compartido), y sólo si no está ahí, el índice de pausados del entorno.
+export function resolveItemForEnvironment(id, { catalogItem, pausedIndex }) {
+  if (catalogItem) {
+    return {
+      source: 'catalog.json',
+      status: asText(catalogItem.status) || null,
+      price: catalogItem.price ?? null,
+      currency: asText(catalogItem.currency || catalogItem.currency_id) || null,
+      available_quantity: catalogItem.available_quantity ?? null,
+      httpExpected: 200,
+    };
+  }
+  if (pausedIndex?.has(id)) {
+    return {
+      source: 'paused-index',
+      status: 'paused',
+      // El índice de pausados NO transporta precio ni moneda: no es que el
+      // producto no tenga precio, es que esta fuente no lo publica.
+      price: 'no-transportado-por-la-fuente',
+      currency: 'no-transportado-por-la-fuente',
+      available_quantity: 0,
+      httpExpected: 200,
+    };
+  }
+  return {
+    source: null,
+    status: null,
+    price: null,
+    currency: null,
+    available_quantity: null,
+    httpExpected: 404,
+  };
+}
+
+export function classifyCohortRow(row) {
+  const { produccion, preview } = row.environments;
+  if (produccion.httpExpected !== 200 || preview.httpExpected !== 200) {
+    return 'no_comparable_404';
+  }
+  if (produccion.source === 'paused-index' || produccion.status === 'paused') {
+    return 'pausado_sin_precio_en_la_fuente';
+  }
+  if (produccion.source === 'catalog.json' && Number(produccion.price) > 0) {
+    return 'activo_con_precio_real';
+  }
+  return 'causa_pendiente_de_verificar';
+}
+
+export async function main() {
+  const inputPath = asText(process.env.QW1_EVIDENCE_INPUT) || 'artifacts/merchant/merchant-readonly-report.json';
+  const outputDir = asText(process.env.QW1_EVIDENCE_OUTPUT_DIR) || 'artifacts/merchant';
+  const report = JSON.parse(await readFile(inputPath, 'utf8'));
+  const cohort = (report.productBreakdown?.missingPrice || []).map(row => ({
+    offerId: asText(row.offerId).toUpperCase(),
+    link: row.link,
+  }));
+
+  const fetchedAt = new Date().toISOString();
+  const catalog = await getJson(CATALOG_URL);
+  const catalogById = new Map(
+    (Array.isArray(catalog?.items) ? catalog.items : [])
+      .map(item => [asText(item.id).toUpperCase(), item]),
+  );
+
+  const environments = {};
+  for (const [name, url] of Object.entries(MANIFESTS)) {
+    environments[name] = await loadEnvironment(name, url);
+  }
+
+  const rows = cohort.map(entry => {
+    const perEnvironment = {};
+    for (const [name, env] of Object.entries(environments)) {
+      perEnvironment[name] = resolveItemForEnvironment(entry.offerId, {
+        catalogItem: catalogById.get(entry.offerId) || null,
+        pausedIndex: env.paused,
+      });
+    }
+    const row = { offerId: entry.offerId, link: entry.link, environments: perEnvironment };
+    row.classification = classifyCohortRow(row);
+    return row;
+  });
+
+  const counts = rows.reduce((acc, row) => {
+    acc[row.classification] = (acc[row.classification] || 0) + 1;
+    return acc;
+  }, {});
+
+  const summary = {
+    schemaVersion: 1,
+    fetchedAt,
+    sources: {
+      catalog: { url: CATALOG_URL, updated_at: catalog?.updated_at || null, items: catalogById.size },
+      produccion: {
+        manifestUrl: environments.produccion.manifestUrl,
+        version: environments.produccion.manifestVersion,
+        activeIndexItems: environments.produccion.active.size,
+        pausedIndexItems: environments.produccion.paused.size,
+      },
+      preview: {
+        manifestUrl: environments.preview.manifestUrl,
+        version: environments.preview.manifestVersion,
+        activeIndexItems: environments.preview.active.size,
+        pausedIndexItems: environments.preview.paused.size,
+      },
+    },
+    cohortSize: rows.length,
+    counts,
+    rows,
+  };
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(path.join(outputDir, 'qw1-cohort-catalog-evidence.json'), `${JSON.stringify(summary, null, 2)}\n`);
+
+  console.log('=== QW1 EVIDENCIA DE CATÁLOGO (sin inferencias) ===');
+  console.log(JSON.stringify({
+    fetchedAt: summary.fetchedAt,
+    sources: summary.sources,
+    cohortSize: summary.cohortSize,
+    counts,
+  }, null, 2));
+
+  console.log('=== QW1 muestra por clasificación (hasta 3 por clase) ===');
+  const sample = {};
+  for (const row of rows) {
+    sample[row.classification] = sample[row.classification] || [];
+    if (sample[row.classification].length < 3) sample[row.classification].push(row);
+  }
+  console.log(JSON.stringify(sample, null, 2));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/seo/qw1-preview-validation.mjs
+++ b/scripts/seo/qw1-preview-validation.mjs
@@ -1,0 +1,153 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// QW1 — validación de solo lectura del criterio de aceptación real: para
+// TODO el cohorte de missing_price ya identificado por Merchant, compara
+// PRODUCCIÓN vs PREVIEW del PR #313 (mismo path, otro host) y clasifica el
+// resultado real. No modifica nada — sólo GET a páginas públicas.
+
+const PREVIEW_HOST = 'pr-313.amadolibros-web.pages.dev';
+const FETCH_TIMEOUT_MS = 15_000;
+
+function asText(value) {
+  return String(value ?? '').trim();
+}
+
+function toPreviewUrl(productionUrl) {
+  try {
+    const url = new URL(productionUrl);
+    url.hostname = PREVIEW_HOST;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function extractCanonical(html) {
+  const match = String(html || '').match(/<link[^>]+rel=["']canonical["'][^>]*href=["']([^"']+)["']/i);
+  return match ? match[1] : null;
+}
+
+function extractOffer(html) {
+  const blocks = [...String(html || '').matchAll(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)];
+  for (const block of blocks) {
+    let parsed;
+    try { parsed = JSON.parse(block[1]); } catch { continue; }
+    const types = Array.isArray(parsed?.['@type']) ? parsed['@type'] : [parsed?.['@type']];
+    if (!types.includes('Product')) continue;
+    const offer = parsed.offers;
+    if (!offer) return null;
+    return {
+      price: asText(offer.price) || null,
+      priceCurrency: asText(offer.priceCurrency) || null,
+      availability: asText(offer.availability).replace('https://schema.org/', '') || null,
+      url: asText(offer.url) || null,
+    };
+  }
+  return null;
+}
+
+async function fetchSide(url) {
+  if (!url) return { httpStatus: null, offer: null, canonical: null, error: 'sin URL' };
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { 'user-agent': 'AmadoLibros-QW1-Validation/1.0 (solo lectura)' },
+    });
+    const html = response.status === 200 ? await response.text() : '';
+    return {
+      httpStatus: response.status,
+      offer: response.status === 200 ? extractOffer(html) : null,
+      canonical: response.status === 200 ? extractCanonical(html) : null,
+      error: null,
+    };
+  } catch (error) {
+    return { httpStatus: null, offer: null, canonical: null, error: asText(error?.message) || 'fetch failed' };
+  }
+}
+
+function offerLooksValid(side) {
+  if (side.httpStatus !== 200 || !side.offer) return false;
+  const price = Number(side.offer.price);
+  return Number.isFinite(price) && price > 0 &&
+    side.offer.priceCurrency === 'UYU' &&
+    ['InStock', 'OutOfStock'].includes(side.offer.availability) &&
+    Boolean(side.canonical) && side.offer.url === side.canonical;
+}
+
+function classify(production, preview) {
+  if (production.httpStatus !== 200 || preview.httpStatus !== 200) return 'D';
+  const productionOk = offerLooksValid(production);
+  const previewOk = offerLooksValid(preview);
+  if (!productionOk && previewOk) return 'A';
+  if (!productionOk && !preview.offer) return 'B';
+  return 'C';
+}
+
+async function measureOne(row) {
+  const productionUrl = row.link;
+  const previewUrl = toPreviewUrl(productionUrl);
+  const [production, preview] = await Promise.all([fetchSide(productionUrl), fetchSide(previewUrl)]);
+  return {
+    offerId: row.offerId,
+    productionUrl,
+    previewUrl,
+    production,
+    preview,
+    classification: classify(production, preview),
+  };
+}
+
+async function mapWithConcurrency(items, limit, fn) {
+  const results = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (next < items.length) {
+      const index = next;
+      next += 1;
+      results[index] = await fn(items[index]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+export async function main() {
+  const inputPath = asText(process.env.QW1_VALIDATION_INPUT) || 'artifacts/merchant/merchant-readonly-report.json';
+  const outputDir = asText(process.env.QW1_VALIDATION_OUTPUT_DIR) || 'artifacts/qw1-validation';
+  const raw = await readFile(inputPath, 'utf8');
+  const report = JSON.parse(raw);
+  const rows = report.productBreakdown?.missingPrice || [];
+
+  const results = await mapWithConcurrency(rows, 8, measureOne);
+
+  const counts = { A: 0, B: 0, C: 0, D: 0 };
+  for (const row of results) counts[row.classification] += 1;
+
+  const summary = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    totalCohort: results.length,
+    counts,
+    results,
+  };
+
+  const { mkdir } = await import('node:fs/promises');
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(path.join(outputDir, 'qw1-preview-validation.json'), `${JSON.stringify(summary, null, 2)}\n`);
+
+  console.log('=== QW1 PREVIEW VALIDATION (solo lectura) ===');
+  console.log(JSON.stringify({ totalCohort: summary.totalCohort, counts }, null, 2));
+  console.log('=== QW1 detalle C (sigue fallando por otra causa) ===');
+  console.log(JSON.stringify(results.filter(row => row.classification === 'C'), null, 2));
+  console.log('=== QW1 detalle D (no aplica) ===');
+  console.log(JSON.stringify(results.filter(row => row.classification === 'D'), null, 2));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/seo/qw1-preview-validation.mjs
+++ b/scripts/seo/qw1-preview-validation.mjs
@@ -76,13 +76,21 @@ function offerLooksValid(side) {
     Boolean(side.canonical) && side.offer.url === side.canonical;
 }
 
-function classify(production, preview) {
-  if (production.httpStatus !== 200 || preview.httpStatus !== 200) return 'D';
+// Revisión de Astra: la etiqueta anterior "B = sigue sin Offer porque no
+// tiene precio real" era una INFERENCIA — desde el HTML sólo se ve que no
+// hay Offer, nunca por qué. Esta comparación HTTP no puede establecer la
+// causa; quien la establece es `qw1-cohort-catalog-evidence.mjs`, que cruza
+// cada MLU contra el catálogo que consume cada entorno.
+export function classify(production, preview) {
+  if (production.httpStatus !== 200 || preview.httpStatus !== 200) {
+    return 'no_comparable_http';
+  }
   const productionOk = offerLooksValid(production);
   const previewOk = offerLooksValid(preview);
-  if (!productionOk && previewOk) return 'A';
-  if (!productionOk && !preview.offer) return 'B';
-  return 'C';
+  if (!productionOk && previewOk) return 'corregido_por_313';
+  if (productionOk && previewOk) return 'ya_correcto_en_ambos';
+  if (productionOk && !previewOk) return 'regresion_en_313';
+  return 'sin_offer_causa_pendiente_de_verificar';
 }
 
 async function measureOne(row) {
@@ -122,13 +130,22 @@ export async function main() {
 
   const results = await mapWithConcurrency(rows, 8, measureOne);
 
-  const counts = { A: 0, B: 0, C: 0, D: 0 };
+  const counts = {
+    corregido_por_313: 0,
+    ya_correcto_en_ambos: 0,
+    regresion_en_313: 0,
+    sin_offer_causa_pendiente_de_verificar: 0,
+    no_comparable_http: 0,
+  };
   for (const row of results) counts[row.classification] += 1;
 
   const summary = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     generatedAt: new Date().toISOString(),
     totalCohort: results.length,
+    // Lo que esta comparación NO puede establecer: la causa de que falte el
+    // `Offer`. Eso se resuelve en qw1-cohort-catalog-evidence.mjs.
+    alcance: 'comparacion HTTP Produccion vs Preview; no infiere causas',
     counts,
     results,
   };
@@ -139,10 +156,14 @@ export async function main() {
 
   console.log('=== QW1 PREVIEW VALIDATION (solo lectura) ===');
   console.log(JSON.stringify({ totalCohort: summary.totalCohort, counts }, null, 2));
-  console.log('=== QW1 detalle C (sigue fallando por otra causa) ===');
-  console.log(JSON.stringify(results.filter(row => row.classification === 'C'), null, 2));
-  console.log('=== QW1 detalle D (no aplica) ===');
-  console.log(JSON.stringify(results.filter(row => row.classification === 'D'), null, 2));
+  console.log('=== QW1 detalle: regresión introducida por #313 ===');
+  console.log(JSON.stringify(results.filter(row => row.classification === 'regresion_en_313'), null, 2));
+  console.log('=== QW1 detalle: no comparable por HTTP (hasta 10) ===');
+  console.log(JSON.stringify(
+    results.filter(row => row.classification === 'no_comparable_http').slice(0, 10),
+    null,
+    2,
+  ));
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/seo/qw1-render-diff.mjs
+++ b/scripts/seo/qw1-render-diff.mjs
@@ -1,0 +1,110 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// QW1 — compara dos informes de render producidos con el MISMO snapshot de
+// catálogo: uno con el renderizador de `main` y otro con el de la rama del
+// PR #313. Responde la pregunta que faltaba: qué casos reales cambia el fix.
+
+function asText(value) {
+  return String(value ?? '').trim();
+}
+
+function offerKey(offer) {
+  if (!offer) return 'sin-offer';
+  return [offer.price, offer.priceCurrency, offer.availability, offer.url].join('|');
+}
+
+export function classifyChange(before, after) {
+  const hadOffer = Boolean(before?.offer);
+  const hasOffer = Boolean(after?.offer);
+  if (!hadOffer && hasOffer) return 'offer_agregado';
+  if (hadOffer && !hasOffer) return 'offer_removido';
+  if (hadOffer && hasOffer && offerKey(before.offer) !== offerKey(after.offer)) return 'offer_modificado';
+  return 'sin_cambio';
+}
+
+// Coherencia comercial: publicar un Offer con precio mientras la ficha no
+// muestra ningún precio visible es incoherente para una persona; publicar el
+// botón de compra sin stock sería peor. Se mide, no se asume.
+export function coherence(row) {
+  const hasOffer = Boolean(row?.offer);
+  const availability = row?.offer?.availability || null;
+  return {
+    offerSinPrecioVisible: hasOffer && !row.visiblePriceBox,
+    precioVisibleSinOffer: !hasOffer && Boolean(row.visiblePriceBox),
+    botonCompraSinStock: Boolean(row.cartButton) && Number(row.available_quantity) <= 0,
+    offerOutOfStockConBoton: availability === 'OutOfStock' && Boolean(row.cartButton),
+  };
+}
+
+export async function main() {
+  const beforePath = asText(process.env.QW1_DIFF_BEFORE) || 'artifacts/qw1/render-main.json';
+  const afterPath = asText(process.env.QW1_DIFF_AFTER) || 'artifacts/qw1/render-pr313.json';
+  const outputPath = asText(process.env.QW1_DIFF_OUTPUT) || 'artifacts/qw1/render-diff.json';
+
+  const before = JSON.parse(await readFile(beforePath, 'utf8'));
+  const after = JSON.parse(await readFile(afterPath, 'utf8'));
+  const beforeById = new Map(before.results.map(row => [row.id, row]));
+  const afterById = new Map(after.results.map(row => [row.id, row]));
+
+  const changes = [];
+  const counts = { offer_agregado: 0, offer_removido: 0, offer_modificado: 0, sin_cambio: 0 };
+  const coherenceCounts = {
+    before: { offerSinPrecioVisible: 0, precioVisibleSinOffer: 0, botonCompraSinStock: 0, offerOutOfStockConBoton: 0 },
+    after: { offerSinPrecioVisible: 0, precioVisibleSinOffer: 0, botonCompraSinStock: 0, offerOutOfStockConBoton: 0 },
+  };
+
+  for (const [id, beforeRow] of beforeById) {
+    const afterRow = afterById.get(id);
+    if (!afterRow) continue;
+    const change = classifyChange(beforeRow, afterRow);
+    counts[change] += 1;
+    for (const [key, value] of Object.entries(coherence(beforeRow))) {
+      if (value) coherenceCounts.before[key] += 1;
+    }
+    for (const [key, value] of Object.entries(coherence(afterRow))) {
+      if (value) coherenceCounts.after[key] += 1;
+    }
+    if (change !== 'sin_cambio') {
+      changes.push({
+        id,
+        change,
+        status: afterRow.status,
+        price: afterRow.price,
+        available_quantity: afterRow.available_quantity,
+        before: beforeRow.offer,
+        after: afterRow.offer,
+        visiblePriceBox: afterRow.visiblePriceBox,
+        cartButton: afterRow.cartButton,
+      });
+    }
+  }
+
+  const summary = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    before: { label: before.label, sha: before.gitSha, items: before.results.length },
+    after: { label: after.label, sha: after.gitSha, items: after.results.length },
+    snapshot: after.snapshot || before.snapshot || null,
+    comparedItems: [...beforeById.keys()].filter(id => afterById.has(id)).length,
+    counts,
+    coherence: coherenceCounts,
+    changes,
+  };
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(summary, null, 2)}\n`);
+
+  console.log('=== QW1 DIFF DE RENDERIZADORES (main vs PR #313, mismo snapshot) ===');
+  console.log(JSON.stringify({ ...summary, changes: undefined }, null, 2));
+  console.log('=== QW1 cambios reales (hasta 20) ===');
+  console.log(JSON.stringify(changes.slice(0, 20), null, 2));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/seo/qw1-renderer-offer-report.mjs
+++ b/scripts/seo/qw1-renderer-offer-report.mjs
@@ -1,0 +1,93 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { renderPage } from '../../functions/libro/[[path]].js';
+
+// QW1 — informe del Offer que produce ESTE checkout del renderizador sobre
+// datos reales de catálogo. Se ejecuta dos veces con el MISMO snapshot (una
+// vez en `main`, otra en la rama del PR #313) y se comparan las salidas: eso
+// demuestra qué casos reales cambia el fix, sin depender de que Preview tenga
+// desplegado el producto. Solo lectura: no toca red salvo el snapshot, que se
+// pasa por archivo.
+
+function asText(value) {
+  return String(value ?? '').trim();
+}
+
+function extractProductSchema(html) {
+  for (const match of String(html).matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    let parsed;
+    try { parsed = JSON.parse(match[1]); } catch { continue; }
+    const types = Array.isArray(parsed?.['@type']) ? parsed['@type'] : [parsed?.['@type']];
+    if (types.includes('Product')) return parsed;
+  }
+  return null;
+}
+
+export function describeRender(item) {
+  const slug = asText(item.slug) || 'ficha';
+  const html = renderPage(item, slug, false, '', '', []);
+  const schema = extractProductSchema(html);
+  const offer = schema?.offers || null;
+  return {
+    id: asText(item.id).toUpperCase(),
+    status: asText(item.status) || null,
+    price: item.price ?? null,
+    currency: asText(item.currency || item.currency_id) || null,
+    available_quantity: item.available_quantity ?? null,
+    offer: offer
+      ? {
+          price: asText(offer.price) || null,
+          priceCurrency: asText(offer.priceCurrency) || null,
+          availability: asText(offer.availability).replace('https://schema.org/', '') || null,
+          url: asText(offer.url) || null,
+        }
+      : null,
+    // Coherencia entre lo que ve una persona y lo que ve Google.
+    visiblePriceBox: /class="price-box"/.test(html),
+    cartButton: /Agregar al carrito/i.test(html),
+    canonicalInHtml: (html.match(/<link rel="canonical" href="([^"]+)">/) || [])[1] || null,
+  };
+}
+
+export async function main() {
+  const snapshotPath = asText(process.env.QW1_SNAPSHOT) || 'artifacts/qw1/catalog-snapshot.json';
+  const outputPath = asText(process.env.QW1_RENDER_OUTPUT) || 'artifacts/qw1/render-report.json';
+  const snapshot = JSON.parse(await readFile(snapshotPath, 'utf8'));
+  const items = Array.isArray(snapshot.items) ? snapshot.items : [];
+
+  const results = items.map(describeRender);
+  const withOffer = results.filter(row => row.offer).length;
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify({
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    snapshot: {
+      catalogUpdatedAt: snapshot.catalogUpdatedAt || null,
+      fetchedAt: snapshot.fetchedAt || null,
+      source: snapshot.source || null,
+      items: items.length,
+    },
+    gitSha: asText(process.env.QW1_RENDER_SHA) || null,
+    label: asText(process.env.QW1_RENDER_LABEL) || null,
+    totals: { items: results.length, withOffer, withoutOffer: results.length - withOffer },
+    results,
+  }, null, 2)}\n`);
+
+  console.log(JSON.stringify({
+    label: process.env.QW1_RENDER_LABEL || null,
+    sha: process.env.QW1_RENDER_SHA || null,
+    items: results.length,
+    withOffer,
+    withoutOffer: results.length - withOffer,
+  }));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}

--- a/worker-sync/cover-mirror.js
+++ b/worker-sync/cover-mirror.js
@@ -259,8 +259,16 @@ function webpInfo(bytes) {
   return null;
 }
 
+// QW2 (medición de solo lectura, sin upscale ni escritura): mismo parseo de
+// bytes reales que ya usa inspectCoverBytes(), sin el rango de validación
+// pensado para decidir si algo se guarda en R2 — un medidor externo necesita
+// el ancho/alto real tal cual venga, incluso fuera de ese rango.
+export function readImageDimensions(bytes) {
+  return pngInfo(bytes) || jpegInfo(bytes) || webpInfo(bytes);
+}
+
 export function inspectCoverBytes(bytes, responseMime) {
-  const image = pngInfo(bytes) || jpegInfo(bytes) || webpInfo(bytes);
+  const image = readImageDimensions(bytes);
   if (!image || image.width < 100 || image.height < 100 || image.width > 12_000 || image.height > 12_000) {
     throw new Error('Imagen inválida o con dimensiones fuera de rango.');
   }


### PR DESCRIPTION
Diagnóstico de solo lectura de Merchant Center (cuenta `5330457716`), ampliado en esta ronda con la **evidencia que pidió la revisión de Astra** para cerrar QW1 con causas verificadas en lugar de inferencias.

## Scripts de evidencia nuevos (todos GET-only)

| Script | Qué responde |
| --- | --- |
| `qw1-cohort-catalog-evidence.mjs` | Cruza cada MLU del cohorte con `status`, precio, moneda y stock del catálogo que **realmente consume cada entorno**. Cuando la fuente no lleva el dato lo dice (`no-transportado-por-la-fuente`) en vez de afirmar «no tiene precio». |
| `qw1-catalog-snapshot.mjs` | Congela un snapshot reproducible (URLs de origen, `catalogUpdatedAt`, versión de manifest, `fetchedAt`). |
| `qw1-renderer-offer-report.mjs` | Renderiza cada ítem del snapshot y reporta `Offer`, precio visible, botón de compra y canonical. |
| `qw1-render-diff.mjs` | Compara dos corridas del anterior — una con el renderizador de `main`, otra con el de #313 — sobre el **mismo** snapshot. |
| `catalog-coverage-effective.mjs` | Cobertura **cruda vs efectiva** tras `applyBookEnrichment()`, separando autor REAL de autor no vacío y descripción útil de descripción no vacía. |

También se corrige aquí la clasificación de `qw1-preview-validation.mjs` (misma corrección que en [PR #317](https://github.com/trexxeseba/amadolibros-web/pull/317)): deja de inferir causas y separa `ya_correcto_en_ambos` y `no_comparable_http`.

## Resultados reales

Run [34005410037](https://github.com/trexxeseba/amadolibros-web/actions/runs/34005410037). Snapshot: `catalog.json` `updated_at` `2026-09-05T07:19:57.025Z`; manifest de Producción `20260905012150762`.

**Cohorte `missing_price` — 171 MLU resueltos:**

| Clasificación | Cantidad |
| --- | ---: |
| Pausado; la fuente no transporta precio ni moneda | 85 |
| No comparable por HTTP 404 en Preview | 85 |
| Activo con precio real (`MLU728138914`) | 1 |
| Causa pendiente de verificar | 0 |

Los 85 «no comparables» quedan explicados: los manifiestos de pausados **difieren por entorno** (`catalog/manifest.json` vs `stock1-preview/manifest.json`), así que existen en el índice de Producción y no en el de Preview. `catalog.json` en cambio es compartido.

**Diff de renderizadores, mismo snapshot, 7.277 ítems** (`main` `ea0c475` vs #313 `6d38d22`):

| | Cantidad |
| --- | ---: |
| `Offer` agregados / removidos / modificados | 0 / 0 / 0 |
| Sin cambio | 7.277 |

Coherencia precio visible ↔ JSON-LD: **0 incoherencias** con ambos renderizadores.

**Cobertura cruda vs efectiva** (7.107 activos con stock; `applyBookEnrichment()` toca 2.985): páginas 0,07% → **22,92%**; editorial real 3,79% → **21,65%**; año 55,42% → **72,72%**. Tabla completa en [PR #316](https://github.com/trexxeseba/amadolibros-web/pull/316).

## Contrato de solo lectura

Sostenido por tests: sólo llamadas GET, sin `:insert`/`:fetch`/`triggerAction`, sin POST/PATCH/PUT/DELETE, sin tocar Merchant, sin deploy, sin cambios de checkout.

Suite completa de Functions: **1.186/1.186**. `scripts/validate-ci.sh`: OK. Draft, sin mergear.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri