### PR TITLE
Ajustes del panel: la dirección y los horarios de retiro los carga el equipo

### DIFF
--- a/functions/__tests__/panel-page.test.js
+++ b/functions/__tests__/panel-page.test.js
@@ -490,3 +490,129 @@ test('sin sesión la ficha muestra el login, nunca los datos del pedido', async 
   assert.doesNotMatch(html, /Bulevar España/);
   assert.doesNotMatch(html, /Valentina/);
 });
+
+
+function kvStub(initial = null) {
+  const store = { value: initial, writes: 0 };
+  return {
+    store,
+    get: async () => store.value,
+    put: async (_k, v) => { store.value = v; store.writes += 1; },
+    delete: async () => {},
+  };
+}
+
+function settingsForm(values) {
+  const form = new URLSearchParams();
+  for (const [k, v] of Object.entries(values)) form.set(k, v);
+  return form;
+}
+
+test('ajustes guarda los datos de retiro y los devuelve en el formulario', async () => {
+  const kv = kvStub();
+  const guardado = await onRequest({
+    request: request('/panel/ajustes', {
+      method: 'POST', cookie: await sessionCookie(),
+      body: settingsForm({ address: 'Bulevar Espana 2341', zone: 'Pocitos, Montevideo', hours: 'Lun a vie de 10 a 18', holdDays: '20' }),
+    }),
+    env: baseEnv({ AMADO_KV: kv }),
+  });
+  assert.equal(guardado.status, 200);
+  assert.match(await guardado.text(), /Guardado\./);
+  assert.equal(kv.store.writes, 1);
+  assert.deepEqual(JSON.parse(kv.store.value), {
+    address: 'Bulevar Espana 2341', zone: 'Pocitos, Montevideo', hours: 'Lun a vie de 10 a 18', holdDays: 20,
+  });
+
+  const vista = await onRequest({
+    request: request('/panel/ajustes', { cookie: await sessionCookie() }),
+    env: baseEnv({ AMADO_KV: kv }),
+  });
+  const html = await vista.text();
+  assert.match(html, /value="Bulevar Espana 2341"/);
+  assert.match(html, /Lun a vie de 10 a 18/);
+  assert.doesNotMatch(html, /Falta completar/);
+});
+
+test('mientras falte un dato, ajustes avisa que el correo de retiro no se puede mandar', async () => {
+  const response = await onRequest({
+    request: request('/panel/ajustes', {
+      method: 'POST', cookie: await sessionCookie(),
+      body: settingsForm({ address: 'Bulevar Espana 2341', zone: '', hours: '', holdDays: '15' }),
+    }),
+    env: baseEnv({ AMADO_KV: kvStub() }),
+  });
+  assert.match(await response.text(), /Falta completar/);
+});
+
+test('los datos de retiro se limpian y se acotan antes de guardarse', async () => {
+  const kv = kvStub();
+  await onRequest({
+    request: request('/panel/ajustes', {
+      method: 'POST', cookie: await sessionCookie(),
+      body: settingsForm({
+        // Un caracter de control invisible no puede terminar en el correo.
+        address: '  Calle 1  con basura  ',
+        zone: 'Centro',
+        hours: 'Lunes a viernes\r\nSabados de 10 a 13',
+        holdDays: '999',
+      }),
+    }),
+    env: baseEnv({ AMADO_KV: kv }),
+  });
+  const saved = JSON.parse(kv.store.value);
+  assert.equal(saved.address, 'Calle 1  con basura', 'el caracter de control no llega al correo');
+  assert.equal(saved.hours, 'Lunes a viernes\nSabados de 10 a 13', 'el salto de linea si se conserva');
+  assert.equal(saved.holdDays, 90, 'los dias se acotan a un rango razonable');
+});
+
+test('lo que carga el equipo sale escapado, no como HTML', async () => {
+  const kv = kvStub(JSON.stringify({
+    address: '<img src=x onerror=alert(1)>', zone: 'Centro', hours: '10 a 18', holdDays: 15,
+  }));
+  const html = await (await onRequest({
+    request: request('/panel/ajustes', { cookie: await sessionCookie() }),
+    env: baseEnv({ AMADO_KV: kv }),
+  })).text();
+  assert.doesNotMatch(html, /<img src=x onerror/);
+  assert.match(html, /&lt;img src=x onerror=alert\(1\)&gt;/);
+});
+
+test('un POST desde otro sitio se rechaza aunque traiga cookie', async () => {
+  const headers = new Headers({ cookie: await sessionCookie(), origin: 'https://sitio-ajeno.example' });
+  const kv = kvStub();
+  const response = await onRequest({
+    request: new Request('https://www.amadolibros.com/panel/ajustes', {
+      method: 'POST', headers, body: settingsForm({ address: 'x', zone: 'y', hours: 'z', holdDays: '1' }),
+    }),
+    env: baseEnv({ AMADO_KV: kv }),
+  });
+  assert.equal(response.status, 403);
+  assert.equal(kv.store.writes, 0, 'no se escribio nada');
+});
+
+test('sin sesion no se puede ni ver ni guardar los ajustes', async () => {
+  const kv = kvStub();
+  const vista = await onRequest({ request: request('/panel/ajustes'), env: baseEnv({ AMADO_KV: kv }) });
+  assert.match(await vista.text(), /type="password"/);
+
+  await onRequest({
+    request: request('/panel/ajustes', { method: 'POST', body: settingsForm({ address: 'x', zone: 'y', hours: 'z', holdDays: '1' }) }),
+    env: baseEnv({ AMADO_KV: kv }),
+  });
+  assert.equal(kv.store.writes, 0, 'sin sesion no se escribe');
+});
+
+test('si KV no esta, avisa en vez de decir que guardo', async () => {
+  const response = await onRequest({
+    request: request('/panel/ajustes', {
+      method: 'POST', cookie: await sessionCookie(),
+      body: settingsForm({ address: 'x', zone: 'y', hours: 'z', holdDays: '1' }),
+    }),
+    env: baseEnv({ AMADO_KV: undefined }),
+  });
+  assert.equal(response.status, 500);
+  const html = await response.text();
+  assert.match(html, /No se pudo guardar/);
+  assert.doesNotMatch(html, /Guardado\./);
+});

--- a/functions/__tests__/panel-page.test.js
+++ b/functions/__tests__/panel-page.test.js
@@ -387,3 +387,106 @@ test('la fecha del catálogo sale del campo que el catálogo realmente trae', as
   );
   assert.equal(summary.generatedAt, '2026-09-10T00:30:00.000Z');
 });
+
+const ORDER = {
+  id: 42, public_code: 'AL-260909-K71QP2', status: 'paid', payment_status: 'approved',
+  buyer_name: 'Valentina Rodríguez', buyer_email: 'valen@example.com', buyer_phone: '099 214 887',
+  delivery_type: 'shipping', address: 'Bulevar España 2341 ap. 604', locality: 'Pocitos',
+  department: 'Montevideo', delivery_notes: '<b>Portero</b> hasta las 18',
+  requested_delivery_date: '2026-09-11', requested_delivery_from: '14:00', requested_delivery_to: '18:00',
+  products_total_uyu: 3770, pickup_discount_uyu: 0, shipping_cost_uyu: 190, payable_total_uyu: 3960,
+  currency: 'UYU', payment_provider: 'mercadopago', payment_id: '118742339015',
+  created_at: '2026-09-07T10:00:00.000Z', paid_at: '2026-09-07T10:05:00.000Z',
+  fulfilled_at: null, cancelled_at: null,
+};
+const ORDER_ITEMS = [
+  { title: '<script>alert(1)</script>Biblia Reina-Valera', product_id: 'MLU651526046', quantity: 1, unit_price_uyu: 1990, line_total_uyu: 1990 },
+  { title: 'El Tarot de Marsella', product_id: 'MLU478189961', quantity: 2, unit_price_uyu: 890, line_total_uyu: 1780 },
+];
+
+function orderDb({ found = true } = {}) {
+  const seen = [];
+  const answer = (sql, params) => {
+    seen.push({ sql, params });
+    if (sql.includes('FROM orders') && sql.includes('public_code = ?')) return found ? [ORDER] : [];
+    if (sql.includes('FROM order_items')) return ORDER_ITEMS;
+    if (sql.includes('FROM order_events')) return [{ event_type: 'payment_approved', created_at: '2026-09-07T10:05:00.000Z' }];
+    return [];
+  };
+  return {
+    seen,
+    prepare(sql) {
+      let bound = [];
+      const st = { bind: (...p) => { bound = p; return st; }, all: async () => ({ results: answer(sql, bound) }) };
+      return st;
+    },
+  };
+}
+
+test('la ficha muestra qué va en la caja y a dónde va, con todo escapado', async () => {
+  const db = orderDb();
+  const response = await onRequest({
+    request: request('/panel/pedido/AL-260909-K71QP2', { cookie: await sessionCookie() }),
+    env: baseEnv({ ORDERS_DB: db }),
+  });
+  assert.equal(response.status, 200);
+  const html = await response.text();
+
+  // Lo que hoy la lista no muestra y hace falta para despachar.
+  assert.match(html, /Qué va en la caja/);
+  assert.match(html, /El Tarot de Marsella/);
+  assert.match(html, /2×/);
+  assert.match(html, /Bulevar España 2341/);
+  assert.match(html, /099 214 887/);
+  assert.match(html, /2026-09-11, de 14:00 a 18:00/);
+  assert.match(html, /Pago aprobado/);
+  assert.match(html, /\$ 3[.,]?960/);
+
+  // Un título hostil de Mercado Libre no ejecuta nada.
+  assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
+  assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  // Ni una nota de entrega con etiquetas.
+  assert.doesNotMatch(html, /<b>Portero<\/b>/);
+});
+
+test('sigue siendo solo lectura: la ficha no escribe nada', async () => {
+  const db = orderDb();
+  await onRequest({
+    request: request('/panel/pedido/AL-260909-K71QP2', { cookie: await sessionCookie() }),
+    env: baseEnv({ ORDERS_DB: db }),
+  });
+  for (const { sql } of db.seen) {
+    assert.doesNotMatch(sql, /\b(INSERT|UPDATE|DELETE|DROP|ALTER)\b/i, `consulta que escribe: ${sql}`);
+  }
+});
+
+test('un código con forma inválida no llega a consultar la base', async () => {
+  const db = orderDb();
+  const response = await onRequest({
+    request: request(`/panel/pedido/${encodeURIComponent("AL-1' OR 1=1--")}`, { cookie: await sessionCookie() }),
+    env: baseEnv({ ORDERS_DB: db }),
+  });
+  assert.equal(response.status, 404);
+  assert.equal(db.seen.length, 0, 'un código que no tiene la forma real ni siquiera se consulta');
+});
+
+test('un pedido inexistente responde 404 sin revelar si el código existe', async () => {
+  const response = await onRequest({
+    request: request('/panel/pedido/AL-260101-ZZZZZZ', { cookie: await sessionCookie() }),
+    env: baseEnv({ ORDERS_DB: orderDb({ found: false }) }),
+  });
+  assert.equal(response.status, 404);
+  assert.match(await response.text(), /Pedido no encontrado/);
+});
+
+test('sin sesión la ficha muestra el login, nunca los datos del pedido', async () => {
+  const response = await onRequest({
+    request: request('/panel/pedido/AL-260909-K71QP2'),
+    env: baseEnv({ ORDERS_DB: orderDb() }),
+  });
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert.match(html, /type="password"/);
+  assert.doesNotMatch(html, /Bulevar España/);
+  assert.doesNotMatch(html, /Valentina/);
+});

--- a/functions/_shared/panel-data.js
+++ b/functions/_shared/panel-data.js
@@ -23,9 +23,16 @@ const RECENT_ORDERS_LIMIT = 20;
 const STUCK_LIMIT = 25;
 const CRAWL_DAYS = 7;
 const MISSING_IMAGE_LIMIT = 25;
+const ORDER_EVENTS_LIMIT = 30;
+// El código va en la URL y de ahí a una consulta: sólo se acepta su forma real.
+const ORDER_CODE_RE = /^AL-[0-9]{6}-[A-Z0-9]{6}$/;
 
 // El id va a parar a un href. Sólo se acepta la forma real de Mercado Libre;
 // cualquier otra cosa queda en cadena vacía y el panel muestra el texto sin enlace.
+function cleanString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
 function cleanId(value) {
   return /^MLU\d+$/.test(String(value || '')) ? String(value) : '';
 }
@@ -266,6 +273,54 @@ export async function loadCatalogSummary(ctx) {
     // Las otras dos formas nunca existieron: por eso el panel mostraba "—".
     generatedAt: catalog?.updated_at || catalog?.generated_at || catalog?.generatedAt || null,
   };
+}
+
+
+/**
+ * Un pedido completo: qué libros, a dónde va y qué le pasó.
+ * Es lo que hace falta para despachar, y hasta ahora el panel no lo mostraba:
+ * la lista daba una fila por pedido y nunca el contenido de la caja.
+ */
+export async function loadOrder(db, publicCode) {
+  const code = cleanString(publicCode).toUpperCase();
+  if (!ORDER_CODE_RE.test(code)) return null;
+
+  const [order] = await queryAll(
+    db,
+    `SELECT id, public_code, status, payment_status, buyer_name, buyer_email, buyer_phone,
+            delivery_type, address, locality, department, delivery_notes,
+            requested_delivery_date, requested_delivery_from, requested_delivery_to,
+            products_total_uyu, pickup_discount_uyu, shipping_cost_uyu, payable_total_uyu,
+            currency, payment_provider, payment_id,
+            created_at, paid_at, fulfilled_at, cancelled_at
+       FROM orders
+      WHERE public_code = ?
+      LIMIT 1`,
+    [code],
+  );
+  if (!order) return null;
+
+  const [items, events] = await Promise.all([
+    queryAll(
+      db,
+      `SELECT title, product_id, quantity, unit_price_uyu, line_total_uyu
+         FROM order_items
+        WHERE order_id = ?
+        ORDER BY id ASC`,
+      [order.id],
+    ),
+    queryAll(
+      db,
+      `SELECT event_type, created_at
+         FROM order_events
+        WHERE order_id = ?
+        ORDER BY created_at DESC, id DESC
+        LIMIT ?`,
+      [order.id, ORDER_EVENTS_LIMIT],
+    ),
+  ]);
+
+  return { order, items, events };
 }
 
 export function environmentSummary(env) {

--- a/functions/_shared/panel-settings.js
+++ b/functions/_shared/panel-settings.js
@@ -1,0 +1,87 @@
+/**
+ * functions/_shared/panel-settings.js
+ *
+ * Los datos de retiro que carga el equipo desde /panel/ajustes y que después
+ * salen en el correo que recibe el cliente.
+ *
+ * Vive aparte de panel-data.js a propósito: ese módulo es solo-lectura y tiene
+ * un test que falla si alguna de sus consultas escribe. Acá sí se escribe, pero
+ * SÓLO en KV y SÓLO estos cuatro campos. Ni pedidos, ni catálogo, ni Mercado
+ * Libre: nada de eso se toca desde el panel.
+ *
+ * Estos valores terminan en un correo a un cliente, así que se recortan y se
+ * limpian antes de guardarse. Un salto de línea es legítimo en los horarios;
+ * cualquier otro carácter de control no.
+ */
+
+const PICKUP_KEY = 'panel:pickup';
+
+const LIMITS = { address: 160, zone: 120, hours: 240 };
+const HOLD_DAYS_MIN = 1;
+const HOLD_DAYS_MAX = 90;
+const HOLD_DAYS_DEFAULT = 15;
+
+export const PICKUP_EMPTY = Object.freeze({
+  address: '', zone: '', hours: '', holdDays: HOLD_DAYS_DEFAULT,
+});
+
+function cleanText(value, max) {
+  return String(value ?? '')
+    .replace(/\r\n?/g, '\n')
+    // Se quitan los caracteres de control salvo el salto de linea:
+    // los horarios se escriben en varias lineas y eso es legitimo.
+    .replace(/[\u0000-\u0009\u000b-\u001f\u007f]/g, '')
+    .trim()
+    .slice(0, max);
+}
+
+function cleanHoldDays(value) {
+  const number = Math.trunc(Number(value));
+  if (!Number.isFinite(number)) return HOLD_DAYS_DEFAULT;
+  return Math.min(HOLD_DAYS_MAX, Math.max(HOLD_DAYS_MIN, number));
+}
+
+export function normalizePickup(input) {
+  return {
+    address: cleanText(input?.address, LIMITS.address),
+    zone: cleanText(input?.zone, LIMITS.zone),
+    hours: cleanText(input?.hours, LIMITS.hours),
+    holdDays: cleanHoldDays(input?.holdDays),
+  };
+}
+
+/**
+ * Un correo de retiro sin dirección, barrio u horarios es un cliente llamando
+ * por teléfono. Mientras esto sea falso, ese aviso no se manda.
+ */
+export function pickupComplete(pickup) {
+  return Boolean(pickup?.address && pickup?.zone && pickup?.hours);
+}
+
+export async function loadPickup(env) {
+  const kv = env?.AMADO_KV;
+  if (!kv || typeof kv.get !== 'function') return { ...PICKUP_EMPTY };
+  try {
+    const raw = await kv.get(PICKUP_KEY);
+    if (!raw) return { ...PICKUP_EMPTY };
+    return normalizePickup(JSON.parse(raw));
+  } catch {
+    // Un valor ilegible se trata como vacío: el panel muestra el formulario
+    // en blanco y avisa que falta cargarlo, en vez de romper la página.
+    return { ...PICKUP_EMPTY };
+  }
+}
+
+export async function savePickup(env, input) {
+  const kv = env?.AMADO_KV;
+  const pickup = normalizePickup(input);
+  if (!kv || typeof kv.put !== 'function') {
+    return { ok: false, pickup, error: 'AMADO_KV no está disponible en este entorno.' };
+  }
+  try {
+    await kv.put(PICKUP_KEY, JSON.stringify(pickup));
+    return { ok: true, pickup };
+  } catch (error) {
+    return { ok: false, pickup, error: String(error?.message || error || 'error desconocido') };
+  }
+}

--- a/functions/panel/[[path]].js
+++ b/functions/panel/[[path]].js
@@ -5,6 +5,8 @@
  *
  * Rutas:
  *   GET  /panel         → login si no hay sesión válida, tablero si la hay
+ *   GET  /panel/pedido/<código> → la ficha del pedido: qué va en la caja,
+ *                       a dónde va, el pago y el historial
  *   POST /panel/login   → Turnstile + contraseña → cookie de sesión firmada
  *   POST /panel/logout  → borra la cookie
  *
@@ -31,7 +33,7 @@ import {
   sessionCookieHeader,
   timingSafeEqual,
 } from '../_shared/panel-auth.js';
-import { loadPanelData } from '../_shared/panel-data.js';
+import { loadOrder, loadPanelData } from '../_shared/panel-data.js';
 
 // Mismo patrón que functions/api/_stock_waitlist_handler.js: el panel no puede
 // aceptar un hostname de Preview que el resto del sitio rechaza, ni al revés.
@@ -142,6 +144,25 @@ function layout(title, body) {
            color:#fff; font-size:.95rem; cursor:pointer; }
   .logout { background:none; color:#6b7280; border:1px solid #cbd2d9; margin:0; padding:.35rem .8rem; }
   .empty { color:#6b7280; font-style:italic; font-size:.85rem; }
+  .topbar { display:flex; justify-content:space-between; align-items:flex-start; gap:1rem;
+            flex-wrap:wrap; margin-bottom:1.25rem; }
+  .back { display:inline-block; color:#6b7280; text-decoration:none; font-size:.85rem;
+          margin-bottom:.35rem; }
+  .back:hover { color:#1f2933; }
+  .tag { border:1px solid #cbd2d9; border-radius:999px; padding:.2rem .7rem; font-size:.8rem;
+         color:#6b7280; white-space:nowrap; }
+  .tag.alerta { border-color:#f0b429; background:#fffbeb; color:#8a5200; font-weight:600; }
+  dl { margin:0; display:grid; grid-template-columns:auto 1fr; gap:.35rem .9rem; font-size:.88rem; }
+  dt { color:#6b7280; white-space:nowrap; }
+  dd { margin:0; text-align:right; }
+  dl.totales { margin-top:.9rem; padding-top:.75rem; border-top:1px solid #eef0f3; }
+  .total { font-weight:700; font-size:1rem; color:#1f2933; }
+  .direccion { margin:.85rem 0 0; padding:.7rem .8rem; background:#f6f7f9; border-radius:8px;
+               font-size:.9rem; line-height:1.45; }
+  .nota { margin:.6rem 0 0; padding:.6rem .8rem; border-left:3px solid #cbd2d9; color:#4b5563;
+          font-style:italic; font-size:.88rem; }
+  tbody tr a { color:inherit; text-decoration:none; display:block; }
+  tbody tr:hover { background:#f6f7f9; }
 </style>
 </head>
 <body><main>${body}</main></body>
@@ -189,6 +210,95 @@ function sectionOrError(block, render) {
   return render(block.data);
 }
 
+
+const EVENT_LABEL = {
+  preference_created: 'Pago iniciado',
+  payment_approved: 'Pago aprobado',
+  payment_pending: 'Pago pendiente',
+  payment_rejected: 'Pago rechazado',
+  payment_cancelled: 'Pago cancelado',
+  payment_refunded: 'Pago devuelto',
+  order_unavailable: 'Sin stock al confirmar',
+  already_sent: 'Aviso ya enviado',
+};
+
+function deliveryWindow(order) {
+  const day = shortDate(order.requested_delivery_date);
+  if (day === '—') return 'Sin fecha pedida';
+  const from = cleanString(order.requested_delivery_from);
+  const to = cleanString(order.requested_delivery_to);
+  return from && to ? `${day.slice(0, 10)}, de ${escapeHtml(from)} a ${escapeHtml(to)}` : day.slice(0, 10);
+}
+
+/**
+ * La ficha de un pedido: qué va en la caja, a dónde va y qué le pasó.
+ * Es la pantalla que se usa para despachar, así que lo primero es el contenido
+ * y la dirección — no los identificadores internos.
+ */
+function orderPage(found) {
+  const { order, items, events } = found;
+  const units = items.reduce((total, item) => total + Number(item.quantity || 0), 0);
+  const pickup = order.delivery_type === 'pickup';
+  const pending = order.payment_status === 'approved' && !order.fulfilled_at;
+
+  const body = `
+<div class="topbar">
+  <div>
+    <a class="back" href="/panel">← Pedidos</a>
+    <h1>${escapeHtml(order.public_code)}</h1>
+    <p class="muted">${escapeHtml(order.buyer_name)} · ${escapeHtml(units)} libro${units === 1 ? '' : 's'} · ${shortDate(order.created_at)}</p>
+  </div>
+  <span class="tag ${pending ? 'alerta' : ''}">${pending ? 'Pagado sin despachar' : escapeHtml(order.status)}</span>
+</div>
+
+<section class="card">
+  <h2>Qué va en la caja</h2>
+  ${table(['Cant.', 'Libro', 'Publicación', 'Precio'], items, row => `
+    <tr><td>${escapeHtml(row.quantity)}×</td>
+        <td>${escapeHtml(row.title)}</td>
+        <td>${escapeHtml(row.product_id)}</td>
+        <td>${money(row.line_total_uyu)}</td></tr>`)}
+  <dl class="totales">
+    <dt>Libros</dt><dd>${money(order.products_total_uyu)}</dd>
+    ${Number(order.shipping_cost_uyu) ? `<dt>Envío</dt><dd>${money(order.shipping_cost_uyu)}</dd>` : ''}
+    ${Number(order.pickup_discount_uyu) ? `<dt>Descuento por retiro</dt><dd>−${money(order.pickup_discount_uyu)}</dd>` : ''}
+    <dt class="total">Total</dt><dd class="total">${money(order.payable_total_uyu)}</dd>
+  </dl>
+</section>
+
+<section class="card">
+  <h2>${pickup ? 'Retira en el local' : 'A dónde va'}</h2>
+  <dl>
+    <dt>Entrega</dt><dd>${pickup ? 'Retiro' : 'Envío'}</dd>
+    <dt>Teléfono</dt><dd>${escapeHtml(order.buyer_phone)}</dd>
+    <dt>Correo</dt><dd>${escapeHtml(order.buyer_email)}</dd>
+    <dt>Fecha pedida</dt><dd>${deliveryWindow(order)}</dd>
+  </dl>
+  ${pickup ? '' : `<p class="direccion">${escapeHtml(order.address)}<br>${escapeHtml(order.locality)}, ${escapeHtml(order.department)}</p>`}
+  ${cleanString(order.delivery_notes) ? `<p class="nota">“${escapeHtml(order.delivery_notes)}”</p>` : ''}
+</section>
+
+<section class="card">
+  <h2>Pago</h2>
+  <dl>
+    <dt>Estado</dt><dd>${escapeHtml(order.payment_status)}</dd>
+    <dt>Medio</dt><dd>${escapeHtml(order.payment_provider) || '—'}</dd>
+    <dt>ID de pago</dt><dd>${escapeHtml(order.payment_id) || '—'}</dd>
+    <dt>Cobrado</dt><dd>${shortDate(order.paid_at)}</dd>
+    <dt>Despachado</dt><dd>${shortDate(order.fulfilled_at)}</dd>
+  </dl>
+</section>
+
+<section class="card">
+  <h2>Historial</h2>
+  ${table(['Qué pasó', 'Cuándo'], events, row => `
+    <tr><td>${escapeHtml(EVENT_LABEL[row.event_type] || row.event_type)}</td>
+        <td>${shortDate(row.created_at)}</td></tr>`)}
+</section>`;
+
+  return layout(`Pedido ${order.public_code}`, body);
+}
+
 function dashboardPage(data) {
   const env = data.environment;
   const stuckCount = data.stuck?.ok ? data.stuck.data.total : null;
@@ -215,7 +325,7 @@ function dashboardPage(data) {
   ${sectionOrError(data.stuck, stuck => `
     <h3 class="muted">Pagados sin despachar</h3>
     ${table(['Pedido', 'Comprador', 'Total', 'Pagado'], stuck.paidNotFulfilled, row => `
-      <tr><td>${escapeHtml(row.public_code)}</td><td>${escapeHtml(row.buyer_name)}</td>
+      <tr><td><a href="/panel/pedido/${encodeURIComponent(row.public_code)}">${escapeHtml(row.public_code)}</a></td><td>${escapeHtml(row.buyer_name)}</td>
           <td>${money(row.payable_total_uyu)}</td><td>${shortDate(row.paid_at)}</td></tr>`)}
 
     <h3 class="muted">Pago colgado hace más de una hora</h3>
@@ -266,7 +376,7 @@ function dashboardPage(data) {
     ${statusList(orders.byStatus)}
     <h3 class="muted">Últimos ${orders.recent.length}</h3>
     ${table(['Pedido', 'Estado', 'Pago', 'Comprador', 'Entrega', 'Total', 'Creado'], orders.recent, row => `
-      <tr><td>${escapeHtml(row.public_code)}</td><td>${escapeHtml(row.status)}</td>
+      <tr><td><a href="/panel/pedido/${encodeURIComponent(row.public_code)}">${escapeHtml(row.public_code)}</a></td><td>${escapeHtml(row.status)}</td>
           <td>${escapeHtml(row.payment_status)}</td><td>${escapeHtml(row.buyer_name)}</td>
           <td>${escapeHtml(row.delivery_type)}</td><td>${money(row.payable_total_uyu)}</td>
           <td>${shortDate(row.created_at)}</td></tr>`)}
@@ -419,6 +529,28 @@ export async function onRequest(context) {
   if (path === '/panel/login') {
     if (request.method !== 'POST') return new Response('Method Not Allowed', { status: 405 });
     return handleLogin(context, config);
+  }
+
+  const pedido = /^\/panel\/pedido\/([^/]+)$/.exec(path);
+  if (pedido) {
+    if (request.method !== 'GET') return new Response('Method Not Allowed', { status: 405 });
+    if (!(await hasValidSession(request, await deriveSessionSecret(config.password)))) {
+      return htmlResponse(loginPage({
+        siteKey: cleanString(context.env?.STOCK_WAITLIST_TURNSTILE_SITE_KEY),
+      }));
+    }
+    const db = context.env?.ORDERS_DB;
+    // Un pedido inexistente y un código inválido responden igual: la ficha no
+    // sirve para averiguar qué códigos existen.
+    const found = db ? await loadOrder(db, decodeURIComponent(pedido[1])) : null;
+    if (!found) {
+      return htmlResponse(
+        layout('Pedido no encontrado', '<main class="card"><a class="back" href="/panel">← Pedidos</a>'
+          + '<h1>Pedido no encontrado</h1><p class="muted">Revisá el código.</p></main>'),
+        { status: 404 },
+      );
+    }
+    return htmlResponse(orderPage(found));
   }
 
   if (path !== '/panel') return new Response('Not Found', { status: 404 });

--- a/functions/panel/[[path]].js
+++ b/functions/panel/[[path]].js
@@ -8,6 +8,8 @@
  *   GET  /panel/pedido/<código> → la ficha del pedido: qué va en la caja,
  *                       a dónde va, el pago y el historial
  *   POST /panel/login   → Turnstile + contraseña → cookie de sesión firmada
+ *   GET  /panel/ajustes → datos de retiro que salen en el correo al cliente
+ *   POST /panel/ajustes → los guarda en KV (única escritura del panel)
  *   POST /panel/logout  → borra la cookie
  *
  * Reglas que este archivo no puede romper:
@@ -34,6 +36,7 @@ import {
   timingSafeEqual,
 } from '../_shared/panel-auth.js';
 import { loadOrder, loadPanelData } from '../_shared/panel-data.js';
+import { loadPickup, pickupComplete, savePickup } from '../_shared/panel-settings.js';
 
 // Mismo patrón que functions/api/_stock_waitlist_handler.js: el panel no puede
 // aceptar un hostname de Preview que el resto del sitio rechaza, ni al revés.
@@ -163,6 +166,17 @@ function layout(title, body) {
           font-style:italic; font-size:.88rem; }
   tbody tr a { color:inherit; text-decoration:none; display:block; }
   tbody tr:hover { background:#f6f7f9; }
+  form.card label { margin:1rem 0 .3rem; }
+  form.card input[type=text], form.card input[type=number], form.card textarea {
+    width:100%; max-width:32rem; padding:.55rem .65rem; border:1px solid #cbd2d9;
+    border-radius:8px; font:inherit; font-size:.95rem; }
+  form.card textarea { resize:vertical; }
+  form.card input[type=number] { max-width:7rem; }
+  .acciones { display:flex; gap:.5rem; align-items:center; }
+  .linkbtn { border:1px solid #cbd2d9; border-radius:8px; padding:.35rem .8rem;
+             color:#6b7280; text-decoration:none; font-size:.95rem; }
+  .linkbtn:hover { color:#1f2933; }
+  .ok-box { border-color:#7ac9a5; background:#effaf4; color:#087443; }
 </style>
 </head>
 <body><main>${body}</main></body>
@@ -299,6 +313,73 @@ function orderPage(found) {
   return layout(`Pedido ${order.public_code}`, body);
 }
 
+
+/**
+ * Ajustes: los datos de retiro que el equipo carga y que despues salen en el
+ * correo al cliente. Es la unica pantalla del panel que escribe, y escribe
+ * solo estos cuatro campos en KV.
+ */
+function settingsPage(pickup, { saved = false, error = '' } = {}) {
+  const falta = !pickupComplete(pickup);
+  return layout('Ajustes - Amado Libros', `
+<div class="topbar">
+  <div>
+    <a class="back" href="/panel">&larr; Pedidos</a>
+    <h1>Ajustes</h1>
+    <p class="muted">Lo que se escribe acá aparece en los correos que recibe el cliente.</p>
+  </div>
+</div>
+
+${saved ? '<p class="card ok-box">Guardado.</p>' : ''}
+${error ? `<p class="card err">No se pudo guardar: ${escapeHtml(error)}</p>` : ''}
+${falta ? '<p class="card alert">Falta completar dirección, barrio u horarios. Hasta que estén, el aviso de retiro no se puede enviar.</p>' : ''}
+
+<form class="card" method="POST" action="/panel/ajustes">
+  <h2>Retiro en el local</h2>
+
+  <label for="address">Dirección</label>
+  <input id="address" name="address" type="text" maxlength="160" autocomplete="off"
+         placeholder="Calle y número, apartamento o local" value="${escapeHtml(pickup.address)}">
+
+  <label for="zone">Barrio y ciudad</label>
+  <input id="zone" name="zone" type="text" maxlength="120" autocomplete="off"
+         placeholder="Pocitos, Montevideo" value="${escapeHtml(pickup.zone)}">
+
+  <label for="hours">Horarios</label>
+  <textarea id="hours" name="hours" maxlength="240" rows="3"
+            placeholder="Lunes a viernes de 10 a 18, sábados de 10 a 13">${escapeHtml(pickup.hours)}</textarea>
+
+  <label for="holdDays">Días que se guarda el pedido</label>
+  <input id="holdDays" name="holdDays" type="number" min="1" max="90" value="${escapeHtml(pickup.holdDays)}">
+  <p class="muted">Se le dice al cliente en el correo de retiro.</p>
+
+  <button type="submit">Guardar</button>
+</form>`);
+}
+
+async function handleSettingsSave(context) {
+  const { request } = context;
+  // La cookie de sesión es SameSite=Strict, así que un POST desde otro sitio
+  // ni siquiera la lleva. El origen se verifica igual, por las dudas.
+  const origin = request.headers.get('origin');
+  if (origin && origin !== new URL(request.url).origin) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  const form = await request.formData();
+  const result = await savePickup(context.env, {
+    address: form.get('address'),
+    zone: form.get('zone'),
+    hours: form.get('hours'),
+    holdDays: form.get('holdDays'),
+  });
+
+  return htmlResponse(settingsPage(result.pickup, {
+    saved: result.ok,
+    error: result.ok ? '' : result.error,
+  }), { status: result.ok ? 200 : 500 });
+}
+
 function dashboardPage(data) {
   const env = data.environment;
   const stuckCount = data.stuck?.ok ? data.stuck.data.total : null;
@@ -317,7 +398,7 @@ function dashboardPage(data) {
       datos al ${shortDate(data.generatedAt)} UTC
     </p>
   </div>
-  <form method="POST" action="/panel/logout"><button class="logout" type="submit">Salir</button></form>
+  <div class="acciones"><a class="linkbtn" href="/panel/ajustes">Ajustes</a><form method="POST" action="/panel/logout"><button class="logout" type="submit">Salir</button></form></div>
 </div>
 
 <section class="card ${stuckCount || missingImageCount ? 'alert' : ''}">
@@ -529,6 +610,19 @@ export async function onRequest(context) {
   if (path === '/panel/login') {
     if (request.method !== 'POST') return new Response('Method Not Allowed', { status: 405 });
     return handleLogin(context, config);
+  }
+
+  if (path === '/panel/ajustes') {
+    if (!['GET', 'POST'].includes(request.method)) {
+      return new Response('Method Not Allowed', { status: 405 });
+    }
+    if (!(await hasValidSession(request, await deriveSessionSecret(config.password)))) {
+      return htmlResponse(loginPage({
+        siteKey: cleanString(context.env?.STOCK_WAITLIST_TURNSTILE_SITE_KEY),
+      }));
+    }
+    if (request.method === 'POST') return handleSettingsSave(context);
+    return htmlResponse(settingsPage(await loadPickup(context.env)));
   }
 
   const pedido = /^\/panel\/pedido\/([^/]+)$/.exec(path);


### PR DESCRIPTION
Segunda entrega del rediseño del panel. **Va apilado sobre el #345**, que toca el mismo archivo — mergear ese primero.

## Por qué

El sitio le dice al cliente: *"para retirar, y ahí te pasamos la dirección exacta"*.

Esa dirección **existe pero no está en ningún lado del código**, y el correo de retiro que viene en la próxima entrega la necesita. Decidido con Seba: **la carga Gaby desde el panel**, no se escribe en el repositorio.

## El cambio

`/panel/ajustes` con cuatro campos:

| Campo | Para qué |
|---|---|
| Dirección | dónde retirar |
| Barrio y ciudad | dónde retirar |
| Horarios | cuándo se puede |
| Días que se guarda | se le dice al cliente en el correo |

Mientras falte dirección, barrio u horarios, **la pantalla lo dice** en vez de fingir que está configurado. Un correo de retiro con la dirección en blanco es un cliente llamando por teléfono.

## Esta es la primera escritura del panel

Va acotada a propósito:

- **Vive en su propio módulo** (`panel-settings.js`), para que `panel-data.js` siga siendo solo-lectura **con su test que falla si alguna consulta escribe**.
- **Escribe en KV, nunca en D1.** Ni pedidos, ni catálogo, ni Mercado Libre.
- **Son esos cuatro campos y nada más.**
- **CSRF:** la cookie de sesión ya es `SameSite=Strict`, así que un POST desde otro sitio ni siquiera la lleva. Igual se verifica el origen, y hay un test con un origen ajeno que comprueba que **no se escriba nada**.
- **Sin sesión** no se puede ni ver ni guardar.
- **Si KV no está** responde 500 y lo dice, en vez de decir que guardó algo que no guardó.

## Estos valores terminan en un correo a un cliente

Así que se limpian antes de guardarse:

- se recortan a un largo máximo (160 / 120 / 240)
- se quitan los caracteres de control — **salvo el salto de línea**, que en los horarios es legítimo
- los días se acotan entre 1 y 90
- lo que carga el equipo **sale escapado** en el HTML, con un test que usa un `<img onerror>`

## Validación

`bash scripts/validate-ci.sh` completo en verde: **1.836 tests, 0 fallos**, ambos builds OK. Siete tests nuevos.

## Lo que falta

La tercera entrega es **el correo**: *"listo para retirar"* y *"el envío sale hoy"*, usando estos datos y el servicio de correo que ya existe (el mismo que manda los de compra, con idempotencia).

Con este PR mergeado, **Gaby ya puede cargar los datos** aunque el correo todavía no exista.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM)_