### PR TITLE
Esperar a que TODAS las rutas del Preview propaguen, no sólo dos

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -92,13 +92,27 @@ jobs:
         env:
           PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
         run: |
+          # Se espera por TODAS las rutas que la auditoría va a pedir, no sólo
+          # por dos. Los sitemaps son Functions distintas y propagan por su
+          # cuenta: esperar sólo home y feed dejaba pasar el job con los
+          # sitemaps todavía en 404, y la auditoría moría a los 30 segundos
+          # con "sitemap-pages.xml respondió HTTP 404". Pasó en el #334 y en
+          # el #342, y cada vez costó una re-ejecución a mano.
+          ROUTES="/ /feed.xml /sitemap.xml /sitemap-pages.xml /sitemap-categories.xml /sitemap-books-active.xml /sitemap-books-paused.xml"
           for attempt in 1 2 3 4 5 6 7 8; do
-            HOME_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 "$PREVIEW_URL/")
-            FEED_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 "$PREVIEW_URL/feed.xml")
-            [ "$HOME_CODE" = "200" ] && [ "$FEED_CODE" = "200" ] && exit 0
-            echo "Preview propagándose: intento $attempt/8, home HTTP $HOME_CODE, feed HTTP $FEED_CODE."
+            PENDING=""
+            for route in $ROUTES; do
+              CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 "$PREVIEW_URL$route")
+              [ "$CODE" = "200" ] || PENDING="$PENDING $route(HTTP $CODE)"
+            done
+            if [ -z "$PENDING" ]; then
+              echo "Preview propagado: todas las rutas responden 200."
+              exit 0
+            fi
+            echo "Preview propagándose: intento $attempt/8, faltan:$PENDING"
             sleep 10
           done
+          echo "ERROR: el Preview no propagó todas las rutas. Faltan:$PENDING"
           exit 1
 
       - name: Verify reported missing Product.image on isolated Preview


### PR DESCRIPTION
## El problema

El job de Preview espera a que respondan `/` y `/feed.xml`, y recién ahí audita. Pero **los sitemaps son Functions distintas y propagan por su cuenta**, así que el job puede darse por listo con los sitemaps todavía en 404 — y la auditoría muere a los 30 segundos:

```
Error: https://pr-342.amadolibros-web.pages.dev/sitemap-pages.xml respondió HTTP 404
```

Pasó en el **#334** (`sitemap.xml`, murió en 39s) y otra vez hoy en el **#342** (`sitemap-pages.xml`, murió en 31s). Las dos veces era una carrera de propagación, no un problema del PR, y las dos veces costó una re-ejecución a mano **más un rato de diagnóstico para descartar que fuera el cambio** — que es lo caro.

## El cambio

Se espera por las **siete rutas que la auditoría realmente pide**, no por dos:

```
/  /feed.xml  /sitemap.xml  /sitemap-pages.xml
/sitemap-categories.xml  /sitemap-books-active.xml  /sitemap-books-paused.xml
```

Y el mensaje ahora dice **cuáles faltan** en vez de imprimir dos códigos sueltos. Si se agotan los ocho intentos, el error final también las nombra, así el diagnóstico es inmediato.

**No cambia el número de intentos ni la espera:** mismos 8 × 10s.

## Validación

`bash scripts/validate-ci.sh` completo en verde. No toca código de la web: sólo el workflow.

El propio CI de este PR es la prueba — corre exactamente este paso modificado.

## Lo que este PR NO resuelve

No elimina la carrera, la espera bien. Si Cloudflare tardara más de 80 segundos en propagar, el job seguiría fallando — pero ahora fallaría diciendo exactamente qué ruta faltó, en vez de morir después en la auditoría con un 404 que parece un bug del PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM)_