### PR TITLE
Leer la fecha del catálogo del campo que el catálogo realmente trae

### DIFF
--- a/functions/__tests__/panel-page.test.js
+++ b/functions/__tests__/panel-page.test.js
@@ -376,3 +376,14 @@ test('las fichas sin foto se ordenan por las que venden primero', async () => {
     'Pausado sin foto',
   ]);
 });
+
+test('la fecha del catálogo sale del campo que el catálogo realmente trae', async () => {
+  // buildCatalog escribe `updated_at`. El panel buscaba `generated_at` y
+  // `generatedAt`, que no existen en ningún catálogo real: por eso mostraba "—".
+  const { loadCatalogSummary } = await import('../_shared/panel-data.js');
+  const summary = await withCatalog(
+    { updated_at: '2026-09-10T00:30:00.000Z', items: [] },
+    () => loadCatalogSummary({}),
+  );
+  assert.equal(summary.generatedAt, '2026-09-10T00:30:00.000Z');
+});

--- a/functions/_shared/panel-data.js
+++ b/functions/_shared/panel-data.js
@@ -262,7 +262,9 @@ export async function loadCatalogSummary(ctx) {
         .map(([reason, total]) => ({ reason, total }))
         .sort((a, b) => b.total - a.total),
     },
-    generatedAt: catalog?.generated_at || catalog?.generatedAt || null,
+    // El catálogo real trae `updated_at` (lo escribe buildCatalog en el Worker).
+    // Las otras dos formas nunca existieron: por eso el panel mostraba "—".
+    generatedAt: catalog?.updated_at || catalog?.generated_at || catalog?.generatedAt || null,
   };
 }
 


### PR DESCRIPTION
## El síntoma

En producción el panel muestra:

```
Catálogo generado: —
```

## La causa

No falta el dato. El panel buscaba `generated_at` y `generatedAt`; el catálogo real trae **`updated_at`**, que es lo que escribe `buildCatalog` en el Worker (`worker-sync/meli-catalog.js:256`).

Ninguna de las dos formas que buscaba existió nunca en un catálogo real, así que ese renglón **nunca pudo mostrar nada**. No es una regresión: venía así desde el #334.

## El arreglo

Se lee `updated_at` primero. Se conservan las otras dos formas por si algún consumidor viejo las usara.

## Validación

`bash scripts/validate-ci.sh` completo en verde: **1.750 tests, 0 fallos**, ambos builds OK.

El test nuevo usa un catálogo con `updated_at`, que es la forma real — no la que el código esperaba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM)_