### PR TITLE
fix(merchant): la comparación HTTP de QW1 deja de inferir causas

### DIFF
--- a/functions/__tests__/qw1-preview-validation.test.js
+++ b/functions/__tests__/qw1-preview-validation.test.js
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+test('la implementación es de solo lectura: sin escritura, sin Merchant, un fetch por lado', () => {
+  const source = readFileSync('scripts/seo/qw1-preview-validation.mjs', 'utf8');
+  assert.doesNotMatch(source, /method\s*:\s*['"](?:POST|PATCH|PUT|DELETE)['"]/i);
+  assert.doesNotMatch(source, /merchantapi\.googleapis\.com/i);
+  const fetchCalls = source.match(/\bfetch\(/g) || [];
+  assert.equal(fetchCalls.length, 1);
+});

--- a/functions/__tests__/qw1-preview-validation.test.js
+++ b/functions/__tests__/qw1-preview-validation.test.js
@@ -2,6 +2,35 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
+import { classify } from '../../scripts/seo/qw1-preview-validation.mjs';
+
+const OFFER_OK = {
+  httpStatus: 200,
+  canonical: 'https://www.amadolibros.com/libro/MLU1/x',
+  offer: {
+    price: '1500',
+    priceCurrency: 'UYU',
+    availability: 'InStock',
+    url: 'https://www.amadolibros.com/libro/MLU1/x',
+  },
+};
+const SIN_OFFER = { httpStatus: 200, canonical: 'https://www.amadolibros.com/libro/MLU1/x', offer: null };
+
+// Revisión de Astra: la ausencia de `Offer` en el HTML no prueba ausencia de
+// precio. Esta comparación sólo puede decir qué cambió entre entornos; la
+// causa la establece qw1-cohort-catalog-evidence.mjs contra el catálogo.
+test('no se infiere "no tiene precio" desde "no hay Offer"', () => {
+  assert.equal(classify(SIN_OFFER, SIN_OFFER), 'sin_offer_causa_pendiente_de_verificar');
+});
+
+test('se separan corregido, ya correcto en ambos, regresión y no comparable', () => {
+  assert.equal(classify(SIN_OFFER, OFFER_OK), 'corregido_por_313');
+  assert.equal(classify(OFFER_OK, OFFER_OK), 'ya_correcto_en_ambos');
+  assert.equal(classify(OFFER_OK, SIN_OFFER), 'regresion_en_313');
+  assert.equal(classify(OFFER_OK, { httpStatus: 404, offer: null }), 'no_comparable_http');
+  assert.equal(classify({ httpStatus: 404, offer: null }, OFFER_OK), 'no_comparable_http');
+});
+
 test('la implementación es de solo lectura: sin escritura, sin Merchant, un fetch por lado', () => {
   const source = readFileSync('scripts/seo/qw1-preview-validation.mjs', 'utf8');
   assert.doesNotMatch(source, /method\s*:\s*['"](?:POST|PATCH|PUT|DELETE)['"]/i);

--- a/scripts/seo/qw1-preview-validation.mjs
+++ b/scripts/seo/qw1-preview-validation.mjs
@@ -1,0 +1,153 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// QW1 — validación de solo lectura del criterio de aceptación real: para
+// TODO el cohorte de missing_price ya identificado por Merchant, compara
+// PRODUCCIÓN vs PREVIEW del PR #313 (mismo path, otro host) y clasifica el
+// resultado real. No modifica nada — sólo GET a páginas públicas.
+
+const PREVIEW_HOST = 'pr-313.amadolibros-web.pages.dev';
+const FETCH_TIMEOUT_MS = 15_000;
+
+function asText(value) {
+  return String(value ?? '').trim();
+}
+
+function toPreviewUrl(productionUrl) {
+  try {
+    const url = new URL(productionUrl);
+    url.hostname = PREVIEW_HOST;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function extractCanonical(html) {
+  const match = String(html || '').match(/<link[^>]+rel=["']canonical["'][^>]*href=["']([^"']+)["']/i);
+  return match ? match[1] : null;
+}
+
+function extractOffer(html) {
+  const blocks = [...String(html || '').matchAll(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)];
+  for (const block of blocks) {
+    let parsed;
+    try { parsed = JSON.parse(block[1]); } catch { continue; }
+    const types = Array.isArray(parsed?.['@type']) ? parsed['@type'] : [parsed?.['@type']];
+    if (!types.includes('Product')) continue;
+    const offer = parsed.offers;
+    if (!offer) return null;
+    return {
+      price: asText(offer.price) || null,
+      priceCurrency: asText(offer.priceCurrency) || null,
+      availability: asText(offer.availability).replace('https://schema.org/', '') || null,
+      url: asText(offer.url) || null,
+    };
+  }
+  return null;
+}
+
+async function fetchSide(url) {
+  if (!url) return { httpStatus: null, offer: null, canonical: null, error: 'sin URL' };
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { 'user-agent': 'AmadoLibros-QW1-Validation/1.0 (solo lectura)' },
+    });
+    const html = response.status === 200 ? await response.text() : '';
+    return {
+      httpStatus: response.status,
+      offer: response.status === 200 ? extractOffer(html) : null,
+      canonical: response.status === 200 ? extractCanonical(html) : null,
+      error: null,
+    };
+  } catch (error) {
+    return { httpStatus: null, offer: null, canonical: null, error: asText(error?.message) || 'fetch failed' };
+  }
+}
+
+function offerLooksValid(side) {
+  if (side.httpStatus !== 200 || !side.offer) return false;
+  const price = Number(side.offer.price);
+  return Number.isFinite(price) && price > 0 &&
+    side.offer.priceCurrency === 'UYU' &&
+    ['InStock', 'OutOfStock'].includes(side.offer.availability) &&
+    Boolean(side.canonical) && side.offer.url === side.canonical;
+}
+
+function classify(production, preview) {
+  if (production.httpStatus !== 200 || preview.httpStatus !== 200) return 'D';
+  const productionOk = offerLooksValid(production);
+  const previewOk = offerLooksValid(preview);
+  if (!productionOk && previewOk) return 'A';
+  if (!productionOk && !preview.offer) return 'B';
+  return 'C';
+}
+
+async function measureOne(row) {
+  const productionUrl = row.link;
+  const previewUrl = toPreviewUrl(productionUrl);
+  const [production, preview] = await Promise.all([fetchSide(productionUrl), fetchSide(previewUrl)]);
+  return {
+    offerId: row.offerId,
+    productionUrl,
+    previewUrl,
+    production,
+    preview,
+    classification: classify(production, preview),
+  };
+}
+
+async function mapWithConcurrency(items, limit, fn) {
+  const results = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (next < items.length) {
+      const index = next;
+      next += 1;
+      results[index] = await fn(items[index]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+export async function main() {
+  const inputPath = asText(process.env.QW1_VALIDATION_INPUT) || 'artifacts/merchant/merchant-readonly-report.json';
+  const outputDir = asText(process.env.QW1_VALIDATION_OUTPUT_DIR) || 'artifacts/qw1-validation';
+  const raw = await readFile(inputPath, 'utf8');
+  const report = JSON.parse(raw);
+  const rows = report.productBreakdown?.missingPrice || [];
+
+  const results = await mapWithConcurrency(rows, 8, measureOne);
+
+  const counts = { A: 0, B: 0, C: 0, D: 0 };
+  for (const row of results) counts[row.classification] += 1;
+
+  const summary = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    totalCohort: results.length,
+    counts,
+    results,
+  };
+
+  const { mkdir } = await import('node:fs/promises');
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(path.join(outputDir, 'qw1-preview-validation.json'), `${JSON.stringify(summary, null, 2)}\n`);
+
+  console.log('=== QW1 PREVIEW VALIDATION (solo lectura) ===');
+  console.log(JSON.stringify({ totalCohort: summary.totalCohort, counts }, null, 2));
+  console.log('=== QW1 detalle C (sigue fallando por otra causa) ===');
+  console.log(JSON.stringify(results.filter(row => row.classification === 'C'), null, 2));
+  console.log('=== QW1 detalle D (no aplica) ===');
+  console.log(JSON.stringify(results.filter(row => row.classification === 'D'), null, 2));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/seo/qw1-preview-validation.mjs
+++ b/scripts/seo/qw1-preview-validation.mjs
@@ -76,13 +76,21 @@ function offerLooksValid(side) {
     Boolean(side.canonical) && side.offer.url === side.canonical;
 }
 
-function classify(production, preview) {
-  if (production.httpStatus !== 200 || preview.httpStatus !== 200) return 'D';
+// Revisión de Astra: la etiqueta anterior "B = sigue sin Offer porque no
+// tiene precio real" era una INFERENCIA — desde el HTML sólo se ve que no
+// hay Offer, nunca por qué. Esta comparación HTTP no puede establecer la
+// causa; quien la establece es `qw1-cohort-catalog-evidence.mjs`, que cruza
+// cada MLU contra el catálogo que consume cada entorno.
+export function classify(production, preview) {
+  if (production.httpStatus !== 200 || preview.httpStatus !== 200) {
+    return 'no_comparable_http';
+  }
   const productionOk = offerLooksValid(production);
   const previewOk = offerLooksValid(preview);
-  if (!productionOk && previewOk) return 'A';
-  if (!productionOk && !preview.offer) return 'B';
-  return 'C';
+  if (!productionOk && previewOk) return 'corregido_por_313';
+  if (productionOk && previewOk) return 'ya_correcto_en_ambos';
+  if (productionOk && !previewOk) return 'regresion_en_313';
+  return 'sin_offer_causa_pendiente_de_verificar';
 }
 
 async function measureOne(row) {
@@ -122,13 +130,22 @@ export async function main() {
 
   const results = await mapWithConcurrency(rows, 8, measureOne);
 
-  const counts = { A: 0, B: 0, C: 0, D: 0 };
+  const counts = {
+    corregido_por_313: 0,
+    ya_correcto_en_ambos: 0,
+    regresion_en_313: 0,
+    sin_offer_causa_pendiente_de_verificar: 0,
+    no_comparable_http: 0,
+  };
   for (const row of results) counts[row.classification] += 1;
 
   const summary = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     generatedAt: new Date().toISOString(),
     totalCohort: results.length,
+    // Lo que esta comparación NO puede establecer: la causa de que falte el
+    // `Offer`. Eso se resuelve en qw1-cohort-catalog-evidence.mjs.
+    alcance: 'comparacion HTTP Produccion vs Preview; no infiere causas',
     counts,
     results,
   };
@@ -139,10 +156,14 @@ export async function main() {
 
   console.log('=== QW1 PREVIEW VALIDATION (solo lectura) ===');
   console.log(JSON.stringify({ totalCohort: summary.totalCohort, counts }, null, 2));
-  console.log('=== QW1 detalle C (sigue fallando por otra causa) ===');
-  console.log(JSON.stringify(results.filter(row => row.classification === 'C'), null, 2));
-  console.log('=== QW1 detalle D (no aplica) ===');
-  console.log(JSON.stringify(results.filter(row => row.classification === 'D'), null, 2));
+  console.log('=== QW1 detalle: regresión introducida por #313 ===');
+  console.log(JSON.stringify(results.filter(row => row.classification === 'regresion_en_313'), null, 2));
+  console.log('=== QW1 detalle: no comparable por HTTP (hasta 10) ===');
+  console.log(JSON.stringify(
+    results.filter(row => row.classification === 'no_comparable_http').slice(0, 10),
+    null,
+    2,
+  ));
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
Compara Producción vs Preview del PR #313 para todo el cohorte `missing_price`, y **corrige la clasificación** que Astra rechazó.

## Qué estaba mal

La clase «B» decía *«sigue sin `Offer` porque no tiene precio real»*. Eso es una **inferencia**: desde el HTML sólo se observa que no hay `Offer`, nunca por qué. Y las clases opacas A/B/C/D escondían dos casos distintos dentro de C y D.

## Clasificación corregida

| Clase | Qué significa |
| --- | --- |
| `corregido_por_313` | No había `Offer` válido en Producción y sí lo hay en Preview. |
| `ya_correcto_en_ambos` | Tenía `Offer` válido antes y después. (Antes se mezclaba dentro de C.) |
| `regresion_en_313` | Tenía `Offer` válido en Producción y lo pierde en Preview. |
| `sin_offer_causa_pendiente_de_verificar` | No hay `Offer` en ninguno de los dos. **La causa no la puede establecer esta comparación.** |
| `no_comparable_http` | Una de las dos respuestas no fue HTTP 200. (Antes era «D — no aplica».) |

El informe declara además su propio alcance (`comparacion HTTP Produccion vs Preview; no infiere causas`) para que no vuelva a leerse como una conclusión sobre causas.

## Dónde sí se establece la causa

En `scripts/seo/qw1-cohort-catalog-evidence.mjs` ([PR #312](https://github.com/trexxeseba/amadolibros-web/pull/312)), que cruza cada MLU con `status`, precio, moneda y stock del catálogo que **realmente consume cada entorno**, y declara explícitamente `no-transportado-por-la-fuente` cuando la fuente no lleva el dato — en lugar de afirmar que el producto «no tiene precio».

Con esa evidencia el cohorte queda resuelto: de 171 MLU, **85 pausados**, **85 no comparables por 404 en Preview**, **1 activo con precio real**, **0 con causa pendiente**. Ver [PR #316](https://github.com/trexxeseba/amadolibros-web/pull/316) para el detalle.

## Validación

- `functions/__tests__/qw1-preview-validation.test.js`: 3/3, con dos pruebas nuevas — una fija que no se infiere «no tiene precio» desde «no hay `Offer`», otra que separa las cinco clases.
- Suite completa de Functions: **1.157/1.157**. `scripts/validate-ci.sh`: OK.

Sólo GET a páginas públicas — sin Merchant, sin escritura, sin deploy. Draft, sin mergear.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri