### PR TITLE
feat(merchant): QW2 — script de medición read-only de dimensiones de imagen

### DIFF
--- a/functions/__tests__/image-dimension-audit.test.js
+++ b/functions/__tests__/image-dimension-audit.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+test('la implementación es de solo lectura: no escribe en R2, no llama a Merchant, no usa Cloudflare Images', () => {
+  const source = readFileSync('scripts/seo/image-dimension-audit.mjs', 'utf8');
+  assert.doesNotMatch(source, /\.put\(|\.delete\(/);
+  assert.doesNotMatch(source, /merchantapi\.googleapis\.com/i);
+  assert.doesNotMatch(source, /env\.IMAGES|imagesBinding|upscale/i);
+  const fetchCalls = source.match(/\bfetch\(/g) || [];
+  assert.equal(fetchCalls.length, 1);
+});
+
+test('readImageDimensions (worker-sync/cover-mirror.js) sigue exportada y mide JPEG/PNG reales', async () => {
+  const { readImageDimensions } = await import('../../worker-sync/cover-mirror.js');
+  // JPEG 2x1 mínimo válido (marcador SOF0) — sólo se necesita el header.
+  const jpeg = new Uint8Array([
+    0xff, 0xd8, 0xff, 0xc0, 0x00, 0x11, 0x08,
+    0x00, 0x01, 0x00, 0x02, // height=1, width=2
+    0x03, 0x01, 0x11, 0x00, 0x02, 0x11, 0x01, 0x03, 0x11, 0x01,
+    0xff, 0xd9,
+  ]);
+  const dims = readImageDimensions(jpeg);
+  assert.equal(dims.width, 2);
+  assert.equal(dims.height, 1);
+  assert.equal(dims.mime, 'image/jpeg');
+});

--- a/scripts/seo/image-dimension-audit.mjs
+++ b/scripts/seo/image-dimension-audit.mjs
@@ -1,0 +1,125 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { readImageDimensions } from '../../worker-sync/cover-mirror.js';
+
+// QW2 (Merchant, Gran Apuesta en curso): medición de SOLO LECTURA sobre las
+// imágenes ya identificadas como image_too_small. No modifica Merchant, no
+// escribe en R2, no activa Cloudflare Images (pago). Toma la lista de
+// productos ya calculada por merchant-readonly-audit.mjs (offer_id + link +
+// imageLink) y mide el ancho/alto REAL de la imagen que se está sirviendo
+// hoy — la misma que ve Google — clasificando por lado corto: <500, 500-999,
+// >=1000. No inventa ni corrige nada.
+
+const CONCURRENCY = 8;
+const FETCH_TIMEOUT_MS = 15_000;
+
+function asText(value) {
+  return String(value ?? '').trim();
+}
+
+function bucketFor(shortSide) {
+  if (shortSide == null) return 'sin_medir';
+  if (shortSide < 500) return '<500';
+  if (shortSide < 1000) return '500-999';
+  return '>=1000';
+}
+
+function positionFromUrl(url) {
+  const match = /\/book-cover\/[^/]+\/cover(?:-(\d+))?\.jpg$/i.exec(asText(url));
+  if (!match) return null;
+  return match[1] ? Number(match[1]) - 1 : 0;
+}
+
+async function measureOne(row) {
+  const { offerId, imageLink } = row;
+  if (!imageLink) return { offerId, imageLink: null, shortSide: null, width: null, height: null, bucket: 'sin_medir', error: 'sin imageLink' };
+  try {
+    const response = await fetch(imageLink, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { 'user-agent': 'Mozilla/5.0 (compatible; AmadoLibrosImageAudit/1.0; solo lectura)' },
+    });
+    if (!response.ok) {
+      return { offerId, imageLink, shortSide: null, width: null, height: null, bucket: 'sin_medir', error: `HTTP ${response.status}` };
+    }
+    const buffer = new Uint8Array(await response.arrayBuffer());
+    const dimensions = readImageDimensions(buffer);
+    if (!dimensions) {
+      return { offerId, imageLink, shortSide: null, width: null, height: null, bucket: 'sin_medir', error: 'no se pudo parsear la imagen' };
+    }
+    const shortSide = Math.min(dimensions.width, dimensions.height);
+    return {
+      offerId,
+      imageLink,
+      width: dimensions.width,
+      height: dimensions.height,
+      shortSide,
+      bucket: bucketFor(shortSide),
+      position: positionFromUrl(imageLink),
+      external: !/\/book-cover\//i.test(imageLink),
+      error: null,
+    };
+  } catch (error) {
+    return { offerId, imageLink, shortSide: null, width: null, height: null, bucket: 'sin_medir', error: asText(error?.message) || 'fetch failed' };
+  }
+}
+
+async function mapWithConcurrency(items, limit, fn) {
+  const results = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (next < items.length) {
+      const index = next;
+      next += 1;
+      results[index] = await fn(items[index]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+export async function main() {
+  const inputPath = asText(process.env.IMAGE_AUDIT_INPUT) || 'artifacts/merchant/merchant-readonly-report.json';
+  const outputDir = asText(process.env.IMAGE_AUDIT_OUTPUT_DIR) || 'artifacts/image-audit';
+  const raw = await readFile(inputPath, 'utf8');
+  const report = JSON.parse(raw);
+  const rows = (report.productBreakdown?.imageTooSmall || []).map(row => ({
+    offerId: row.offerId,
+    imageLink: row.imageLink,
+    dataSource: row.dataSource,
+  }));
+
+  const results = await mapWithConcurrency(rows, CONCURRENCY, measureOne);
+
+  const byBucket = {};
+  const byPosition = {};
+  for (const row of results) {
+    byBucket[row.bucket] = (byBucket[row.bucket] || 0) + 1;
+    const posKey = row.position == null ? 'externa' : `posicion_${row.position}`;
+    byPosition[posKey] = byPosition[posKey] || {};
+    byPosition[posKey][row.bucket] = (byPosition[posKey][row.bucket] || 0) + 1;
+  }
+
+  const summary = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    totalMeasured: results.length,
+    byBucket,
+    byPosition,
+    results,
+  };
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(path.join(outputDir, 'image-dimension-audit.json'), `${JSON.stringify(summary, null, 2)}\n`);
+
+  console.log('=== QW2 IMAGE DIMENSION AUDIT (solo lectura) ===');
+  console.log(JSON.stringify({ totalMeasured: summary.totalMeasured, byBucket, byPosition }, null, 2));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}

--- a/worker-sync/cover-mirror.js
+++ b/worker-sync/cover-mirror.js
@@ -259,8 +259,16 @@ function webpInfo(bytes) {
   return null;
 }
 
+// QW2 (medición de solo lectura, sin upscale ni escritura): mismo parseo de
+// bytes reales que ya usa inspectCoverBytes(), sin el rango de validación
+// pensado para decidir si algo se guarda en R2 — un medidor externo necesita
+// el ancho/alto real tal cual venga, incluso fuera de ese rango.
+export function readImageDimensions(bytes) {
+  return pngInfo(bytes) || jpegInfo(bytes) || webpInfo(bytes);
+}
+
 export function inspectCoverBytes(bytes, responseMime) {
-  const image = pngInfo(bytes) || jpegInfo(bytes) || webpInfo(bytes);
+  const image = readImageDimensions(bytes);
   if (!image || image.width < 100 || image.height < 100 || image.width > 12_000 || image.height > 12_000) {
     throw new Error('Imagen inválida o con dimensiones fuera de rango.');
   }


### PR DESCRIPTION
Mide el ancho y alto **reales** de las imágenes que Merchant marcó como `image_too_small`, reutilizando `readImageDimensions` de `worker-sync/cover-mirror.js` (mismo lector que ya usa el pipeline de portadas). Sólo GET a URLs públicas: no toca Merchant, no activa Cloudflare Images, no despliega.

## Corrección de encuadre (revisión de Astra)

La versión anterior de este informe decía que «la mayoría de las <500px son secundarias de galería (posición ≥1)». **Eso minimizaba el problema y hay que retirarlo:** la posición en nuestra galería no es la función en Merchant. **Toda URL que aparece en `imageLink` es la imagen principal del producto para Google**, aunque internamente sea la segunda de la galería.

Reencuadrado por función real, de los 32 productos con imagen <500px de la última corrida:

| Origen de la URL | Cantidad | Función en Merchant |
| --- | ---: | --- |
| Servida por nuestro proxy (`/book-cover/...`) | 24 | **Principal** |
| Servida directo desde Mercado Libre | 8 | **Principal** |

Las 32 son principales para Merchant. La distinción útil no es «principal vs secundaria» sino **quién sirve el byte**, porque determina dónde se corrige.

## Lo que la medición sí estableció

- Distribución real de los `image_too_small`: 53 <500px, 38 entre 500 y 999px, 7 ≥1000px.
- Todas las URLs medidas usan ya la variante `-O`, la mayor que Mercado Libre ofrece por URL. **No hay una fuente mayor por simple sustitución de URL.**

## Lo que todavía NO está establecido

**Falta verificar si existe una fuente real mejor por ISBN/edición** (catálogo del editor, BNE, Open Library) antes de concluir que sólo quedan dos salidas —upscale por IA u omitir el producto—. Esa verificación no se hizo y no debe darse por hecha.

Google exige 500×500 desde el 31/01/2027 y **desaconseja expresamente ampliar miniaturas artificialmente**, así que la fuente real es la primera opción a agotar.

Sin corrección implementada. Draft, sin mergear, sin deploy, sin activar Cloudflare Images pago.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri