### PR TITLE
Auditoría vidriera: separar "ficha rota" de "libro ya no publicado"

### DIFF
--- a/functions/__tests__/showcase-curated-policy.test.js
+++ b/functions/__tests__/showcase-curated-policy.test.js
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { curatedIsRetired } from '../../scripts/seo/showcase-curated-policy.mjs';
+
+const sano = [0, 0, 0, 0, 0];
+
+test('el único caso que se perdona: la ficha no está y el catálogo lo confirma', () => {
+  assert.equal(curatedIsRetired({
+    status: 404, publishedInCatalog: false, automaticFailureCounts: sano,
+  }), true);
+});
+
+test('si la ficha responde, se le exige todo igual que antes', () => {
+  // Este es el caso que el control existe para agarrar: la ficha curada está
+  // publicada pero alguien le pisó el H1 o el texto. No se perdona nunca.
+  for (const status of [200, 301, 500, 503]) {
+    assert.equal(curatedIsRetired({
+      status, publishedInCatalog: false, automaticFailureCounts: sano,
+    }), false, `HTTP ${status} no puede eximir al piloto`);
+  }
+});
+
+test('si el libro SIGUE activo en el catálogo, un 404 es una falla real', () => {
+  assert.equal(curatedIsRetired({
+    status: 404, publishedInCatalog: true, automaticFailureCounts: sano,
+  }), false);
+});
+
+test('si no se pudo leer el catálogo, no se perdona: no saber no alcanza', () => {
+  assert.equal(curatedIsRetired({
+    status: 404, publishedInCatalog: null, automaticFailureCounts: sano,
+  }), false);
+  // Ni siquiera con formas raras que podrían colarse como "falsy".
+  for (const desconocido of [undefined, 0, '', NaN]) {
+    assert.equal(curatedIsRetired({
+      status: 404, publishedInCatalog: desconocido, automaticFailureCounts: sano,
+    }), false, `${String(desconocido)} no es un "no está publicado" confirmado`);
+  }
+});
+
+test('si el sitio está roto, el 404 del piloto no se tapa', () => {
+  // Si las fichas automáticas también fallan, ese 404 es del sitio entero y
+  // hay que verlo. Perdonarlo acá sería esconder una caída.
+  assert.equal(curatedIsRetired({
+    status: 404, publishedInCatalog: false, automaticFailureCounts: [0, 0, 3, 0, 0],
+  }), false);
+  assert.equal(curatedIsRetired({
+    status: 404, publishedInCatalog: false, automaticFailureCounts: [2, 2, 2, 2, 2],
+  }), false);
+});
+
+test('sin muestras automáticas no hay con qué comparar, así que no se perdona', () => {
+  for (const muestras of [[], null, undefined, 'nada']) {
+    assert.equal(curatedIsRetired({
+      status: 404, publishedInCatalog: false, automaticFailureCounts: muestras,
+    }), false, 'sin muestras sanas no se puede afirmar que el sitio funciona');
+  }
+});

--- a/scripts/seo/showcase-curated-policy.mjs
+++ b/scripts/seo/showcase-curated-policy.mjs
@@ -1,0 +1,44 @@
+/**
+ * scripts/seo/showcase-curated-policy.mjs
+ *
+ * Cuándo la auditoría de fichas vidriera deja de exigir el piloto curado.
+ *
+ * Vive aparte y sin efectos para poder probarlo: el auditor baja páginas y el
+ * catálogo por red, y una regla que decide si un control se aplica o no tiene
+ * que poder verificarse sin depender de eso.
+ *
+ * La regla protege lo mismo que antes. Sólo separa dos cosas que hasta ahora
+ * eran la misma falla:
+ *
+ *   - alguien rompió la ficha escrita a mano  → sigue fallando, igual que antes
+ *   - ese libro ya no está a la venta          → deja de exigirse, y se informa
+ *
+ * Nunca perdona por duda: si no se pudo leer el catálogo, o si el resto del
+ * sitio también está fallando, el piloto se exige igual.
+ */
+
+/**
+ * @param {object} input
+ * @param {number} input.status              HTTP de la ficha curada.
+ * @param {boolean|null} input.publishedInCatalog
+ *        true  = sigue activo en el catálogo
+ *        false = ya no está activo
+ *        null  = no se pudo leer el catálogo, o sea que NO SE SABE
+ * @param {number[]} input.automaticFailureCounts
+ *        Cuántas fallas tuvo cada ficha automática de la muestra.
+ * @returns {boolean} true sólo si corresponde no exigir el piloto.
+ */
+export function curatedIsRetired({ status, publishedInCatalog, automaticFailureCounts }) {
+  // 1. Sólo un 404 puede significar "ya no está". Una ficha que responde 200
+  //    se revisa entera, sin excepciones.
+  if (status !== 404) return false;
+
+  // 2. Sólo un "false" explícito sirve. `null` es no saber, y no saber nunca
+  //    alcanza para perdonar una falla.
+  if (publishedInCatalog !== false) return false;
+
+  // 3. El resto del sitio tiene que estar sano. Si las fichas automáticas
+  //    también fallan, ese 404 es del sitio y hay que verlo, no taparlo.
+  if (!Array.isArray(automaticFailureCounts) || automaticFailureCounts.length === 0) return false;
+  return automaticFailureCounts.every(count => count === 0);
+}

--- a/scripts/seo/showcase-live-audit.mjs
+++ b/scripts/seo/showcase-live-audit.mjs
@@ -1,5 +1,6 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { curatedIsRetired } from './showcase-curated-policy.mjs';
 
 import {
   SHOWCASE_COHORT_V1_URL,
@@ -184,6 +185,38 @@ function automaticSampleEligibility(result) {
   return null;
 }
 
+const SHOWCASE_CATALOG_URL = process.env.SHOWCASE_CATALOG_URL
+  || 'https://pub-b2b408811ae24e3da04cda79c6ff084d.r2.dev/catalog.json';
+
+/**
+ * ¿El piloto curado sigue publicado y activo?
+ *
+ * Distingue dos cosas que hasta ahora eran la misma falla: que alguien haya
+ * roto la ficha escrita a mano (grave) y que ese libro ya no esté a la venta
+ * (normal, pasa con cualquier libro que se vende o se pausa).
+ *
+ * Devuelve `null`, no `false`, cuando el catálogo no se puede leer. Esa
+ * diferencia importa: sin catálogo NO se puede afirmar que el libro dejó de
+ * estar publicado, y la auditoría no debe perdonar un 404 por las dudas.
+ */
+async function curatedStillPublished(productId) {
+  try {
+    const response = await fetch(SHOWCASE_CATALOG_URL, {
+      headers: { 'user-agent': 'AmadoLibros-Showcase-Audit/2.0', 'cache-control': 'no-cache' },
+      signal: AbortSignal.timeout(60_000),
+    });
+    if (!response.ok) return null;
+    const catalog = await response.json();
+    const items = Array.isArray(catalog?.items) ? catalog.items : null;
+    // Un catálogo vacío o con otra forma no prueba nada.
+    if (!items || items.length === 0) return null;
+    const found = items.find(item => String(item?.id || '').toUpperCase() === productId);
+    return Boolean(found && found.status === 'active');
+  } catch {
+    return null;
+  }
+}
+
 async function selectAutomaticSamples() {
   const cohort = await fetchCohortCandidateIds();
   const ids = [...new Set([...cohort.ids, ...SHOWCASE_PREVIEW_SAMPLE_IDS])]
@@ -303,10 +336,35 @@ function inspectProduct(result, { curated = false } = {}) {
 async function main() {
   const selection = await selectAutomaticSamples();
   const curatedResult = await fetchProduct(CURATED_ID);
-  const products = [
-    ...selection.selected.map(result => inspectProduct(result)),
-    inspectProduct(curatedResult, { curated: true }),
-  ];
+  const automaticProducts = selection.selected.map(result => inspectProduct(result));
+  const curatedProduct = inspectProduct(curatedResult, { curated: true });
+
+  // El piloto curado deja de exigirse SOLO si se cumplen las tres condiciones,
+  // y cada una tapa una forma distinta de perdonar una falla real:
+  //   1. la ficha responde 404 — no es que este rota, es que no esta;
+  //   2. el catalogo dice que ese libro ya no esta activo, y el catalogo se
+  //      pudo leer de verdad (null = no se sabe, y entonces se exige igual);
+  //   3. el resto del sitio funciona: si las fichas automaticas tambien
+  //      fallan, el 404 es del sitio y no hay nada que perdonar.
+  // Si la ficha responde 200, se le exige exactamente lo mismo que antes.
+  const curatedPublished = curatedResult.status === 404
+    ? await curatedStillPublished(CURATED_ID)
+    : true;
+  const curatedRetired = curatedIsRetired({
+    status: curatedResult.status,
+    publishedInCatalog: curatedPublished,
+    automaticFailureCounts: automaticProducts.map(product => product.failures.length),
+  });
+
+  if (curatedRetired) {
+    curatedProduct.retired = true;
+    curatedProduct.retiredReason =
+      'el piloto curado ya no figura activo en el catálogo: su ficha no se exige';
+    curatedProduct.originalFailures = curatedProduct.failures;
+    curatedProduct.failures = [];
+  }
+
+  const products = [...automaticProducts, curatedProduct];
   const selectionFailures = selection.selected.length < SAMPLE_SIZE
     ? [`muestras automáticas insuficientes: ${selection.selected.length}/${SAMPLE_SIZE} después de ${selection.candidatesChecked} candidatos`]
     : [];
@@ -328,7 +386,13 @@ async function main() {
     skippedCandidates: selection.skipped,
     automaticSamples: automatic.length,
     automaticPassed: automatic.filter(product => product.failures.length === 0).length,
-    curatedPassed: products.find(product => product.curated)?.failures.length === 0,
+    curatedPassed: curatedProduct.failures.length === 0,
+    // Un piloto retirado NO es un piloto aprobado. Se informa aparte para que
+    // nadie lea "curatedPassed: true" y crea que la ficha curada sigue viva.
+    curatedRetired,
+    curatedRetiredReason: curatedRetired ? curatedProduct.retiredReason : null,
+    curatedStatus: curatedResult.status,
+    curatedPublished,
     failures,
     products,
   };
@@ -343,8 +407,15 @@ async function main() {
     automaticSamples: report.automaticSamples,
     automaticPassed: report.automaticPassed,
     curatedPassed: report.curatedPassed,
+    curatedRetired: report.curatedRetired,
     failures: report.failures.length,
   }));
+  if (curatedRetired) {
+    console.warn(
+      `AVISO: ${CURATED_ID} ya no está activo en el catálogo, así que su ficha `
+      + 'curada no se exigió. Si el piloto sigue importando, hay que publicarlo '
+      + 'de nuevo o elegir otro en CURATED_ID.');
+  }
   console.log(`Escrito: ${outputPath}`);
 
   if (failures.length) {


### PR DESCRIPTION
## Qué está pasando hoy

El job `preview` está fallando en **todos** los PR del repo, toquen o no fichas de producto. El motivo es siempre el mismo:

```
ficha curada MLU633557235 respondió HTTP 404
```

`MLU633557235` es "Padres fuertes, hijas felices" (Meg Meeker), el **piloto curado**: la única ficha escrita a mano que la auditoría exige que esté perfecta. Su id está fijo en el código (`CURATED_ID`).

Ese libro dejó de estar publicado. La ficha ya no existe, devuelve 404, y la auditoría lo cuenta como falla. **Se reprodujo idéntico en una segunda corrida** (46s, mismo error): no es intermitente, no se arregla reintentando.

## Por qué no alcanza con apagar el control

El control sirve, y sirve para algo importante: si alguien le pisa el H1, el título o el texto a una ficha escrita a mano, hay que enterarse en el PR y no tres semanas después. Apagarlo o sacar el piloto de la lista sería tapar eso.

Lo que el control **no** distinguía eran dos cosas muy distintas que llegan las dos como 404:

| | Qué pasó | Qué corresponde |
|---|---|---|
| Ficha rota | alguien la rompió, o el sitio se cayó | **falla**, igual que antes |
| Libro no publicado | se vendió o se pausó — normal | informar, no fallar |

## Qué cambia

El piloto deja de exigirse **sólo si se cumplen las tres condiciones a la vez**:

1. la ficha responde **404** — no está rota, no está;
2. el **catálogo confirma** que ese libro ya no figura activo;
3. el **resto de la muestra pasa sin una sola falla**.

Cada una tapa una forma distinta de perdonar una falla real. Y **nunca perdona por duda**:

- si el catálogo no se puede leer, la respuesta es `null` ("no se sabe"), **no** `false` — y con `null` se exige igual;
- si las fichas automáticas también fallan, ese 404 es del sitio entero y hay que verlo, no taparlo;
- si la ficha responde **200**, se le revisa **todo exactamente como antes**, sin excepciones.

## Cómo se verifica

La regla vive aparte en `scripts/seo/showcase-curated-policy.mjs`, pura y sin efectos, justamente para poder probarla sin red — el auditor baja páginas y el catálogo por HTTP, y una regla que decide si un control se aplica o no tiene que poder verificarse sin depender de eso.

`functions/__tests__/showcase-curated-policy.test.js` — **6 tests, 6 en verde**: el único caso que se perdona, y los cinco que no (HTTP 200/301/500/503; libro todavía activo; catálogo ilegible incluyendo `null`/`undefined`/`0`/`''`/`NaN`; sitio roto; muestra vacía o inválida).

`bash scripts/validate-ci.sh` completo: **1.842 tests, 0 fallos**, ambos builds OK.

## Lo que el informe pasa a decir

El JSON agrega `curatedRetired`, `curatedRetiredReason`, `curatedStatus` y `curatedPublished`, y avisa por consola cuando el piloto se retira. Un piloto retirado **no** es un piloto aprobado y no se disfraza de uno: `curatedPassed` y `curatedRetired` son campos separados.

## Decisión que queda abierta (no bloquea)

Si "Padres fuertes, hijas felices" tiene que volver a estar publicado, hay que republicarlo. Si el piloto tiene que ser otro título, se cambia `CURATED_ID`. Este PR no decide eso — sólo evita que la pregunta deje el CI rojo mientras tanto.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM)_