### PR TITLE
PANEL-BACKEND-1: cargar la contraseña del panel desde un secret de GitHub

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -238,6 +238,26 @@ jobs:
           printf '%s' "$GA4_API_SECRET" |
             npx wrangler@3.114.17 pages secret put GA4_API_SECRET --project-name amadolibros-web
 
+      - name: Sync panel password to Cloudflare Pages
+        # PANEL-BACKEND-1: la contraseña de /panel se carga como secret de
+        # GitHub y se sincroniza desde acá, para no depender de que alguien la
+        # cargue a mano en el panel de Cloudflare (donde una variable común se
+        # ignora: en este proyecto sólo los Secrets se administran ahí).
+        # A diferencia de los dos secrets de arriba, si falta NO corta el
+        # deploy: el panel ya falla cerrado solo (responde 503 sin contraseña),
+        # así que no vale la pena bloquear una publicación del sitio por esto.
+        env:
+          PANEL_PASSWORD: ${{ secrets.PANEL_PASSWORD }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -z "$PANEL_PASSWORD" ]; then
+            echo "::warning::Sin PANEL_PASSWORD en GitHub: /panel seguirá respondiendo 503."
+            exit 0
+          fi
+          printf '%s' "$PANEL_PASSWORD" |
+            npx wrangler@3.114.17 pages secret put PANEL_PASSWORD --project-name amadolibros-web
+
       - name: Deploy via Wrangler
         run: npx wrangler@3.114.17 pages deploy ./astro-front/dist --project-name amadolibros-web --branch main
         env:


### PR DESCRIPTION
## Problema

`/panel` quedó respondiendo 503 ("Falta PANEL_PASSWORD") tanto en Preview como en Producción, después de dos intentos de cargar la variable a mano en Cloudflare Pages.

Dos trampas del panel de Cloudflare lo explican:

1. **Variable vs Secret.** Este proyecto se configura con `wrangler.toml`, y el propio Cloudflare avisa: *"Las variables de entorno para este proyecto se administran a través de wrangler.toml. Solo se puede administrar Secrets (variables cifradas) a través del panel de control."* Una variable común cargada ahí se ignora.
2. **Producción vs Vista previa.** Son dos listas separadas; cargarla en una no la pone en la otra.

## Solución

El deploy sincroniza `PANEL_PASSWORD` desde los secrets de GitHub a Cloudflare Pages, exactamente igual que el repo ya hace con `RESEND_API_KEY` y `GA4_API_SECRET`.

Ventajas sobre cargarla a mano:

- se carga en **un solo lugar** (GitHub), sin la distinción Variable/Secret ni Producción/Preview;
- se **reaplica en cada publicación**, así que no se puede perder;
- la contraseña nunca entra al repositorio — sigue siendo un secret.

## Diferencia deliberada con los otros dos secrets

`RESEND_API_KEY` y `GA4_API_SECRET` **cortan el deploy** si faltan. Este **no**: avisa con un `::warning::` y sigue.

El motivo es que el panel ya falla cerrado por su cuenta — sin contraseña responde 503 y nunca queda abierto. Bloquear la publicación de todo el sitio porque falta la clave de una página interna sería peor que el problema que evita.

## Para que empiece a andar

Cargar el secret `PANEL_PASSWORD` (mínimo 12 caracteres) en:
https://github.com/trexxeseba/amadolibros-web/settings/secrets/actions

En el siguiente deploy a Producción, `/panel` queda operativo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM)_