### PR TITLE
Cuenta opcional: Continuar con Google y perfil guardado para completar el checkout

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -41,6 +41,9 @@ jobs:
           PUBLIC_CHECKOUT_ENABLED: 'false'
           PUBLIC_TURNSTILE_SITE_KEY: '0x4AAAAAAD6E9kz8K3comwjj'
           PUBLIC_TURNSTILE_ALLOWED_HOSTS: '.amadolibros-web.pages.dev'
+          # CUENTA-1 · ver el comentario en deploy.yml. Vacía mientras no
+          # exista la variable: el bloque de cuenta no aparece.
+          PUBLIC_GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
         run: npm run build
 
       - name: Run universal image pipeline in R2 Preview

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -210,6 +210,11 @@ jobs:
           PUBLIC_CHECKOUT_ENABLED: 'true'
           PUBLIC_TURNSTILE_SITE_KEY: ${{ steps.ts_config.outputs.site_key }}
           PUBLIC_TURNSTILE_ALLOWED_HOSTS: ${{ steps.ts_config.outputs.allowed_hosts }}
+          # CUENTA-1 · Client ID web de Google. Es un dato público: viaja en
+          # la página, así que es variable de repositorio y no secreto. Si no
+          # está definida, queda vacía y el bloque de cuenta no se muestra —
+          # el checkout funciona igual que antes.
+          PUBLIC_GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
         run: npm run build
 
       - name: Sync Resend secret to Cloudflare Pages

--- a/astro-front/src/lib/__tests__/perfil-checkout.test.js
+++ b/astro-front/src/lib/__tests__/perfil-checkout.test.js
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  CAMPOS_PERFIL,
+  CAMPO_A_ID,
+  camposACompletar,
+  perfilDesdeValores,
+  tieneAlgoParaGuardar,
+} from '../perfil-checkout.js';
+
+const PERFIL = {
+  buyer_name: 'Ana Pérez', buyer_phone: '099111222',
+  address: 'Rincón 608', locality: 'Ciudad Vieja', department: 'Montevideo',
+};
+
+// Los ids son los que ya tenía el formulario: renombrarlos rompería el
+// autocompletado del navegador y los handlers existentes.
+test('el mapa apunta a los ids que ya existían en el checkout', () => {
+  assert.deepEqual(CAMPO_A_ID, {
+    buyer_name: 'buyer-name',
+    buyer_phone: 'buyer-phone',
+    address: 'delivery-address',
+    locality: 'delivery-barrio',
+    department: 'delivery-departamento',
+  });
+  assert.equal(CAMPOS_PERFIL.length, 5);
+});
+
+test('con el formulario vacío se completan todos los campos guardados', () => {
+  const vacio = { buyer_name: '', buyer_phone: '', address: '', locality: '', department: '' };
+  assert.deepEqual(camposACompletar(PERFIL, vacio, []), PERFIL);
+});
+
+test('nunca pisa un campo que ya tiene texto', () => {
+  const conDatos = { ...PERFIL, buyer_name: 'Otro Nombre Escrito' };
+  const r = camposACompletar(PERFIL, conDatos, []);
+  assert.deepEqual(r, {}, 'si está todo escrito, no toca nada');
+});
+
+test('un campo con sólo espacios cuenta como vacío', () => {
+  const r = camposACompletar(PERFIL, { buyer_name: '   ', buyer_phone: '', address: '', locality: '', department: '' }, []);
+  assert.equal(r.buyer_name, 'Ana Pérez');
+});
+
+// El caso que pide el encargo: la respuesta del perfil llega tarde y la
+// persona ya escribió mientras esperaba.
+test('una respuesta tardía no sobrescribe lo que se escribió mientras llegaba', () => {
+  const alPedir = { buyer_name: '', buyer_phone: '', address: '', locality: '', department: '' };
+  // Mientras el pedido viajaba, la persona escribió el teléfono.
+  const alLlegar = { ...alPedir, buyer_phone: '098765432' };
+  const r = camposACompletar(PERFIL, alLlegar, ['buyer_phone']);
+  assert.equal(r.buyer_phone, undefined, 'el teléfono escrito se respeta');
+  assert.equal(r.buyer_name, 'Ana Pérez', 'los demás sí se completan');
+});
+
+test('un campo tocado y después borrado tampoco se completa', () => {
+  const r = camposACompletar(PERFIL, { buyer_name: '', buyer_phone: '', address: '', locality: '', department: '' }, ['buyer_name']);
+  assert.equal(r.buyer_name, undefined, 'lo borró a propósito: no se lo devolvemos');
+});
+
+test('sin perfil guardado no se completa nada', () => {
+  assert.deepEqual(camposACompletar(null, { buyer_name: '' }, []), {});
+  assert.deepEqual(camposACompletar({}, { buyer_name: '' }, []), {});
+});
+
+test('se guarda lo que hay escrito, y un campo vacío sirve para borrar', () => {
+  const perfil = perfilDesdeValores({ buyer_name: '  Ana  Pérez ', buyer_phone: '', address: 'Rincón 608' });
+  assert.equal(perfil.buyer_name, 'Ana Pérez');
+  assert.equal(perfil.buyer_phone, '');
+  assert.equal(perfil.department, '', 'un campo ausente se manda vacío, no undefined');
+});
+
+test('no se ofrece guardar un formulario del todo vacío', () => {
+  assert.equal(tieneAlgoParaGuardar(perfilDesdeValores({})), false);
+  assert.equal(tieneAlgoParaGuardar(perfilDesdeValores({ buyer_phone: '099' })), true);
+});

--- a/astro-front/src/lib/perfil-checkout.js
+++ b/astro-front/src/lib/perfil-checkout.js
@@ -1,0 +1,61 @@
+// Reglas del perfil guardado en el checkout.
+//
+// Copia probada/canónica de las funciones inline en
+// astro-front/src/pages/carrito.astro (bloque <script is:inline>, que no puede
+// usar `import` porque corre sin bundler). Si se cambia acá, replicar allá —
+// ver el comentario recíproco junto a `camposACompletar` en carrito.astro.
+//
+// La regla central: los datos guardados NUNCA pisan lo que la persona
+// escribió. Se completa un campo sólo si sigue vacío y no fue tocado desde
+// que se pidió el perfil. Así una respuesta que llega tarde no borra lo que
+// se estuvo escribiendo mientras tanto.
+
+// Nombre del campo en el perfil → id del control en el formulario. Los ids
+// son los que ya existían; no se renombró ninguno.
+export const CAMPO_A_ID = Object.freeze({
+  buyer_name: 'buyer-name',
+  buyer_phone: 'buyer-phone',
+  address: 'delivery-address',
+  locality: 'delivery-barrio',
+  department: 'delivery-departamento',
+});
+
+export const CAMPOS_PERFIL = Object.freeze(Object.keys(CAMPO_A_ID));
+
+function limpiar(valor) {
+  return String(valor === null || valor === undefined ? '' : valor).replace(/\s+/g, ' ').trim();
+}
+
+export function camposACompletar(perfil, valoresActuales, tocados) {
+  var yaTocado = {};
+  for (var i = 0; i < (tocados || []).length; i++) yaTocado[tocados[i]] = true;
+
+  var aCompletar = {};
+  for (var j = 0; j < CAMPOS_PERFIL.length; j++) {
+    var campo = CAMPOS_PERFIL[j];
+    var guardado = perfil ? limpiar(perfil[campo]) : '';
+    if (!guardado) continue;
+    if (yaTocado[campo]) continue;
+    if (limpiar(valoresActuales ? valoresActuales[campo] : '')) continue;
+    aCompletar[campo] = guardado;
+  }
+  return aCompletar;
+}
+
+// Lo que se manda a guardar sale de lo que hay escrito en el formulario en
+// ese momento. Un campo vacío se manda vacío: sirve para borrar un dato.
+export function perfilDesdeValores(valoresActuales) {
+  var perfil = {};
+  for (var i = 0; i < CAMPOS_PERFIL.length; i++) {
+    var campo = CAMPOS_PERFIL[i];
+    perfil[campo] = limpiar(valoresActuales ? valoresActuales[campo] : '');
+  }
+  return perfil;
+}
+
+export function tieneAlgoParaGuardar(perfil) {
+  for (var i = 0; i < CAMPOS_PERFIL.length; i++) {
+    if (limpiar(perfil ? perfil[CAMPOS_PERFIL[i]] : '')) return true;
+  }
+  return false;
+}

--- a/astro-front/src/pages/carrito.astro
+++ b/astro-front/src/pages/carrito.astro
@@ -15,6 +15,12 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
   .split(',')
   .map((h) => h.trim())
   .filter(Boolean);
+
+// CUENTA-1 · Client ID web de Google, inyectado por ambiente en tiempo de
+// build igual que la site key de Turnstile. Si está vacío, el bloque de
+// cuenta no se muestra y la compra como invitado sigue igual: nunca se
+// simula un ingreso ni se anuncia una función que no está configurada.
+const googleClientId = import.meta.env.PUBLIC_GOOGLE_CLIENT_ID || '';
 ---
 <BaseLayout
   title="Tu carrito — Amado Libros"
@@ -202,6 +208,28 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
           <section class="cart-section">
             <h2 class="cart-section-h2">Tus datos</h2>
             <p class="buyer-note">Mientras completás el pedido, recordamos estos datos sólo en esta pestaña para que no los pierdas si abrís el banco o WhatsApp.</p>
+
+            <!-- CUENTA-1 · Identificarse es OPCIONAL: el formulario de abajo
+                 está disponible desde el primer momento y la compra como
+                 invitado no cambia. Todo este bloque queda oculto si no hay
+                 Client ID de Google configurado. -->
+            <div class="cuenta-bloque" id="cuenta-bloque" hidden>
+              <div id="cuenta-anonima">
+                <p class="cuenta-nota">¿Ya compraste antes y guardaste tus datos? Podés traerlos.</p>
+                <div id="cuenta-boton-google"></div>
+              </div>
+              <div id="cuenta-identificada" hidden>
+                <p class="cuenta-nota">
+                  Entraste como <strong id="cuenta-email"></strong>.
+                  <button type="button" class="cuenta-enlace" id="cuenta-salir">Salir</button>
+                </p>
+                <div class="cuenta-acciones">
+                  <button type="button" class="cuenta-accion" id="cuenta-usar" hidden>Usar mis datos guardados</button>
+                  <button type="button" class="cuenta-accion" id="cuenta-guardar">Guardar estos datos para la próxima</button>
+                </div>
+              </div>
+              <p class="cuenta-aviso" id="cuenta-aviso" role="status" aria-live="polite"></p>
+            </div>
             <div class="form-grid">
               <div class="form-field">
                 <label for="buyer-name" class="form-label">Nombre <span class="form-req" aria-hidden="true">*</span></label>
@@ -1485,9 +1513,20 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       display: none;
     }
   }
+  /* CUENTA-1 · bloque opcional de cuenta */
+  .cuenta-bloque { margin: 0 0 1.25rem; padding: .9rem 1rem; border: 1px solid #dfe3e8;
+    border-radius: .5rem; background: #fafbfc; }
+  .cuenta-nota { margin: 0 0 .6rem; font-size: .93rem; color: #444; }
+  .cuenta-acciones { display: flex; flex-wrap: wrap; gap: .5rem; }
+  .cuenta-accion { padding: .55rem .9rem; font-size: .93rem; border: 1px solid #1c3f60;
+    border-radius: .4rem; background: #fff; color: #1c3f60; cursor: pointer; }
+  .cuenta-accion[disabled] { opacity: .55; cursor: progress; }
+  .cuenta-enlace { border: 0; background: none; padding: 0; color: #1c3f60;
+    text-decoration: underline; cursor: pointer; font-size: inherit; }
+  .cuenta-aviso { margin: .6rem 0 0; font-size: .9rem; color: #1c3f60; min-height: 1.2rem; }
 </style>
 
-<script is:inline define:vars={{ turnstileSiteKey, turnstileAllowedHosts }}>
+<script is:inline define:vars={{ turnstileSiteKey, turnstileAllowedHosts, googleClientId }}>
   // ── Turnstile ────────────────────────────────────────────────────────────
   var onlineCheckoutEnabled = document.querySelector('.cart-page')?.dataset.onlineCheckout === 'enabled';
 
@@ -1931,6 +1970,262 @@ const turnstileAllowedHosts = (import.meta.env.PUBLIC_TURNSTILE_ALLOWED_HOSTS ||
       radio.addEventListener('change', clearDeliveryError);
     });
     window.addEventListener('pagehide', saveDraft);
+
+    // ── CUENTA-1 · cuenta opcional con Google ────────────────────────────
+    //
+    // Identificarse es opcional y NO es parte del pago. Si falla cualquier
+    // cosa —Google no carga, la persona cancela, la API responde mal— el
+    // formulario sigue funcionando igual y se compra como invitado.
+    //
+    // Copia inline de astro-front/src/lib/perfil-checkout.js (probada con
+    // `node --test` en src/lib/__tests__/perfil-checkout.test.js). Este
+    // bloque corre sin bundler y no puede importar: si se cambia la lógica
+    // acá, replicar el cambio allá.
+    var CAMPO_A_ID = {
+      buyer_name: 'buyer-name',
+      buyer_phone: 'buyer-phone',
+      address: 'delivery-address',
+      locality: 'delivery-barrio',
+      department: 'delivery-departamento',
+    };
+    var CAMPOS_PERFIL = Object.keys(CAMPO_A_ID);
+
+    function limpiarCuenta(valor) {
+      return String(valor === null || valor === undefined ? '' : valor).replace(/\s+/g, ' ').trim();
+    }
+
+    // Sólo se completa un campo vacío que la persona no tocó. Así una
+    // respuesta que llega tarde no borra lo que estuvo escribiendo.
+    function camposACompletar(perfil, valoresActuales, tocados) {
+      var yaTocado = {};
+      for (var i = 0; i < (tocados || []).length; i++) yaTocado[tocados[i]] = true;
+      var aCompletar = {};
+      for (var j = 0; j < CAMPOS_PERFIL.length; j++) {
+        var campo = CAMPOS_PERFIL[j];
+        var guardado = perfil ? limpiarCuenta(perfil[campo]) : '';
+        if (!guardado) continue;
+        if (yaTocado[campo]) continue;
+        if (limpiarCuenta(valoresActuales ? valoresActuales[campo] : '')) continue;
+        aCompletar[campo] = guardado;
+      }
+      return aCompletar;
+    }
+
+    var cuentaBloque = document.getElementById('cuenta-bloque');
+    if (cuentaBloque && googleClientId) {
+      var cuentaAnonima = document.getElementById('cuenta-anonima');
+      var cuentaIdentificada = document.getElementById('cuenta-identificada');
+      var cuentaEmail = document.getElementById('cuenta-email');
+      var cuentaAviso = document.getElementById('cuenta-aviso');
+      var botonUsar = document.getElementById('cuenta-usar');
+      var botonGuardar = document.getElementById('cuenta-guardar');
+      var botonSalir = document.getElementById('cuenta-salir');
+      var tocados = [];
+      var nombreSugerido = null;
+      var emailSugerido = null;
+
+      cuentaBloque.hidden = false;
+
+      function avisar(texto) { cuentaAviso.textContent = texto || ''; }
+
+      function valorDe(campo) {
+        var el = document.getElementById(CAMPO_A_ID[campo]);
+        return el && typeof el.value === 'string' ? el.value : '';
+      }
+
+      function valoresActuales() {
+        var valores = {};
+        for (var i = 0; i < CAMPOS_PERFIL.length; i++) valores[CAMPOS_PERFIL[i]] = valorDe(CAMPOS_PERFIL[i]);
+        return valores;
+      }
+
+      // Cualquier escritura marca el campo como tocado: desde ahí, los datos
+      // guardados ya no lo pisan.
+      for (var t = 0; t < CAMPOS_PERFIL.length; t++) {
+        (function (campo) {
+          var el = document.getElementById(CAMPO_A_ID[campo]);
+          if (!el) return;
+          var marcar = function () { if (tocados.indexOf(campo) === -1) tocados.push(campo); };
+          el.addEventListener('input', marcar);
+          el.addEventListener('change', marcar);
+        })(CAMPOS_PERFIL[t]);
+      }
+      var emailEl = document.getElementById('buyer-email');
+      var emailTocado = false;
+      if (emailEl) {
+        emailEl.addEventListener('input', function () { emailTocado = true; });
+        emailEl.addEventListener('change', function () { emailTocado = true; });
+      }
+
+      function leerCsrf() {
+        var partes = String(document.cookie || '').split(';');
+        for (var i = 0; i < partes.length; i++) {
+          var corte = partes[i].indexOf('=');
+          if (corte === -1) continue;
+          if (partes[i].slice(0, corte).trim() !== '__Host-al_csrf') continue;
+          return partes[i].slice(corte + 1).trim();
+        }
+        return '';
+      }
+
+      function mostrarIdentificada(datos) {
+        cuentaAnonima.hidden = true;
+        cuentaIdentificada.hidden = false;
+        cuentaEmail.textContent = datos.email || '';
+        nombreSugerido = datos.nombre_sugerido || null;
+        emailSugerido = datos.email || null;
+        botonUsar.hidden = !(datos.tiene_perfil || nombreSugerido || emailSugerido);
+      }
+
+      function mostrarAnonima() {
+        cuentaIdentificada.hidden = true;
+        cuentaAnonima.hidden = false;
+        nombreSugerido = null;
+        emailSugerido = null;
+      }
+
+      // ── Usar mis datos guardados (acción explícita) ────────────────────
+      botonUsar.addEventListener('click', function () {
+        botonUsar.disabled = true;
+        avisar('Buscando tus datos…');
+        // Se toman los valores AL LLEGAR la respuesta, no al pedirla: si la
+        // persona escribió mientras esperaba, eso es lo que vale.
+        fetch('/api/cuenta/perfil', { credentials: 'same-origin' })
+          .then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (datos) {
+            botonUsar.disabled = false;
+            var perfil = (datos && datos.perfil) || {};
+            if (nombreSugerido && !perfil.buyer_name) perfil.buyer_name = nombreSugerido;
+            var aCompletar = camposACompletar(perfil, valoresActuales(), tocados);
+            var completados = 0;
+            for (var campo in aCompletar) {
+              if (!Object.prototype.hasOwnProperty.call(aCompletar, campo)) continue;
+              var el = document.getElementById(CAMPO_A_ID[campo]);
+              if (!el) continue;
+              el.value = aCompletar[campo];
+              completados++;
+            }
+            if (emailSugerido && emailEl && !emailTocado && !limpiarCuenta(emailEl.value)) {
+              emailEl.value = emailSugerido;
+              completados++;
+            }
+            saveDraft();
+            avisar(completados
+              ? 'Completamos ' + completados + ' dato(s). Revisalos y editá lo que haga falta.'
+              : 'No había nada para completar: ya estaba todo escrito.');
+          })
+          .catch(function () {
+            botonUsar.disabled = false;
+            avisar('No pudimos traer tus datos. Podés escribirlos y seguir igual.');
+          });
+      });
+
+      // ── Guardar estos datos (acción explícita, ajena al pago) ──────────
+      botonGuardar.addEventListener('click', function () {
+        var perfil = {};
+        var hayAlgo = false;
+        for (var i = 0; i < CAMPOS_PERFIL.length; i++) {
+          perfil[CAMPOS_PERFIL[i]] = limpiarCuenta(valorDe(CAMPOS_PERFIL[i]));
+          if (perfil[CAMPOS_PERFIL[i]]) hayAlgo = true;
+        }
+        if (!hayAlgo) { avisar('Escribí algún dato antes de guardarlo.'); return; }
+        botonGuardar.disabled = true;
+        avisar('Guardando…');
+        fetch('/api/cuenta/perfil', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': leerCsrf() },
+          body: JSON.stringify({ perfil: perfil }),
+        }).then(function (r) {
+          botonGuardar.disabled = false;
+          // Guardar el perfil no crea ni modifica ningún pedido.
+          avisar(r.ok ? 'Guardado. La próxima los traés con un botón.' : 'No pudimos guardarlos. Tus datos siguen acá y podés comprar igual.');
+          if (r.ok) botonUsar.hidden = false;
+        }).catch(function () {
+          botonGuardar.disabled = false;
+          avisar('No pudimos guardarlos. Tus datos siguen acá y podés comprar igual.');
+        });
+      });
+
+      botonSalir.addEventListener('click', function () {
+        fetch('/api/cuenta/salir', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': leerCsrf() },
+        }).then(function () {
+          mostrarAnonima();
+          avisar('Saliste. Tus datos escritos siguen donde estaban.');
+          prepararGoogle();
+        }).catch(function () { avisar('No pudimos cerrar la sesión.'); });
+      });
+
+      // ── Google Identity Services ───────────────────────────────────────
+      //
+      // Ventana emergente, no redirección: así no se sale del carrito y no
+      // hay nada que restaurar. El nonce lo emite el servidor y se consume
+      // una sola vez, contra reenvío del mismo token.
+      function alRecibirCredencial(respuesta, nonce) {
+        avisar('Verificando…');
+        fetch('/api/cuenta/google', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ credential: respuesta.credential, nonce: nonce }),
+        }).then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (datos) {
+            if (!datos) { avisar('No pudimos verificar tu ingreso. Podés comprar como invitado.'); prepararGoogle(); return; }
+            mostrarIdentificada(datos);
+            avisar(datos.tiene_perfil
+              ? 'Listo. Podés traer tus datos guardados.'
+              : 'Listo. Cuando completes tus datos, podés guardarlos para la próxima.');
+          })
+          .catch(function () {
+            avisar('No pudimos verificar tu ingreso. Podés comprar como invitado.');
+            prepararGoogle();
+          });
+      }
+
+      function prepararGoogle() {
+        if (!window.google || !window.google.accounts || !window.google.accounts.id) return;
+        // Nonce nuevo por intento: el anterior ya se consumió.
+        fetch('/api/cuenta/nonce', { credentials: 'same-origin' })
+          .then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (datos) {
+            if (!datos || !datos.nonce) return;
+            window.google.accounts.id.initialize({
+              client_id: googleClientId,
+              nonce: datos.nonce,
+              ux_mode: 'popup',
+              auto_select: false,
+              cancel_on_tap_outside: true,
+              callback: function (respuesta) { alRecibirCredencial(respuesta, datos.nonce); },
+            });
+            var contenedor = document.getElementById('cuenta-boton-google');
+            if (contenedor) {
+              contenedor.innerHTML = '';
+              window.google.accounts.id.renderButton(contenedor, {
+                type: 'standard', theme: 'outline', size: 'large',
+                text: 'continue_with', locale: 'es', width: 260,
+              });
+            }
+          })
+          .catch(function () { /* sin cuenta: se compra como invitado */ });
+      }
+
+      // Si ya había sesión abierta, se refleja sin pedir nada.
+      fetch('/api/cuenta/sesion', { credentials: 'same-origin' })
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .then(function (datos) {
+          if (datos && datos.autenticado) { mostrarIdentificada(datos); return; }
+          var gs = document.createElement('script');
+          gs.src = 'https://accounts.google.com/gsi/client';
+          gs.async = true; gs.defer = true;
+          gs.onload = prepararGoogle;
+          document.head.appendChild(gs);
+        })
+        .catch(function () { /* sin cuenta: se compra como invitado */ });
+    }
+    // ─────────────────────────────────────────────────────────────────────
 
     // ── PICKUP-CX-1 ──────────────────────────────────────────────────────
     var pickupAckBox = document.getElementById('pickup-ack-box');

--- a/functions/__tests__/cuenta-google-handler.test.js
+++ b/functions/__tests__/cuenta-google-handler.test.js
@@ -1,0 +1,339 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  crearGoogleHandler,
+  crearNonceHandler,
+  crearPerfilHandler,
+  crearSalidaHandler,
+  crearSesionHandler,
+} from '../api/_cuenta_handler.js';
+import { COOKIE_CSRF, COOKIE_SESION, hashSecreto } from '../api/_cuenta_logic.js';
+
+const AHORA = new Date('2026-09-07T12:00:00.000Z');
+const getNow = () => AHORA;
+const CLIENT_ID = '123.apps.googleusercontent.com';
+
+// D1 falso que EXPLOTA ante SQL que no conoce: si el handler cambia su
+// consulta, la prueba se rompe en vez de seguir pasando contra un doble que
+// ya no representa lo que corre.
+function d1Falso() {
+  const estado = { nonces: [], identities: [], sessions: [], profiles: [], sqlVisto: [] };
+
+  function ejecutar(sql, args) {
+    estado.sqlVisto.push(sql);
+    if (sql.startsWith('INSERT INTO auth_nonces')) {
+      estado.nonces.push({ nonce_hash: args[0], created_at: args[1], expires_at: args[2], used_at: null });
+      return { run: { meta: { changes: 1 } } };
+    }
+    if (sql.startsWith('UPDATE auth_nonces SET used_at')) {
+      const [usedAt, hash, ahoraIso] = args;
+      const fila = estado.nonces.find(n => n.nonce_hash === hash);
+      const aplica = Boolean(fila) && !fila.used_at && fila.expires_at > ahoraIso;
+      if (aplica) fila.used_at = usedAt;
+      return { run: { meta: { changes: aplica ? 1 : 0 } } };
+    }
+    if (sql.startsWith('SELECT id FROM account_identities')) {
+      return { first: estado.identities.find(i => i.provider === args[0] && i.subject === args[1]) || null };
+    }
+    if (sql.startsWith('UPDATE account_identities SET email')) {
+      const fila = estado.identities.find(i => i.id === args[2]);
+      if (fila) { fila.email = args[0]; fila.last_seen_at = args[1]; }
+      return { run: { meta: { changes: fila ? 1 : 0 } } };
+    }
+    if (sql.startsWith('INSERT INTO account_identities')) {
+      const [id, provider, subject, email, created_at, last_seen_at] = args;
+      estado.identities.push({ id, provider, subject, email, created_at, last_seen_at });
+      return { run: { meta: { changes: 1 } } };
+    }
+    if (sql.startsWith('INSERT INTO account_sessions')) {
+      const [session_hash, identity_id, csrf_hash, created_at, expires_at] = args;
+      estado.sessions.push({ session_hash, identity_id, csrf_hash, created_at, expires_at, revoked_at: null });
+      return { run: { meta: { changes: 1 } } };
+    }
+    if (sql.startsWith('UPDATE account_sessions SET revoked_at')) {
+      const fila = estado.sessions.find(s => s.session_hash === args[1] && !s.revoked_at);
+      if (fila) fila.revoked_at = args[0];
+      return { run: { meta: { changes: fila ? 1 : 0 } } };
+    }
+    if (sql.includes('FROM account_sessions s JOIN account_identities i')) {
+      const s = estado.sessions.find(x => x.session_hash === args[0]);
+      if (!s) return { first: null };
+      const i = estado.identities.find(x => x.id === s.identity_id);
+      return { first: { ...s, email: i ? i.email : null } };
+    }
+    if (sql.startsWith('SELECT identity_id FROM account_profiles')) {
+      return { first: estado.profiles.find(p => p.identity_id === args[0]) || null };
+    }
+    if (sql.includes('FROM account_profiles WHERE identity_id')) {
+      return { first: estado.profiles.find(p => p.identity_id === args[0]) || null };
+    }
+    if (sql.startsWith('INSERT INTO account_profiles')) {
+      const [identity_id, buyer_name, buyer_phone, address, locality, department, updated_at] = args;
+      const previo = estado.profiles.find(p => p.identity_id === identity_id);
+      const fila = { identity_id, buyer_name, buyer_phone, address, locality, department, updated_at };
+      if (previo) Object.assign(previo, fila); else estado.profiles.push(fila);
+      return { run: { meta: { changes: 1 } } };
+    }
+    throw new Error(`El D1 falso no conoce esta consulta: ${sql}`);
+  }
+
+  return {
+    estado,
+    db: {
+      prepare(sql) {
+        return {
+          bind(...args) {
+            return {
+              async first() { return ejecutar(sql, args).first ?? null; },
+              async all() { return { results: ejecutar(sql, args).results ?? [] }; },
+              async run() { return ejecutar(sql, args).run ?? { meta: { changes: 0 } }; },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+function entorno(db, { conGoogle = true } = {}) {
+  return { ORDERS_DB: db, GOOGLE_CLIENT_ID: conGoogle ? CLIENT_ID : '' };
+}
+
+function pedir(cuerpo, { method = 'POST', cookie = '', csrf = '' } = {}) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (cookie) headers.Cookie = cookie;
+  if (csrf) headers['X-CSRF-Token'] = csrf;
+  return new Request('https://www.amadolibros.com/api/cuenta/google', {
+    method, headers, body: cuerpo === undefined ? undefined : JSON.stringify(cuerpo),
+  });
+}
+
+function tokenFalso({ sub = '11223344', email = 'clienta@ejemplo.com', aud = CLIENT_ID, nonce, name = 'Clienta' } = {}) {
+  return async () => ({
+    aud, iss: 'https://accounts.google.com',
+    exp: Math.floor(AHORA.getTime() / 1000) + 600,
+    nonce, sub, email, email_verified: true, name,
+  });
+}
+
+async function ingresar(falso, opciones = {}) {
+  const env = entorno(falso.db);
+  const nonceRes = await crearNonceHandler({ getNow })({ request: pedir(undefined, { method: 'GET' }), env });
+  const { nonce } = await nonceRes.json();
+  const res = await crearGoogleHandler({ getNow, verificarToken: tokenFalso({ ...opciones, nonce }) })({
+    request: pedir({ credential: 'jwt-falso', nonce }), env,
+  });
+  const cookies = res.headers.getSetCookie ? res.headers.getSetCookie() : [res.headers.get('Set-Cookie')];
+  const sesion = (cookies.find(c => c && c.startsWith(COOKIE_SESION)) || '').split(';')[0];
+  const csrfCookie = (cookies.find(c => c && c.startsWith(COOKIE_CSRF)) || '').split(';')[0];
+  return { res, env, nonce, cookie: sesion, csrf: csrfCookie.split('=')[1] || '' };
+}
+
+// ─── Sin configuración de Google ─────────────────────────────────────────────
+
+test('sin Client ID no hay login y no se simula ninguno', async () => {
+  const falso = d1Falso();
+  const env = entorno(falso.db, { conGoogle: false });
+  const nonce = await crearNonceHandler({ getNow })({ request: pedir(undefined, { method: 'GET' }), env });
+  assert.equal(nonce.status, 503);
+  assert.equal((await nonce.json()).code, 'google_no_configurado');
+
+  const login = await crearGoogleHandler({ getNow })({ request: pedir({ credential: 'x', nonce: 'n'.repeat(43) }), env });
+  assert.equal(login.status, 503);
+  assert.equal(falso.estado.sessions.length, 0);
+});
+
+// ─── Ingreso ─────────────────────────────────────────────────────────────────
+
+test('un cliente nuevo entra: se crea identidad y sesión, con las dos cookies', async () => {
+  const falso = d1Falso();
+  const { res, cookie, csrf } = await ingresar(falso);
+  assert.equal(res.status, 200);
+  const cuerpo = await res.json();
+  assert.equal(cuerpo.autenticado, true);
+  assert.equal(cuerpo.email, 'clienta@ejemplo.com');
+  assert.equal(cuerpo.nombre_sugerido, 'Clienta');
+  assert.equal(cuerpo.tiene_perfil, false, 'todavía no guardó nada');
+  assert.equal(res.headers.get('Cache-Control'), 'no-store');
+  assert.ok(cookie.startsWith(COOKIE_SESION));
+  assert.ok(csrf.length > 0);
+  assert.equal(falso.estado.identities.length, 1);
+  // Lo guardado es el hash, no la cookie que viaja.
+  assert.equal(falso.estado.sessions[0].session_hash, await hashSecreto(cookie.split('=')[1]));
+});
+
+test('un cliente que vuelve reusa su identidad, no crea otra', async () => {
+  const falso = d1Falso();
+  await ingresar(falso);
+  await ingresar(falso, { email: 'clienta.nueva@ejemplo.com' });
+  assert.equal(falso.estado.identities.length, 1, 'mismo sub de Google, misma identidad');
+  assert.equal(falso.estado.identities[0].email, 'clienta.nueva@ejemplo.com', 'el correo se actualiza');
+  assert.equal(falso.estado.sessions.length, 2);
+});
+
+test('dos cuentas de Google distintas no se unen aunque compartan correo', async () => {
+  const falso = d1Falso();
+  await ingresar(falso, { sub: 'AAA', email: 'mismo@ejemplo.com' });
+  await ingresar(falso, { sub: 'BBB', email: 'mismo@ejemplo.com' });
+  assert.equal(falso.estado.identities.length, 2, 'la llave es el sub, nunca el correo');
+});
+
+test('el nonce sirve una sola vez: un token repetido no entra', async () => {
+  const falso = d1Falso();
+  const env = entorno(falso.db);
+  const { nonce } = await (await crearNonceHandler({ getNow })({ request: pedir(undefined, { method: 'GET' }), env })).json();
+  const handler = crearGoogleHandler({ getNow, verificarToken: tokenFalso({ nonce }) });
+
+  assert.equal((await handler({ request: pedir({ credential: 'jwt', nonce }), env })).status, 200);
+  const repetido = await handler({ request: pedir({ credential: 'jwt', nonce }), env });
+  assert.equal(repetido.status, 400);
+  assert.equal((await repetido.json()).motivo, 'nonce');
+  assert.equal(falso.estado.sessions.length, 1);
+});
+
+test('un nonce vencido no entra', async () => {
+  const falso = d1Falso();
+  const env = entorno(falso.db);
+  const { nonce } = await (await crearNonceHandler({ getNow })({ request: pedir(undefined, { method: 'GET' }), env })).json();
+  const tarde = new Date(AHORA.getTime() + 11 * 60_000);
+  const res = await crearGoogleHandler({ getNow: () => tarde, verificarToken: tokenFalso({ nonce }) })({
+    request: pedir({ credential: 'jwt', nonce }), env,
+  });
+  assert.equal(res.status, 400);
+});
+
+test('un token para otra aplicación se rechaza y consume el nonce igual', async () => {
+  const falso = d1Falso();
+  const env = entorno(falso.db);
+  const { nonce } = await (await crearNonceHandler({ getNow })({ request: pedir(undefined, { method: 'GET' }), env })).json();
+  const res = await crearGoogleHandler({ getNow, verificarToken: tokenFalso({ nonce, aud: 'otra-app' }) })({
+    request: pedir({ credential: 'jwt', nonce }), env,
+  });
+  assert.equal(res.status, 401);
+  assert.equal((await res.json()).motivo, 'audiencia_incorrecta');
+  assert.equal(falso.estado.sessions.length, 0);
+});
+
+test('si Google no responde, no se entra', async () => {
+  const falso = d1Falso();
+  const env = entorno(falso.db);
+  const { nonce } = await (await crearNonceHandler({ getNow })({ request: pedir(undefined, { method: 'GET' }), env })).json();
+  const res = await crearGoogleHandler({ getNow, verificarToken: async () => null })({
+    request: pedir({ credential: 'jwt', nonce }), env,
+  });
+  assert.equal(res.status, 401);
+  assert.equal(falso.estado.sessions.length, 0);
+});
+
+// ─── Perfil ──────────────────────────────────────────────────────────────────
+
+const PERFIL = {
+  buyer_name: 'Ana Pérez', buyer_phone: '099111222',
+  address: 'Rincón 608', locality: 'Ciudad Vieja', department: 'Montevideo',
+};
+
+test('sin sesión no se lee ni se escribe perfil', async () => {
+  const falso = d1Falso();
+  const env = entorno(falso.db);
+  const handler = crearPerfilHandler({ getNow });
+  assert.equal((await handler({ request: pedir(undefined, { method: 'GET' }), env })).status, 401);
+  assert.equal((await handler({ request: pedir({ perfil: PERFIL }), env })).status, 401);
+  assert.equal(falso.estado.profiles.length, 0);
+});
+
+test('guardar el perfil exige CSRF y no crea ningún pedido', async () => {
+  const falso = d1Falso();
+  const { env, cookie, csrf } = await ingresar(falso);
+  const handler = crearPerfilHandler({ getNow });
+
+  const sinCsrf = await handler({ request: pedir({ perfil: PERFIL }, { cookie }), env });
+  assert.equal(sinCsrf.status, 403);
+
+  const conCsrf = await handler({ request: pedir({ perfil: PERFIL }, { cookie, csrf }), env });
+  assert.equal(conCsrf.status, 200);
+  assert.equal(falso.estado.profiles.length, 1);
+  assert.equal(falso.estado.profiles[0].buyer_name, 'Ana Pérez');
+
+  // Guardar datos no toca pedidos ni pagos: ninguna consulta miró esas tablas.
+  const tocoPedidos = falso.estado.sqlVisto.some(s => /\borders\b|order_items|payments?/i.test(s));
+  assert.equal(tocoPedidos, false, 'guardar perfil no debe rozar la tabla de pedidos');
+});
+
+test('el perfil se lee sin caché y sólo el propio', async () => {
+  const falso = d1Falso();
+  const primera = await ingresar(falso, { sub: 'AAA', email: 'ana@ejemplo.com' });
+  await crearPerfilHandler({ getNow })({
+    request: pedir({ perfil: PERFIL }, { cookie: primera.cookie, csrf: primera.csrf }), env: primera.env,
+  });
+
+  const propia = await crearPerfilHandler({ getNow })({
+    request: pedir(undefined, { method: 'GET', cookie: primera.cookie }), env: primera.env,
+  });
+  assert.equal(propia.headers.get('Cache-Control'), 'no-store');
+  assert.equal((await propia.json()).perfil.buyer_name, 'Ana Pérez');
+
+  // Otra cuenta de Google, en el mismo navegador: no puede ver lo anterior.
+  const segunda = await ingresar(falso, { sub: 'BBB', email: 'beto@ejemplo.com' });
+  const ajena = await crearPerfilHandler({ getNow })({
+    request: pedir(undefined, { method: 'GET', cookie: segunda.cookie }), env: segunda.env,
+  });
+  assert.equal((await ajena.json()).perfil, null, 'cambiar de cuenta no muestra datos de la anterior');
+});
+
+test('un campo fuera de la lista no se guarda aunque se mande', async () => {
+  const falso = d1Falso();
+  const { env, cookie, csrf } = await ingresar(falso);
+  await crearPerfilHandler({ getNow })({
+    request: pedir({ perfil: { ...PERFIL, identity_id: 'ajeno', saldo: 999 } }, { cookie, csrf }), env,
+  });
+  const guardado = falso.estado.profiles[0];
+  assert.equal(guardado.saldo, undefined);
+  assert.notEqual(guardado.identity_id, 'ajeno', 'el perfil se ata a la sesión, no al cuerpo');
+});
+
+// ─── Sesión y salida ─────────────────────────────────────────────────────────
+
+test('la sesión se consulta y refleja si hay perfil', async () => {
+  const falso = d1Falso();
+  const { env, cookie, csrf } = await ingresar(falso);
+  const antes = await crearSesionHandler({ getNow })({ request: pedir(undefined, { method: 'GET', cookie }), env });
+  assert.deepEqual(await antes.json(), { autenticado: true, email: 'clienta@ejemplo.com', tiene_perfil: false });
+
+  await crearPerfilHandler({ getNow })({ request: pedir({ perfil: PERFIL }, { cookie, csrf }), env });
+  const despues = await crearSesionHandler({ getNow })({ request: pedir(undefined, { method: 'GET', cookie }), env });
+  assert.equal((await despues.json()).tiene_perfil, true);
+});
+
+test('salir revoca la sesión y borra las dos cookies', async () => {
+  const falso = d1Falso();
+  const { env, cookie, csrf } = await ingresar(falso);
+  const salida = await crearSalidaHandler({ getNow })({ request: pedir(undefined, { cookie, csrf }), env });
+  assert.equal(salida.status, 200);
+  const cookies = salida.headers.getSetCookie ? salida.headers.getSetCookie() : [salida.headers.get('Set-Cookie')];
+  assert.equal(cookies.filter(c => /Max-Age=0/.test(c)).length, 2);
+
+  const despues = await crearSesionHandler({ getNow })({ request: pedir(undefined, { method: 'GET', cookie }), env });
+  assert.deepEqual(await despues.json(), { autenticado: false });
+
+  const perfil = await crearPerfilHandler({ getNow })({ request: pedir(undefined, { method: 'GET', cookie }), env });
+  assert.equal(perfil.status, 401, 'la cookie revocada tampoco sirve para el perfil');
+});
+
+test('una sesión vencida deja de servir aunque la cookie siga en el navegador', async () => {
+  const falso = d1Falso();
+  const { env, cookie } = await ingresar(falso);
+  const enUnAno = new Date(AHORA.getTime() + 366 * 24 * 60 * 60 * 1000);
+  const res = await crearPerfilHandler({ getNow: () => enUnAno })({
+    request: pedir(undefined, { method: 'GET', cookie }), env,
+  });
+  assert.equal(res.status, 401);
+});
+
+test('salir sin CSRF no revoca la sesión ajena', async () => {
+  const falso = d1Falso();
+  const { env, cookie } = await ingresar(falso);
+  const res = await crearSalidaHandler({ getNow })({ request: pedir(undefined, { cookie }), env });
+  assert.equal(res.status, 403);
+  assert.equal(falso.estado.sessions[0].revoked_at, null);
+});

--- a/functions/__tests__/cuenta-google-logic.test.js
+++ b/functions/__tests__/cuenta-google-logic.test.js
@@ -1,0 +1,171 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  CAMPOS_PERFIL,
+  COOKIE_CSRF,
+  COOKIE_SESION,
+  camposACompletar,
+  construirCookie,
+  hashSecreto,
+  generarSecreto,
+  leerCookie,
+  normalizarPerfil,
+  pareceSecreto,
+  validarClaims,
+} from '../api/_cuenta_logic.js';
+
+const AHORA = new Date('2026-09-07T12:00:00.000Z');
+const NONCE = 'n'.repeat(43);
+const CLIENT_ID = '123.apps.googleusercontent.com';
+
+function claims(patch = {}) {
+  return {
+    aud: CLIENT_ID,
+    iss: 'https://accounts.google.com',
+    exp: Math.floor(AHORA.getTime() / 1000) + 600,
+    nonce: NONCE,
+    sub: '11223344',
+    email: 'Clienta@Ejemplo.com',
+    email_verified: true,
+    name: 'Clienta Ejemplo',
+    ...patch,
+  };
+}
+
+test('un token correcto se acepta y normaliza el correo', () => {
+  const r = validarClaims(claims(), { clientId: CLIENT_ID, nonceEsperado: NONCE, ahora: AHORA });
+  assert.equal(r.ok, true);
+  assert.equal(r.subject, '11223344');
+  assert.equal(r.email, 'clienta@ejemplo.com');
+  assert.equal(r.nombre, 'Clienta Ejemplo');
+});
+
+// Un token emitido para OTRA aplicación es perfectamente válido para Google.
+// Si no se compara la audiencia, sirve para entrar acá.
+test('un token para otra aplicación no entra', () => {
+  const r = validarClaims(claims({ aud: 'otra-app.apps.googleusercontent.com' }),
+    { clientId: CLIENT_ID, nonceEsperado: NONCE, ahora: AHORA });
+  assert.equal(r.ok, false);
+  assert.equal(r.motivo, 'audiencia_incorrecta');
+});
+
+test('sin Client ID configurado ningún token entra', () => {
+  const r = validarClaims(claims(), { clientId: '', nonceEsperado: NONCE, ahora: AHORA });
+  assert.equal(r.ok, false);
+  assert.equal(r.motivo, 'audiencia_incorrecta');
+});
+
+test('emisor, vencimiento, nonce y correo sin verificar cierran la puerta', () => {
+  const base = { clientId: CLIENT_ID, nonceEsperado: NONCE, ahora: AHORA };
+  const casos = [
+    [{ iss: 'https://accounts.example.com' }, 'emisor_incorrecto'],
+    [{ exp: Math.floor(AHORA.getTime() / 1000) - 1 }, 'vencido'],
+    [{ exp: 'no-es-numero' }, 'vencido'],
+    [{ nonce: 'otro'.padEnd(43, 'x') }, 'nonce_incorrecto'],
+    [{ email_verified: false }, 'email_sin_verificar'],
+    [{ sub: '' }, 'sin_subject'],
+    [{ email: '' }, 'sin_email'],
+  ];
+  for (const [patch, motivo] of casos) {
+    const r = validarClaims(claims(patch), base);
+    assert.equal(r.ok, false, `debería rechazar ${motivo}`);
+    assert.equal(r.motivo, motivo);
+  }
+  assert.equal(validarClaims(null, base).motivo, 'sin_claims');
+});
+
+test('los dos emisores que usa Google se aceptan', () => {
+  for (const iss of ['accounts.google.com', 'https://accounts.google.com']) {
+    assert.equal(validarClaims(claims({ iss }), { clientId: CLIENT_ID, nonceEsperado: NONCE, ahora: AHORA }).ok, true);
+  }
+});
+
+test('sin nonce esperado no se acepta ningún token', () => {
+  const r = validarClaims(claims(), { clientId: CLIENT_ID, nonceEsperado: null, ahora: AHORA });
+  assert.equal(r.motivo, 'nonce_incorrecto');
+});
+
+// ─── Cookies ─────────────────────────────────────────────────────────────────
+
+test('la cookie de sesión es __Host-, HttpOnly y Secure; la de CSRF es legible', () => {
+  const sesion = construirCookie(COOKIE_SESION, 'a'.repeat(43), { maxAgeSegundos: 60 });
+  assert.ok(COOKIE_SESION.startsWith('__Host-'));
+  for (const d of ['HttpOnly', 'Secure', 'SameSite=Lax', 'Path=/']) assert.match(sesion, new RegExp(d.replace('/', '\\/')));
+
+  const csrf = construirCookie(COOKIE_CSRF, 'b'.repeat(43), { maxAgeSegundos: 60, httpOnly: false });
+  assert.doesNotMatch(csrf, /HttpOnly/, 'el JS del sitio tiene que poder leerla para reenviarla');
+  assert.match(csrf, /Secure/);
+});
+
+test('sólo se lee una cookie con forma de secreto', () => {
+  const valor = 'c'.repeat(43);
+  assert.equal(leerCookie(`x=1; ${COOKIE_SESION}=${valor}`, COOKIE_SESION), valor);
+  assert.equal(leerCookie(`${COOKIE_SESION}=corto`, COOKIE_SESION), null);
+  assert.equal(leerCookie('x=1', COOKIE_SESION), null);
+});
+
+test('el secreto guardado es el hash, no el secreto', async () => {
+  const s = generarSecreto();
+  assert.ok(pareceSecreto(s));
+  const h = await hashSecreto(s);
+  assert.match(h, /^[0-9a-f]{64}$/);
+  assert.notEqual(h, s);
+});
+
+// ─── Perfil ──────────────────────────────────────────────────────────────────
+
+test('el perfil acepta sólo los campos de la lista y recorta espacios', () => {
+  const { perfil } = normalizarPerfil({
+    buyer_name: '  Ana   Pérez ', buyer_phone: '099 111 222',
+    address: 'Rincón 608', locality: 'Ciudad Vieja', department: 'Montevideo',
+    saldo: 999999, identity_id: 'ajeno',
+  });
+  assert.equal(perfil.buyer_name, 'Ana Pérez');
+  assert.deepEqual(Object.keys(perfil).sort(), [...CAMPOS_PERFIL].sort());
+  assert.equal(perfil.saldo, undefined, 'un campo fuera de la lista no entra');
+  assert.equal(perfil.identity_id, undefined, 'ni siquiera para elegir de quién es el perfil');
+});
+
+test('un perfil vacío o desmedido se rechaza', () => {
+  assert.match(normalizarPerfil({}).error, /ningún dato/);
+  assert.match(normalizarPerfil({ buyer_name: '   ' }).error, /ningún dato/);
+  assert.match(normalizarPerfil({ address: 'x'.repeat(201) }).error, /demasiado largo/);
+});
+
+// ─── La regla que impide pisar lo escrito ────────────────────────────────────
+
+test('sólo se completan campos vacíos y no tocados', () => {
+  const perfil = {
+    buyer_name: 'Ana Pérez', buyer_phone: '099111222',
+    address: 'Rincón 608', locality: 'Ciudad Vieja', department: 'Montevideo',
+  };
+  const aCompletar = camposACompletar({
+    perfil,
+    valoresActuales: { buyer_name: 'Otro Nombre', buyer_phone: '', address: '   ', locality: '', department: '' },
+    tocados: ['locality'],
+  });
+  assert.equal(aCompletar.buyer_name, undefined, 'no pisa lo que ya estaba escrito');
+  assert.equal(aCompletar.locality, undefined, 'no pisa un campo que la persona tocó');
+  assert.equal(aCompletar.buyer_phone, '099111222');
+  assert.equal(aCompletar.address, 'Rincón 608', 'un campo con sólo espacios cuenta como vacío');
+  assert.equal(aCompletar.department, 'Montevideo');
+});
+
+// Éste es el caso que pide el encargo: la respuesta llega tarde y la persona
+// ya escribió mientras esperaba.
+test('una respuesta tardía no sobrescribe lo que se escribió mientras llegaba', () => {
+  const perfil = { buyer_name: 'Ana Pérez', buyer_phone: '099111222' };
+  // Al pedir los datos ambos campos estaban vacíos; para cuando llegó la
+  // respuesta la persona ya había escrito el teléfono.
+  const aCompletar = camposACompletar({
+    perfil,
+    valoresActuales: { buyer_name: '', buyer_phone: '098765432' },
+    tocados: ['buyer_phone'],
+  });
+  assert.deepEqual(aCompletar, { buyer_name: 'Ana Pérez' });
+});
+
+test('sin perfil guardado no se completa nada', () => {
+  assert.deepEqual(camposACompletar({ perfil: null, valoresActuales: {} }), {});
+});

--- a/functions/api/_cuenta_handler.js
+++ b/functions/api/_cuenta_handler.js
@@ -1,0 +1,284 @@
+import {
+  CAMPOS_PERFIL,
+  COOKIE_CSRF,
+  COOKIE_SESION,
+  MAX_BODY_BYTES,
+  NONCE_TTL_MINUTES,
+  SESSION_TTL_DAYS,
+  cookieDeBorrado,
+  construirCookie,
+  estaVencido,
+  generarSecreto,
+  hashSecreto,
+  leerCookie,
+  normalizarPerfil,
+  pareceSecreto,
+  perfilPublico,
+  validarClaims,
+  vencimiento,
+} from './_cuenta_logic.js';
+
+// Verificación del ID token contra el propio Google. Se elige este camino en
+// lugar de validar la firma acá porque el proyecto no tiene ninguna
+// dependencia npm en Functions y el encargo pide explícitamente NO escribir
+// criptografía JWT propia. Google verifica firma y vencimiento; las demás
+// comprobaciones (audiencia, emisor, nonce, correo verificado) se hacen en
+// validarClaims(). Queda inyectable para poder cambiarlo por validación local
+// con JWKS sin tocar el resto.
+const TOKENINFO = 'https://oauth2.googleapis.com/tokeninfo?id_token=';
+
+async function verificarConGoogle(idToken, fetchFn = fetch) {
+  const controlador = new AbortController();
+  const temporizador = setTimeout(() => controlador.abort(), 8_000);
+  try {
+    const respuesta = await fetchFn(`${TOKENINFO}${encodeURIComponent(idToken)}`, {
+      signal: controlador.signal,
+    });
+    if (!respuesta.ok) return null;
+    return await respuesta.json();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(temporizador);
+  }
+}
+
+function json(data, status = 200, extraHeaders = {}) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json;charset=UTF-8', 'Cache-Control': 'no-store', ...extraHeaders },
+  });
+}
+
+async function leerCuerpo(request) {
+  const tipo = (request.headers.get('Content-Type') || '').toLowerCase();
+  if (!tipo.includes('application/json')) return { error: json({ error: 'Content-Type debe ser application/json.' }, 415) };
+  try {
+    const texto = await request.text();
+    if (new TextEncoder().encode(texto).byteLength > MAX_BODY_BYTES) return { error: json({ error: 'Body demasiado grande.' }, 413) };
+    return { body: JSON.parse(texto) };
+  } catch {
+    return { error: json({ error: 'JSON inválido.' }, 400) };
+  }
+}
+
+function clientId(env) {
+  return String(env?.GOOGLE_CLIENT_ID || '').trim();
+}
+
+// Sin Client ID no hay login: se responde "no configurado" y el frontend
+// esconde el botón. Nunca se simula un ingreso exitoso.
+function sinConfigurar() {
+  return json({ error: 'Ingreso con Google no configurado.', code: 'google_no_configurado' }, 503);
+}
+
+async function resolverSesion(request, db, ahora) {
+  const secreto = leerCookie(request.headers.get('Cookie'), COOKIE_SESION);
+  if (!secreto) return { ok: false, motivo: 'sin_cookie' };
+  const hash = await hashSecreto(secreto);
+  const fila = await db.prepare(
+    'SELECT s.session_hash, s.identity_id, s.csrf_hash, s.expires_at, s.revoked_at, i.email ' +
+    'FROM account_sessions s JOIN account_identities i ON i.id = s.identity_id ' +
+    'WHERE s.session_hash = ?',
+  ).bind(hash).first();
+  if (!fila) return { ok: false, motivo: 'inexistente' };
+  if (fila.revoked_at) return { ok: false, motivo: 'revocada', hash };
+  if (estaVencido(fila.expires_at, ahora)) return { ok: false, motivo: 'vencida', hash };
+  return { ok: true, hash, identityId: fila.identity_id, email: fila.email, csrfHash: fila.csrf_hash };
+}
+
+// Doble envío: la cookie CSRF la lee el JS del sitio y la repite en la
+// cabecera. Un formulario de otro sitio no puede leerla, así que no puede
+// mandarla. Se compara contra el hash guardado con la sesión.
+async function csrfValido(request, sesion) {
+  const enviado = String(request.headers.get('X-CSRF-Token') || '').trim();
+  if (!pareceSecreto(enviado)) return false;
+  return (await hashSecreto(enviado)) === sesion.csrfHash;
+}
+
+// ─── GET /api/cuenta/nonce ───────────────────────────────────────────────────
+
+export function crearNonceHandler({ getNow = () => new Date() } = {}) {
+  return async function onRequest({ request, env }) {
+    if (request.method !== 'GET') return json({ error: 'Método no permitido.' }, 405, { Allow: 'GET' });
+    if (!clientId(env)) return sinConfigurar();
+    const db = env?.ORDERS_DB;
+    if (!db) return json({ error: 'Servicio no disponible.' }, 503);
+
+    const ahora = getNow();
+    const nonce = generarSecreto();
+    await db.prepare('INSERT INTO auth_nonces (nonce_hash, created_at, expires_at) VALUES (?, ?, ?)')
+      .bind(await hashSecreto(nonce), ahora.toISOString(), vencimiento(ahora, NONCE_TTL_MINUTES).toISOString())
+      .run();
+    return json({ nonce });
+  };
+}
+
+// ─── POST /api/cuenta/google ─────────────────────────────────────────────────
+
+export function crearGoogleHandler({
+  getNow = () => new Date(),
+  verificarToken = verificarConGoogle,
+  fetchFn = fetch,
+} = {}) {
+  return async function onRequest({ request, env }) {
+    if (request.method !== 'POST') return json({ error: 'Método no permitido.' }, 405, { Allow: 'POST' });
+    const idCliente = clientId(env);
+    if (!idCliente) return sinConfigurar();
+    const db = env?.ORDERS_DB;
+    if (!db) return json({ error: 'Servicio no disponible.' }, 503);
+
+    const { body, error } = await leerCuerpo(request);
+    if (error) return error;
+
+    const credencial = typeof body?.credential === 'string' ? body.credential.trim() : '';
+    const nonce = typeof body?.nonce === 'string' ? body.nonce.trim() : '';
+    if (!credencial || !pareceSecreto(nonce)) return json({ error: 'Ingreso inválido.' }, 400);
+
+    const ahora = getNow();
+    const ahoraIso = ahora.toISOString();
+
+    // El nonce se consume en la condición del UPDATE: si dos peticiones traen
+    // el mismo, sólo una cambia la fila. Mirar y después escribir dejaría una
+    // ventana para reusar el token.
+    const consumo = await db.prepare(
+      'UPDATE auth_nonces SET used_at = ? WHERE nonce_hash = ? AND used_at IS NULL AND expires_at > ?',
+    ).bind(ahoraIso, await hashSecreto(nonce), ahoraIso).run();
+    if (consumo?.meta?.changes !== 1) return json({ error: 'Ingreso inválido o vencido.', motivo: 'nonce' }, 400);
+
+    const claims = await verificarToken(credencial, fetchFn);
+    const validez = validarClaims(claims, { clientId: idCliente, nonceEsperado: nonce, ahora });
+    if (!validez.ok) return json({ error: 'No pudimos verificar tu ingreso.', motivo: validez.motivo }, 401);
+
+    // Identidad por proveedor + subject. El correo se guarda como dato, no
+    // como llave: dos cuentas nunca se unen por compartir un email.
+    const existente = await db.prepare(
+      'SELECT id FROM account_identities WHERE provider = ? AND subject = ?',
+    ).bind('google', validez.subject).first();
+
+    let identityId = existente?.id || null;
+    if (identityId) {
+      await db.prepare('UPDATE account_identities SET email = ?, last_seen_at = ? WHERE id = ?')
+        .bind(validez.email, ahoraIso, identityId).run();
+    } else {
+      identityId = generarSecreto();
+      await db.prepare(
+        'INSERT INTO account_identities (id, provider, subject, email, created_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?)',
+      ).bind(identityId, 'google', validez.subject, validez.email, ahoraIso, ahoraIso).run();
+    }
+
+    const sesion = generarSecreto();
+    const csrf = generarSecreto();
+    const vence = vencimiento(ahora, SESSION_TTL_DAYS * 24 * 60);
+    await db.prepare(
+      'INSERT INTO account_sessions (session_hash, identity_id, csrf_hash, created_at, expires_at) VALUES (?, ?, ?, ?, ?)',
+    ).bind(await hashSecreto(sesion), identityId, await hashSecreto(csrf), ahoraIso, vence.toISOString()).run();
+
+    const perfil = await db.prepare(
+      `SELECT ${CAMPOS_PERFIL.join(', ')} FROM account_profiles WHERE identity_id = ?`,
+    ).bind(identityId).first();
+
+    const maxAge = SESSION_TTL_DAYS * 24 * 60 * 60;
+    const headers = new Headers({ 'Content-Type': 'application/json;charset=UTF-8', 'Cache-Control': 'no-store' });
+    headers.append('Set-Cookie', construirCookie(COOKIE_SESION, sesion, { maxAgeSegundos: maxAge }));
+    headers.append('Set-Cookie', construirCookie(COOKIE_CSRF, csrf, { maxAgeSegundos: maxAge, httpOnly: false }));
+
+    return new Response(JSON.stringify({
+      autenticado: true,
+      email: validez.email,
+      // Google básico puede aportar el nombre. El teléfono y la dirección NO
+      // vienen de Google: salen del navegador o los escribe la persona.
+      nombre_sugerido: validez.nombre,
+      tiene_perfil: Boolean(perfil),
+    }), { status: 200, headers });
+  };
+}
+
+// ─── GET /api/cuenta/sesion ──────────────────────────────────────────────────
+
+export function crearSesionHandler({ getNow = () => new Date() } = {}) {
+  return async function onRequest({ request, env }) {
+    if (request.method !== 'GET') return json({ error: 'Método no permitido.' }, 405, { Allow: 'GET' });
+    const db = env?.ORDERS_DB;
+    if (!db) return json({ autenticado: false });
+    const sesion = await resolverSesion(request, db, getNow());
+    if (!sesion.ok) return json({ autenticado: false });
+    const perfil = await db.prepare('SELECT identity_id FROM account_profiles WHERE identity_id = ?')
+      .bind(sesion.identityId).first();
+    return json({ autenticado: true, email: sesion.email, tiene_perfil: Boolean(perfil) });
+  };
+}
+
+// ─── /api/cuenta/perfil ──────────────────────────────────────────────────────
+
+export function crearPerfilHandler({ getNow = () => new Date() } = {}) {
+  return async function onRequest({ request, env }) {
+    const db = env?.ORDERS_DB;
+    if (!db) return json({ error: 'Servicio no disponible.' }, 503);
+    if (request.method !== 'GET' && request.method !== 'POST') {
+      return json({ error: 'Método no permitido.' }, 405, { Allow: 'GET, POST' });
+    }
+
+    const sesion = await resolverSesion(request, db, getNow());
+    if (!sesion.ok) return json({ error: 'No autenticado.' }, 401);
+
+    if (request.method === 'GET') {
+      // La consulta se ata a la identidad de la SESIÓN. Si el identity_id
+      // viniera de la petición, cualquiera leería el perfil ajeno.
+      const fila = await db.prepare(
+        `SELECT ${CAMPOS_PERFIL.join(', ')} FROM account_profiles WHERE identity_id = ?`,
+      ).bind(sesion.identityId).first();
+      return json({ perfil: perfilPublico(fila) });
+    }
+
+    if (!(await csrfValido(request, sesion))) return json({ error: 'Verificación CSRF fallida.' }, 403);
+
+    const { body, error } = await leerCuerpo(request);
+    if (error) return error;
+
+    const { perfil, error: errorPerfil } = normalizarPerfil(body?.perfil);
+    if (errorPerfil) return json({ error: errorPerfil }, 400);
+
+    const ahoraIso = getNow().toISOString();
+    // Guardar el perfil NO crea ni modifica ningún pedido: escribe una sola
+    // fila en su propia tabla.
+    await db.prepare(
+      'INSERT INTO account_profiles (identity_id, buyer_name, buyer_phone, address, locality, department, updated_at) ' +
+      'VALUES (?, ?, ?, ?, ?, ?, ?) ' +
+      'ON CONFLICT(identity_id) DO UPDATE SET ' +
+      'buyer_name = excluded.buyer_name, buyer_phone = excluded.buyer_phone, address = excluded.address, ' +
+      'locality = excluded.locality, department = excluded.department, updated_at = excluded.updated_at',
+    ).bind(
+      sesion.identityId, perfil.buyer_name, perfil.buyer_phone,
+      perfil.address, perfil.locality, perfil.department, ahoraIso,
+    ).run();
+
+    return json({ ok: true, perfil });
+  };
+}
+
+// ─── POST /api/cuenta/salir ──────────────────────────────────────────────────
+
+export function crearSalidaHandler({ getNow = () => new Date() } = {}) {
+  return async function onRequest({ request, env }) {
+    if (request.method !== 'POST') return json({ error: 'Método no permitido.' }, 405, { Allow: 'POST' });
+    const db = env?.ORDERS_DB;
+    if (!db) return json({ error: 'Servicio no disponible.' }, 503);
+
+    const sesion = await resolverSesion(request, db, getNow());
+    if (sesion.ok && !(await csrfValido(request, sesion))) {
+      return json({ error: 'Verificación CSRF fallida.' }, 403);
+    }
+    if (sesion.hash) {
+      await db.prepare('UPDATE account_sessions SET revoked_at = ? WHERE session_hash = ? AND revoked_at IS NULL')
+        .bind(getNow().toISOString(), sesion.hash).run();
+    }
+
+    // Las cookies se borran siempre: salir nunca deja al navegador con una
+    // credencial en la mano.
+    const headers = new Headers({ 'Content-Type': 'application/json;charset=UTF-8', 'Cache-Control': 'no-store' });
+    headers.append('Set-Cookie', cookieDeBorrado(COOKIE_SESION));
+    headers.append('Set-Cookie', cookieDeBorrado(COOKIE_CSRF, { httpOnly: false }));
+    return new Response(JSON.stringify({ ok: true }), { status: 200, headers });
+  };
+}

--- a/functions/api/_cuenta_logic.js
+++ b/functions/api/_cuenta_logic.js
@@ -1,0 +1,165 @@
+// Lógica pura de la cuenta opcional del comprador. Sin red, sin base y sin
+// reloj propio: todo lo que decide se prueba sin levantar nada.
+//
+// Alcance: identificarse con Google es opcional y sólo sirve para traer los
+// datos que el cliente decidió guardar. No toca precios, envío, stock,
+// idempotencia, Mercado Pago ni los correos de compra.
+
+export const SESSION_TTL_DAYS = 30;
+export const NONCE_TTL_MINUTES = 10;
+export const MAX_BODY_BYTES = 8 * 1024;
+
+// __Host- obliga a Secure, Path=/ y sin Domain: un subdominio no puede
+// fijarle la cookie al sitio.
+export const COOKIE_SESION = '__Host-al_cuenta';
+// La de CSRF se lee desde JS a propósito (doble envío), así que NO es HttpOnly.
+// No es una credencial por sí sola: sin la cookie de sesión no autoriza nada.
+export const COOKIE_CSRF = '__Host-al_csrf';
+
+export const GOOGLE_ISSUERS = Object.freeze(['accounts.google.com', 'https://accounts.google.com']);
+
+// Lista explícita de campos del perfil. Cualquier cosa fuera de acá no se lee
+// ni se escribe, venga de donde venga.
+export const CAMPOS_PERFIL = Object.freeze([
+  'buyer_name', 'buyer_phone', 'address', 'locality', 'department',
+]);
+
+export const LIMITES_PERFIL = Object.freeze({
+  buyer_name: 120, buyer_phone: 40, address: 200, locality: 120, department: 60,
+});
+
+function limpiar(valor) {
+  return String(valor ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function base64url(bytes) {
+  let binario = '';
+  for (const byte of bytes) binario += String.fromCharCode(byte);
+  return btoa(binario).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function generarSecreto(getRandomValues = crypto.getRandomValues.bind(crypto)) {
+  return base64url(getRandomValues(new Uint8Array(32)));
+}
+
+export async function hashSecreto(secreto, subtle = crypto.subtle) {
+  const datos = new TextEncoder().encode(String(secreto));
+  const digest = await subtle.digest('SHA-256', datos);
+  return [...new Uint8Array(digest)].map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export function pareceSecreto(valor) {
+  return typeof valor === 'string' && /^[A-Za-z0-9_-]{43}$/.test(valor);
+}
+
+export function vencimiento(desde, minutos) {
+  return new Date(desde.getTime() + minutos * 60_000);
+}
+
+export function estaVencido(expiresAt, ahora) {
+  const limite = Date.parse(expiresAt);
+  return !Number.isFinite(limite) || limite <= ahora.getTime();
+}
+
+export function construirCookie(nombre, valor, { maxAgeSegundos, httpOnly = true }) {
+  return [
+    `${nombre}=${valor}`,
+    'Path=/',
+    httpOnly ? 'HttpOnly' : null,
+    'Secure',
+    'SameSite=Lax',
+    `Max-Age=${maxAgeSegundos}`,
+  ].filter(Boolean).join('; ');
+}
+
+export function cookieDeBorrado(nombre, { httpOnly = true } = {}) {
+  return construirCookie(nombre, '', { maxAgeSegundos: 0, httpOnly });
+}
+
+export function leerCookie(cabecera, nombre) {
+  if (typeof cabecera !== 'string' || !cabecera) return null;
+  for (const parte of cabecera.split(';')) {
+    const corte = parte.indexOf('=');
+    if (corte === -1) continue;
+    if (parte.slice(0, corte).trim() !== nombre) continue;
+    const valor = parte.slice(corte + 1).trim();
+    return pareceSecreto(valor) ? valor : null;
+  }
+  return null;
+}
+
+// ─── Validación del ID token de Google ───────────────────────────────────────
+//
+// La firma y el vencimiento los verifica Google; acá se comprueba todo lo que
+// además tiene que cumplirse para que ese token sea PARA ESTE SITIO y para
+// ESTE ingreso. Sin estas comprobaciones, un token legítimo emitido para otra
+// aplicación serviría para entrar acá.
+
+export function validarClaims(claims, { clientId, nonceEsperado, ahora }) {
+  if (!claims || typeof claims !== 'object') return { ok: false, motivo: 'sin_claims' };
+
+  const aud = limpiar(claims.aud);
+  if (!clientId || aud !== clientId) return { ok: false, motivo: 'audiencia_incorrecta' };
+
+  if (!GOOGLE_ISSUERS.includes(limpiar(claims.iss))) return { ok: false, motivo: 'emisor_incorrecto' };
+
+  const exp = Number(claims.exp);
+  if (!Number.isFinite(exp) || exp * 1000 <= ahora.getTime()) return { ok: false, motivo: 'vencido' };
+
+  // El nonce lo emitió este servidor y se consume una sola vez: sin esto, un
+  // token capturado se podría reenviar.
+  if (!nonceEsperado || limpiar(claims.nonce) !== nonceEsperado) return { ok: false, motivo: 'nonce_incorrecto' };
+
+  const subject = limpiar(claims.sub);
+  if (!subject) return { ok: false, motivo: 'sin_subject' };
+
+  const email = limpiar(claims.email).toLowerCase();
+  if (!email) return { ok: false, motivo: 'sin_email' };
+  // Google marca los correos no verificados; no se aceptan como identidad.
+  if (claims.email_verified !== true && claims.email_verified !== 'true') {
+    return { ok: false, motivo: 'email_sin_verificar' };
+  }
+
+  return { ok: true, subject, email, nombre: limpiar(claims.name) || null };
+}
+
+// ─── Perfil ──────────────────────────────────────────────────────────────────
+
+export function normalizarPerfil(entrada) {
+  const perfil = {};
+  for (const campo of CAMPOS_PERFIL) {
+    const valor = limpiar(entrada?.[campo]);
+    if (!valor) { perfil[campo] = null; continue; }
+    if (valor.length > LIMITES_PERFIL[campo]) return { error: `El campo ${campo} es demasiado largo.` };
+    perfil[campo] = valor;
+  }
+  const alguno = CAMPOS_PERFIL.some(campo => perfil[campo]);
+  if (!alguno) return { error: 'No hay ningún dato para guardar.' };
+  return { perfil };
+}
+
+export function perfilPublico(fila) {
+  if (!fila) return null;
+  const perfil = {};
+  for (const campo of CAMPOS_PERFIL) perfil[campo] = fila[campo] ?? null;
+  return perfil;
+}
+
+// ─── La regla que impide pisar lo que el cliente escribió ────────────────────
+//
+// Se completa un campo SÓLO si sigue vacío y el cliente no lo tocó desde que
+// pidió sus datos. Así una respuesta que llega tarde no borra lo que estuvo
+// escribiendo mientras esperaba.
+
+export function camposACompletar({ perfil, valoresActuales, tocados = [] }) {
+  const tocadosSet = new Set(tocados);
+  const aCompletar = {};
+  for (const campo of CAMPOS_PERFIL) {
+    const guardado = perfil?.[campo];
+    if (!guardado) continue;
+    if (tocadosSet.has(campo)) continue;
+    if (limpiar(valoresActuales?.[campo])) continue;
+    aCompletar[campo] = guardado;
+  }
+  return aCompletar;
+}

--- a/functions/api/cuenta/google.js
+++ b/functions/api/cuenta/google.js
@@ -1,0 +1,3 @@
+import { crearGoogleHandler } from "../_cuenta_handler.js";
+
+export const onRequest = crearGoogleHandler();

--- a/functions/api/cuenta/nonce.js
+++ b/functions/api/cuenta/nonce.js
@@ -1,0 +1,3 @@
+import { crearNonceHandler } from "../_cuenta_handler.js";
+
+export const onRequest = crearNonceHandler();

--- a/functions/api/cuenta/perfil.js
+++ b/functions/api/cuenta/perfil.js
@@ -1,0 +1,3 @@
+import { crearPerfilHandler } from "../_cuenta_handler.js";
+
+export const onRequest = crearPerfilHandler();

--- a/functions/api/cuenta/salir.js
+++ b/functions/api/cuenta/salir.js
@@ -1,0 +1,3 @@
+import { crearSalidaHandler } from "../_cuenta_handler.js";
+
+export const onRequest = crearSalidaHandler();

--- a/functions/api/cuenta/sesion.js
+++ b/functions/api/cuenta/sesion.js
@@ -1,0 +1,3 @@
+import { crearSesionHandler } from "../_cuenta_handler.js";
+
+export const onRequest = crearSesionHandler();

--- a/migrations/0010_cuenta_google_perfil.sql
+++ b/migrations/0010_cuenta_google_perfil.sql
@@ -1,0 +1,61 @@
+-- CUENTA-1: identificarse con Google es OPCIONAL y sólo sirve para traer los
+-- datos que el propio cliente decidió guardar. La compra como invitado sigue
+-- funcionando igual y nada de esto toca precios, stock, pagos ni pedidos.
+--
+-- Cuatro tablas separadas a propósito:
+--
+--   account_identities  quién es (proveedor + sub de Google). Existe desde el
+--                       primer ingreso.
+--   account_profiles    qué datos guardó. NO existe hasta que el cliente
+--                       aprieta "guardar": nunca se importan direcciones de
+--                       pedidos viejos, que pueden haber sido regalos.
+--   account_sessions    la sesión abierta, con su token CSRF y su revocación.
+--   auth_nonces         un solo uso por ingreso, contra repetición del token.
+--
+-- Nunca se guarda en claro ni la cookie de sesión ni el nonce: sólo su
+-- SHA-256. Leer estas tablas no da credenciales usables.
+
+CREATE TABLE IF NOT EXISTS account_identities (
+  id          TEXT PRIMARY KEY,
+  provider    TEXT NOT NULL CHECK (provider IN ('google')),
+  subject     TEXT NOT NULL CHECK (length(trim(subject)) > 0),
+  email       TEXT NOT NULL CHECK (length(trim(email)) > 0),
+  created_at  TEXT NOT NULL,
+  last_seen_at TEXT NOT NULL
+);
+
+-- La identidad es proveedor + subject, NUNCA el correo: dos cuentas no se
+-- unen por escribir el mismo email en el formulario.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_account_identities_provider_subject
+  ON account_identities (provider, subject);
+
+CREATE TABLE IF NOT EXISTS account_profiles (
+  identity_id  TEXT PRIMARY KEY REFERENCES account_identities(id) ON DELETE CASCADE,
+  buyer_name   TEXT,
+  buyer_phone  TEXT,
+  address      TEXT,
+  locality     TEXT,
+  department   TEXT,
+  updated_at   TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS account_sessions (
+  session_hash TEXT PRIMARY KEY,
+  identity_id  TEXT NOT NULL REFERENCES account_identities(id) ON DELETE CASCADE,
+  csrf_hash    TEXT NOT NULL,
+  created_at   TEXT NOT NULL,
+  expires_at   TEXT NOT NULL,
+  revoked_at   TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_account_sessions_identity ON account_sessions (identity_id);
+CREATE INDEX IF NOT EXISTS idx_account_sessions_expires  ON account_sessions (expires_at);
+
+CREATE TABLE IF NOT EXISTS auth_nonces (
+  nonce_hash TEXT PRIMARY KEY,
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  used_at    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_nonces_expires ON auth_nonces (expires_at);


### PR DESCRIPTION
Implementa el encargo de `docs/checkout-google-handoff.md` (#327). Base `main` **d380374**, head **1128bae**.

**Falta el Client ID de Google.** Todo está implementado y probado con dobles; el ingreso real contra Google **no está verificado** y no se declara terminado. La lista exacta de lo que hace falta está al final.

Sin merge, sin deploy productivo, sin migración productiva. No mezcla con #325 ni con QW2/imágenes.

---

## 1. Qué cambia para quien compra

Nada, salvo que aparece una opción más. El formulario está disponible desde el primer momento, **la compra como invitado no cambia**, y si Google no está configurado el bloque **no se muestra**.

| Situación | Qué pasa |
| --- | --- |
| Sin Client ID configurado | El bloque sale con `hidden` y el script de Google **ni se carga**. Se compra igual que hoy |
| Google cancelado o caído | Se avisa y se sigue como invitado. Los datos escritos no se tocan |
| Cliente nuevo | Google aporta correo y, si lo tiene, nombre. **Teléfono y dirección no vienen de Google** |
| Cliente con perfil guardado | Botón «Usar mis datos guardados», que sólo completa campos vacíos |
| Guardar datos | Acción explícita, aparte del pago. **No crea ni modifica ningún pedido** |

Es ventana emergente, no redirección: **no se sale del carrito**, así que productos, modalidad de entrega, medio de pago y borrador siguen intactos sin necesidad de restaurarlos.

## 2. La regla que más importa

**Los datos guardados nunca pisan lo que la persona escribió.** Un campo se completa sólo si sigue vacío **y** no fue tocado desde que se pidieron los datos. Así, si la respuesta llega tarde y mientras tanto escribió el teléfono, ese teléfono se respeta.

La regla vive en `astro-front/src/lib/perfil-checkout.js` con pruebas, y está replicada inline en `carrito.astro` — el mismo patrón que `turnstile-hosts.js`, porque un `<script is:inline>` no puede importar.

## 3. Seguridad

Además de lo que verifica Google (firma y vencimiento), se comprueba:

| Comprobación | Por qué |
| --- | --- |
| **Audiencia** = Client ID propio | Un token emitido para otra aplicación es **válido para Google**. Sin esta comparación, serviría para entrar acá |
| **Emisor** entre los dos de Google | — |
| **Vencimiento** | — |
| **Correo verificado** | Google marca los no verificados |
| **Nonce** emitido por el servidor | Se consume **una sola vez, en la condición del `UPDATE`**: dos peticiones con el mismo nonce, sólo una entra. Contra reenvío del token |

- **Identidad = proveedor + `sub`.** El correo se guarda como dato, **nunca como llave**: dos cuentas de Google distintas no se unen por compartir un email, y escribir un correo en el formulario no da acceso a nada.
- Cookies `__Host-`, `Secure`, `SameSite=Lax`. La de sesión es `HttpOnly`; la de CSRF es legible para el doble envío y por sí sola no autoriza nada. En D1 se guarda **el hash, nunca el secreto**.
- Escrituras con CSRF; lectura **atada a la identidad de la sesión**, nunca a un parámetro de la petición; lista explícita de campos; consultas parametrizadas; `Cache-Control: no-store`. Sin datos personales ni tokens en logs.
- El perfil **sólo** tiene lo que el cliente guardó con un botón. **No se importan direcciones de pedidos históricos**, que pueden haber sido regalos.

## 4. Decisión que conviene revisar

El token se verifica llamando al **tokeninfo de Google** en lugar de validar la firma localmente con JWKS. El motivo: el proyecto **no tiene ninguna dependencia npm en Functions** y el encargo pide explícitamente no escribir criptografía JWT propia. Agregar `jose` significaría meter la primera dependencia de runtime y tocar dos workflows de deploy, que excede este alcance.

El costo es una llamada más a Google por ingreso. Está **inyectable** (`verificarToken`), así que pasar a validación local con JWKS es cambiar una función sin tocar el resto. Si preferís esa vía, decilo y la hago aparte.

## 5. Migración

`migrations/0010_cuenta_google_perfil.sql`, **aditiva**, cuatro tablas nuevas y ninguna modificación de tablas existentes: `account_identities`, `account_profiles`, `account_sessions`, `auth_nonces`. **No se aplicó a producción.**

## 6. Pruebas

| Suite | Casos |
| --- | ---: |
| `cuenta-google-logic.test.js` | 14 |
| `cuenta-google-handler.test.js` | 16 |
| `perfil-checkout.test.js` (front) | 9 |
| **Suite completa de Functions** | **1.189/1.189** |

El D1 falso **explota ante SQL que no conoce**: si un handler cambia su consulta, la prueba se rompe en vez de seguir pasando contra un doble que ya no representa lo que corre.

Cubren los puntos de aceptación del encargo: invitado, Google nuevo y recurrente; respuesta tardía que no sobrescribe; cambiar de cuenta no muestra datos de la anterior; token con audiencia incorrecta, nonce repetido, nonce vencido y Google caído; acceso cruzado al perfil; salir revoca; guardar no toca pedidos (hay una prueba que **falla si alguna consulta roza la tabla `orders`**).

## 7. Controles

- `scripts/validate-ci.sh`: **OK**
- `git diff --check "origin/main...HEAD"`: **limpio**
- Build verificado en los dos modos: sin `PUBLIC_GOOGLE_CLIENT_ID` el bloque sale `hidden` y no hay ningún `<script>` de `accounts.google.com`; con la variable, se inyecta bien
- Los seis ids del formulario intactos: `buyer-name`, `buyer-phone`, `buyer-email`, `delivery-address`, `delivery-barrio`, `delivery-departamento`
- No se toca precio, envío, descuento, stock, idempotencia, Mercado Pago ni los correos de compra

## 8. Lo que falta y depende de Seba

Ver el comentario con la lista exacta de configuración. Hasta tenerla:

- El ingreso real con Google **no está probado** — sólo con dobles.
- El Preview de este PR muestra el checkout **sin** el bloque de cuenta, que es exactamente el comportamiento correcto cuando falta configuración.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri

---
_Generated by [Claude Code](https://claude.ai/code/session_014vUFN9BC9DEb3Nh1B477Ri)_