### PR TITLE
QW1 (Offer/precio): NO MERGEAR — la validación demuestra que es inerte

### DIFF
--- a/functions/__tests__/social-merchant-policies.test.js
+++ b/functions/__tests__/social-merchant-policies.test.js
@@ -94,3 +94,86 @@ test('las ofertas activas referencian la política global y las pausadas no crea
   ));
   assert.equal(paused.offers, undefined);
 });
+
+// QW1 (Merchant, PR de recuperación de missing_price): un producto ACTIVO
+// con precio real de catálogo debe publicar Offer aunque hoy no tenga stock
+// — Google necesita ver el precio real + disponibilidad real, no la ausencia
+// total de Offer (eso es lo que generaba missing_price para fichas que sí
+// tienen precio comercial). 'paused' (arriba) sigue sin Offer: no cambia.
+
+test('QW1: activo con precio real pero sin stock publica Offer con OutOfStock (no omite el precio)', () => {
+  const outOfStock = productSchemaFromHtml(renderPage(
+    item({ status: 'active', available_quantity: 0 }),
+    'libro-de-prueba',
+    false,
+    '',
+  ));
+  assert.ok(outOfStock.offers, 'debe existir Offer para un producto activo con precio real');
+  assert.equal(outOfStock.offers.price, '1500');
+  assert.equal(outOfStock.offers.priceCurrency, 'UYU');
+  assert.equal(outOfStock.offers.availability, 'https://schema.org/OutOfStock');
+  assert.equal(outOfStock.offers.url, 'https://www.amadolibros.com/libro/MLU123456789/libro-de-prueba');
+});
+
+test('QW1: activo con stock sigue publicando Offer con InStock (sin regresión)', () => {
+  const inStock = productSchemaFromHtml(renderPage(item(), 'libro-de-prueba', false, ''));
+  assert.equal(inStock.offers.availability, 'https://schema.org/InStock');
+  assert.equal(inStock.offers.price, '1500');
+});
+
+test('QW1: sin precio real de catálogo NUNCA se inventa un Offer (price=0, null o ausente)', () => {
+  for (const badPrice of [0, null, undefined, '']) {
+    const noPrice = productSchemaFromHtml(renderPage(
+      item({ price: badPrice, available_quantity: 3 }),
+      'libro-de-prueba',
+      false,
+      '',
+    ));
+    assert.equal(noPrice.offers, undefined, `price=${JSON.stringify(badPrice)} no debe generar Offer`);
+  }
+});
+
+test('QW1: moneda no soportada (no UYU) tampoco genera Offer — no se inventa una conversión', () => {
+  const otherCurrency = productSchemaFromHtml(renderPage(
+    item({ currency: 'USD', available_quantity: 3 }),
+    'libro-de-prueba',
+    false,
+    '',
+  ));
+  assert.equal(otherCurrency.offers, undefined);
+});
+
+test('QW1: paused sin stock sigue sin Offer aunque tenga precio real (no cambia)', () => {
+  const paused = productSchemaFromHtml(renderPage(
+    item({ status: 'paused', available_quantity: 0, price: 1500 }),
+    'libro-de-prueba',
+    false,
+    '',
+  ));
+  assert.equal(paused.offers, undefined);
+});
+
+test('QW1: Offer.url siempre coincide con la URL canónica de la ficha', () => {
+  const html = renderPage(item({ available_quantity: 0 }), 'otro-slug-de-prueba', false, '');
+  const schema = productSchemaFromHtml(html);
+  const canonicalMatch = html.match(/<link rel="canonical" href="([^"]+)">/);
+  assert.ok(canonicalMatch, 'debe existir <link rel=canonical>');
+  assert.equal(schema.offers.url, canonicalMatch[1]);
+});
+
+test('QW1: itemCondition sigue aplicándose sobre el Offer aunque esté sin stock', () => {
+  const used = productSchemaFromHtml(renderPage(
+    item({ condition: 'used', available_quantity: 0 }),
+    'libro-de-prueba',
+    false,
+    '',
+  ));
+  assert.equal(used.offers.itemCondition, 'https://schema.org/UsedCondition');
+});
+
+test('QW1: no hay regresión en el carrito/checkout — sellableInCheckout sigue exigiendo stock real', () => {
+  const html = renderPage(item({ available_quantity: 0 }), 'libro-de-prueba', false, '');
+  // El botón de acción y el bloque de precio comprables siguen ausentes sin
+  // stock real, aunque el JSON-LD ahora publique el Offer con OutOfStock.
+  assert.doesNotMatch(html, /Agregar al carrito/i);
+});

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -456,6 +456,12 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
     const stockQty      = Number(item.available_quantity) || 0;
     const inStock       = item.status === 'active' && stockQty > 0;
     const sellableInCheckout = inStock && checkoutCurrencySupported;
+    // QW1 (Merchant): un producto activo con precio real de catálogo publica
+    // Offer aunque hoy esté sin stock — Google necesita ver el precio real y
+    // la disponibilidad real (OutOfStock), no la ausencia total de Offer.
+    // 'paused' sigue sin Offer (no está realmente en venta). Nunca se inventa
+    // un precio: sin precio real de catálogo, tampoco hay Offer.
+    const hasRealPrice = item.status === 'active' && checkoutCurrencySupported && price > 0;
     const hasFreeShipping = sellableInCheckout && price >= FREE_SHIPPING_THRESHOLD_UYU;
     const condition     = formatCondition(item.condition);
     const dimensions    = item.dimensions_text || formatDimensions(item.dimensions);
@@ -556,13 +562,13 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
         'description': description || (displayAuthor ? `${item.title} — ${displayAuthor}` : item.title),
         'sku':      item.id,
     };
-    if (sellableInCheckout) {
+    if (hasRealPrice) {
         schemaProduct.offers = {
             '@type':        'Offer',
             'url':          canonicalUrl,
             'priceCurrency': currency,
             'price':        String(price),
-            'availability': 'https://schema.org/InStock',
+            'availability': inStock ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock',
             'seller': {
                 '@type': 'OnlineStore',
                 '@id': `${BASE}/#bookstore`,


### PR DESCRIPTION
> **Este PR no se propone para merge.** La validación técnica que pidió Astra —«#313 debe demostrar qué casos reales corrige antes de proponer merge»— se hizo, y el resultado es que **no corrige ningún caso real**. Queda abierto en Draft como registro de la investigación.

## Qué proponía

Publicar `Offer` en el JSON-LD cuando el producto está **activo y con precio real de catálogo**, aunque hoy no tenga stock, en lugar de exigir `inStock`:

```js
const hasRealPrice = item.status === 'active' && checkoutCurrencySupported && price > 0;
// availability: inStock ? InStock : OutOfStock
```

## Por qué es inerte

Su supuesto —activo, con precio real, sin stock— **no existe en el catálogo publicado**. `catalog.json` contiene únicamente activos **con** stock (7.107 == 7.107); los pausados llegan por un índice aparte que sólo transporta `['id','title','author','isbn','image']`, **sin precio ni moneda**.

Diff entre el renderizador de `main` (`ea0c475`) y el de esta rama (`6d38d22`) sobre el **mismo snapshot** del catálogo real (7.277 ítems: 7.107 activos + 170 pausados), run [34005410037](https://github.com/trexxeseba/amadolibros-web/actions/runs/34005410037):

| | Cantidad |
| --- | ---: |
| `Offer` agregados | 0 |
| `Offer` removidos | 0 |
| `Offer` modificados | 0 |
| **Sin cambio** | **7.277** |

Ambos renderizadores publican `Offer` en los 7.107 activos con stock y en ninguno de los 170 pausados.

## Coherencia entre precio visible y JSON-LD

Medida sobre los 7.277 ítems con ambos renderizadores, sin habilitar compra sin stock:

| Señal | `main` | #313 |
| --- | ---: | ---: |
| `Offer` sin precio visible | 0 | 0 |
| Precio visible sin `Offer` | 0 | 0 |
| Botón de compra sin stock | 0 | 0 |
| `Offer` OutOfStock con botón de compra | 0 | 0 |

No hay incoherencia que resolver hoy, y este cambio tampoco introduce ninguna.

## Cuál es la causa raíz real de los `missing_price`

De los 171 MLU del cohorte que se pudieron resolver contra el catálogo que consume cada entorno:

| Clasificación | Cantidad |
| --- | ---: |
| Pausado, la fuente no transporta precio ni moneda | 85 |
| No comparable por HTTP 404 en Preview (los manifiestos de pausados difieren por entorno) | 85 |
| Activo con precio real (`MLU728138914`) | 1 |
| Causa pendiente de verificar | 0 |

**170 de 171 son publicaciones pausadas que siguen enviándose a Merchant.** La vía real es dejar de enviarlas al feed (o transportar su precio), no cambiar el renderizador. Eso se trata fuera de este PR.

Scripts de evidencia y pruebas en [PR #312](https://github.com/trexxeseba/amadolibros-web/pull/312). Sin merge, sin deploy, sin cambios de checkout.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri