### PR TITLE
No espejar portadas al publicar el catálogo: eso ya lo hace el cron

### DIFF
--- a/worker-sync/__tests__/meli-catalog.test.js
+++ b/worker-sync/__tests__/meli-catalog.test.js
@@ -753,3 +753,52 @@ test('CF-R2-2-BRIDGE: producción tampoco cambia su manifest si falla la verific
   assert.equal(writtenKeys.includes(PRODUCTION_MANIFEST_KEY), false);
   assert.ok(writtenKeys.some(key => key.includes('/versions/')));
 });
+
+test('publicar el catálogo productivo no toca el espejo de portadas: eso lo hace el cron', async () => {
+  // Cloudflare mataba este pedido con 1102 ("Worker exceeded resource limits")
+  // porque, después de publicar, arrancaba el espejo de portadas con el
+  // catálogo entero todavía en memoria. El cron `*/5 * * * *` ya lo hace, con
+  // los pausados incluidos, así que acá no corresponde.
+  const objects = new Map();
+  const coverAccess = [];
+  // Cualquier lectura o escritura de portadas desde esta ruta rompe el test.
+  const forbiddenCoverBucket = new Proxy({}, {
+    get(_target, property) {
+      coverAccess.push(String(property));
+      return () => { throw new Error(`COVER_R2.${String(property)} no debe usarse al publicar el catálogo.`); };
+    },
+  });
+
+  const result = await runProductionCatalogPublish({
+    PRODUCTION_PAUSED_CATALOG_PUBLISH_ENABLED: true,
+    COVER_MIRROR_BATCH_SIZE: '100',
+    COVER_R2: forbiddenCoverBucket,
+    CATALOG_R2: {
+      async put(key, body) { objects.set(key, body); },
+      async get(key) {
+        const body = objects.get(key);
+        return body == null ? null : { async text() { return body; } };
+      },
+      async head(key) {
+        const body = objects.get(key);
+        return body == null ? null : {
+          size: typeof body === 'string' ? new TextEncoder().encode(body).length : body.byteLength,
+        };
+      },
+    },
+  }, {
+    getAccessTokenFn: async () => 'token',
+    buildCatalogFn: async () => ({
+      updated_at: '2026-08-01T09:00:00.000Z',
+      items: [
+        { id: 'MLU1', title: 'Activo', status: 'active', available_quantity: 2 },
+        { id: 'MLU2', title: 'Pausado', status: 'paused', available_quantity: 0 },
+      ],
+    }),
+  });
+
+  assert.equal(result.status, 'published-production');
+  assert.equal(result.published, true);
+  assert.deepEqual(coverAccess, [], 'publicar el catálogo no debe tocar COVER_R2');
+  assert.deepEqual(result.cover_mirror, { status: 'delegated-to-cron', cron: '*/5 * * * *' });
+});

--- a/worker-sync/index.js
+++ b/worker-sync/index.js
@@ -310,21 +310,18 @@ async function publishPausedCatalog(env, {
       },
     });
 
-    let coverMirror = null;
-    if (scope === 'production') {
-      try {
-        coverMirror = await syncCoverMirror(env, catalog, {
-          limit: Math.max(20, Number(env.COVER_MIRROR_BATCH_SIZE) || 100),
-          includePaused: true,
-        });
-      } catch (error) {
-        console.warn(`[${errorLabel} catalog] Mirror de galerías pendiente: ${error.message}`);
-        coverMirror = {
-          status: 'error',
-          error: String(error?.message || 'Error').slice(0, 240),
-        };
-      }
-    }
+    // El espejo de portadas NO corre acá. Lo hace el cron `*/5 * * * *` con
+    // runCoverMirror, que ya recorre los pausados con su propio cursor — o sea
+    // que hacerlo también en esta ruta era trabajo duplicado.
+    //
+    // Duplicarlo no era gratis: se ejecutaba al final de un pedido que todavía
+    // tiene el catálogo entero en memoria (~17,8 MB, 17.249 ítems) más los 128
+    // bloques del índice pausado, y encima toca un índice público de ~31,6 MB
+    // repartido en 256 shards. Esa suma agotaba los recursos del isolate y
+    // Cloudflare mataba el pedido con 1102 ("Worker exceeded resource limits"),
+    // dejando el job de deploy en rojo aunque el catálogo ya estuviera
+    // publicado. Ver runs 34366493021 (1102 explícito) y 34409174184.
+    const coverMirror = { status: 'delegated-to-cron', cron: '*/5 * * * *' };
 
     const samplePaused = catalog.items.find(item => item.status === 'paused') || null;
     return {


### PR DESCRIPTION
## El problema

El job **"Publish production paused catalog"** viene fallando una de cada dos publicaciones desde el 9/9:

| Run | Resultado |
|---|---|
| #231 (8/9) | ✅ |
| #232 (9/9) | ❌ intento 1, ✅ intento 2 |
| #233 (9/9) | ❌ |
| #234 (9/9) | ✅ |
| #235 (9/9) | ❌ |

**No es red ni intermitencia.** El [run 34366493021](https://github.com/trexxeseba/amadolibros-web/actions/runs/34366493021) dejó el mensaje textual de Cloudflare:

```
HTTP status: 503
PRODUCTION_CATALOG_RESULT=error code: 1102
```

**1102 = "Worker exceeded resource limits".** El [34409174184](https://github.com/trexxeseba/amadolibros-web/actions/runs/34409174184) cortó como `curl: (56) connection reset by peer`, que es el mismo final visto desde afuera: el isolate muere y la conexión se corta sin respuesta.

## Por qué

Todo ocurre en **un solo pedido HTTP**, sin cortes. Números reales de la corrida que sí pasó (#234):

| Paso | Tamaño |
|---|---|
| Catálogo entero en memoria | **17,8 MB** — 17.249 ítems |
| Índices + 128 bloques del pausado | 1,8 MB + **11 MB** de detalle |
| Escribir y verificar 128 bloques | 256 viajes a R2, uno atrás del otro |
| **Y recién ahí: espejo de portadas** | índice público de **31,6 MB** en 256 shards, 80.863 entradas |

Esa corrida tardó **7 minutos 54**. No es que a veces falle: **siempre llegaba raspando**, y cuando toca un poco más de trabajo, no llega.

El paso del espejo coincide con la fecha: el índice de 256 shards entró el 8/9 (`Serve all cover lookups from atomic sharded public index`) y los fallos arrancan el 9/9.

## El arreglo

Sacar el espejo de portadas de esta ruta. Nada más.

**Ese trabajo ya lo hace el cron `*/5 * * * *`** con `runCoverMirror`, que recorre los pausados con su propio cursor sobre los bloques. Hacerlo también acá era trabajo duplicado — y en el peor momento posible, con el catálogo entero todavía en memoria.

El propio código ya lo trataba como opcional: iba envuelto en `try/catch` y su fallo no rompía la publicación. O sea, **no era parte del contrato de este job, pero era lo que lo mataba.**

`cover_mirror` pasa a informar `"delegated-to-cron"` en vez de desaparecer en silencio.

## Lo que NO cambia

Mismas **133 escrituras**, mismo manifest atómico escrito último, mismas claves, misma verificación previa. No toca precios, stock, títulos, slugs, imágenes, canonical, carrito ni Mercado Libre.

## Validación

`bash scripts/validate-ci.sh` completo en verde: **1.744 tests, 0 fallos**, ambos builds (checkout ON/OFF) OK.

El test nuevo le pasa un `COVER_R2` que **lanza ante cualquier acceso**, así que si alguien vuelve a meter trabajo de portadas en esta ruta, el test falla. No queda dependiendo de que alguien se acuerde.

## Cómo se comprueba después del merge

El propio deploy lo prueba: si el job queda verde y se mantiene en las publicaciones siguientes, funcionó.

## Lo que este PR NO resuelve

- **Si fue memoria o CPU.** El mensaje 1102 no lo distingue y no tengo acceso a los logs de Cloudflare. Este PR quita la carga más grande del pedido; no mide cuál de los dos límites se tocaba.
- **El pedido sigue siendo pesado.** Bajar el catálogo entero, armar 128 bloques y verificarlos uno por uno sigue tardando varios minutos. Si vuelve a fallar más adelante, el siguiente paso es cortar eso en tandas — pero eso es un cambio bastante más grande y hoy no hace falta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM)_