### PR TITLE
Alinear la retención de la evidencia de imágenes con el resto del repo

### DIFF
--- a/.github/workflows/cover-index-preview.yml
+++ b/.github/workflows/cover-index-preview.yml
@@ -82,4 +82,4 @@ jobs:
           name: cover-index-${{ github.run_id }}
           path: artifacts/cover-index/
           if-no-files-found: error
-          retention-days: 90
+          retention-days: 30

--- a/.github/workflows/cover-resource-preview.yml
+++ b/.github/workflows/cover-resource-preview.yml
@@ -61,4 +61,4 @@ jobs:
           name: cover-resource-${{ github.run_id }}
           path: artifacts/cover-resource/
           if-no-files-found: error
-          retention-days: 90
+          retention-days: 30

--- a/.github/workflows/cover-scroll-preview.yml
+++ b/.github/workflows/cover-scroll-preview.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           name: cover-scroll-browser-${{ github.run_id }}
           path: artifacts/cover-scroll/browser-info.json
-          retention-days: 90
+          retention-days: 30
           if-no-files-found: error
       - name: Browser verification window (8 minutes)
         if: steps.gate.outputs.enabled == 'true'
@@ -108,5 +108,5 @@ jobs:
         with:
           name: cover-scroll-cleanup-${{ github.run_id }}
           path: artifacts/cover-scroll/
-          retention-days: 90
+          retention-days: 30
           if-no-files-found: error

--- a/.github/workflows/images-production-verification.yml
+++ b/.github/workflows/images-production-verification.yml
@@ -43,5 +43,5 @@ jobs:
         with:
           name: published-images-${{ github.run_id }}
           path: artifacts/commerce/
-          retention-days: 90
+          retention-days: 30
           if-no-files-found: error


### PR DESCRIPTION
## El problema

La cuenta llegó al **100% de los 0,5 GB** de almacenamiento de Actions. Lo que lo llena son los archivos de evidencia que los workflows guardan al terminar.

## Qué encontré

De los **19 workflows** que guardan evidencia:

| Retención | Cuántos |
|---|---|
| 30 días | 14 |
| 14 días | 1 |
| **90 días** | **4** |

Los únicos cuatro en 90 son los de imágenes — y son justo los más pesados: evidencia de portadas, capturas de navegador y el índice público de portadas, que hoy pesa **31,6 MB**.

```
cover-index-preview.yml
cover-resource-preview.yml
cover-scroll-preview.yml   (×2)
images-production-verification.yml
```

O sea: **90 era la excepción, no la norma.**

## El cambio

Esos cuatro pasan a 30 días, como los otros catorce. Cinco líneas.

La evidencia reciente queda igual de disponible: la más vieja que citan los PR abiertos es del 6/9, o sea que 30 días la cubre con semanas de sobra.

## Lo que este PR NO resuelve

**No libera el medio giga que ya está ocupado.** La retención sólo aplica a los archivos nuevos; los que ya existen siguen ahí hasta que venzan.

Para recuperar el espacio ahora hay dos caminos, los dos gratis:

1. Borrar los archivos viejos a mano desde la pestaña **Actions** del repo.
2. No hacer nada: el contador se reinicia solo el **1 de octubre**.

Este PR es para que el aviso no vuelva el mes que viene.

## Validación

`bash scripts/validate-ci.sh` completo en verde. No toca código de la web: sólo cuatro archivos de workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM)_