### PR TITLE
Checkout: mejorar autocompletado y definir Google con datos guardados

### DIFF
--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -558,3 +558,11 @@ autorización explícita y separada de Seba.
 - **Límites reales:** ML puede no ofrecer una fuente >=500; esos casos quedan pendientes con evidencia y reintento, no se contabilizan como corregidos. Buscar fuentes editoriales por edición sigue requiriendo datos verificables.
 - Sin merge, sin deploy de producción, sin escritura en R2 productivo ni cambios en checkout. La prueba temporal sólo escribe en R2 Preview; el manifest productivo se lee para medir el impacto del filtro.
 - QW3A2 y la consolidación central de documentación en #316 siguen a cargo de Claude. Este apartado registra únicamente el trabajo QW2 de esta rama.
+
+
+## Checkout — datos sugeridos y Google opcional (2026-09-07)
+
+- Responsable Codex (autocompletado, S) y Claude (Google/perfil, M). Seba aclaró que quiere completar datos en la web sin correo y detuvo el enlace mágico. Autoriza el cambio puntual de datos del comprador; Merchant sigue como única Gran Apuesta. Sin aprobación de merge ni deploy.
+- Rama Codex `codex/checkout-autofill` desde main `d380374`: los autocomplete ya existían. Se agregan nombres de controles y se corrige localidad a address-level2; IDs, handlers y reglas comerciales conservados. 114/114 controles existentes de checkout verdes. Verificación de sugerencias con un perfil real de navegador todavía pendiente.
+- Contrato listo para Claude en `docs/checkout-google-handoff.md`: Google opcional, perfil guardado explícitamente, datos editables, invitado disponible y borrador protegido. No hay login Google implementado en esta rama.
+- B12/#325 e imágenes/QW2 quedan fuera de este cambio. Google real en Preview requiere Client ID/orígenes correctos; no inventar credenciales ni declarar verificado sin esa prueba.

--- a/PLAN-MAESTRO.md
+++ b/PLAN-MAESTRO.md
@@ -555,3 +555,14 @@ del backlog.
   lista de las URLs de la muestra y su `canonical`/`indexable` real
   observado; referencia explícita a qué auditorías previas de B11 ya
   cubrían parte de este alcance, para no repetir verificaciones cerradas.
+
+
+### Excepción puntual autorizada — datos del comprador (2026-09-07)
+
+Seba pidió autocompletado inmediato y Google opcional; detuvo el enlace mágico.
+Responsable Codex para metadatos del formulario (S), Claude para Google y perfil
+(M). No cambia la única Gran Apuesta Merchant. Alcance y aceptación en
+`docs/checkout-google-handoff.md`: perfil confirmado, invitado disponible,
+carrito/borrador preservados, privacidad entre cuentas y Preview verificado.
+No autoriza cambios en precios/pagos ni merge o despliegue. Evidencia inicial:
+114/114 tests de checkout verdes en la rama Codex; Google aún no implementado.

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -148,7 +148,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
             <div id="shipping-fields" class="shipping-fields" hidden>
               <div class="form-field">
                 <label for="delivery-address" class="form-label">Dirección <span class="form-req" aria-hidden="true">*</span></label>
-                <input type="text" id="delivery-address" class="form-input"
+                <input type="text" id="delivery-address" name="shipping-address" class="form-input"
                   placeholder="Ej: Av. Italia 2000, Apto 3"
                   autocomplete="shipping street-address"
                   aria-describedby="err-delivery-address">
@@ -156,15 +156,15 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
               </div>
               <div class="form-field">
                 <label for="delivery-barrio" class="form-label">Barrio / Localidad <span class="form-req" aria-hidden="true">*</span></label>
-                <input type="text" id="delivery-barrio" class="form-input"
+                <input type="text" id="delivery-barrio" name="shipping-locality" class="form-input"
                   placeholder="Ej: Pocitos, Centro, Malvín"
-                  autocomplete="shipping address-level3"
+                  autocomplete="shipping address-level2"
                   aria-describedby="err-delivery-barrio">
                 <span class="field-error" id="err-delivery-barrio" role="alert" hidden></span>
               </div>
               <div class="form-field">
                 <label for="delivery-departamento" class="form-label">Departamento <span class="form-req" aria-hidden="true">*</span></label>
-                <select id="delivery-departamento" class="form-input"
+                <select id="delivery-departamento" name="shipping-department" class="form-input"
                   autocomplete="shipping address-level1"
                   aria-describedby="err-delivery-departamento">
                   <option value="">Seleccioná tu departamento</option>
@@ -205,13 +205,13 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
             <div class="form-grid">
               <div class="form-field">
                 <label for="buyer-name" class="form-label">Nombre <span class="form-req" aria-hidden="true">*</span></label>
-                <input type="text" id="buyer-name" class="form-input" autocomplete="name"
+                <input type="text" id="buyer-name" name="name" class="form-input" autocomplete="name"
                   aria-describedby="err-buyer-name">
                 <span class="field-error" id="err-buyer-name" role="alert" hidden></span>
               </div>
               <div class="form-field">
                 <label for="buyer-phone" class="form-label">WhatsApp / Teléfono <span class="form-req" aria-hidden="true">*</span></label>
-                <input type="tel" id="buyer-phone" class="form-input"
+                <input type="tel" id="buyer-phone" name="tel" class="form-input"
                   placeholder="Ej: 099 123 456"
                   autocomplete="tel"
                   inputmode="tel"
@@ -221,7 +221,7 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
               </div>
               <div class="form-field">
                 <label for="buyer-email" class="form-label">Correo electrónico <span class="form-req" aria-hidden="true">*</span></label>
-                <input type="email" id="buyer-email" class="form-input"
+                <input type="email" id="buyer-email" name="email" class="form-input"
                   placeholder="tu@email.com"
                   autocomplete="email"
                   inputmode="email"

--- a/docs/checkout-google-handoff.md
+++ b/docs/checkout-google-handoff.md
@@ -1,0 +1,122 @@
+# Compra con datos guardados — encargo para Claude
+
+## Decisión de Seba (2026-09-07)
+
+Objetivo: completar nombre, teléfono y dirección en el checkout sin esperar
+un correo. Google es opcional; la compra de invitado debe seguir disponible.
+El enlace mágico fue detenido por Seba. Conservar su trabajo en su rama;
+reutilizar únicamente piezas revisadas, sin integrar ese flujo por accidente.
+
+Seba autorizó este cambio puntual de datos del comprador. Merchant sigue
+siendo la única Gran Apuesta activa. No hay autorización de merge, migración
+productiva ni despliegue. No mezclar con B12/#325 ni QW2/imágenes.
+
+## División para trabajar en paralelo
+
+- Codex, esfuerzo S: metadatos del autocompletado del navegador en
+  `astro-front/src/pages/carrito.astro`. Base `d380374775db7b5d2ef80b09ae97351ccdcd88f9`,
+  rama `codex/checkout-autofill`. Sin API, autenticación ni nuevo almacenamiento.
+- Claude, esfuerzo M: Google, sesión y perfil mínimo del comprador en una
+  rama nueva desde main actualizado, sugerida `claude/checkout-google-profile`.
+  Revisar el trabajo detenido antes de reutilizarlo. No fusionar ramas viejas.
+- Codex revisa el PR; Seba aprueba cualquier merge/despliegue posterior.
+
+## Lo que ya existe y no hay que reescribir
+
+El checkout ya declara autocomplete para nombre, teléfono, email y dirección.
+Ya conserva un borrador en sessionStorage (`amado-checkout-draft-v2`).
+La API de pedidos recibe `buyer: { name, phone, email }` y, cuando es envío,
+`shipping: { address, locality, department, notes? }`.
+Los IDs que deben conservarse son:
+
+| Dato | ID actual | Autocomplete |
+| --- | --- | --- |
+| Nombre | buyer-name | name |
+| Teléfono | buyer-phone | tel |
+| Email | buyer-email | email |
+| Dirección | delivery-address | shipping street-address |
+| Localidad | delivery-barrio | shipping address-level2 |
+| Departamento | delivery-departamento | shipping address-level1 |
+
+Codex agrega atributos `name` estables y cambia localidad de address-level3
+a address-level2. El campo actual admite barrio/localidad: el autocompletado
+puede sugerir una localidad, siempre editable. No hay form nativo con submit:
+se conserva el envío mediante los handlers actuales. No prometer que todos
+los navegadores ofrecerán datos; depende de sus perfiles y ajustes.
+
+## Experiencia requerida
+
+1. El formulario está disponible de inmediato. Google no es obligatorio.
+2. Mostrar un botón oficial «Continuar con Google» cuando esté configurado.
+3. Tras identificarse, volver al carrito conservando productos, modalidad
+   de entrega, medio de pago elegido y datos ya escritos.
+4. Si existe un perfil confirmado por el cliente, permitir «Usar mis datos
+   guardados». No sobrescribir texto ya escrito, borrador restaurado ni datos
+   autocompletados sin acción expresa del cliente.
+5. Si es primera visita, Google puede aportar nombre y correo; el teléfono y
+   la dirección vienen del navegador o se completan manualmente. Nunca
+   afirmar que el login básico de Google entrega esos dos datos.
+6. Permitir guardar/actualizar los datos mediante una acción explícita,
+   independiente del pago. Guardar perfil no crea ni modifica un pedido.
+7. Si Google o la API de perfil fallan, mantener los datos escritos y permitir
+   continuar como invitado. No agregar nuevas pantallas obligatorias.
+
+No incluir Facebook, magic links ni «Mis pedidos» en este alcance inicial.
+
+## Contrato de implementación
+
+- Preferir el flujo oficial de Google Identity Services y una validación
+  mantenida compatible con Workers. No implementar criptografía JWT propia.
+- Verificar firma, issuer, audience, expiración y las protecciones CSRF/replay
+  correspondientes al flujo elegido (nonce/state cuando apliquen).
+- Identidad estable por proveedor + `sub`; no unir cuentas ni recuperar
+  perfiles privados porque alguien escribió un email en el formulario.
+- Guardar sesión y perfil en D1 como fuente autoritativa. Cookie opaca
+  `__Host-...`, Secure, HttpOnly, SameSite apropiado; vencimiento y revocación
+  comprobados en servidor. Sin tokens de sesión en localStorage.
+- Perfil mínimo: buyer.name, buyer.phone y shipping.address/locality/department.
+  El email verificado pertenece a la identidad; el email editable del pedido
+  no cambia automáticamente la cuenta ni su acceso a datos.
+- Endpoints de perfil autenticados y `Cache-Control: no-store`; identidad
+  tomada de sesión, lista explícita de campos, consultas parametrizadas y
+  protección CSRF en escrituras. No registrar datos personales/tokens en logs.
+- El perfil sólo proviene de datos que el cliente decidió guardar. No importar
+  automáticamente direcciones de pedidos históricos (pueden ser regalos).
+- No tocar cálculo de precios, descuentos, envío, stock, idempotencia,
+  Mercado Pago, confirmaciones ni correos de compra. Reutilizar sus validadores.
+- Implementar migraciones aditivas con el siguiente número real disponible;
+  nunca aplicarlas sobre la base productiva sin aprobación.
+- El frontend debe funcionar con la configuración de Google ausente:
+  ocultar la opción, preservar invitado, sin simular login ni mostrar éxito.
+
+## Configuración: pedir todo junto, después de revisar lo existente
+
+Inventariar nombres de configuración y bindings sin exponer secretos.
+Preparar los orígenes autorizados reales de producción y un Preview estable;
+agregar URI de callback exacta sólo si el flujo elegido la utiliza. Un Client
+ID web de Google es necesario; pedir Client Secret sólo si ese flujo lo exige.
+No solicitar acceso a Gmail, contactos o direcciones mediante People API.
+No reutilizar credenciales de Mercado Libre ni credenciales de Merchant.
+Si falta configuración, avanzar hasta un Draft probado con dobles y entregar
+una sola lista exacta para Seba. No declarar el login real verificado hasta
+probar con Google en Preview.
+
+## Aceptación y evidencia
+
+- Invitado, Google nuevo y Google recurrente: nombre/teléfono/dirección
+  editables; carrito y borrador conservados; Google cancelado o caído no bloquea.
+- Una respuesta tardía de perfil no sobrescribe lo que el cliente escribió.
+- Cambiar de cuenta no muestra datos de la cuenta anterior.
+- Token inválido/expirado/audience incorrecta y acceso cruzado a perfil fallan.
+- Cerrar sesión revoca el acceso; guardar datos no dispara pedidos ni pagos.
+- Probar retiro/envío y transferencia/Mercado Pago mediante el instrumental
+  existente; ningún test debe crear compras reales ni escribir D1 productivo.
+- Ejecutar `scripts/validate-ci.sh` y `git diff --check origin/main...HEAD`.
+- Entregar Draft PR, SHA final, CI y demostración Preview con datos ficticios.
+  Separar autocompletado real del navegador, Google real y pruebas con dobles.
+
+## Referencias verificadas
+
+- https://developers.google.com/identity/openid-connect/openid-connect
+- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete
+- https://developers.cloudflare.com/kv/concepts/how-kv-works/


### PR DESCRIPTION
Seba quiere completar datos del comprador en la web sin esperar un correo y con Google opcional. El formulario ya tenía autocomplete: este cambio añade nombres estables a seis controles y corrige localidad a address-level2. Los IDs, handlers y reglas comerciales permanecen iguales.

Incluye el contrato ejecutable por Claude en docs/checkout-google-handoff.md: Google opcional, perfil confirmado, borrador conservado, invitado disponible y alcance separado de B12/QW2. No implementa Google ni guarda perfiles.

Responsable Codex; esfuerzo S. Base main d380374; head cf671e27a4042a19be71e3de5b6dda4b37d24022.

Validación: 114/114 controles focales de checkout y 1.647/1.647 tests de las cinco suites locales. Igualdad completa del fuente descontando seis atributos name y el token de localidad. La instalación local de dependencias fue bloqueada por red, pero CI completó el validador compartido, incluidos ambos builds y diff, en success: https://github.com/trexxeseba/amadolibros-web/actions/runs/34119019675.

Preview desplegado: https://pr-327.amadolibros-web.pages.dev/carrito/. Descarga HTTP 200 y parseo del HTML real verifican 6/6 contratos name + autocomplete de los controles. Las sugerencias nativas con un perfil de navegador real todavía no fueron comprobadas; dependen de los datos y ajustes del navegador. No declarar Google ni autocompletado universal terminado.

Seba autorizó el cambio puntual del formulario, sin aprobación de merge ni deploy productivo. Claude debe implementar autenticación/perfil en otra rama desde main actualizado y leer docs/checkout-google-handoff.md.