### PR TITLE
Conservar la portada real en Product.image y detectar su ausencia

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -101,6 +101,12 @@ jobs:
           done
           exit 1
 
+      - name: Verify reported missing Product.image on isolated Preview
+        if: github.head_ref == 'codex/product-image-fallback'
+        env:
+          COMMERCE_BASE_URL: ${{ steps.deploy.outputs.preview_url }}
+        run: node scripts/commerce/product-image-preview-check.mjs
+
       - name: Verify exact native cover bytes on Preview
         if: github.head_ref == 'codex/catalog-image-system'
         env:

--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -1,5 +1,13 @@
 # ESTADO ACTUAL — B11: enriquecimiento editorial real (2.000 fichas)
 
+## Corrección de imagen declarada para Google — 2026-09-09
+
+- Producción comprobada en [run 34342149786](https://github.com/trexxeseba/amadolibros-web/actions/runs/34342149786): MLU651526046 responde 200 con Product y Offer, pero sin image; portada R2 426×500 y HTTP 200. No hay evidencia de fallo de lectura del índice en esa solicitud.
+- Preparación en codex/product-image-fallback: si la selección de alta calidad está vacía se conserva la primera foto real; si no existe ninguna, se omite sin inventar logo y el auditor lo marca. Se mantiene la preferencia por fotos calificadas y la galería.
+- 27 pruebas focales correctas: handler en modo producción con 426×500, índice ausente/corrupto/inaccesible, secundaria de calidad y producto sin foto; detector de JSON-LD real incluyendo @graph e ImageObject.
+- CI y Preview pendientes al registrar este avance. No fusionado ni desplegado a la tienda.
+
+
 ## Incidente activo de portadas y catálogo — 2026-09-07
 
 - Responsable: Codex. Esfuerzo: M. Prioridad operativa dentro de Merchant: recuperar las imágenes visibles y el catálogo antes de activar la aceleración #329.

--- a/PLAN-MAESTRO.md
+++ b/PLAN-MAESTRO.md
@@ -1,5 +1,10 @@
 # PLAN MAESTRO — B11: enriquecimiento editorial real del catálogo
 
+## Corrección Product.image — autorizada 2026-09-09
+
+Seba pide una solución final tras confirmar una ficha con foto real 426×500 y Product.image ausente. Alcance: conservar una portada existente cuando el filtro de calidad quede vacío, cubrir el caso de índice inaccesible y verificar Product.image en la auditoría. Rama acotada desde main; no merge ni despliegue productivo sin aprobación de la revisión validada. El monitor privado se amplía en ADMIN-WEB-01. No se cambian el feed, el umbral de calidad del mirror ni los trabajos del índice público de #333.
+
+
 ## 🎯 Gran Apuesta en curso — Google Merchant Center
 
 Este documento es la única fuente de prioridades del proyecto. Seba

--- a/functions/__tests__/full-commerce-audit.test.js
+++ b/functions/__tests__/full-commerce-audit.test.js
@@ -74,11 +74,11 @@ test('distingue una ficha indexable de un Preview protegido', () => {
   const page = robots => `<!doctype html><html><head>
     <meta name="robots" content="${robots}">
     <link rel="canonical" href="https://www.amadolibros.com/libro/MLU123456/libro-real">
-    <title>Libro real</title><script type="application/ld+json">{"@type":"Book"}</script>
+    <title>Libro real</title><script type="application/ld+json">{"@type":"Product","image":"https://www.amadolibros.com/book-cover/MLU123456/cover.jpg"}</script>
   </head><body><h1>Libro real</h1></body></html>`;
   const url = 'https://preview.example/libro/MLU123456/libro-real';
   assert.deepEqual(inspectProductHtml(page('index, follow'), url, { expectIndexable: true }).issues, []);
   assert.deepEqual(inspectProductHtml(page('noindex, follow'), url, { expectIndexable: false }).issues, []);
   assert.ok(inspectProductHtml(page('index, follow'), url, { expectIndexable: false }).issues.includes('PREVIEW_INDEXABLE'));
-  assert.equal(inspectProductHtml(page('index, follow').replace('"@type":"Book"', '"@type":["Product","Book"]'), url).product_schema, true);
+  assert.equal(inspectProductHtml(page('index, follow').replace('"@type":"Product"', '"@type":["Product","Book"]'), url).product_schema, true);
 });

--- a/functions/__tests__/image-source-policy.test.js
+++ b/functions/__tests__/image-source-policy.test.js
@@ -35,7 +35,7 @@ test('JSON-LD respeta imágenes verificadas sin esconder la galería visible', (
   const filtered = renderPage(item,'libro-de-prueba',false,'','',[],[good]);
   assert.deepEqual(productSchema(filtered).image,[good]);
   const pending = renderPage(item,'libro-de-prueba',false,'','',[],[]);
-  assert.equal(productSchema(pending).image,undefined);
+  assert.deepEqual(productSchema(pending).image,['https://www.amadolibros.com/book-cover/MLU123456/cover.jpg']);
   assert.match(pending,/cover-2\.jpg/);
 });
 

--- a/functions/__tests__/product-image-fallback.test.js
+++ b/functions/__tests__/product-image-fallback.test.js
@@ -61,3 +61,9 @@ test('detector lee Product de @graph; og:image y otros esquemas no ocultan su au
     assert.ok(inspectProductImages(schema({ '@type':'Product',image:invalid })).issues.includes('PRODUCT_IMAGE_INVALID'));
   assert.ok(inspectProductImages('<script type="application/ld+json">broken</script>').issues.includes('PRODUCT_JSONLD_INVALID'));
 });
+test('auditor conserva fichas editoriales Book; no permite que Book oculte un Product sin imagen', () => {
+  const book='<script type="application/ld+json">{"@type":"Book","name":"Libro"}</script>';
+  assert.deepEqual(inspectProductImages(book,{allowBookOnly:true}).issues,[]);
+  assert.ok(inspectProductImages(book).issues.includes('PRODUCT_SCHEMA_MISSING'));
+  assert.ok(inspectProductImages(book+'<script type="application/ld+json">{"@type":"Product"}</script>',{allowBookOnly:true}).issues.includes('PRODUCT_IMAGE_MISSING'));
+});

--- a/functions/__tests__/product-image-fallback.test.js
+++ b/functions/__tests__/product-image-fallback.test.js
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { onRequest, renderPage } from '../libro/[[path]].js';
+import { CATALOG_URL } from '../_shared/catalog.js';
+import { inspectProductImages } from '../../shared/product-image-audit.js';
+import { inspectProductHtml } from '../../scripts/commerce/full-commerce-audit.mjs';
+
+const id = 'MLU123456'; const slug = 'libro-de-prueba';
+const url = `https://www.amadolibros.com/libro/${id}/${slug}`;
+const sources = ['https://http2.mlstatic.com/D_FIRST-O.jpg', 'https://http2.mlstatic.com/D_SECOND-O.jpg'];
+const item = { id, title: 'Libro de prueba', price: 500, currency: 'UYU', status: 'active', available_quantity: 1, pictures: sources };
+const image = position => `https://www.amadolibros.com/book-cover/${id}/${position ? 'cover-2.jpg' : 'cover.jpg'}`;
+const entry = (position, width, height) => ({ current: {
+  object_key: `covers/v1/objects/${String(position + 1).repeat(64)}.jpg`, sha256: String(position + 1).repeat(64),
+  mime: 'image/jpeg', source_url: sources[position], width, height,
+} });
+
+async function page(bucket) {
+  const previous = globalThis.caches;
+  globalThis.caches = { default: { match: async request => request.url === CATALOG_URL ? Response.json({ items: [item] }) : undefined } };
+  try {
+    const response = await onRequest({ request: new Request(url), params: { path: [id, slug] }, data: {},
+      env: { APP_ENV: 'production', COVER_GOOGLE_QUALITY_GATE: 'true', COVER_R2: bucket } });
+    assert.equal(response.status, 200);
+    return await response.text();
+  } finally { if (previous) globalThis.caches = previous; else delete globalThis.caches; }
+}
+const bucket = entries => ({ get: async () => ({ text: async () => JSON.stringify({ schema_version: 1, entries }) }) });
+
+test('regresión 426×500: el handler productivo conserva portada y oferta', async () => {
+  const html = await page(bucket({ [`${id}:0`]: entry(0,426,500) }));
+  assert.deepEqual(inspectProductImages(html).products[0].images, [image(0)]);
+  assert.deepEqual(inspectProductHtml(html,url).issues, []);
+  assert.match(html, /"@type":"Offer"/);
+});
+test('índice ausente, corrupto o inaccesible conserva la foto real sin esconder la falla', async () => {
+  for (const data of [
+    { get: async () => null },
+    { get: async () => ({ text: async () => '{invalid' }) },
+    { get: async () => { throw new Error('R2 unavailable'); } },
+  ]) assert.deepEqual(inspectProductImages(await page(data)).products[0].images, [image(0)]);
+});
+test('se prefiere una secundaria de calidad y se conserva la galería', async () => {
+  const html = await page(bucket({ [`${id}:0`]: entry(0,426,500), [`${id}:1`]: entry(1,800,1000) }));
+  assert.deepEqual(inspectProductImages(html).products[0].images, [image(1)]);
+  assert.match(html, /class="cover-main"/);
+  assert.match(html, /data-idx="1"/);
+});
+test('sin fotos reales no inventa logo ni una imagen vacía y la auditoría lo detecta', () => {
+  const html = renderPage({ ...item, pictures: [], thumbnail: '' },slug,false,'','',[],[]);
+  const result = inspectProductImages(html);
+  assert.deepEqual(result.products[0].images, []);
+  assert.ok(inspectProductHtml(html,url).issues.includes('PRODUCT_IMAGE_MISSING'));
+});
+test('detector lee Product de @graph; og:image y otros esquemas no ocultan su ausencia', () => {
+  const schema = object => `<meta property="og:image" content="${image(0)}"><script type="application/ld+json">${JSON.stringify(object)}</script>`;
+  assert.ok(inspectProductImages(schema({ '@graph': [{ '@type':'Organization', image:image(0) }, { '@type':['Book','Product'], sku:id }] })).issues.includes('PRODUCT_IMAGE_MISSING'));
+  assert.deepEqual(inspectProductImages(schema({ '@type':'Product',image:[{ '@type':'ImageObject',contentUrl:image(0) }] })).issues, []);
+  for (const invalid of ['', [], null]) assert.ok(inspectProductImages(schema({ '@type':'Product',image:invalid })).issues.includes('PRODUCT_IMAGE_MISSING'));
+  for (const invalid of ['javascript:alert(1)', '/relative.jpg', 'https://www.amadolibros.com/images/logo-amado.webp'])
+    assert.ok(inspectProductImages(schema({ '@type':'Product',image:invalid })).issues.includes('PRODUCT_IMAGE_INVALID'));
+  assert.ok(inspectProductImages('<script type="application/ld+json">broken</script>').issues.includes('PRODUCT_JSONLD_INVALID'));
+});

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -560,14 +560,16 @@ export function renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverS
         '@context': 'https://schema.org',
         '@type':    ['Product', 'Book'],
         'name':     item.title,
-        'image':    images.length ? images : img,
+        ...(images.length ? { image: images } : {}),
         'description': description || (displayAuthor ? `${item.title} — ${displayAuthor}` : item.title),
         'sku':      item.id,
     };
-    if (googleImages !== null) {
-        if (googleImages.length) schemaProduct.image = googleImages;
-        else delete schemaProduct.image;
-    }
+    // La calidad determina la preferencia, no la existencia de la foto.
+    // [] también puede significar que falló la lectura del índice de R2.
+    // Conservamos la primera portada real de la galería en ambos casos;
+    // si no existe ninguna, no inventamos una ni usamos el logo.
+    if (googleImages?.length) schemaProduct.image = googleImages;
+    else if (googleImages !== null && images.length) schemaProduct.image = images.slice(0, 1);
     if (sellableInCheckout) {
         schemaProduct.offers = {
             '@type':        'Offer',

--- a/scripts/commerce/full-commerce-audit.mjs
+++ b/scripts/commerce/full-commerce-audit.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { inspectCoverBytes } from '../../worker-sync/cover-mirror.js';
 import { isBookProduct } from '../../functions/feed.xml.js';
+import { inspectProductImages } from '../../shared/product-image-audit.js';
 
 const DEFAULT_BASE_URL = 'https://www.amadolibros.com';
 const DEFAULT_CATALOG_URL = 'https://pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev/catalog.json';
@@ -236,7 +237,8 @@ export function inspectProductHtml(html, requestedUrl, { expectIndexable = true 
   const canonical = htmlValue(html, /<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']+)/i);
   const titleValue = htmlValue(html, /<title>([\s\S]*?)<\/title>/i);
   const h1 = htmlValue(html, /<h1[^>]*>([\s\S]*?)<\/h1>/i).replace(/<[^>]+>/g, '').trim();
-  const productSchema = /"@type"\s*:\s*(?:"(?:Product|Book)"|\[[^\]]*"(?:Product|Book)")/i.test(html);
+  const imageInspection = inspectProductImages(html);
+  const productSchema = imageInspection.products.length > 0;
   const noindex = /\bnoindex\b/i.test(robots);
   const issues = [];
   if (expectIndexable && noindex) issues.push('NOINDEX_LIVE');
@@ -244,7 +246,7 @@ export function inspectProductHtml(html, requestedUrl, { expectIndexable = true 
   if (!canonical) issues.push('CANONICAL_MISSING');
   if (!titleValue) issues.push('TITLE_MISSING');
   if (!h1) issues.push('H1_MISSING');
-  if (!productSchema) issues.push('PRODUCT_SCHEMA_MISSING');
+  issues.push(...imageInspection.issues);
   let canonicalMatches = false;
   try { canonicalMatches = new URL(canonical).pathname === new URL(requestedUrl).pathname; } catch {}
   if (canonical && !canonicalMatches) issues.push('CANONICAL_PATH_MISMATCH');

--- a/scripts/commerce/full-commerce-audit.mjs
+++ b/scripts/commerce/full-commerce-audit.mjs
@@ -237,8 +237,10 @@ export function inspectProductHtml(html, requestedUrl, { expectIndexable = true 
   const canonical = htmlValue(html, /<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']+)/i);
   const titleValue = htmlValue(html, /<title>([\s\S]*?)<\/title>/i);
   const h1 = htmlValue(html, /<h1[^>]*>([\s\S]*?)<\/h1>/i).replace(/<[^>]+>/g, '').trim();
-  const imageInspection = inspectProductImages(html);
-  const productSchema = imageInspection.products.length > 0;
+  // Las fichas editoriales Book sin Product ya estaban admitidas. Esta
+  // comprobación agrega image a los Product, sin cambiar esa política.
+  const imageInspection = inspectProductImages(html, { allowBookOnly: true });
+  const productSchema = imageInspection.products.length > 0 || imageInspection.hasBook;
   const noindex = /\bnoindex\b/i.test(robots);
   const issues = [];
   if (expectIndexable && noindex) issues.push('NOINDEX_LIVE');

--- a/scripts/commerce/product-image-preview-check.mjs
+++ b/scripts/commerce/product-image-preview-check.mjs
@@ -14,3 +14,13 @@ assert.deepEqual(result.issues, []);
 assert.ok(result.products.some(p => p.sku === 'MLU651526046' && p.images.length > 0));
 console.log(JSON.stringify({ status: 'reported_product_preview_verified', url: response.url,
   checkedAt: new Date().toISOString(), productId: 'MLU651526046', imagePresent: true, noindex: true }));
+// Clasificar dos páginas señaladas por la nueva lectura estricta del auditor.
+// No altera el veredicto de la auditoría ni modifica los datos de las fichas.
+for (const path of ['/libro/MLU603140534/astromostra-guia-astrologica-para-sobrevivir-en-la-tierra',
+  '/libro/MLU609552990/realismo-imaginativo-james-gurney']) {
+  const r = await fetch(new URL(path,base),{signal:AbortSignal.timeout(30000)});
+  const body = await r.text();
+  console.log(JSON.stringify({status:'product_schema_audit_diagnostic',path,httpStatus:r.status,
+    inspection:inspectProductImages(body,{allowBookOnly:true}),
+    ldScriptTags:[...body.matchAll(/<script\b[^>]*>/gi)].map(m=>m[0]).filter(t=>t.includes('ld+json')).map(t=>t.slice(0,180))}));
+}

--- a/scripts/commerce/product-image-preview-check.mjs
+++ b/scripts/commerce/product-image-preview-check.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { inspectProductImages } from '../../shared/product-image-audit.js';
+const base = new URL(process.env.COMMERCE_BASE_URL);
+assert.match(base.hostname, /(?:^|\.)amadolibros-web\.pages\.dev$/);
+assert.equal(base.protocol, 'https:');
+const path = '/libro/MLU651526046/big-english-1-british-pupil-s-book-pearson';
+const response = await fetch(new URL(path, base), { signal: AbortSignal.timeout(30000) });
+assert.equal(response.status, 200, 'Ficha de Preview no disponible');
+assert.equal(new URL(response.url).origin, base.origin, 'La comprobación salió del Preview');
+const html = await response.text();
+assert.match(html, /name="robots"[^>]+noindex/);
+const result = inspectProductImages(html);
+assert.deepEqual(result.issues, []);
+assert.ok(result.products.some(p => p.sku === 'MLU651526046' && p.images.length > 0));
+console.log(JSON.stringify({ status: 'reported_product_preview_verified', url: response.url,
+  checkedAt: new Date().toISOString(), productId: 'MLU651526046', imagePresent: true, noindex: true }));

--- a/shared/product-image-audit.js
+++ b/shared/product-image-audit.js
@@ -1,11 +1,12 @@
 // Función autónoma compartida por la auditoría HTTP y el monitor externo.
 // Inspecciona el HTML recibido del servidor; no confunde og:image con Product.image.
-export function inspectProductImages(html) {
-  const products = []; const issues = new Set();
+export function inspectProductImages(html, { allowBookOnly = false } = {}) {
+  const products = []; const issues = new Set(); let hasBook = false;
   const visit = value => {
     if (Array.isArray(value)) { value.forEach(visit); return; }
     if (!value || typeof value !== 'object') return;
     const types = Array.isArray(value['@type']) ? value['@type'] : [value['@type']];
+    if (types.includes('Book')) hasBook = true;
     if (types.includes('Product')) {
       const raw = Array.isArray(value.image) ? value.image : [value.image];
       const urls = raw.map(image => typeof image === 'string' ? image : image?.contentUrl || image?.url);
@@ -27,6 +28,6 @@ export function inspectProductImages(html) {
     if (!/(?:^|\s)type\s*=\s*["']application\/ld\+json["']/i.test(match[1])) continue;
     try { visit(JSON.parse(match[2])); } catch { issues.add('PRODUCT_JSONLD_INVALID'); }
   }
-  if (!products.length) issues.add('PRODUCT_SCHEMA_MISSING');
-  return { products, issues: [...issues] };
+  if (!products.length && !(allowBookOnly && hasBook)) issues.add('PRODUCT_SCHEMA_MISSING');
+  return { products, hasBook, issues: [...issues] };
 }

--- a/shared/product-image-audit.js
+++ b/shared/product-image-audit.js
@@ -1,0 +1,32 @@
+// Función autónoma compartida por la auditoría HTTP y el monitor externo.
+// Inspecciona el HTML recibido del servidor; no confunde og:image con Product.image.
+export function inspectProductImages(html) {
+  const products = []; const issues = new Set();
+  const visit = value => {
+    if (Array.isArray(value)) { value.forEach(visit); return; }
+    if (!value || typeof value !== 'object') return;
+    const types = Array.isArray(value['@type']) ? value['@type'] : [value['@type']];
+    if (types.includes('Product')) {
+      const raw = Array.isArray(value.image) ? value.image : [value.image];
+      const urls = raw.map(image => typeof image === 'string' ? image : image?.contentUrl || image?.url);
+      const present = urls.filter(url => typeof url === 'string' && url.trim());
+      const valid = present.filter(url => {
+        try {
+          const u = new URL(url);
+          return ['https:', 'http:'].includes(u.protocol) && !u.username && !u.password &&
+            !/^\/images\/logo-amado\.(webp|svg|png|jpe?g)$/i.test(u.pathname);
+        } catch { return false; }
+      });
+      if (!present.length) issues.add('PRODUCT_IMAGE_MISSING');
+      else if (valid.length !== urls.length) issues.add('PRODUCT_IMAGE_INVALID');
+      products.push({ sku: typeof value.sku === 'string' ? value.sku : null, images: valid });
+    }
+    Object.values(value).forEach(visit);
+  };
+  for (const match of String(html || '').matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi)) {
+    if (!/(?:^|\s)type\s*=\s*["']application\/ld\+json["']/i.test(match[1])) continue;
+    try { visit(JSON.parse(match[2])); } catch { issues.add('PRODUCT_JSONLD_INVALID'); }
+  }
+  if (!products.length) issues.add('PRODUCT_SCHEMA_MISSING');
+  return { products, issues: [...issues] };
+}


### PR DESCRIPTION
La ficha MLU651526046 responde 200 y tiene una portada R2 válida de 426×500, pero el filtro interno elimina Product.image porque exige ambas dimensiones >=500. El mismo resultado puede ocurrir si no se puede leer el índice de portadas; esto último es un riesgo reproducido, no la causa demostrada de esa petición. Evidencia real: https://github.com/trexxeseba/amadolibros-web/actions/runs/34342149786.

Este cambio conserva la primera foto real de la galería cuando la selección de alta calidad queda vacía; mantiene la preferencia por imágenes calificadas. Si no hay foto, no inventa un logo. La auditoría analiza el JSON-LD y detecta imagen ausente/inválida, incluyendo Product en @graph e ImageObject. Conserva el contrato previo para fichas editoriales Book sin oferta; un Book nunca oculta un Product sin imagen.

Código validado: 462d729157c51af0e9eff19310688cac4d32de02.
- Pruebas focales correctas: handler productivo con 426×500, índice ausente/corrupto/inaccesible, secundaria de calidad y producto sin foto.
- CI: https://github.com/trexxeseba/amadolibros-web/actions/runs/34359782848 — success.
- Preview completo: https://github.com/trexxeseba/amadolibros-web/actions/runs/34359782792 — success. La ficha reportada tiene Product.image; 80/80 imágenes y 80/80 páginas auditadas, cero fallas críticas.
- La primera auditoría encontró 23 fichas Book sin Product. Se verificaron ejemplos reales y se restauró el contrato editorial previo antes de aprobar la corrida completa.

Feed, mirror, galería, checkout y cambios de rendimiento de #333 conservan su implementación. Seba aclaró que el panel avanzó en otro chat: la ampliación de monitoreo se detuvo; no se declara un control automático de Product.image activo.

Draft: no fusionado ni desplegado a producción. La aprobación de Seba debe referirse a esta revisión validada. Después de publicar corresponde verificar la URL productiva y luego la actualización de Google tras su rastreo; la aprobación interna no demuestra un resultado en Search Console.