### PR TITLE
fix(seo): el selector de investigación mide huecos sobre la ficha efectiva

### DIFF
--- a/functions/__tests__/book-intelligence-research-run.test.js
+++ b/functions/__tests__/book-intelligence-research-run.test.js
@@ -49,7 +49,7 @@ function classification(overrides = {}) {
   };
 }
 
-test('selecciona ISBN activos unicos, excluye enriquecidos y prioriza brechas', () => {
+test('selecciona ISBN activos unicos y prioriza brechas', () => {
   const result = selectResearchCohort({
     catalogItems: [
       catalogItem('MLU1', ISBN_A, { description: 'x'.repeat(900) }),
@@ -62,11 +62,48 @@ test('selecciona ISBN activos unicos, excluye enriquecidos y prioriza brechas', 
   });
 
   assert.equal(result.selected.length, 2);
-  assert.equal(result.eligible_unique_isbns, 2);
-  assert.equal(result.excluded_already_enriched, 1);
+  assert.equal(result.isbns_en_registro, 1);
   assert.equal(result.selected[0].isbn, ISBN_B);
   assert.equal(result.selected[0].id, 'MLU3');
   assert.deepEqual(result.selected[0].listing_ids, ['MLU2', 'MLU3']);
+});
+
+// Revisión de Astra: estar en el registro no es estar completo. Un ISBN ya
+// investigado que sigue sin `pages` ni `publisher` debe poder volver a
+// investigarse; sólo queda fuera si su ficha efectiva no tiene huecos.
+test('un ISBN del registro con campos incompletos sigue siendo candidato', () => {
+  const result = selectResearchCohort({
+    catalogItems: [catalogItem('MLU9', ISBN_C, { available_quantity: 5 })],
+    existingEnrichments: [{ isbn: ISBN_C }],
+    limit: 0,
+  });
+
+  assert.equal(result.isbns_en_registro, 1);
+  assert.equal(result.selected.length, 1);
+  assert.equal(result.selected[0].isbn, ISBN_C);
+  assert.equal(result.selected[0].already_in_registry, true);
+  assert.equal(result.reinvestigables_en_registro, 1);
+  assert.ok(result.selected[0].research.missing_fields.length > 0);
+});
+
+// ...y el ISBN sin ningún hueco pendiente no gasta cupo.
+test('un ISBN sin campos pendientes queda fuera del cohorte', () => {
+  const completo = catalogItem('MLU10', ISBN_A, {
+    author: 'Autora Real',
+    publisher: 'Editorial Real',
+    pages: 320,
+    bibliographic: {
+      language: 'Español',
+      format: 'Tapa blanda',
+      edition: '2.ª edición',
+      publication_year: '2019',
+      subjects: ['Narrativa'],
+    },
+  });
+  const result = selectResearchCohort({ catalogItems: [completo], existingEnrichments: [], limit: 0 });
+
+  assert.equal(result.selected.length, 0);
+  assert.equal(result.eligible_unique_isbns, 0);
 });
 
 test('temas oficiales cuentan como mejora SEO cuando la edición no los tenía', () => {

--- a/scripts/seo/book-intelligence-research-run.mjs
+++ b/scripts/seo/book-intelligence-research-run.mjs
@@ -11,7 +11,7 @@ import { pathToFileURL } from 'node:url';
 
 import { CATALOG_URL } from '../../functions/_shared/catalog.js';
 import { normalizeBookLanguage } from '../../functions/_shared/book-bibliographic-normalization.js';
-import { listBookEnrichments } from '../../functions/_shared/book-enrichment-registry.js';
+import { applyBookEnrichment, listBookEnrichments } from '../../functions/_shared/book-enrichment-registry.js';
 import {
   classifyBookIntelligenceEvidence,
   summarizeBookIntelligenceEvidence,
@@ -94,12 +94,20 @@ export function selectResearchCohort({
   for (const item of Array.isArray(catalogItems) ? catalogItems : []) {
     if (!isShowcaseEligible(item)) continue;
     const isbn = normalizeValidIsbn(item?.isbn);
-    if (!isbn || alreadyEnriched.has(isbn)) continue;
+    if (!isbn) continue;
     if (!byIsbn.has(isbn)) byIsbn.set(isbn, []);
     byIsbn.get(isbn).push(item);
   }
 
   const candidates = [...byIsbn.entries()].map(([isbn, listings]) => {
+    // Los huecos se miden sobre la ficha EFECTIVA (catálogo + registro), que
+    // es la que se publica. Estar en el registro no implica estar completo:
+    // una edición ya investigada que sólo aportó `publication_year` sigue
+    // necesitando `pages` o `publisher`.
+    const effective = listings.map(listing => applyBookEnrichment(listing));
+    const missingFields = EDITION_FIELDS.filter(field =>
+      effective.some(listing => !existingFact(listing, field)),
+    );
     const representative = [...listings].sort(compareRepresentatives)[0];
     const totalStock = listings.reduce(
       (sum, item) => sum + Math.max(0, Number(item?.available_quantity) || 0),
@@ -112,22 +120,23 @@ export function selectResearchCohort({
       listing_count: listings.length,
       total_stock: totalStock,
       priority_score: candidateScore(representative, listings.length),
+      already_in_registry: alreadyEnriched.has(isbn),
       research: {
         cohort_source: 'active_sellable_unique_isbn',
         description_length: descriptionLength(representative),
         // El gateway se aplica a todos los duplicados del ISBN. Una edición
         // cuenta como mejora si completa el campo en al menos una de sus
         // publicaciones, aunque el representante ya lo tuviera.
-        missing_fields: EDITION_FIELDS.filter(field =>
-          listings.some(listing => !existingFact(listing, field)),
-        ),
+        missing_fields: missingFields,
       },
     };
-  }).sort((a, b) =>
-    b.priority_score - a.priority_score ||
-    b.total_stock - a.total_stock ||
-    a.isbn.localeCompare(b.isbn),
-  );
+  }).filter(candidate => candidate.research.missing_fields.length > 0)
+    .sort((a, b) =>
+      Number(a.already_in_registry) - Number(b.already_in_registry) ||
+      b.priority_score - a.priority_score ||
+      b.total_stock - a.total_stock ||
+      a.isbn.localeCompare(b.isbn),
+    );
 
   if (requestedLimit > 0 && candidates.length < requestedLimit) {
     throw new Error(`ISBN-1000 resolvio ${candidates.length}/${requestedLimit} ediciones activas y vendibles.`);
@@ -136,7 +145,10 @@ export function selectResearchCohort({
   return {
     selected: requestedLimit > 0 ? candidates.slice(0, requestedLimit) : candidates,
     eligible_unique_isbns: candidates.length,
-    excluded_already_enriched: alreadyEnriched.size,
+    // Ya no se excluye un ISBN por estar en el registro: se excluye sólo si
+    // su ficha efectiva no tiene ningún campo pendiente.
+    isbns_en_registro: alreadyEnriched.size,
+    reinvestigables_en_registro: candidates.filter(candidate => candidate.already_in_registry).length,
   };
 }
 
@@ -502,7 +514,8 @@ export async function runResearch({
       requested: positiveInteger(limit, DEFAULT_LIMIT),
       selected: selected.length,
       eligible_unique_isbns: cohort.eligible_unique_isbns,
-      excluded_already_enriched: cohort.excluded_already_enriched,
+      isbns_en_registro: cohort.isbns_en_registro,
+      reinvestigables_en_registro: cohort.reinvestigables_en_registro,
     },
     catalog: {
       source: catalogSource,


### PR DESCRIPTION
Corrige el punto 5 de la revisión de Astra: *"revisar el selector: hoy excluye cualquier ISBN presente en el registry, aunque conserve campos incompletos"*.

## El defecto

`selectResearchCohort()` hacía:

```js
if (!isbn || alreadyEnriched.has(isbn)) continue;
```

Es decir, un ISBN quedaba excluido **por estar en el registro**, no por estar completo. Una edición investigada en un lote anterior que sólo aportó `publication_year` quedaba bloqueada para siempre, aunque su ficha siguiera sin `pages`, `publisher` ni `edition`.

## El cambio

- Los huecos se calculan sobre la ficha **efectiva** — catálogo más `applyBookEnrichment()`, que es exactamente lo que se publica en la ficha, el JSON-LD y el feed. Esto también responde al pedido de *"medir mejoras sobre el catálogo efectivo, sin volver a contar datos ya publicados"*.
- Un ISBN queda fuera del cohorte **sólo si no le falta ningún campo** de `EDITION_FIELDS`.
- Los ISBN nunca investigados mantienen prioridad sobre los reinvestigables, así que el trabajo nuevo no se desplaza por trabajo repetido.
- `excluded_already_enriched` (que ya no describía nada real) se reemplaza por `isbns_en_registro` y `reinvestigables_en_registro`.

## Validación

- `functions/__tests__/book-intelligence-research-run.test.js`: 12/12, con dos pruebas nuevas — un ISBN del registro con campos incompletos sigue siendo candidato; un ISBN sin ningún hueco queda fuera.
- Suite completa de Functions: **1.156/1.156**.
- `scripts/validate-ci.sh`: OK. `git diff --check`: limpio.

Sin cambios en checkout, sin deploy, sin tocar Merchant. Draft, sin mergear.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri

---
_Generated by [Claude Code](https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri)_