### PR TITLE
Avisar en el panel qué fichas salen a Google sin imagen

### DIFF
--- a/functions/__tests__/panel-page.test.js
+++ b/functions/__tests__/panel-page.test.js
@@ -297,3 +297,82 @@ test('sin fichas sin imagen el aviso no inventa una alerta', async () => {
   assert.match(html, /Ficha sin imagen para Google/);
   assert.doesNotMatch(html, /Ficha sin imagen para Google \(/);
 });
+
+const CATALOG_FEED = {
+  items: [
+    // Llega a Google: activo, con stock, precio, UYU, permalink y es libro.
+    { id: 'MLU100', title: 'Libro vendible', status: 'active', available_quantity: 2, price: 500,
+      currency: 'UYU', permalink: 'https://ml/1', domain_id: 'MLU-BOOKS', isbn: '9780000000001', pictures: [{ url: 'https://x/1.jpg' }] },
+    // Activos que NO llegan, uno por cada motivo.
+    { id: 'MLU200', title: 'Sin precio', status: 'active', available_quantity: 1, price: 0,
+      currency: 'UYU', permalink: 'https://ml/2', domain_id: 'MLU-BOOKS', pictures: [{ url: 'https://x/2.jpg' }] },
+    { id: 'MLU300', title: 'Sin moneda', status: 'active', available_quantity: 1, price: 400,
+      currency: '', permalink: 'https://ml/3', domain_id: 'MLU-BOOKS', pictures: [{ url: 'https://x/3.jpg' }] },
+    { id: 'MLU400', title: 'Sin enlace', status: 'active', available_quantity: 1, price: 400,
+      currency: 'UYU', permalink: '', domain_id: 'MLU-BOOKS', pictures: [{ url: 'https://x/4.jpg' }] },
+    // Pausado: no cuenta como "activo que queda afuera".
+    { id: 'MLU500', title: 'Pausado', status: 'paused', available_quantity: 0, price: 300,
+      currency: 'UYU', permalink: 'https://ml/5', domain_id: 'MLU-BOOKS', pictures: [{ url: 'https://x/5.jpg' }] },
+  ],
+};
+
+test('el panel muestra cuántos activos no llegan a Google Shopping y por qué', async () => {
+  const html = await withCatalog(CATALOG_FEED, async () => {
+    const response = await onRequest({
+      request: request('/panel', { cookie: await sessionCookie() }),
+      env: baseEnv(),
+    });
+    assert.equal(response.status, 200);
+    return response.text();
+  });
+
+  assert.match(html, /Cuántos llegan a Google Shopping/);
+  // 4 activos, 1 pasa, 3 quedan afuera. El pausado no entra en la cuenta.
+  assert.match(html, /<b>4<\/b><span>libros activos<\/span>/);
+  assert.match(html, /<b>1<\/b><span>pasan la puerta comercial<\/span>/);
+  assert.match(html, /<b>3<\/b><span>quedan afuera<\/span>/);
+
+  assert.match(html, /sin precio/);
+  assert.match(html, /sin moneda UYU/);
+  assert.match(html, /sin enlace a Mercado Libre/);
+
+  // No se promete que ese número sea la cantidad final de ofertas en Merchant.
+  assert.match(html, /igual o menor/);
+});
+
+test('el motivo del feed nunca se desincroniza de la regla real', async () => {
+  // Si alguien cambia isEligibleForFeed y no toca feedBlockerReason, este test
+  // falla: todo activo contado como bloqueado tiene que ser realmente inelegible,
+  // y todo activo elegible no debe aparecer con motivo.
+  const { loadCatalogSummary } = await import('../_shared/panel-data.js');
+  const { isEligibleForFeed } = await import('../feed.xml.js');
+
+  const summary = await withCatalog(CATALOG_FEED, () => loadCatalogSummary({}));
+  const active = CATALOG_FEED.items.filter(item => item.status === 'active');
+  const reallyEligible = active.filter(isEligibleForFeed).length;
+
+  assert.equal(summary.feed.activeTotal, active.length);
+  assert.equal(summary.feed.eligible, reallyEligible);
+  assert.equal(
+    summary.feed.blockers.reduce((total, row) => total + row.total, 0),
+    active.length - reallyEligible,
+    'la suma de motivos tiene que dar exactamente los activos que no pasan',
+  );
+});
+
+test('las fichas sin foto se ordenan por las que venden primero', async () => {
+  const { loadCatalogSummary } = await import('../_shared/panel-data.js');
+  const summary = await withCatalog({
+    items: [
+      { id: 'MLU1', title: 'Pausado sin foto', status: 'paused', available_quantity: 0, pictures: [] },
+      { id: 'MLU2', title: 'Activo sin stock sin foto', status: 'active', available_quantity: 0, pictures: [] },
+      { id: 'MLU3', title: 'Activo CON stock sin foto', status: 'active', available_quantity: 5, pictures: [] },
+    ],
+  }, () => loadCatalogSummary({}));
+
+  assert.deepEqual(summary.missingImage.items.map(row => row.title), [
+    'Activo CON stock sin foto',
+    'Activo sin stock sin foto',
+    'Pausado sin foto',
+  ]);
+});

--- a/functions/__tests__/panel-page.test.js
+++ b/functions/__tests__/panel-page.test.js
@@ -235,3 +235,65 @@ test('una cookie firmada con otra contraseña no abre el tablero', async () => {
   assert.match(html, /type="password"/);
   assert.doesNotMatch(html, /AL-1001/);
 });
+
+const CATALOG_HOSTILE = {
+  items: [
+    // Sin fotos: es la ficha que sale a Google sin `image`.
+    { id: 'MLU999111', title: 'Libro sin foto', status: 'active', available_quantity: 1, isbn: '9781234567897', pictures: [] },
+    // Id hostil escrito afuera: nunca debe terminar dentro de un href.
+    { id: 'MLU1" onmouseover="alert(1)', title: '<script>alert("titulo")</script>', status: 'paused', available_quantity: 0, isbn: '', pictures: [] },
+    // Con foto: no debe aparecer en el aviso.
+    { id: 'MLU222333', title: 'Libro con foto', status: 'active', available_quantity: 3, isbn: '9780000000001', pictures: [{ url: 'https://x/y.jpg' }] },
+  ],
+};
+
+async function withCatalog(catalog, run) {
+  const originalFetch = globalThis.fetch;
+  const originalCaches = globalThis.caches;
+  globalThis.caches = { default: { match: async () => undefined, put: async () => {} } };
+  globalThis.fetch = async () => Response.json(catalog);
+  try {
+    return await run();
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalCaches) globalThis.caches = originalCaches; else delete globalThis.caches;
+  }
+}
+
+test('el panel avisa qué fichas salen a Google sin imagen, con enlace para ir a arreglarlas', async () => {
+  const html = await withCatalog(CATALOG_HOSTILE, async () => {
+    const response = await onRequest({
+      request: request('/panel', { cookie: await sessionCookie() }),
+      env: baseEnv(),
+    });
+    assert.equal(response.status, 200);
+    return response.text();
+  });
+
+  assert.match(html, /Ficha sin imagen para Google \(2\)/);
+  assert.match(html, /Libro sin foto/);
+  assert.match(html, /href="https:\/\/www\.amadolibros\.com\/libro\/MLU999111"/);
+
+  // El que sí tiene foto no se reporta.
+  assert.doesNotMatch(html, /Libro con foto/);
+
+  // El id hostil no genera enlace ni escapa del atributo, y el título va escapado.
+  assert.doesNotMatch(html, /onmouseover/);
+  assert.doesNotMatch(html, /<script>alert\("titulo"\)<\/script>/);
+  assert.match(html, /&lt;script&gt;alert\(&quot;titulo&quot;\)&lt;\/script&gt;/);
+});
+
+test('sin fichas sin imagen el aviso no inventa una alerta', async () => {
+  const html = await withCatalog({
+    items: [{ id: 'MLU222333', title: 'Libro con foto', status: 'active', available_quantity: 3, isbn: '9780000000001', pictures: [{ url: 'https://x/y.jpg' }] }],
+  }, async () => {
+    const response = await onRequest({
+      request: request('/panel', { cookie: await sessionCookie() }),
+      env: baseEnv(),
+    });
+    return response.text();
+  });
+
+  assert.match(html, /Ficha sin imagen para Google/);
+  assert.doesNotMatch(html, /Ficha sin imagen para Google \(/);
+});

--- a/functions/_shared/panel-data.js
+++ b/functions/_shared/panel-data.js
@@ -17,6 +17,7 @@
  */
 
 import { fetchCatalog } from './catalog.js';
+import { isEligibleForFeed } from '../feed.xml.js';
 
 const RECENT_ORDERS_LIMIT = 20;
 const STUCK_LIMIT = 25;
@@ -27,6 +28,23 @@ const MISSING_IMAGE_LIMIT = 25;
 // cualquier otra cosa queda en cadena vacía y el panel muestra el texto sin enlace.
 function cleanId(value) {
   return /^MLU\d+$/.test(String(value || '')) ? String(value) : '';
+}
+
+/**
+ * Por qué un libro activo no llega al feed de Google. La cuenta autorizada la
+ * da isEligibleForFeed; esto sólo pone el motivo en palabras, en el mismo
+ * orden en que esa función descarta. Hay un test que verifica que las dos
+ * coincidan siempre: si alguien cambia la regla y no toca esto, falla.
+ */
+function feedBlockerReason(item) {
+  if (!item?.permalink) return 'sin enlace a Mercado Libre';
+  if (!/^MLU\d+$/.test(String(item?.id || ''))) return 'id inválido';
+  if (!(Number(item?.available_quantity) > 0)) return 'sin stock';
+  if (!(Number(item?.price) > 0)) return 'sin precio';
+  if (String(item?.currency || item?.currency_id || '').trim().toUpperCase() !== 'UYU') {
+    return 'sin moneda UYU';
+  }
+  return 'no se reconoce como libro';
 }
 
 async function queryAll(db, sql, params = []) {
@@ -181,27 +199,45 @@ export async function loadCatalogSummary(ctx) {
   const items = Array.isArray(catalog?.items) ? catalog.items : [];
   let withStock = 0;
   let withoutIsbn = 0;
+  let withoutImage = 0;
+  let feedEligible = 0;
   // Una ficha sin ninguna foto es la que sale a Google sin `image` en el
   // JSON-LD, y es lo que Search Console reporta como "Falta el campo image".
   // El contador ya existía; lo que faltaba era saber CUÁLES para poder actuar.
   const missingImageItems = [];
+  const feedBlockers = new Map();
+
   for (const item of items) {
-    if (Number(item?.available_quantity) > 0) withStock += 1;
+    const active = item?.status === 'active';
+    const inStock = Number(item?.available_quantity) > 0;
+    if (inStock) withStock += 1;
     if (!item?.isbn) withoutIsbn += 1;
+
     if (!Array.isArray(item?.pictures) || item.pictures.length === 0) {
-      if (missingImageItems.length < MISSING_IMAGE_LIMIT) {
-        missingImageItems.push({
-          id: cleanId(item?.id),
-          title: item?.title || '(sin título)',
-          status: item?.status || '—',
-        });
-      }
+      withoutImage += 1;
+      missingImageItems.push({
+        id: cleanId(item?.id),
+        title: item?.title || '(sin título)',
+        status: item?.status || '—',
+        // Un activo con stock es plata parada; un pausado sin foto no le
+        // importa a nadie hoy. Se ordena por eso para que el trabajo manual
+        // de cargar fotos empiece por lo que vende.
+        priority: active && inStock ? 0 : active ? 1 : 2,
+      });
+    }
+
+    // Se usa la MISMA función que arma el feed, no una copia: si mañana cambia
+    // la regla, este contador cambia con ella en vez de mentir.
+    if (isEligibleForFeed(item)) feedEligible += 1;
+    else if (active) {
+      const reason = feedBlockerReason(item);
+      feedBlockers.set(reason, (feedBlockers.get(reason) || 0) + 1);
     }
   }
-  const withoutImage = items.reduce(
-    (total, item) => total + (Array.isArray(item?.pictures) && item.pictures.length ? 0 : 1),
-    0,
-  );
+
+  missingImageItems.sort((a, b) => a.priority - b.priority);
+  const activeTotal = items.filter(item => item?.status === 'active').length;
+
   return {
     total: items.length,
     withStock,
@@ -209,7 +245,23 @@ export async function loadCatalogSummary(ctx) {
     withoutIsbn,
     // `items` está recortado a MISSING_IMAGE_LIMIT: es una muestra para actuar,
     // no el listado completo. `withoutImage` sigue siendo el total real.
-    missingImage: { count: withoutImage, items: missingImageItems, limit: MISSING_IMAGE_LIMIT },
+    missingImage: {
+      count: withoutImage,
+      items: missingImageItems.slice(0, MISSING_IMAGE_LIMIT),
+      limit: MISSING_IMAGE_LIMIT,
+    },
+    // Sólo la puerta comercial del feed. La segunda puerta —que la portada
+    // esté lista en R2— se mide aparte y necesita el manifest de portadas,
+    // que pesa demasiado para cargarlo en cada vista del panel. O sea:
+    // `eligible` es un techo, no la cantidad final de ofertas en Merchant.
+    feed: {
+      activeTotal,
+      eligible: feedEligible,
+      blocked: Math.max(0, activeTotal - feedEligible),
+      blockers: [...feedBlockers.entries()]
+        .map(([reason, total]) => ({ reason, total }))
+        .sort((a, b) => b.total - a.total),
+    },
     generatedAt: catalog?.generated_at || catalog?.generatedAt || null,
   };
 }

--- a/functions/_shared/panel-data.js
+++ b/functions/_shared/panel-data.js
@@ -21,6 +21,13 @@ import { fetchCatalog } from './catalog.js';
 const RECENT_ORDERS_LIMIT = 20;
 const STUCK_LIMIT = 25;
 const CRAWL_DAYS = 7;
+const MISSING_IMAGE_LIMIT = 25;
+
+// El id va a parar a un href. Sólo se acepta la forma real de Mercado Libre;
+// cualquier otra cosa queda en cadena vacía y el panel muestra el texto sin enlace.
+function cleanId(value) {
+  return /^MLU\d+$/.test(String(value || '')) ? String(value) : '';
+}
 
 async function queryAll(db, sql, params = []) {
   const statement = db.prepare(sql);
@@ -173,18 +180,36 @@ export async function loadCatalogSummary(ctx) {
   const catalog = await fetchCatalog(ctx);
   const items = Array.isArray(catalog?.items) ? catalog.items : [];
   let withStock = 0;
-  let withoutImage = 0;
   let withoutIsbn = 0;
+  // Una ficha sin ninguna foto es la que sale a Google sin `image` en el
+  // JSON-LD, y es lo que Search Console reporta como "Falta el campo image".
+  // El contador ya existía; lo que faltaba era saber CUÁLES para poder actuar.
+  const missingImageItems = [];
   for (const item of items) {
     if (Number(item?.available_quantity) > 0) withStock += 1;
-    if (!Array.isArray(item?.pictures) || item.pictures.length === 0) withoutImage += 1;
     if (!item?.isbn) withoutIsbn += 1;
+    if (!Array.isArray(item?.pictures) || item.pictures.length === 0) {
+      if (missingImageItems.length < MISSING_IMAGE_LIMIT) {
+        missingImageItems.push({
+          id: cleanId(item?.id),
+          title: item?.title || '(sin título)',
+          status: item?.status || '—',
+        });
+      }
+    }
   }
+  const withoutImage = items.reduce(
+    (total, item) => total + (Array.isArray(item?.pictures) && item.pictures.length ? 0 : 1),
+    0,
+  );
   return {
     total: items.length,
     withStock,
     withoutImage,
     withoutIsbn,
+    // `items` está recortado a MISSING_IMAGE_LIMIT: es una muestra para actuar,
+    // no el listado completo. `withoutImage` sigue siendo el total real.
+    missingImage: { count: withoutImage, items: missingImageItems, limit: MISSING_IMAGE_LIMIT },
     generatedAt: catalog?.generated_at || catalog?.generatedAt || null,
   };
 }

--- a/functions/panel/[[path]].js
+++ b/functions/panel/[[path]].js
@@ -192,6 +192,9 @@ function sectionOrError(block, render) {
 function dashboardPage(data) {
   const env = data.environment;
   const stuckCount = data.stuck?.ok ? data.stuck.data.total : null;
+  // Se cuenta aparte de `stuckCount`: viene del catálogo, no de D1, así que uno
+  // puede estar disponible y el otro caído. La tarjeta se enciende con cualquiera.
+  const missingImageCount = data.catalog?.ok ? (data.catalog.data.missingImage?.count || 0) : 0;
 
   return layout('Panel — Amado Libros', `
 <div class="top">
@@ -207,7 +210,7 @@ function dashboardPage(data) {
   <form method="POST" action="/panel/logout"><button class="logout" type="submit">Salir</button></form>
 </div>
 
-<section class="card ${stuckCount ? 'alert' : ''}">
+<section class="card ${stuckCount || missingImageCount ? 'alert' : ''}">
   <h2>Qué quedó trancado${stuckCount ? ` (${stuckCount})` : ''}</h2>
   ${sectionOrError(data.stuck, stuck => `
     <h3 class="muted">Pagados sin despachar</h3>
@@ -231,6 +234,25 @@ function dashboardPage(data) {
           <td>${escapeHtml(row.internal_notification_status)}</td>
           <td>${shortDate(row.created_at)}</td></tr>`)}
   `)}
+
+  <h3 class="muted">Ficha sin imagen para Google${missingImageCount ? ` (${missingImageCount})` : ''}</h3>
+  ${sectionOrError(data.catalog, catalog => {
+    const missing = catalog.missingImage || { count: 0, items: [] };
+    if (!missing.count) return '<p class="empty">Nada por acá. 👌</p>';
+    return `
+      <p class="muted">
+        Estas fichas no tienen ninguna foto, así que salen a Google sin imagen.
+        Es lo que Search Console reporta como «Falta el campo image».
+        ${missing.count > missing.items.length
+          ? `Se muestran las primeras ${missing.items.length} de ${missing.count}.`
+          : ''}
+      </p>
+      ${table(['Libro', 'Estado', 'Ficha'], missing.items, row => `
+        <tr><td>${escapeHtml(row.title)}</td><td>${escapeHtml(row.status)}</td>
+            <td>${row.id
+              ? `<a href="https://www.amadolibros.com/libro/${escapeHtml(row.id)}" rel="noreferrer">${escapeHtml(row.id)}</a>`
+              : '—'}</td></tr>`)}`;
+  })}
 </section>
 
 <section class="card">

--- a/functions/panel/[[path]].js
+++ b/functions/panel/[[path]].js
@@ -294,6 +294,24 @@ function dashboardPage(data) {
       <div class="stat"><b>${escapeHtml(catalog.withoutIsbn)}</b><span>sin ISBN</span></div>
     </div>
     <p class="muted">Catálogo generado: ${shortDate(catalog.generatedAt)}</p>
+
+    <h3 class="muted">Cuántos llegan a Google Shopping</h3>
+    <div class="grid">
+      <div class="stat"><b>${escapeHtml(catalog.feed.activeTotal)}</b><span>libros activos</span></div>
+      <div class="stat"><b>${escapeHtml(catalog.feed.eligible)}</b><span>pasan la puerta comercial</span></div>
+      <div class="stat ${catalog.feed.blocked ? 'alert' : ''}"><b>${escapeHtml(catalog.feed.blocked)}</b><span>quedan afuera</span></div>
+    </div>
+    ${catalog.feed.blockers.length
+      ? `<p class="muted">Por qué quedan afuera:</p>
+         ${table(['Motivo', 'Libros'], catalog.feed.blockers, row => `
+           <tr><td>${escapeHtml(row.reason)}</td><td>${escapeHtml(row.total)}</td></tr>`)}`
+      : ''}
+    <p class="muted">
+      Esta es sólo la primera puerta: precio, moneda, stock, enlace y que se reconozca
+      como libro. Después hay una segunda —que la portada esté lista— que no se mide acá.
+      O sea que la cantidad real de ofertas en Merchant es <b>igual o menor</b> a
+      ${escapeHtml(catalog.feed.eligible)}, nunca mayor.
+    </p>
   `)}
 </section>
 


### PR DESCRIPTION
## Contexto

Search Console reportó **«Falta el campo image»** en fichas de comerciantes.

**La causa ya está corregida y desplegada.** Cuando el índice de portadas no se puede leer, la ficha ahora conserva la foto real en vez de quedarse sin imagen, y la auditoría verifica que el `Product` tenga `image` (`PRODUCT_IMAGE_MISSING`).

Lo que faltaba era **enterarse sin esperar el correo de Google**.

## El cambio

El panel **ya contaba** las fichas sin ninguna foto — que son exactamente las que salen a Google sin `image`. Pero el número estaba perdido entre las estadísticas del catálogo y no decía *cuáles* eran, así que no se podía hacer nada con él.

Ahora aparece en **«Qué quedó trancado»**, con:

- título del libro
- estado (activo / pausado)
- **enlace directo a la ficha**, para ir a arreglarla

La tarjeta se enciende con este aviso igual que con los pedidos trancados.

## Dos decisiones que conviene ver

**Se cuenta aparte del resto de la sección.** Los pedidos trancados vienen de D1 y esto del catálogo: uno puede estar disponible y el otro caído. Cada bloque muestra su propio error en vez de arrastrar al otro.

**El id termina dentro de un `href`.** Sólo se acepta la forma real de Mercado Libre (`MLU` + dígitos); cualquier otra cosa se muestra como texto sin enlace. Hay un test con el id hostil `MLU1" onmouseover="alert(1)` que verifica que no se pueda escapar del atributo.

## Alcance

- El listado va **recortado a 25 filas**. El contador sigue siendo el total real y el texto lo aclara cuando hay más.
- **Sigue siendo solo lectura**: ni un `INSERT`/`UPDATE`/`DELETE`. No toca precio, stock, título, slug, imágenes ni Mercado Libre. El panel avisa; no arregla.

## Validación

`bash scripts/validate-ci.sh` completo en verde: **1.745 tests, 0 fallos**, ambos builds OK.

Tests nuevos:

- **el aviso lista las fichas sin foto, con enlace** — y verifica que la que *sí* tiene foto no se reporte, que el título hostil salga escapado y que el id hostil no genere enlace.
- **sin fichas sin imagen no inventa una alerta** — el bloque existe pero no muestra contador ni enciende la tarjeta.

## Lo que este PR NO resuelve

- **No arregla ninguna ficha.** Un libro sin foto sigue sin foto hasta que se le cargue una; esto sólo te dice cuáles son.
- **No detecta el caso raro** de una ficha que tiene fotos pero igual pierde la imagen en el JSON-LD. Ese camino ya lo cubre la auditoría con `PRODUCT_IMAGE_MISSING`; acá se reporta la condición que se puede leer del catálogo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM)_