### PR TITLE
Aplicar el mínimo de imagen VIGENTE de Google, no el que rige desde 2027

### DIFF
--- a/functions/__tests__/image-source-policy.test.js
+++ b/functions/__tests__/image-source-policy.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { nativeImageAlternatives, mlImageIdentity, googleReadyImage } from '../_shared/image-source-policy.js';
+import { nativeImageAlternatives, mlImageIdentity, googleReadyImage, googleFutureReadyImage,
+  googleImageMinEdge, GOOGLE_IMAGE_MIN_EDGE_ENFORCED_FROM } from '../_shared/image-source-policy.js';
 import { renderPage } from '../libro/[[path]].js';
 import { filterItemsWithReadyPrimaryCover, additionalMerchantImageLinks } from '../feed.xml.js';
 
@@ -12,17 +13,43 @@ test('sólo compara variantes de la misma imagen y no confunde tapas con contrap
   assert.equal(mlImageIdentity('https://evil.example/D_123456-MLU123456789_012026-O.jpg'),null);
 });
 
-test('gate Google exige ambos lados de 500 y no elimina productos al desactivarlo',()=>{
+test('el gate del feed aplica el mínimo VIGENTE de Google, no el de 2027',()=>{
   const item={id:'MLU123456',pictures:[a,b]};
   const entry=(source,hash,width,height)=>({current:{source_url:source,sha256:hash,object_key:`covers/v1/objects/${hash}.jpg`,mime:'image/jpeg',width,height}});
+  // 400×1200 es una portada vertical típica: pasa de sobra el mínimo real de
+  // hoy (100×100) y se caía por 100px de ancho contra la regla de 2027.
   const manifest={schema_version:1,entries:{'MLU123456:0':entry(a,'a'.repeat(64),400,1200),'MLU123456:1':entry(b,'b'.repeat(64),300,500)}};
   assert.equal(filterItemsWithReadyPrimaryCover([item],manifest).length,1);
-  assert.equal(filterItemsWithReadyPrimaryCover([item],manifest,true).length,0);
-  manifest.entries['MLU123456:0'].current.width=800;
-  assert.equal(filterItemsWithReadyPrimaryCover([item],manifest,true).length,1);
-  assert.deepEqual(additionalMerchantImageLinks(item,manifest,10,true),[]);
+  assert.equal(filterItemsWithReadyPrimaryCover([item],manifest,true).length,1,
+    'con el gate encendido, una portada vertical de 400×1200 debe llegar al feed hoy');
+  assert.equal(additionalMerchantImageLinks(item,manifest,10,true).length,1);
   assert.equal(additionalMerchantImageLinks(item,manifest,10,false).length,1);
-  assert.equal(googleReadyImage({object_key:'x',width:500,height:499}),false);
+
+  // Una imagen realmente inservible sigue afuera con el gate encendido.
+  const tiny={schema_version:1,entries:{'MLU123456:0':entry(a,'c'.repeat(64),80,90)}};
+  assert.equal(filterItemsWithReadyPrimaryCover([item],tiny,true).length,0);
+});
+
+test('el mínimo se endurece solo el 2027-01-31, sin que nadie se acuerde',()=>{
+  const cover={object_key:'x',width:400,height:1200};
+  const antes=Date.UTC(2026,8,10);
+  const justoAntes=GOOGLE_IMAGE_MIN_EDGE_ENFORCED_FROM-1;
+  const desde=GOOGLE_IMAGE_MIN_EDGE_ENFORCED_FROM;
+
+  assert.equal(googleImageMinEdge(antes),100);
+  assert.equal(googleImageMinEdge(justoAntes),100);
+  assert.equal(googleImageMinEdge(desde),500);
+
+  assert.equal(googleReadyImage(cover,antes),true);
+  assert.equal(googleReadyImage(cover,justoAntes),true);
+  assert.equal(googleReadyImage(cover,desde),false,'el 2027-01-31 la misma portada deja de servir');
+
+  // El objetivo del backlog de portadas no se afloja nunca: siempre 500×500.
+  assert.equal(googleFutureReadyImage(cover),false);
+  assert.equal(googleFutureReadyImage({object_key:'x',width:500,height:499}),false);
+  assert.equal(googleFutureReadyImage({object_key:'x',width:500,height:500}),true);
+  // Sin copia en R2 no hay imagen servible, mida lo que mida.
+  assert.equal(googleReadyImage({width:9000,height:9000},antes),false);
 });
 
 

--- a/functions/__tests__/product-image-fallback.test.js
+++ b/functions/__tests__/product-image-fallback.test.js
@@ -40,9 +40,13 @@ test('índice ausente, corrupto o inaccesible conserva la foto real sin esconder
     { get: async () => { throw new Error('R2 unavailable'); } },
   ]) assert.deepEqual(inspectProductImages(await page(data)).products[0].images, [image(0)]);
 });
-test('se prefiere una secundaria de calidad y se conserva la galería', async () => {
+test('la secundaria de calidad va primera, y la chica se conserva en vez de tirarse', async () => {
+  // La portada (426×500) sirve hoy pero no llega al mínimo de 2027; la
+  // secundaria (800×1000) cumple las dos. Google toma la PRIMERA como
+  // principal, así que la buena va adelante — pero la otra no se descarta:
+  // descartarla era lo que dejaba miles de libros sin imagen para Google.
   const html = await page(bucket({ [`${id}:0`]: entry(0,426,500), [`${id}:1`]: entry(1,800,1000) }));
-  assert.deepEqual(inspectProductImages(html).products[0].images, [image(1)]);
+  assert.deepEqual(inspectProductImages(html).products[0].images, [image(1), image(0)]);
   assert.match(html, /class="cover-main"/);
   assert.match(html, /data-idx="1"/);
 });

--- a/functions/_shared/image-source-policy.js
+++ b/functions/_shared/image-source-policy.js
@@ -24,7 +24,37 @@ export function nativeImageAlternatives(source, catalogSources = []) {
   ])].slice(0, 4);
 }
 
-export function googleReadyImage(current) {
+/**
+ * Dos umbrales distintos, porque son dos preguntas distintas.
+ *
+ * `googleReadyImage` responde "¿Google acepta esta imagen HOY?". Hasta el
+ * 2027-01-31 el mínimo real de Merchant para productos que no son indumentaria
+ * —los libros lo son— es 100×100; desde julio de 2026 Google muestra AVISOS
+ * para las menores a 500×500, pero avisar no es rechazar. Exigir 500 hoy deja
+ * fuera del feed miles de libros que Google publicaría igual.
+ *
+ * `googleFutureReadyImage` responde "¿va a seguir sirviendo después del
+ * 2027-01-31?", que es la pregunta del backlog de portadas: ahí el objetivo
+ * sigue siendo 500×500 y no se afloja.
+ *
+ * El umbral se endurece solo en la fecha. Nadie tiene que acordarse.
+ */
+export const GOOGLE_IMAGE_MIN_EDGE_TODAY = 100;
+export const GOOGLE_IMAGE_MIN_EDGE_ENFORCED_FROM = Date.UTC(2027, 0, 31);
+
+export function googleImageMinEdge(now = Date.now()) {
+  return now >= GOOGLE_IMAGE_MIN_EDGE_ENFORCED_FROM
+    ? GOOGLE_IMAGE_MIN_EDGE
+    : GOOGLE_IMAGE_MIN_EDGE_TODAY;
+}
+
+export function googleReadyImage(current, now = Date.now()) {
+  const minEdge = googleImageMinEdge(now);
+  return Boolean(current?.object_key && Number(current.width) >= minEdge &&
+    Number(current.height) >= minEdge);
+}
+
+export function googleFutureReadyImage(current) {
   return Boolean(current?.object_key && Number(current.width) >= GOOGLE_IMAGE_MIN_EDGE &&
     Number(current.height) >= GOOGLE_IMAGE_MIN_EDGE);
 }

--- a/functions/libro/[[path]].js
+++ b/functions/libro/[[path]].js
@@ -1,5 +1,5 @@
 import { coverSources } from '../book-cover/[[path]].js';
-import { googleReadyImage } from '../_shared/image-source-policy.js';
+import { googleReadyImage, googleFutureReadyImage } from '../_shared/image-source-policy.js';
 import { findPreviewCover } from '../_shared/preview-cover.js';
 /**
  * functions/libro/[[path]].js
@@ -1206,8 +1206,21 @@ export async function onRequest(context) {
     if (context.env?.COVER_GOOGLE_QUALITY_GATE === 'true') {
         const positions = originalImages.map(source => coverSources(item).indexOf(source));
         const copies = await Promise.all(originalImages.map((source, index) => findPreviewCover(context, item.id, positions[index], source)));
-        googleImages = copies.flatMap((copy, index) => googleReadyImage(copy?.entry?.current)
-          ? [new URL(`/book-cover/${item.id}/${positions[index] === 0 ? 'cover.jpg' : `cover-${positions[index] + 1}.jpg`}`, navigationBase).toString()] : []);
+        googleImages = copies
+            .map((copy, index) => ({ current: copy?.entry?.current, index }))
+            .filter(candidate => googleReadyImage(candidate.current))
+            // La primera de la lista es la que Google toma como principal. Las
+            // que ya cumplen el mínimo de 2027 van adelante: sirven hoy, van a
+            // seguir sirviendo y no arrastran el aviso de resolución. Las que
+            // sólo cumplen el mínimo vigente quedan detrás, pero NO se
+            // descartan — descartarlas era lo que dejaba miles de libros fuera
+            // del feed. El orden dentro de cada grupo se conserva.
+            .sort((left, right) =>
+                (googleFutureReadyImage(right.current) ? 1 : 0) -
+                (googleFutureReadyImage(left.current) ? 1 : 0))
+            .map(candidate => new URL(
+                `/book-cover/${item.id}/${positions[candidate.index] === 0 ? 'cover.jpg' : `cover-${positions[candidate.index] + 1}.jpg`}`,
+                navigationBase).toString());
     }
     const renderStartedAt = perfNow();
     const html = renderPage(item, slug, isPreview, waitlistSiteKey, previewCoverSrc || '', relatedBooks, googleImages);

--- a/worker-sync/cover-mirror.js
+++ b/worker-sync/cover-mirror.js
@@ -1,4 +1,4 @@
-import { IMAGE_SOURCE_POLICY_VERSION, GOOGLE_IMAGE_MIN_EDGE, IMAGE_SOURCE_RECHECK_MS, IMAGE_FETCH_RETRY_MS, nativeImageAlternatives, mlImageIdentity, googleReadyImage, resolutionDowngrade } from '../functions/_shared/image-source-policy.js';
+import { IMAGE_SOURCE_POLICY_VERSION, GOOGLE_IMAGE_MIN_EDGE, IMAGE_SOURCE_RECHECK_MS, IMAGE_FETCH_RETRY_MS, nativeImageAlternatives, mlImageIdentity, googleFutureReadyImage, resolutionDowngrade } from '../functions/_shared/image-source-policy.js';
 import { dedupeByGtinAndCondition, isEligibleForFeed } from '../functions/feed.xml.js';
 import { COVER_INDEX_METADATA, prepareCoverIndex } from '../functions/_shared/cover-public-index.js';
 import { putJsonToR2 } from './json-r2-stream.js';
@@ -217,7 +217,7 @@ function candidatePriority(candidate, entry, nowMs, aiUpscaleEnabled) {
   if (!entry?.current?.object_key) return 0;
   if (entry.current.source_url !== candidate.source_url) return 1;
   if (entry.source_policy_version !== IMAGE_SOURCE_POLICY_VERSION) return 2;
-  if (!googleReadyImage(entry.current) && nowMs - timestamp(entry.native_checked_at) >= IMAGE_SOURCE_RECHECK_MS) return 2;
+  if (!googleFutureReadyImage(entry.current) && nowMs - timestamp(entry.native_checked_at) >= IMAGE_SOURCE_RECHECK_MS) return 2;
   if (aiUpscaleEnabled && needsAiUpscale(entry)) {
     const attempted = Date.parse(entry.last_transform_attempt_at || '');
     if (!Number.isFinite(attempted) || nowMs - attempted >= TRANSFORM_RETRY_MS) return 2;
@@ -639,7 +639,7 @@ export async function syncCoverMirror(env, catalog, {
   const sourcePending = scopeEntries.filter(({row,entry}) =>
     !entry || entry.source_policy_version !== IMAGE_SOURCE_POLICY_VERSION ||
     (entry.current?.source_url !== row.source_url && entry.last_attempted_source_url !== row.source_url)).length;
-  const needsSource = Object.entries(finalManifest.entries).filter(([,entry]) => entry?.current?.object_key && !googleReadyImage(entry.current))
+  const needsSource = Object.entries(finalManifest.entries).filter(([,entry]) => entry?.current?.object_key && !googleFutureReadyImage(entry.current))
     .map(([key,entry]) => ({row:{product_id:entry.product_id || key.split(':')[0],position:Number(entry.position ?? key.split(':')[1]),source_url:entry.current.source_url},entry}));
   const unavailable = new Map(Object.entries(finalManifest.entries)
     .filter(([,entry]) => entry?.last_error && (!entry.current?.object_key || entry.last_attempted_source_url !== entry.current.source_url))


### PR DESCRIPTION
## El hallazgo

El panel mostró que **6.783 de 7.100 libros activos (95,5%)** pasan la puerta comercial del feed. Pero en Merchant hay ~3.700 ofertas. El hueco de ~3.000 libros **no es comercial: es la puerta de la portada.**

La regla que la cierra:

```js
Number(current.width) >= 500 && Number(current.height) >= 500
```

**Exige 500 de ancho Y 500 de alto. Las portadas de libros son verticales.** Los rechazos reales de la última corrida:

| Producto | Ancho | Alto | Se cae por |
|---|---:|---:|---|
| MLU1038927364 | **490** | 1200 | 10 px de ancho |
| MLU1064868142 | **480** | 739 | ancho |
| MLU1414056912 | **477** | 752 | ancho |
| MLU1044032614 | **499** | 500 | **1 px** |
| MLU1011115866 | **400** | 600 | ancho |

Ninguna se cae por el alto.

## Por qué está de más hoy

Ese 500×500 **no es el requisito actual de Google.**

| Cuándo | Mínimo de Merchant |
|---|---|
| **Hoy** | **100 × 100** para productos que no son indumentaria — los libros lo son |
| Desde julio 2026 | **avisos** para las menores a 500×500 — avisar no es rechazar |
| **Desde 2027-01-31** | 500 × 500 obligatorio |

El sitio venía aplicando la regla de 2027 **dieciséis meses antes de tiempo**, y con eso dejaba fuera del feed miles de libros que Google publicaría igual.

Coincide con lo ya medido en el repo: las **2.097 "advertencias de resolución futura"** que registra el #326 son eso, avisos. La cuenta no está desaprobada.

## El cambio

Se separan dos preguntas que estaban mezcladas en una sola función:

| Función | Pregunta | La usa | Umbral |
|---|---|---|---|
| `googleReadyImage` | ¿Google la acepta **hoy**? | feed y JSON-LD | 100, y **500 desde el 2027-01-31** |
| `googleFutureReadyImage` | ¿va a seguir sirviendo **después**? | espejo de portadas | 500 siempre |

**El umbral se endurece solo en la fecha.** Nadie tiene que acordarse, y hay un test que lo comprueba en los tres momentos: antes, el milisegundo anterior, y a partir de la fecha.

**El objetivo de calidad no se afloja.** El espejo sigue buscando fuentes mejores para las 21.836 imágenes que no llegan a 500 — ese backlog queda igual, apuntando a 500.

## Un efecto que no había previsto, y que el test viejo protegía

Al dejar de descartar las imágenes chicas, apareció esto: **la primera imagen de la lista es la que Google toma como principal.** Si conservaba la portada chica, quedaba adelante de una secundaria mejor — peor que antes.

Se corrige **ordenando en vez de descartando**: las que ya cumplen el mínimo de 2027 van primeras, las demás quedan detrás y se conservan. El orden dentro de cada grupo no cambia.

El test que fijaba el comportamiento viejo se actualizó para exigir **más** que antes: no sólo que la buena vaya primera, sino que la otra siga estando.

## Validación

`bash scripts/validate-ci.sh` completo en verde: **1.824 tests, 0 fallos**, ambos builds OK.

Requisitos verificados contra la documentación de Google, no de memoria:
- [Image link [image_link]](https://support.google.com/merchants/answer/6324350?hl=en)
- [How to fix: Image too small](https://support.google.com/merchants/answer/12159030?hl=en)
- [Merchant Center product data specification update 2026](https://support.google.com/merchants/answer/16989427?hl=en)

## Lo que este PR NO resuelve

- **No mide cuántos libros entran.** El efecto real se ve en el feed después del deploy; acá no puedo consultarlo.
- **No mejora ninguna foto.** Las 21.836 imágenes chicas siguen chicas y hay que conseguirles una fuente mejor antes del 2027-01-31. Este PR sólo deja de castigarlas antes de tiempo.
- **Van a aparecer más avisos en Merchant**, del mismo tipo que los 2.097 que ya hay. Son avisos, no desaprobaciones — pero es un cambio visible en la consola y conviene saberlo de antemano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM)_