### PR TITLE
GA4-WHATSAPP-EVENT-1: origen/ruta/libro_id en whatsapp_click

### DIFF
--- a/astro-front/public/analytics-events.js
+++ b/astro-front/public/analytics-events.js
@@ -239,6 +239,16 @@
     }
   }
 
+  function whatsappOrigin(context, element) {
+    if (element && typeof element.closest === 'function' && element.closest('header')) return 'header';
+    if (context.pageType === 'home') return 'home';
+    if (context.pageType === 'category' || context.pageType === 'catalog') return 'catalogo';
+    if (context.pageType === 'product') {
+      return productAvailabilityType() === 'active' ? 'ficha' : 'ficha_pausada';
+    }
+    return 'otro';
+  }
+
   function trackWhatsApp(options) {
     options = options || {};
     var context = pageContext();
@@ -252,6 +262,13 @@
     if (context.productId) params.product_id = context.productId;
     var availabilityType = productAvailabilityType();
     if (availabilityType) params.availability_type = availabilityType;
+
+    // GA4-WHATSAPP-EVENT-1: origen/ruta/libro_id para importar como conversión
+    // en Google Ads/Meta; transport_type=beacon porque el clic navega fuera del sitio.
+    params.origen = whatsappOrigin(context, options.element);
+    params.ruta = window.location.pathname;
+    params.libro_id = context.productId || '';
+    params.transport_type = 'beacon';
 
     window.gtag('event', 'whatsapp_click', params);
   }
@@ -340,6 +357,6 @@
       ? event.target.closest('a[href]')
       : null;
     if (!anchor || !isWhatsAppUrl(anchor.href)) return;
-    trackWhatsApp({ ctaLocation: ctaLocation(anchor) });
+    trackWhatsApp({ ctaLocation: ctaLocation(anchor), element: anchor });
   }, true);
 })();

--- a/functions/__tests__/analytics-events.test.js
+++ b/functions/__tests__/analytics-events.test.js
@@ -20,18 +20,23 @@ test('el evento cubre enlaces y aperturas programáticas de WhatsApp', () => {
   assert.match(analytics, /'whatsapp_click'/);
   assert.match(analytics, /'wa\.me'/);
   assert.match(analytics, /'api\.whatsapp\.com'/);
+  assert.match(analytics, /'web\.whatsapp\.com'/);
   assert.match(bookRequest, /trackWhatsApp\(\{[\s\S]*book_request_form/);
   assert.match(cart, /trackWhatsApp\(\{ ctaLocation: 'checkout_order' \}\)/);
   assert.match(searchOverlay, /trackWhatsApp\(\{ ctaLocation: 'search_overlay' \}\)/);
 });
 
-test('no envía la URL de WhatsApp, el mensaje ni parámetros de búsqueda a GA4', () => {
+test('no envía la URL de WhatsApp, el mensaje, el teléfono ni parámetros de búsqueda a GA4', () => {
   const eventCall = analytics.slice(analytics.indexOf("window.gtag('event', 'whatsapp_click'"));
-  assert.doesNotMatch(eventCall, /link_url|searchParams|location\.search|href:/);
+  assert.doesNotMatch(eventCall, /link_url|searchParams|location\.search|href:|phone/);
   assert.match(analytics, /page_type/);
   assert.match(analytics, /cta_location/);
   assert.match(analytics, /product_id/);
   assert.match(analytics, /topic/);
+  assert.match(analytics, /origen/);
+  assert.match(analytics, /\bruta\b/);
+  assert.match(analytics, /libro_id/);
+  assert.match(analytics, /transport_type = 'beacon'/);
   assert.match(analytics, /allowedParameters/);
   assert.match(baseLayout, /allowedParameters/);
 });
@@ -89,9 +94,102 @@ test('el payload real usa contexto estable y descarta la query sensible', () => 
     page_type: 'specialty',
     cta_location: 'hero_principal',
     topic: 'oftalmologia',
+    origen: 'otro',
+    ruta: '/especialidades/oftalmologia',
+    libro_id: '',
+    transport_type: 'beacon',
   });
   assert.equal(JSON.stringify(params).includes('consulta-privada'), false);
   assert.equal(typeof listeners.click, 'function');
+});
+
+// GA4-WHATSAPP-EVENT-1: origen/ruta/libro_id se agregan al whatsapp_click ya
+// existente (sin reemplazar page_type/cta_location/product_id/
+// availability_type/topic, para no romper nada ya armado en GA4 sobre esos
+// campos) y con transport_type=beacon para que el evento llegue aunque el
+// clic navegue fuera del sitio de inmediato.
+test('el listener delegado detecta los tres dominios de WhatsApp y arma origen/ruta/libro_id con transporte beacon', () => {
+  function fireWhatsAppClick(pathname, { href, hasStockBadge = false, inHeader = false } = {}) {
+    const listeners = {};
+    const window = {
+      location: {
+        hostname: 'www.amadolibros.com',
+        pathname,
+        href: `https://www.amadolibros.com${pathname}`,
+      },
+      dataLayer: [],
+    };
+    const document = {
+      querySelector: (selector) => (selector === '.badge.in-stock' && hasStockBadge ? {} : null),
+      createElement: () => ({}),
+      head: { appendChild: () => {} },
+      addEventListener: (name, handler) => { listeners[name] = handler; },
+    };
+    runInNewContext(analytics, { document, window, URL, Set, Date, Object, String, encodeURIComponent });
+
+    const anchor = {
+      href,
+      closest: (selector) => (selector === 'header' && inHeader ? {} : null),
+    };
+    listeners.click({ target: { closest: (selector) => (selector === 'a[href]' ? anchor : null) } });
+
+    const last = window.dataLayer.at(-1);
+    if (!last || Array.from(last)[0] !== 'event') return null;
+    const [, eventName, params] = Array.from(last);
+    return eventName === 'whatsapp_click' ? { ...params } : null;
+  }
+
+  const whatsappHrefs = [
+    'https://wa.me/59800000000',
+    'https://api.whatsapp.com/send?phone=59800000000',
+    'https://web.whatsapp.com/send?phone=59800000000',
+  ];
+  for (const href of whatsappHrefs) {
+    const params = fireWhatsAppClick('/', { href });
+    assert.ok(params, `no disparó whatsapp_click para ${href}`);
+    assert.equal(params.origen, 'home');
+    assert.equal(params.ruta, '/');
+    assert.equal(params.libro_id, '');
+    assert.equal(params.transport_type, 'beacon');
+  }
+
+  // un enlace que no es de WhatsApp no dispara nada.
+  assert.equal(fireWhatsAppClick('/', { href: 'https://example.com' }), null);
+
+  assert.equal(
+    fireWhatsAppClick('/libros/infantil-juvenil', { href: 'https://wa.me/1' }).origen,
+    'catalogo',
+  );
+  assert.equal(
+    fireWhatsAppClick('/catalogo', { href: 'https://wa.me/1' }).origen,
+    'catalogo',
+  );
+
+  const ficha = fireWhatsAppClick('/libro/MLU1453287196/grandes-clasicos', {
+    href: 'https://wa.me/1',
+    hasStockBadge: true,
+  });
+  assert.equal(ficha.origen, 'ficha');
+  assert.equal(ficha.libro_id, 'MLU1453287196');
+  assert.equal(ficha.ruta, '/libro/MLU1453287196/grandes-clasicos');
+
+  const fichaPausada = fireWhatsAppClick('/libro/MLU1453287196/grandes-clasicos', {
+    href: 'https://wa.me/1',
+    hasStockBadge: false,
+  });
+  assert.equal(fichaPausada.origen, 'ficha_pausada');
+  assert.equal(fichaPausada.libro_id, 'MLU1453287196');
+
+  const header = fireWhatsAppClick('/libro/MLU1453287196/grandes-clasicos', {
+    href: 'https://wa.me/1',
+    inHeader: true,
+  });
+  assert.equal(header.origen, 'header');
+  assert.equal(header.libro_id, 'MLU1453287196');
+
+  const otro = fireWhatsAppClick('/contacto', { href: 'https://wa.me/1' });
+  assert.equal(otro.origen, 'otro');
+  assert.equal(otro.libro_id, '');
 });
 
 test('trackCommerce normaliza el producto y no duplica purchase al recargar', () => {

--- a/functions/__tests__/paused-cohort-observability.test.js
+++ b/functions/__tests__/paused-cohort-observability.test.js
@@ -72,6 +72,10 @@ test('whatsapp_click incluye availability_type en fichas sin enviar datos person
     cta_location: 'primary',
     product_id: 'MLU123',
     availability_type: 'by_request',
+    origen: 'ficha_pausada',
+    ruta: '/libro/MLU123/libro-de-prueba',
+    libro_id: 'MLU123',
+    transport_type: 'beacon',
   });
   assert.equal(JSON.stringify(event[2]).includes('@'), false);
 });


### PR DESCRIPTION
## Objetivo

Registrar en GA4 cada clic a WhatsApp desde amadolibros.com con los parámetros `origen`, `ruta` y `libro_id`, para poder marcarlo como evento clave e importarlo como conversión en Google Ads y Meta.

## Hallazgo antes de implementar

`whatsapp_click` **ya existe en Producción** desde el PR #154/#161 (main desde 2026-08-17), con un listener delegado a nivel documento que ya detecta los tres dominios de WhatsApp (`wa.me`, `api.whatsapp.com`, `web.whatsapp.com`) y ya envía `page_type`, `cta_location`, `product_id`, `availability_type`, `topic`.

Para no romper nada que ya se haya armado en GA4 sobre ese esquema, este PR **extiende** el mismo evento en vez de reemplazarlo: agrega `origen`, `ruta`, `libro_id` y `transport_type=beacon`, conservando los parámetros existentes intactos.

## Qué incorpora

- **Un único listener delegado ya existente** en `astro-front/public/analytics-events.js` (no se tocó ningún componente individual, no hay listeners nuevos).
- `origen`: `home` / `catalogo` / `ficha` / `ficha_pausada` / `header` / `otro`, derivado de la ruta actual y, cuando el clic se origina dentro de `<header>`, del elemento clickeado (el header aparece en todas las páginas, así que ese caso no se puede derivar solo de la ruta).
  - `ficha` vs `ficha_pausada` se distingue igual que ya lo hacía `availability_type` (presencia de `.badge.in-stock` en el DOM).
- `ruta`: `window.location.pathname`.
- `libro_id`: el ID de la ficha (`MLU...`) cuando la página es una ficha (activa o pausada); vacío en el resto.
- `transport_type: 'beacon'`: el evento se envía por beacon para que llegue aunque el clic navegue fuera del sitio de inmediato; no se llama `preventDefault()` en ningún punto, así que la navegación nunca se bloquea ni se demora.
- Sin datos personales ni número de teléfono: solo se envían ruta/ID de producto/origen derivado.
- Sin librerías nuevas.

## Tests

- `functions/__tests__/analytics-events.test.js`: nuevo test que simula clics reales sobre los tres dominios de WhatsApp y verifica que el listener arma `origen`/`ruta`/`libro_id`/`transport_type` correctamente para home, catálogo, ficha activa, ficha pausada, header y "otro"; también verifica que un enlace no-WhatsApp no dispara nada.
- Se actualizaron los dos tests preexistentes con `assert.deepEqual` estricto sobre los parámetros de `whatsapp_click` (`functions/__tests__/analytics-events.test.js` y `functions/__tests__/paused-cohort-observability.test.js`) para incluir los parámetros nuevos sin perder cobertura de los existentes.
- `bash scripts/validate-ci.sh` completo corrido localmente: 1170/1170 tests OK, builds checkout ON/OFF OK.

## No tocado (según restricciones del ticket)

Catálogo, sync, feed, sitemap, Merchant, MercadoLibre, MercadoPago, páginas SSR de producto, configuración del Worker. Cambios limitados a `astro-front/public/analytics-events.js` + tests.

## Pendiente (fuera de lo que se puede hacer desde este entorno)

- **Verificación en Preview con el informe de tiempo real de GA4**: este entorno no tiene acceso a un navegador con sesión de Google ni al deploy de Preview en vivo, así que no pude generar capturas del evento llegando a GA4 Realtime/DebugView. Recomiendo que quien revise el PR haga clic en un enlace de WhatsApp en Preview y confirme `whatsapp_click` con `origen`/`ruta`/`libro_id` en GA4 Realtime antes de aprobar.
- Marcar `whatsapp_click` como evento clave en GA4 (Administrar → Eventos clave) e importarlo en Google Ads (Objetivos → Conversiones → Importar desde GA4) — puede tardar hasta 24h en aparecer disponible para marcar como clave.

## Modo de entrega

Rama propia, PR en **draft**, CI en verde. **No mergear a main ni desplegar a Producción sin autorización escrita de Seba.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM)_