### PR TITLE
QW2: comparar fuentes nativas de 16 fichas afectadas — piloto read-only

### DIFF
--- a/.github/workflows/qw2-native-source-pilot.yml
+++ b/.github/workflows/qw2-native-source-pilot.yml
@@ -1,0 +1,80 @@
+name: QW2 native source pilot
+on:
+  pull_request:
+    branches: [main]
+    paths: ['.github/workflows/qw2-native-source-pilot.yml']
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  measure:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+      - name: Compare existing native image sources for the affected active cohort
+        run: |
+          mkdir -p artifacts/qw2-native-source-pilot
+          node --input-type=module <<'NODE'
+          import { writeFile } from 'node:fs/promises';
+          import { inspectCoverBytes, coverCandidates } from './worker-sync/cover-mirror.js';
+          const out = 'artifacts/qw2-native-source-pilot';
+          const ids = ['MLU628104849','MLU636119126','MLU629952475','MLU629940095','MLU651575382','MLU660323622','MLU670646778','MLU637120759','MLU688989388','MLU643205029','MLU690353270','MLU644928147','MLU702907426','MLU757785172','MLU823903586','MLU882935602'];
+          const catalogUrl = 'https://pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev/catalog.json';
+          const response = await fetch(catalogUrl, { signal: AbortSignal.timeout(60000) });
+          if (!response.ok) throw new Error('catalog HTTP ' + response.status);
+          const catalog = await response.json();
+          const byId = new Map(catalog.items.map(item => [item.id, item]));
+          const results = [];
+          for (const id of ids) {
+            const item = byId.get(id);
+            const row = { id, status: item?.status || 'absent_in_active_catalog', isbn: item?.isbn || null, title: item?.title || null, images: [] };
+            results.push(row);
+            if (!item || item.status !== 'active' || !(Number(item.available_quantity) > 0)) continue;
+            for (const candidate of coverCandidates(item)) {
+              const image = { position: candidate.position, source_url: candidate.source_url };
+              row.images.push(image);
+              try {
+                const res = await fetch(candidate.source_url, { redirect: 'manual', signal: AbortSignal.timeout(15000) });
+                image.http = res.status;
+                if (!res.ok) throw new Error('image HTTP ' + res.status);
+                const bytes = new Uint8Array(await res.arrayBuffer());
+                if (!bytes.length || bytes.length > 8 * 1024 * 1024) throw new Error('Image outside 1 byte–8 MiB size limit');
+                const measured = inspectCoverBytes(bytes, res.headers.get('content-type'));
+                Object.assign(image, measured, { bytes: bytes.length, short_side: Math.min(measured.width, measured.height) });
+                image.file = id + '-' + candidate.position + '.' + measured.ext;
+                await writeFile(out + '/' + image.file, bytes);
+              } catch (error) { image.error = error.message; }
+            }
+          }
+          const images = results.flatMap(row => row.images);
+          const measured = images.filter(image => !image.error);
+          const summary = {
+            cohort_ids: ids.length, active_with_stock: results.filter(row => row.images.length).length,
+            measured: measured.length, errors: images.length - measured.length,
+            below_500: measured.filter(image => image.short_side < 500).length,
+            at_least_500: measured.filter(image => image.short_side >= 500).length,
+            at_least_1000: measured.filter(image => image.short_side >= 1000).length
+          };
+          const report = {
+            generated_at: new Date().toISOString(), catalog_updated_at: catalog.updated_at,
+            catalog_source: catalogUrl,
+            cohort_source: 'Merchant run 34005410037: 16 active matches among 30 image_too_small below 500px; current status rechecked here',
+            scope: 'Existing native catalog sources only. No transformations, no R2 writes, no Merchant changes. Dimensions do not prove visual fidelity or Merchant resolution.',
+            summary, results
+          };
+          await writeFile(out + '/report.json', JSON.stringify(report, null, 2));
+          console.log(JSON.stringify(summary));
+          if (!measured.length) throw new Error('No native image could be measured; pilot is not verified.');
+          NODE
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: qw2-native-source-pilot
+          path: artifacts/qw2-native-source-pilot/
+          if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
Responsable: Codex. Esfuerzo: pequeño, un workflow aislado. Base main ea0c475 verificada; sin integrar ramas antiguas.

Compara las URLs originales que ya contiene el catálogo para 16 productos activos del cohorte de imágenes pequeñas del run 34005410037. Revalida stock/estado actual, reutiliza coverCandidates e inspectCoverBytes existentes y conserva imágenes descargadas + dimensiones + errores en artifact para revisión visual. No genera ni transforma imágenes, no modifica R2/Merchant/checkout y no necesita credenciales de Merchant o Cloudflare.

Motivo: varias fichas guardan versiones -O y D_NQ_NP...-F del mismo identificador de imagen. No se debe concluir que falta una fuente mejor sin medir todas las existentes. El entorno local devuelve HTTP 403 de ML; se ejecuta en Actions como el medidor existente #315.

Aceptación: obtener evidencia reproducible de cuáles fuentes nativas ya alcanzan 500/1000px y después revisar visualmente equivalencia. Medir dimensiones no acredita por sí solo resolución Merchant ni equivalencia de portada. Las imágenes fuera del rango admitido por el inspector R2 quedan como error explícito, no como dimensión inferida.

Validación: YAML y sintaxis del JS embebido OK. Corrida real y revisión visual pendientes al abrir. Es un piloto de evidencia, no QW2 terminado. No merge sin aprobación de Seba. Claude mantiene documentos centrales/#316.

## Resultado verificado — 2026-09-06

[Corrida 34026064103](https://github.com/trexxeseba/amadolibros-web/actions/runs/34026064103), artifact `qw2-native-source-pilot` ID 9987082757, SHA256 `d9585327d4cf6ac233847418138c894537dadb6d1c01ea9a24acdc3e0490a712`.

16/16 siguen activos con stock. 39 imágenes medidas, 0 errores: 34 <500, 5 >=500 (de ellas 1 >=1000). Cinco fuentes mayores corresponden visualmente a cinco imágenes de cuatro fichas:

| MLU | Imagen / posiciones | Fuente pequeña | Fuente mayor existente |
| --- | --- | --- | --- |
| MLU636119126 | Enciende la llama, portada 0 → 2 | 337×500 | 809×1200 |
| MLU629952475 | Los límites, portada 0 → 2 | 400×500 | 960×1200 |
| MLU629952475 | Los límites, contraportada 1 → 3 | 363×500 | 871×1200 |
| MLU670646778 | Lustrous Lenormand, imagen 0 → 2 | 445×500 | 1066×1198 |
| MLU643205029 | La cábala, portada 0 → 2 | 316×500 | 759×1200 |

Codex abrió y comparó visualmente los cinco pares descargados. Coinciden el contenido y diseño de las respectivas portadas/contraportada. Las alternativas son URLs D_NQ_NP...-F ya presentes en pictures; no se generaron variantes ni se aplicó upscale. Por tanto, la afirmación de que -O es siempre la mayor variante disponible no es válida para este cohorte.

Alcance exacto: cuatro fichas tienen una portada mayor disponible; eso NO significa cuatro rechazos Merchant resueltos. En varias fichas Merchant seleccionó otra posición (p.ej. contraportada), y aún falta publicar la fuente correcta mediante R2/URL estable y validar recrawl. Doce de las 16 no tienen ninguna fuente >=500 en las URLs medidas; no se investigaron todavía fuentes editoriales externas.

CI de este SHA: success. Piloto: success. Preview general pendiente al registrar estos resultados. QW2 sigue EN CURSO.

Para #316 (documentos a cargo de Claude): #320 tiene CI y Preview success tras reintento del 404 de sitemap; #321 aporta fuentes mayores verificadas para cuatro fichas, corrección de selección/publicación pendiente. No modificar contador de Merchant resueltos ni declarar QW2 terminado.
