### PR TITLE
fix(images): conservar master de mayor resolución durante refresh — QW2 parcial

### DIFF
--- a/worker-sync/__tests__/cover-mirror.test.js
+++ b/worker-sync/__tests__/cover-mirror.test.js
@@ -274,6 +274,61 @@ test('si la mejora IA falla mantiene la portada original y registra el motivo', 
   assert.equal(bucket.objects.has(entry.current.object_key), true);
 });
 
+for (const mode of ['sin Images', 'Images falla']) {
+  test(`un refresh ${mode} no reemplaza el master bueno por el original pequeño`, async () => {
+    const bucket = new MockR2();
+    const catalog = { items: [item()] };
+    const fetchFn = async () => new Response(pngBytes(400, 600), {
+      headers: { 'content-type': 'image/png' },
+    });
+    await syncCoverMirror({ COVER_R2: bucket, IMAGES: imagesBinding() }, catalog, {
+      now: () => new Date('2026-08-01T12:00:00Z'), fetchFn,
+    });
+    const before = bucket.manifest().entries['MLU123456:0'];
+    const result = await syncCoverMirror({
+      COVER_R2: bucket,
+      ...(mode === 'Images falla' ? { IMAGES: imagesBinding({ fail: true }) } : {}),
+    }, catalog, {
+      now: () => new Date('2026-09-06T12:00:00Z'), fetchFn,
+    });
+    const after = bucket.manifest().entries['MLU123456:0'];
+    assert.deepEqual(after.current, before.current);
+    assert.equal(after.previous_object_key, before.previous_object_key);
+    assert.equal(result.failed, 1);
+    assert.equal(result.pending, 1);
+    assert.match(after.last_error.message, /resolución/);
+  });
+}
+
+test('un refresh conserva un master nativo mayor y permite una mejora real del mismo origen', async () => {
+  const bucket = new MockR2();
+  const catalog = { items: [item()] };
+  let dimensions = [1200, 1800];
+  const fetchFn = async () => new Response(pngBytes(...dimensions), {
+    headers: { 'content-type': 'image/png' },
+  });
+  await syncCoverMirror({ COVER_R2: bucket }, catalog, {
+    now: () => new Date('2026-07-01T12:00:00Z'), fetchFn,
+  });
+  const before = bucket.manifest().entries['MLU123456:0'].current;
+  dimensions = [600, 900];
+  const rejected = await syncCoverMirror({ COVER_R2: bucket }, catalog, {
+    now: () => new Date('2026-08-06T12:00:00Z'), fetchFn,
+  });
+  assert.equal(rejected.failed, 1);
+  assert.deepEqual(bucket.manifest().entries['MLU123456:0'].current, before);
+  dimensions = [1600, 2400];
+  const improved = await syncCoverMirror({ COVER_R2: bucket }, catalog, {
+    now: () => new Date('2026-09-06T12:00:00Z'), fetchFn,
+  });
+  assert.equal(improved.failed, 0);
+  const after = bucket.manifest().entries['MLU123456:0'];
+  assert.equal(after.current.width, 1600);
+  assert.equal(after.current.height, 2400);
+  assert.equal(after.previous_object_key, before.object_key);
+  assert.equal(after.last_error, null);
+});
+
 test('no consume Images para un producto que Merchant excluye', async () => {
   const bucket = new MockR2();
   const images = imagesBinding();

--- a/worker-sync/cover-mirror.js
+++ b/worker-sync/cover-mirror.js
@@ -410,6 +410,15 @@ async function processCover(bucket, candidate, nowIso, fetchFn, imagesBinding) {
     }
   }
   const previousKey = candidate.entry?.current?.object_key || null;
+  const previous = candidate.entry?.current;
+  // Una revalidación del mismo origen puede devolver su original pequeño
+  // si Images falla o no está disponible. Mantener el master ya publicado;
+  // el catch del sincronizador conserva current y deja el intento pendiente.
+  // Un cambio de URL puede ser una corrección de portada y no se bloquea aquí.
+  if (previousKey && previous.source_url === candidate.source_url &&
+      (finalImage.width < Number(previous.width) || finalImage.height < Number(previous.height))) {
+    throw new Error(`Se conserva el master: resolución ${finalImage.width}x${finalImage.height} inferior a ${previous.width}x${previous.height}.${transformError ? ` ${transformError}` : ''}`);
+  }
   return {
     entry: {
       product_id: candidate.product_id,


### PR DESCRIPTION
## Problema y cambio

Una revalidación del mismo origen puede reemplazar un master R2 de 1024×1536 por el original de 400×600 cuando Images falla o no está disponible. Se reprodujo con dos tests que fallaban antes del fix.

El sincronizador ahora rechaza una reducción de ancho o alto respecto de la copia actual del mismo origen, conserva `current` y `previous_object_key`, registra el error y mantiene el intento pendiente. Se permite una mejora real del origen. Un cambio de URL puede representar una corrección de portada y queda fuera de esta protección acotada.

## Responsable, esfuerzo y aceptación

- Responsable: Codex. Claude conserva QW3A2 y documentos centrales.
- Esfuerzo: pequeño; 2 archivos, protección y tests.
- Aceptación: un refresh del mismo origen no degrada las dimensiones del master si Images falla o no está disponible; un master nativo tampoco se degrada; una fuente mejor sí se publica.
- Evidencia local: `node --test worker-sync/__tests__/cover-mirror.test.js` 16/16; `scripts/validate-ci.sh` completo OK antes del último test adicional, y suite focal 16/16 repetida con ese test. `git diff --check` OK. CI del SHA final pendiente al abrir.

## Alcance Merchant

Esto es una corrección preventiva del pipeline, no QW2 completo. No se afirma que haya reparado productos Merchant reales ni se realizó un piloto visual con Images.

Artefacto del run 34005410037: 52 imágenes medidas; 30 <500, 20 de 500–999 y 2 ≥1000 (snapshot 2026-09-06T02:02:40Z). Las 30 pequeñas son imágenes principales seleccionadas por Merchant, aunque 14 correspondan a posición 1 de la galería web.

Corrección al handoff: `worker-sync/wrangler.toml` de main ea0c475 sí contiene `[images] binding = "IMAGES"`. No demuestra por sí solo el binding desplegado. No se habilitan más transformaciones ni se usa upscale como sustituto de buscar fuentes reales mejores.

## Coordinación

Base: main verificado ea0c4756cd1dfb44756d68d719d864cf9d9a8284. Sin cherry-pick de ramas viejas. `ESTADO-ACTUAL.md` y `PLAN-MAESTRO.md` quedan en manos de Claude/#316: registrar este PR como QW2 parcial implementado, validación Merchant pendiente. No merge ni deploy productivo ni cambios de checkout. Requiere aprobación explícita de Seba antes de integrar.