### PR TITLE
Cerrar verificación de imágenes y evitar catálogo/feed desactualizados tras sync

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -102,7 +102,7 @@ jobs:
           exit 1
 
       - name: Verify reported missing Product.image on isolated Preview
-        if: github.head_ref == 'codex/product-image-fallback' || github.head_ref == 'codex/cover-public-index'
+        if: github.head_ref == 'codex/product-image-fallback' || github.head_ref == 'codex/cover-public-index' || github.head_ref == 'codex/images-production-verify'
         env:
           COMMERCE_BASE_URL: ${{ steps.deploy.outputs.preview_url }}
         run: node scripts/commerce/product-image-preview-check.mjs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -291,7 +291,7 @@ jobs:
         run: |
           STATUS_CODE=""
           for attempt in 1 2 3 4 5 6 7 8; do
-            STATUS_CODE="$(curl -sS --max-time 30 -o /tmp/cover-r2-status.json -w '%{http_code}' \
+            STATUS_CODE="$(curl -sS --retry 2 --retry-all-errors --retry-delay 2 --max-time 30 -o /tmp/cover-r2-status.json -w '%{http_code}' \
               'https://www.amadolibros.com/preview-cover/status')"
             [ "$STATUS_CODE" = "200" ] && break
             echo "Portadas R2 todavía propagándose (intento $attempt/8; HTTP $STATUS_CODE)."
@@ -310,7 +310,7 @@ jobs:
           ')"
           BOOK_CODE=""
           for attempt in 1 2 3 4 5 6 7 8; do
-            BOOK_CODE="$(curl -sSL --max-time 60 -o /tmp/cover-r2-book.html -w '%{http_code}' \
+            BOOK_CODE="$(curl -sSL --retry 2 --retry-all-errors --retry-delay 2 --max-time 60 -o /tmp/cover-r2-book.html -w '%{http_code}' \
               "https://www.amadolibros.com/libro/$SAMPLE_ID")"
             if [ "$BOOK_CODE" = "200" ] && grep -Fq "/book-cover/$SAMPLE_ID/cover.jpg" /tmp/cover-r2-book.html; then
               break
@@ -323,7 +323,7 @@ jobs:
             exit 1
           fi
           IMAGE_PATH="/book-cover/$SAMPLE_ID/cover.jpg"
-          curl -fsS --max-time 60 -D /tmp/cover-r2-image.headers \
+          curl -fsS --retry 2 --retry-all-errors --retry-delay 2 --max-time 60 -D /tmp/cover-r2-image.headers \
             "https://www.amadolibros.com$IMAGE_PATH?smoke=${{ github.sha }}" -o /tmp/cover-r2-image.bin
           tr -d '\r' < /tmp/cover-r2-image.headers | grep -Eqi '^content-type: image/(jpeg|png|webp)$'
           tr -d '\r' < /tmp/cover-r2-image.headers | grep -Fqi 'x-cover-source: r2-production'

--- a/.github/workflows/images-production-verification.yml
+++ b/.github/workflows/images-production-verification.yml
@@ -1,0 +1,39 @@
+name: Verify published image solution
+on:
+  push:
+    branches: [codex/images-production-verify]
+permissions:
+  contents: read
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: 305de731510f816af2fa0306d16bcce34d71b6dc
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+      - name: Verify Google image, public index and actual desktop/mobile scroll
+        run: |
+          npm install --prefix "$RUNNER_TEMP/amado-image-qa" --no-audit --no-fund playwright@1.62.1
+          node "$RUNNER_TEMP/amado-image-qa/node_modules/playwright/cli.js" install --with-deps chromium
+          node scripts/commerce/images-live-check.mjs "$RUNNER_TEMP/amado-image-qa/node_modules/playwright/index.mjs"
+      - name: Audit 300 live images and product pages
+        if: ${{ !cancelled() }}
+        env:
+          COMMERCE_OUTPUT_DIR: artifacts/commerce
+          COMMERCE_IMAGE_LIMIT: '300'
+          COMMERCE_PAGE_LIMIT: '300'
+          COMMERCE_CONCURRENCY: '12'
+          COMMERCE_EXPECT_INDEXABLE: 'true'
+          COMMERCE_FAIL_ON_CRITICAL: 'true'
+        run: node scripts/commerce/full-commerce-audit.mjs
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: published-images-${{ github.run_id }}
+          path: artifacts/commerce/
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/images-production-verification.yml
+++ b/.github/workflows/images-production-verification.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: 305de731510f816af2fa0306d16bcce34d71b6dc
+          ref: ${{ github.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version: '22.12.0'
@@ -30,6 +30,14 @@ jobs:
           COMMERCE_EXPECT_INDEXABLE: 'true'
           COMMERCE_FAIL_ON_CRITICAL: 'true'
         run: node scripts/commerce/full-commerce-audit.mjs
+      - name: Explain current feed discrepancies
+        if: always()
+        run: |
+          node --input-type=module -e '
+            import fs from "node:fs";
+            const name = fs.readdirSync("artifacts/commerce").find(x => x.startsWith("full-commerce-audit-") && x.endsWith(".json"));
+            if (name) { const r=JSON.parse(fs.readFileSync("artifacts/commerce/"+name)); console.log(JSON.stringify({feed:r.feed})); }
+          '
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/ESTADO-ACTUAL.md
+++ b/ESTADO-ACTUAL.md
@@ -1,12 +1,13 @@
 # ESTADO ACTUAL — B11: enriquecimiento editorial real (2.000 fichas)
 
-## Cierre de imágenes autorizado — 2026-09-09
+## Imágenes publicadas y verificadas — 2026-09-09
 
-- Seba pidió ejecutar la solución final y robusta después de revisar #333 y #336. Esta instrucción autoriza integrar, fusionar, desplegar y comprobar ambos arreglos. No requiere otra aprobación de publicación.
-- Se integra #336 (462d729) en #333 (902c7eb) y se incorpora main 1aaaba8. El único conflicto es documental; se conserva el historial de ambas correcciones.
-- Product.image: evidencia productiva 34342149786, portada 426×500 válida excluida por el filtro. El fallback preserva la primera foto real si la selección queda vacía, incluso ante un índice inaccesible. PR #336 ya pasó CI 34359782848 y Preview 34359782792: ficha reportada y auditoría 80/80 páginas/imágenes, cero críticos.
-- Se añade una comprobación de producción tras cada despliegue: índice público activo, Product.image, bytes de portadas y scroll real en Chromium de escritorio y móvil. Los resultados se conservan por URL; no se declara producción resuelta antes de la corrida real.
-- Panel privado fuera del alcance. Publicación y aceptación conjunta en curso.
+- #333 y #336 fusionados en main `305de731` con autorización completa de Seba. Pages `34363553956` success en el segundo intento; el primero cortó una comprobación GET por conexión reiniciada. Worker Sync `34363553916` success, catálogo 7.105 y 79.116 referencias en 256 fragmentos publicados; cero fallas del mirror. Checkout sin cambios.
+- Aceptación conjunta `9a1ab427`: CI `34362856125`, 1.720 pruebas y ambos builds; Preview `34362856257`; índice real `34362856142`, 154/154 imágenes, 4/4 páginas, 79.116 referencias preservadas y recuperación de escritura comprobada. Mediana del handler controlado 4.868 → 598 ms, no medición desde Uruguay.
+- Producción `34365186356`: Product.image presente en MLU651526046, cinco portadas HTTP 200/R2/public-index; 126 observaciones de imagen correctas en Chromium de escritorio y móvil, incluidas 48/48 portadas de Psicología en cada viewport. Muestra ampliada: 300/300 imágenes y 300/300 páginas correctas. Artefacto `10109592201` con JSON y capturas. No se afirma cobertura de todo dispositivo o del rastreo de Google.
+- Corrección del test: las portadas del inicio tienen animación continua; esperar inmovilidad era incorrecto. Se usa scroll nativo y se recorren las imágenes visibles también en móvil, conservando la animación y la detección de fallas.
+- Hallazgo adicional al verificar: el feed retuvo cuatro ofertas retiradas y 16 precios anteriores tras el sync. El catálogo interno admitía una hora de caché y el feed seis. Se reduce a 60 s cada caché mutable y se descartan copias cuya duración declarada exceda la nueva política, incluidas las horarias anteriores. El origen y los datos no se modifican; el checkout conserva su índice versionado. Prueba reproduce la copia antigua, la renovación y la reutilización acotada. Esta corrección final y el test de scroll se preparan en revisión; aceptación postpublicación pendiente en este registro.
+- Panel privado fuera del alcance. Evidencias de fallos intermedios conservadas; no se presenta la auditoría general en verde mientras existan diferencias del feed.
 
 ## Historial: índice rápido y scroll verificados en Preview — 2026-09-08
 

--- a/PLAN-MAESTRO.md
+++ b/PLAN-MAESTRO.md
@@ -2,7 +2,7 @@
 
 ## Cierre de imágenes — ejecución completa autorizada 2026-09-09
 
-Seba pidió «una solución final y robusta» y «hace todo lo que debés hacer» tras revisar los arreglos #333 y #336. Autoriza integrarlos, fusionarlos, desplegarlos y verificar producción. Responsable: Codex. Alcance: índice público pequeño y atómico para todas las portadas, fallback de Product.image y control automático después del despliegue con HTTP, JSON-LD y scroll en escritorio/móvil. Se conserva el catálogo, el feed, los masters y la lógica del checkout. El panel privado se trabaja en otro chat. La aceptación exige evidencia real en la tienda, no sólo pruebas de Preview.
+Seba pidió «una solución final y robusta» y «hace todo lo que debés hacer» tras revisar los arreglos #333 y #336. Autoriza integrarlos, fusionarlos, desplegarlos y verificar producción. Responsable: Codex. Alcance: índice público pequeño y atómico para todas las portadas, fallback de Product.image y control automático después del despliegue con HTTP, JSON-LD y scroll en escritorio/móvil. Se conserva el catálogo, el feed, los masters y la lógica del checkout. El panel privado se trabaja en otro chat. La aceptación exige evidencia real en la tienda, no sólo pruebas de Preview. La verificación productiva confirmó las imágenes y detectó copias antiguas de catálogo/feed tras el sync; el cierre incluye acotar esas cachés a 60 segundos y corregir la espera del test sobre portadas animadas. No se cambian precios ni stock en su fuente.
 
 ## 🎯 Gran Apuesta en curso — Google Merchant Center
 

--- a/functions/__tests__/catalog-freshness.test.js
+++ b/functions/__tests__/catalog-freshness.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fetchCatalog, CATALOG_URL } from '../_shared/catalog.js';
+
+test('abandona la copia horaria previa, conserva la fuente y limita la nueva copia a 60 segundos', async () => {
+  const previousFetch = globalThis.fetch;
+  const previousCaches = globalThis.caches;
+  const stale = { updated_at: '2026-09-09T07:18:15.824Z', items: [{ id: 'MLU1', price: 1599 }, { id: 'MLU2' }] };
+  const fresh = { updated_at: '2026-09-09T14:29:29.348Z', items: [{ id: 'MLU1', price: 1543 }] };
+  const cache = new Map([[CATALOG_URL, Response.json(stale, { headers: { 'cache-control': 'public, max-age=3600' } })]]);
+  const writes = [];
+  const requests = [];
+  globalThis.caches = { default: {
+    async match(key) { return cache.get(key.url)?.clone() || null; },
+    async put(key, response) { writes.push([key.url, response.headers.get('cache-control')]); cache.set(key.url, response.clone()); },
+  } };
+  globalThis.fetch = async url => { requests.push(url); return Response.json(fresh); };
+  try {
+    const pending = [];
+    const ctx = { env: { APP_ENV: 'production' }, waitUntil(p) { pending.push(p); } };
+    assert.deepEqual(await fetchCatalog(ctx), fresh);
+    await Promise.all(pending);
+    assert.deepEqual(requests, [CATALOG_URL]);
+    assert.equal(writes[0][1], 'public, max-age=60');
+    assert.equal(writes[0][0], CATALOG_URL);
+    assert.deepEqual(await fetchCatalog(ctx), fresh);
+    assert.equal(requests.length, 1, 'la nueva copia sigue evitando descargas repetidas');
+    assert.deepEqual(await cache.get(CATALOG_URL).json(), fresh, 'la copia sustituida coincide con la fuente');
+  } finally { globalThis.fetch = previousFetch; globalThis.caches = previousCaches; }
+});

--- a/functions/_shared/catalog.js
+++ b/functions/_shared/catalog.js
@@ -18,6 +18,10 @@ async function fetchJsonCached(ctx, url, maxAge, timingName = 'catalog_fetch') {
     const cacheKey = new Request(url);
     const cacheStartedAt = perfNow();
     let response = await cache.match(cacheKey);
+    // Retire a cached response whose lifetime exceeds the current policy,
+    // including one-hour catalog entries already stored before this deploy.
+    const storedMaxAge = Number(response?.headers.get('cache-control')?.match(/(?:^|[,\s])max-age=(\d+)/i)?.[1] || 0);
+    if (storedMaxAge > maxAge) response = null;
     const cacheStatus = response ? 'hit' : 'miss';
     recordPerf(ctx, `${timingName}_cache`, cacheStartedAt, { cache: cacheStatus });
     if (!response) {
@@ -105,7 +109,9 @@ async function fetchGzipJsonCached(ctx, url, maxAge, timingName) {
 }
 
 export async function fetchCatalog(ctx) {
-    return fetchJsonCached(ctx, CATALOG_URL, 3600, 'catalog');
+    // Price/stock updates must reach the feed and product pages promptly.
+    // Existing one-hour entries are retired by fetchJsonCached above.
+    return fetchJsonCached(ctx, CATALOG_URL, 60, 'catalog');
 }
 
 // CF-R2-2-BRIDGE: única fuente de verdad de "qué manifest le corresponde a
@@ -290,7 +296,7 @@ export async function fetchActiveIndex(ctx) {
 }
 
 // Stock y precios de checkout deben seguir el manifiesto vigente (60 s), no
-// catalog.json cacheado durante una hora. El índice activo es versionado y es
+// una copia independiente de catalog.json. El índice activo es versionado y es
 // la misma fuente que publica el sincronizador para Producción y Preview.
 export async function fetchCheckoutCatalog(ctx) {
     const activeIndex = await fetchActiveIndex(ctx);

--- a/functions/feed.xml.js
+++ b/functions/feed.xml.js
@@ -130,7 +130,8 @@ export async function onRequest(context) {
         return new Response(feed, {
             headers: {
                 "content-type": "application/xml;charset=UTF-8",
-                "cache-control": `public, max-age=${pendingCovers > 0 ? 300 : 21600}`,
+                "cache-control": 'public, max-age=60',
+                ...(catalog?.updated_at ? { 'x-amado-catalog-updated-at': String(catalog.updated_at) } : {}),
                 "x-amado-feed-cover-pending": String(pendingCovers),
             },
         });

--- a/scripts/commerce/images-live-check.mjs
+++ b/scripts/commerce/images-live-check.mjs
@@ -82,17 +82,20 @@ try {
       assert.equal(new URL(page.url()).origin, base.origin, 'BROWSER_REDIRECT_OUTSIDE_SITE');
       const row = { path, navigationMs: Date.now() - started, images: [] };
       run.pages.push(row);
-      const selector = path === '/libros/psicologia' ? '.book-card img' : 'main img';
+      const selector = path === '/libros/psicologia' ? '.book-card img' :
+        path === '/' ? '.v2-cover img, .v2-book-cover img' : 'main img';
       await page.waitForSelector(selector, { timeout: 10000 });
       const images = page.locator(selector);
       const count = await images.count();
       assert.ok(count > 0, 'CONTENT_IMAGES_ABSENT');
       if (path === '/libros/psicologia') assert.ok(count >= 24, 'CATALOG_SAMPLE_TOO_SMALL');
       const limit = Math.min(count, path === '/libros/psicologia' ? 48 : 8);
-      for (let i = 0; i < limit; i++) {
+      for (let i = 0; i < count && row.images.length < limit; i++) {
         const image = images.nth(i);
         if (!await image.isVisible()) continue;
-        await image.scrollIntoViewIfNeeded();
+        // Covers on the home page intentionally float. Native scroll observes
+        // the real animation without waiting for a motionless bounding box.
+        await image.evaluate(img => img.scrollIntoView({ block: 'center', behavior: 'instant' }));
         const result = await image.evaluate(async img => {
           const start = performance.now();
           const original = img.currentSrc || img.src;


### PR DESCRIPTION
Publicado y verificado en producción el 9 de septiembre de 2026, con autorización completa de Seba. Main: fc6400ef465542ea90992bf91cc2c120f49e4b60. Pages: https://13944c60.amadolibros-web.pages.dev (despliegue productivo), job 102516751931 correcto.

La corrección de imágenes de #333/#336 ya estaba publicada. Este cierre arregla el test de las portadas animadas y elimina las copias antiguas del catálogo/feed que la verificación encontró tras la sincronización: cuatro ofertas retiradas y 16 precios anteriores.

Cambios:
- Catálogo y feed con caché mutable de 60 segundos cada uno. Las entradas que declaren la duración horaria anterior se descartan inmediatamente. Fuente y contenido intactos; checkout conserva su índice versionado.
- Scroll nativo compatible con la animación del inicio; muestra visible de escritorio y móvil. No se desactiva ni modifica la animación.
- Reintentos acotados en los GET de comprobación del deploy ante reinicio de conexión; no se reintentan escrituras.
- Comprobación de imágenes/Google/scroll integrada en la auditoría posterior a cada despliegue y en la revisión periódica existente.

Verificación final real: https://github.com/trexxeseba/amadolibros-web/actions/runs/34365936570/attempts/2 — success, job 102517120665, 14:54:53–14:55:54 UTC.
- MLU651526046 tiene Product.image. Las cinco portadas históricas responden 200, image/jpeg y r2-production mediante public-index.
- Chromium 1365×900 y 390×844: 8/8 imágenes del inicio, 48/48 de Psicología y 7/7 de la ficha en cada viewport; 126/126 observaciones, cero fallas.
- Muestra comercial: 300/300 imágenes válidas y 300/300 páginas correctas.
- Catálogo: 7.105 productos; feed: 3.694 ofertas únicas; cero discrepancias, cero advertencias y cero críticos.
- Artefacto final 10110206634 (SHA256 7196969937e4010005acc7c0fea82548bc0d2ae92fce8031c3863c11f80a1727) incluye JSON y seis capturas; retención hasta 2026-12-08.

CI 34365940715, Preview 34365940623 y aceptación de recursos 34365940320 pasaron antes del merge. La comprobación inicial contra la producción anterior permaneció roja por las 20 diferencias que este cambio corrige; no se ocultó ni se cambió el criterio para aprobar.

Alcance: mediciones desde runner remoto, sin simular conexión móvil lenta; 300 es una muestra. La espera medida tras desplazar el test no equivale al instante exacto de pintura. La imagen se entrega en la web real; no se afirma que Google ya haya actualizado Search Console. Panel privado fuera de este lote.