### PR TITLE
Ficha de pedido en el panel: qué va en la caja y a dónde va

### DIFF
--- a/functions/__tests__/panel-page.test.js
+++ b/functions/__tests__/panel-page.test.js
@@ -387,3 +387,106 @@ test('la fecha del catálogo sale del campo que el catálogo realmente trae', as
   );
   assert.equal(summary.generatedAt, '2026-09-10T00:30:00.000Z');
 });
+
+const ORDER = {
+  id: 42, public_code: 'AL-260909-K71QP2', status: 'paid', payment_status: 'approved',
+  buyer_name: 'Valentina Rodríguez', buyer_email: 'valen@example.com', buyer_phone: '099 214 887',
+  delivery_type: 'shipping', address: 'Bulevar España 2341 ap. 604', locality: 'Pocitos',
+  department: 'Montevideo', delivery_notes: '<b>Portero</b> hasta las 18',
+  requested_delivery_date: '2026-09-11', requested_delivery_from: '14:00', requested_delivery_to: '18:00',
+  products_total_uyu: 3770, pickup_discount_uyu: 0, shipping_cost_uyu: 190, payable_total_uyu: 3960,
+  currency: 'UYU', payment_provider: 'mercadopago', payment_id: '118742339015',
+  created_at: '2026-09-07T10:00:00.000Z', paid_at: '2026-09-07T10:05:00.000Z',
+  fulfilled_at: null, cancelled_at: null,
+};
+const ORDER_ITEMS = [
+  { title: '<script>alert(1)</script>Biblia Reina-Valera', product_id: 'MLU651526046', quantity: 1, unit_price_uyu: 1990, line_total_uyu: 1990 },
+  { title: 'El Tarot de Marsella', product_id: 'MLU478189961', quantity: 2, unit_price_uyu: 890, line_total_uyu: 1780 },
+];
+
+function orderDb({ found = true } = {}) {
+  const seen = [];
+  const answer = (sql, params) => {
+    seen.push({ sql, params });
+    if (sql.includes('FROM orders') && sql.includes('public_code = ?')) return found ? [ORDER] : [];
+    if (sql.includes('FROM order_items')) return ORDER_ITEMS;
+    if (sql.includes('FROM order_events')) return [{ event_type: 'payment_approved', created_at: '2026-09-07T10:05:00.000Z' }];
+    return [];
+  };
+  return {
+    seen,
+    prepare(sql) {
+      let bound = [];
+      const st = { bind: (...p) => { bound = p; return st; }, all: async () => ({ results: answer(sql, bound) }) };
+      return st;
+    },
+  };
+}
+
+test('la ficha muestra qué va en la caja y a dónde va, con todo escapado', async () => {
+  const db = orderDb();
+  const response = await onRequest({
+    request: request('/panel/pedido/AL-260909-K71QP2', { cookie: await sessionCookie() }),
+    env: baseEnv({ ORDERS_DB: db }),
+  });
+  assert.equal(response.status, 200);
+  const html = await response.text();
+
+  // Lo que hoy la lista no muestra y hace falta para despachar.
+  assert.match(html, /Qué va en la caja/);
+  assert.match(html, /El Tarot de Marsella/);
+  assert.match(html, /2×/);
+  assert.match(html, /Bulevar España 2341/);
+  assert.match(html, /099 214 887/);
+  assert.match(html, /2026-09-11, de 14:00 a 18:00/);
+  assert.match(html, /Pago aprobado/);
+  assert.match(html, /\$ 3[.,]?960/);
+
+  // Un título hostil de Mercado Libre no ejecuta nada.
+  assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
+  assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  // Ni una nota de entrega con etiquetas.
+  assert.doesNotMatch(html, /<b>Portero<\/b>/);
+});
+
+test('sigue siendo solo lectura: la ficha no escribe nada', async () => {
+  const db = orderDb();
+  await onRequest({
+    request: request('/panel/pedido/AL-260909-K71QP2', { cookie: await sessionCookie() }),
+    env: baseEnv({ ORDERS_DB: db }),
+  });
+  for (const { sql } of db.seen) {
+    assert.doesNotMatch(sql, /\b(INSERT|UPDATE|DELETE|DROP|ALTER)\b/i, `consulta que escribe: ${sql}`);
+  }
+});
+
+test('un código con forma inválida no llega a consultar la base', async () => {
+  const db = orderDb();
+  const response = await onRequest({
+    request: request(`/panel/pedido/${encodeURIComponent("AL-1' OR 1=1--")}`, { cookie: await sessionCookie() }),
+    env: baseEnv({ ORDERS_DB: db }),
+  });
+  assert.equal(response.status, 404);
+  assert.equal(db.seen.length, 0, 'un código que no tiene la forma real ni siquiera se consulta');
+});
+
+test('un pedido inexistente responde 404 sin revelar si el código existe', async () => {
+  const response = await onRequest({
+    request: request('/panel/pedido/AL-260101-ZZZZZZ', { cookie: await sessionCookie() }),
+    env: baseEnv({ ORDERS_DB: orderDb({ found: false }) }),
+  });
+  assert.equal(response.status, 404);
+  assert.match(await response.text(), /Pedido no encontrado/);
+});
+
+test('sin sesión la ficha muestra el login, nunca los datos del pedido', async () => {
+  const response = await onRequest({
+    request: request('/panel/pedido/AL-260909-K71QP2'),
+    env: baseEnv({ ORDERS_DB: orderDb() }),
+  });
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert.match(html, /type="password"/);
+  assert.doesNotMatch(html, /Bulevar España/);
+  assert.doesNotMatch(html, /Valentina/);
+});

--- a/functions/_shared/panel-data.js
+++ b/functions/_shared/panel-data.js
@@ -23,9 +23,16 @@ const RECENT_ORDERS_LIMIT = 20;
 const STUCK_LIMIT = 25;
 const CRAWL_DAYS = 7;
 const MISSING_IMAGE_LIMIT = 25;
+const ORDER_EVENTS_LIMIT = 30;
+// El código va en la URL y de ahí a una consulta: sólo se acepta su forma real.
+const ORDER_CODE_RE = /^AL-[0-9]{6}-[A-Z0-9]{6}$/;
 
 // El id va a parar a un href. Sólo se acepta la forma real de Mercado Libre;
 // cualquier otra cosa queda en cadena vacía y el panel muestra el texto sin enlace.
+function cleanString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
 function cleanId(value) {
   return /^MLU\d+$/.test(String(value || '')) ? String(value) : '';
 }
@@ -266,6 +273,54 @@ export async function loadCatalogSummary(ctx) {
     // Las otras dos formas nunca existieron: por eso el panel mostraba "—".
     generatedAt: catalog?.updated_at || catalog?.generated_at || catalog?.generatedAt || null,
   };
+}
+
+
+/**
+ * Un pedido completo: qué libros, a dónde va y qué le pasó.
+ * Es lo que hace falta para despachar, y hasta ahora el panel no lo mostraba:
+ * la lista daba una fila por pedido y nunca el contenido de la caja.
+ */
+export async function loadOrder(db, publicCode) {
+  const code = cleanString(publicCode).toUpperCase();
+  if (!ORDER_CODE_RE.test(code)) return null;
+
+  const [order] = await queryAll(
+    db,
+    `SELECT id, public_code, status, payment_status, buyer_name, buyer_email, buyer_phone,
+            delivery_type, address, locality, department, delivery_notes,
+            requested_delivery_date, requested_delivery_from, requested_delivery_to,
+            products_total_uyu, pickup_discount_uyu, shipping_cost_uyu, payable_total_uyu,
+            currency, payment_provider, payment_id,
+            created_at, paid_at, fulfilled_at, cancelled_at
+       FROM orders
+      WHERE public_code = ?
+      LIMIT 1`,
+    [code],
+  );
+  if (!order) return null;
+
+  const [items, events] = await Promise.all([
+    queryAll(
+      db,
+      `SELECT title, product_id, quantity, unit_price_uyu, line_total_uyu
+         FROM order_items
+        WHERE order_id = ?
+        ORDER BY id ASC`,
+      [order.id],
+    ),
+    queryAll(
+      db,
+      `SELECT event_type, created_at
+         FROM order_events
+        WHERE order_id = ?
+        ORDER BY created_at DESC, id DESC
+        LIMIT ?`,
+      [order.id, ORDER_EVENTS_LIMIT],
+    ),
+  ]);
+
+  return { order, items, events };
 }
 
 export function environmentSummary(env) {

--- a/functions/panel/[[path]].js
+++ b/functions/panel/[[path]].js
@@ -5,6 +5,8 @@
  *
  * Rutas:
  *   GET  /panel         → login si no hay sesión válida, tablero si la hay
+ *   GET  /panel/pedido/<código> → la ficha del pedido: qué va en la caja,
+ *                       a dónde va, el pago y el historial
  *   POST /panel/login   → Turnstile + contraseña → cookie de sesión firmada
  *   POST /panel/logout  → borra la cookie
  *
@@ -31,7 +33,7 @@ import {
   sessionCookieHeader,
   timingSafeEqual,
 } from '../_shared/panel-auth.js';
-import { loadPanelData } from '../_shared/panel-data.js';
+import { loadOrder, loadPanelData } from '../_shared/panel-data.js';
 
 // Mismo patrón que functions/api/_stock_waitlist_handler.js: el panel no puede
 // aceptar un hostname de Preview que el resto del sitio rechaza, ni al revés.
@@ -142,6 +144,25 @@ function layout(title, body) {
            color:#fff; font-size:.95rem; cursor:pointer; }
   .logout { background:none; color:#6b7280; border:1px solid #cbd2d9; margin:0; padding:.35rem .8rem; }
   .empty { color:#6b7280; font-style:italic; font-size:.85rem; }
+  .topbar { display:flex; justify-content:space-between; align-items:flex-start; gap:1rem;
+            flex-wrap:wrap; margin-bottom:1.25rem; }
+  .back { display:inline-block; color:#6b7280; text-decoration:none; font-size:.85rem;
+          margin-bottom:.35rem; }
+  .back:hover { color:#1f2933; }
+  .tag { border:1px solid #cbd2d9; border-radius:999px; padding:.2rem .7rem; font-size:.8rem;
+         color:#6b7280; white-space:nowrap; }
+  .tag.alerta { border-color:#f0b429; background:#fffbeb; color:#8a5200; font-weight:600; }
+  dl { margin:0; display:grid; grid-template-columns:auto 1fr; gap:.35rem .9rem; font-size:.88rem; }
+  dt { color:#6b7280; white-space:nowrap; }
+  dd { margin:0; text-align:right; }
+  dl.totales { margin-top:.9rem; padding-top:.75rem; border-top:1px solid #eef0f3; }
+  .total { font-weight:700; font-size:1rem; color:#1f2933; }
+  .direccion { margin:.85rem 0 0; padding:.7rem .8rem; background:#f6f7f9; border-radius:8px;
+               font-size:.9rem; line-height:1.45; }
+  .nota { margin:.6rem 0 0; padding:.6rem .8rem; border-left:3px solid #cbd2d9; color:#4b5563;
+          font-style:italic; font-size:.88rem; }
+  tbody tr a { color:inherit; text-decoration:none; display:block; }
+  tbody tr:hover { background:#f6f7f9; }
 </style>
 </head>
 <body><main>${body}</main></body>
@@ -189,6 +210,95 @@ function sectionOrError(block, render) {
   return render(block.data);
 }
 
+
+const EVENT_LABEL = {
+  preference_created: 'Pago iniciado',
+  payment_approved: 'Pago aprobado',
+  payment_pending: 'Pago pendiente',
+  payment_rejected: 'Pago rechazado',
+  payment_cancelled: 'Pago cancelado',
+  payment_refunded: 'Pago devuelto',
+  order_unavailable: 'Sin stock al confirmar',
+  already_sent: 'Aviso ya enviado',
+};
+
+function deliveryWindow(order) {
+  const day = shortDate(order.requested_delivery_date);
+  if (day === '—') return 'Sin fecha pedida';
+  const from = cleanString(order.requested_delivery_from);
+  const to = cleanString(order.requested_delivery_to);
+  return from && to ? `${day.slice(0, 10)}, de ${escapeHtml(from)} a ${escapeHtml(to)}` : day.slice(0, 10);
+}
+
+/**
+ * La ficha de un pedido: qué va en la caja, a dónde va y qué le pasó.
+ * Es la pantalla que se usa para despachar, así que lo primero es el contenido
+ * y la dirección — no los identificadores internos.
+ */
+function orderPage(found) {
+  const { order, items, events } = found;
+  const units = items.reduce((total, item) => total + Number(item.quantity || 0), 0);
+  const pickup = order.delivery_type === 'pickup';
+  const pending = order.payment_status === 'approved' && !order.fulfilled_at;
+
+  const body = `
+<div class="topbar">
+  <div>
+    <a class="back" href="/panel">← Pedidos</a>
+    <h1>${escapeHtml(order.public_code)}</h1>
+    <p class="muted">${escapeHtml(order.buyer_name)} · ${escapeHtml(units)} libro${units === 1 ? '' : 's'} · ${shortDate(order.created_at)}</p>
+  </div>
+  <span class="tag ${pending ? 'alerta' : ''}">${pending ? 'Pagado sin despachar' : escapeHtml(order.status)}</span>
+</div>
+
+<section class="card">
+  <h2>Qué va en la caja</h2>
+  ${table(['Cant.', 'Libro', 'Publicación', 'Precio'], items, row => `
+    <tr><td>${escapeHtml(row.quantity)}×</td>
+        <td>${escapeHtml(row.title)}</td>
+        <td>${escapeHtml(row.product_id)}</td>
+        <td>${money(row.line_total_uyu)}</td></tr>`)}
+  <dl class="totales">
+    <dt>Libros</dt><dd>${money(order.products_total_uyu)}</dd>
+    ${Number(order.shipping_cost_uyu) ? `<dt>Envío</dt><dd>${money(order.shipping_cost_uyu)}</dd>` : ''}
+    ${Number(order.pickup_discount_uyu) ? `<dt>Descuento por retiro</dt><dd>−${money(order.pickup_discount_uyu)}</dd>` : ''}
+    <dt class="total">Total</dt><dd class="total">${money(order.payable_total_uyu)}</dd>
+  </dl>
+</section>
+
+<section class="card">
+  <h2>${pickup ? 'Retira en el local' : 'A dónde va'}</h2>
+  <dl>
+    <dt>Entrega</dt><dd>${pickup ? 'Retiro' : 'Envío'}</dd>
+    <dt>Teléfono</dt><dd>${escapeHtml(order.buyer_phone)}</dd>
+    <dt>Correo</dt><dd>${escapeHtml(order.buyer_email)}</dd>
+    <dt>Fecha pedida</dt><dd>${deliveryWindow(order)}</dd>
+  </dl>
+  ${pickup ? '' : `<p class="direccion">${escapeHtml(order.address)}<br>${escapeHtml(order.locality)}, ${escapeHtml(order.department)}</p>`}
+  ${cleanString(order.delivery_notes) ? `<p class="nota">“${escapeHtml(order.delivery_notes)}”</p>` : ''}
+</section>
+
+<section class="card">
+  <h2>Pago</h2>
+  <dl>
+    <dt>Estado</dt><dd>${escapeHtml(order.payment_status)}</dd>
+    <dt>Medio</dt><dd>${escapeHtml(order.payment_provider) || '—'}</dd>
+    <dt>ID de pago</dt><dd>${escapeHtml(order.payment_id) || '—'}</dd>
+    <dt>Cobrado</dt><dd>${shortDate(order.paid_at)}</dd>
+    <dt>Despachado</dt><dd>${shortDate(order.fulfilled_at)}</dd>
+  </dl>
+</section>
+
+<section class="card">
+  <h2>Historial</h2>
+  ${table(['Qué pasó', 'Cuándo'], events, row => `
+    <tr><td>${escapeHtml(EVENT_LABEL[row.event_type] || row.event_type)}</td>
+        <td>${shortDate(row.created_at)}</td></tr>`)}
+</section>`;
+
+  return layout(`Pedido ${order.public_code}`, body);
+}
+
 function dashboardPage(data) {
   const env = data.environment;
   const stuckCount = data.stuck?.ok ? data.stuck.data.total : null;
@@ -215,7 +325,7 @@ function dashboardPage(data) {
   ${sectionOrError(data.stuck, stuck => `
     <h3 class="muted">Pagados sin despachar</h3>
     ${table(['Pedido', 'Comprador', 'Total', 'Pagado'], stuck.paidNotFulfilled, row => `
-      <tr><td>${escapeHtml(row.public_code)}</td><td>${escapeHtml(row.buyer_name)}</td>
+      <tr><td><a href="/panel/pedido/${encodeURIComponent(row.public_code)}">${escapeHtml(row.public_code)}</a></td><td>${escapeHtml(row.buyer_name)}</td>
           <td>${money(row.payable_total_uyu)}</td><td>${shortDate(row.paid_at)}</td></tr>`)}
 
     <h3 class="muted">Pago colgado hace más de una hora</h3>
@@ -266,7 +376,7 @@ function dashboardPage(data) {
     ${statusList(orders.byStatus)}
     <h3 class="muted">Últimos ${orders.recent.length}</h3>
     ${table(['Pedido', 'Estado', 'Pago', 'Comprador', 'Entrega', 'Total', 'Creado'], orders.recent, row => `
-      <tr><td>${escapeHtml(row.public_code)}</td><td>${escapeHtml(row.status)}</td>
+      <tr><td><a href="/panel/pedido/${encodeURIComponent(row.public_code)}">${escapeHtml(row.public_code)}</a></td><td>${escapeHtml(row.status)}</td>
           <td>${escapeHtml(row.payment_status)}</td><td>${escapeHtml(row.buyer_name)}</td>
           <td>${escapeHtml(row.delivery_type)}</td><td>${money(row.payable_total_uyu)}</td>
           <td>${shortDate(row.created_at)}</td></tr>`)}
@@ -419,6 +529,28 @@ export async function onRequest(context) {
   if (path === '/panel/login') {
     if (request.method !== 'POST') return new Response('Method Not Allowed', { status: 405 });
     return handleLogin(context, config);
+  }
+
+  const pedido = /^\/panel\/pedido\/([^/]+)$/.exec(path);
+  if (pedido) {
+    if (request.method !== 'GET') return new Response('Method Not Allowed', { status: 405 });
+    if (!(await hasValidSession(request, await deriveSessionSecret(config.password)))) {
+      return htmlResponse(loginPage({
+        siteKey: cleanString(context.env?.STOCK_WAITLIST_TURNSTILE_SITE_KEY),
+      }));
+    }
+    const db = context.env?.ORDERS_DB;
+    // Un pedido inexistente y un código inválido responden igual: la ficha no
+    // sirve para averiguar qué códigos existen.
+    const found = db ? await loadOrder(db, decodeURIComponent(pedido[1])) : null;
+    if (!found) {
+      return htmlResponse(
+        layout('Pedido no encontrado', '<main class="card"><a class="back" href="/panel">← Pedidos</a>'
+          + '<h1>Pedido no encontrado</h1><p class="muted">Revisá el código.</p></main>'),
+        { status: 404 },
+      );
+    }
+    return htmlResponse(orderPage(found));
   }
 
   if (path !== '/panel') return new Response('Not Found', { status: 404 });


### PR DESCRIPTION
Primera entrega del rediseño del panel, acordada sobre [la maqueta](https://claude.ai/code/artifact/57ca69c3-ac14-47e4-963e-3b78fff1b929).

## El problema

El panel mostraba **una fila por pedido y nada más**. La base guarda bastante más que eso, y nada de eso se veía:

| Guardado en D1 | ¿Se veía? |
|---|---|
| `order_items` — **qué libros pidió el cliente** | ❌ |
| `address`, `locality`, `department` | ❌ |
| `buyer_phone`, `buyer_email` | ❌ |
| `requested_delivery_date` / `from` / `to` | ❌ |
| `delivery_notes` | ❌ |
| `shipping_cost_uyu`, `pickup_discount_uyu` | ❌ |
| `payment_id`, `payment_provider` | ❌ |
| `order_events` — historial | ❌ |

**No se podía despachar un pedido desde el panel, porque no decía qué poner en la caja ni a dónde mandarlo.**

## El cambio

Se agrega `GET /panel/pedido/<código>`, ordenada por lo que se necesita primero:

1. **Qué va en la caja** — libros, cantidades, precios y el desglose hasta el total
2. **A dónde va** — o *Retira en el local*, según el tipo de entrega: teléfono, correo, dirección, fecha pedida y la nota del comprador
3. **Pago** — estado, medio, id, cuándo se cobró y cuándo se despachó
4. **Historial** — los `order_events` con nombres en castellano

El código del pedido en las dos listas del tablero ahora es un enlace a su ficha.

## Seguridad

**Sigue siendo solo lectura.** No se agrega ninguna escritura, y hay un test que recorre todas las consultas que la ficha ejecuta y falla si alguna contiene `INSERT`, `UPDATE`, `DELETE`, `DROP` o `ALTER`.

**El código va en la URL y de ahí a una consulta.** Sólo se acepta su forma real (`AL-YYMMDD-XXXXXX`); cualquier otra cosa responde 404 **sin tocar la base**. Hay un test con `AL-1' OR 1=1--` que verifica que ni siquiera se consulte.

**Un pedido inexistente responde igual que un código inválido**, así que la ficha no sirve para averiguar qué códigos existen.

**Todo lo que viene de afuera va escapado.** Los títulos los escribe Mercado Libre y las notas de entrega las escribe el comprador, y los dos terminan en este HTML. Hay un test con un título que contiene `<script>` y una nota con etiquetas.

**Sin sesión no se ve nada**: la ficha muestra el login, no los datos.

## Validación

`bash scripts/validate-ci.sh` completo en verde: **1.829 tests, 0 fallos**, ambos builds OK. Cinco tests nuevos.

## Lo que este PR NO trae todavía

Va en la siguiente entrega, y **necesita escrituras**, que es un salto distinto:

- **Avisar al cliente por correo** (listo para retirar / el envío sale hoy)
- **Ajustes** con la dirección y horarios de retiro que carga Gaby
- **Marcar despachado** y notas internas
- **Buscar, filtrar y paginar** la lista de pedidos

Decidido con Seba: el panel queda con **una sola contraseña compartida**, así que el historial va a decir "alguien del equipo" y no quién. Es lo razonable para dos personas; si en algún momento son más, conviene revisarlo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM)_