### PR TITLE
Portadas: dejar de guardar dos veces el historial que ya no se lee

### DIFF
--- a/functions/__tests__/cover-probe-retention.test.js
+++ b/functions/__tests__/cover-probe-retention.test.js
@@ -1,0 +1,128 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { shouldKeepProbes, pruneEntryProbes } from '../_shared/cover-probe-retention.js';
+import { GOOGLE_IMAGE_MIN_EDGE } from '../_shared/image-source-policy.js';
+
+const SONDEOS = [
+  { at: '2026-09-09T04:12:31Z', url: 'https://x/-O.webp', status: 200, width: 300, height: 400, chosen: false },
+  { at: '2026-09-09T04:12:32Z', url: 'https://x/-F.webp', status: 200, width: 480, height: 640, chosen: true },
+];
+
+function entrada({ ancho, alto, conCopia = true, sondeos = SONDEOS } = {}) {
+  return {
+    product_id: 'MLU600000001', position: 0,
+    ...(conCopia ? { current: { object_key: 'covers/v1/o/x.jpg', sha256: 'a'.repeat(64),
+      mime: 'image/jpeg', source_url: 'https://x/-F.webp', width: ancho, height: alto, bytes: 1000 } } : {}),
+    last_validated_at: '2026-09-09T04:12:33Z',
+    source_policy_version: 3,
+    source_probes: sondeos,
+  };
+}
+
+test('la portada que todavía no llega a 500px conserva su historial', () => {
+  // Es exactamente la que el reporte de calidad lista en needs_better_source,
+  // y el historial es lo que explica por qué no se consiguió algo mejor.
+  const chica = entrada({ ancho: 480, alto: 640 });
+  assert.equal(shouldKeepProbes(chica), true);
+  assert.equal(pruneEntryProbes(chica), chica, 'no se toca, ni siquiera se copia');
+  assert.deepEqual(pruneEntryProbes(chica).source_probes, SONDEOS);
+});
+
+test('la portada que ya llegó a 500px pierde el historial que nadie lee', () => {
+  const grande = entrada({ ancho: GOOGLE_IMAGE_MIN_EDGE, alto: 1200 });
+  assert.equal(shouldKeepProbes(grande), false);
+  const podada = pruneEntryProbes(grande);
+  assert.ok(!('source_probes' in podada));
+  // Y NADA más se pierde: lo que decide el trabajo del cron sigue entero.
+  for (const campo of ['product_id', 'position', 'current', 'last_validated_at', 'source_policy_version']) {
+    assert.deepEqual(podada[campo], grande[campo], `se perdió ${campo}`);
+  }
+});
+
+test('un sondeo con error se conserva aunque la portada haya quedado bien', () => {
+  // Lo encontró un test que ya existía: si una variante de la fuente se cayó
+  // pero otra anduvo, la portada termina grande y el historial es lo único que
+  // registra que hubo un problema. Sin eso no hay forma de saber que quizás
+  // había una imagen mejor detrás de la variante caída.
+  const conError = entrada({ ancho: 1200, alto: 1600, sondeos: [
+    { at: '2026-09-09T04:12:31Z', url: 'https://x/-O.jpg', error: 'HTTP 503' },
+    { at: '2026-09-09T04:12:32Z', url: 'https://x/-F.webp', status: 200, width: 1200, height: 1600, chosen: true },
+  ] });
+  assert.equal(shouldKeepProbes(conError), true);
+  assert.equal(pruneEntryProbes(conError), conError);
+
+  // También si el error quedó sólo como estado HTTP, sin campo `error`.
+  const soloEstado = entrada({ ancho: 1200, alto: 1600, sondeos: [
+    { at: '2026-09-09T04:12:31Z', url: 'https://x/-O.jpg', status: 404 },
+    { at: '2026-09-09T04:12:32Z', url: 'https://x/-F.webp', status: 200, width: 1200, height: 1600, chosen: true },
+  ] });
+  assert.equal(shouldKeepProbes(soloEstado), true);
+
+  // Pero todo bien y grande sí se poda: no hay nada que investigar.
+  assert.equal(shouldKeepProbes(entrada({ ancho: 1200, alto: 1600 })), false);
+});
+
+test('sondeos con formas raras no se toman por errores ni rompen', () => {
+  for (const sondeos of [null, undefined, 'nada', [null], [42], [{}], [{ status: 'ok' }]]) {
+    const registro = entrada({ ancho: 1200, alto: 1600, sondeos });
+    assert.doesNotThrow(() => shouldKeepProbes(registro));
+    assert.equal(shouldKeepProbes(registro), false,
+      `${JSON.stringify(sondeos)} no registra ningún error`);
+  }
+});
+
+test('el borde de los 500px se respeta exactamente', () => {
+  // Un pixel de menos en cualquiera de los dos lados y todavía hace falta.
+  assert.equal(shouldKeepProbes(entrada({ ancho: GOOGLE_IMAGE_MIN_EDGE - 1, alto: 2000 })), true);
+  assert.equal(shouldKeepProbes(entrada({ ancho: 2000, alto: GOOGLE_IMAGE_MIN_EDGE - 1 })), true);
+  assert.equal(shouldKeepProbes(entrada({ ancho: GOOGLE_IMAGE_MIN_EDGE, alto: GOOGLE_IMAGE_MIN_EDGE })), false);
+});
+
+test('sin copia todavía, el historial es lo único que explica qué pasó', () => {
+  // Una entrada que falló no tiene `current`. Ahí el historial es el
+  // diagnóstico entero: se conserva siempre.
+  assert.equal(shouldKeepProbes(entrada({ conCopia: false })), true);
+  assert.equal(shouldKeepProbes({ current: null, source_probes: SONDEOS }), true);
+  assert.equal(shouldKeepProbes({ current: {}, source_probes: SONDEOS }), true);
+  assert.equal(shouldKeepProbes({ current: { object_key: '' }, source_probes: SONDEOS }), true);
+});
+
+test('una entrada sin historial no se toca ni se copia', () => {
+  const sinSondeos = { product_id: 'MLU1', position: 0,
+    current: { object_key: 'k', width: 1200, height: 1600 } };
+  assert.equal(pruneEntryProbes(sinSondeos), sinSondeos);
+});
+
+test('formas raras no rompen la poda', () => {
+  for (const valor of [null, undefined, 'texto', 42, []]) {
+    assert.doesNotThrow(() => pruneEntryProbes(valor));
+    assert.equal(pruneEntryProbes(valor), valor);
+  }
+});
+
+test('el reporte de calidad no pierde ni una sola de las que mira', () => {
+  // Éste es el test que importa. `needs_better_source` se arma con
+  // `current.object_key && !googleFutureReadyImage(current)`. Después de
+  // podar, TODAS esas tienen que seguir teniendo su historial.
+  let miradas = 0;
+  for (let i = 0; i < 200; i++) {
+    const lado = 300 + i * 3;
+    const registro = entrada({ ancho: lado, alto: lado + 40 });
+    const enElReporte = Math.min(lado, lado + 40) < GOOGLE_IMAGE_MIN_EDGE;
+    if (enElReporte) miradas += 1;
+    const podado = pruneEntryProbes(registro);
+    if (enElReporte) {
+      assert.deepEqual(podado.source_probes, SONDEOS,
+        `${lado}px está en el reporte y se quedó sin historial`);
+    }
+  }
+  assert.ok(miradas > 0 && miradas < 200, 'la muestra tiene de las dos');
+});
+
+test('podar es idempotente: hacerlo de nuevo no copia nada', () => {
+  const grande = entrada({ ancho: 1200, alto: 1600 });
+  const unaVez = pruneEntryProbes(grande);
+  assert.notEqual(unaVez, grande);
+  assert.equal(pruneEntryProbes(unaVez), unaVez, 'la segunda pasada no crea otro objeto');
+});

--- a/functions/_shared/cover-probe-retention.js
+++ b/functions/_shared/cover-probe-retention.js
@@ -1,0 +1,116 @@
+/**
+ * functions/_shared/cover-probe-retention.js
+ *
+ * Qué historial de sondeos vale la pena guardar dentro del manifest privado.
+ *
+ * EL PROBLEMA
+ *
+ * El manifest de portadas pesa ~104 MB y hay que abrirlo entero en memoria
+ * cada vez que el cron escribe. La proyección pública —lo mínimo para servir
+ * una portada— pesa 32 MB. O sea que ~70% del archivo son datos privados que
+ * el sitio no usa para funcionar, y la parte más gorda es `source_probes`:
+ * qué URLs se probaron para cada imagen, con su tamaño y resultado.
+ *
+ * QUIEN LO USA DE VERDAD
+ *
+ * Se rastreó cada lectura de `source_probes` en el repositorio:
+ *
+ *   - `covers/v1/quality-report.json`, en la lista `needs_better_source`
+ *   - la pantalla interna de QA (worker-sync/image-system-preview.js)
+ *
+ * Y NADA MÁS. En particular `candidatePriority` —la función que decide qué
+ * portada trabajar— no lo mira: le alcanza con `last_error.at`,
+ * `current.source_url`, `source_policy_version`, `native_checked_at`,
+ * `last_validated_at` y el tamaño de la imagen. El historial no decide nada.
+ *
+ * LA REGLA
+ *
+ * El reporte arma `needs_better_source` así:
+ *
+ *     entry.current.object_key && !googleFutureReadyImage(entry.current)
+ *
+ * O sea: portadas que YA tienen copia pero todavía no llegan a los 500px que
+ * Google va a exigir. Para esas, el historial es justo lo que se mira para
+ * entender por qué no se consiguió algo mejor.
+ *
+ * Para una portada que ya llegó a 500px, ese historial no lo lee nadie. Nunca.
+ * Es peso muerto que hay que cargar en memoria en cada escritura.
+ *
+ * Así que se guarda el historial de las que faltan y se tira el de las que ya
+ * están. No se pierde nada que alguien mire: se deja de guardar dos veces lo
+ * mismo, porque el reporte de calidad ya lo escribe aparte en cada corrida.
+ *
+ * SE PODA SOLO LO QUE SE ESCRIBE, Y ESO ES A PROPOSITO
+ *
+ * La primera versión barría el manifest entero en cada escritura. Tres tests y
+ * un chequeo de aceptación la voltearon, y con razón: reescribir con un lote
+ * vacío tiene que dejar el manifest IDENTICO. Esa garantía es la que prueba
+ * que una reescritura completa no pierde datos, y vale mucho más que ahorrar
+ * unos megas más rápido.
+ *
+ * Así que sólo se poda la entrada que la corrida está escribiendo igual. El
+ * archivo se achica de a poco, al ritmo con el que el cron revalida cada
+ * portada, en vez de liberar todo de una.
+ *
+ * LA EXCEPCION, QUE LA ENCONTRO UN TEST
+ *
+ * Hay un caso que la regla de arriba se llevaba puesto: cuando una variante de
+ * la fuente se cayó (un 503, por ejemplo) pero otra sí anduvo, la portada
+ * termina bien y el historial es lo ÚNICO que registra que hubo un problema.
+ * Sin eso no hay forma de saber que quizás había una imagen mejor detrás de la
+ * variante caída.
+ *
+ * Así que el historial con algún error se conserva siempre, mida lo que mida
+ * la imagen final. Son pocas entradas y es justo la información que uno va a
+ * querer el día que investigue por qué una portada quedó peor de lo esperado.
+ */
+
+import { googleFutureReadyImage } from './image-source-policy.js';
+
+/**
+ * ¿Hay que conservar el historial de sondeos de esta entrada?
+ *
+ * @param {object|null} entry  una entrada del manifest
+ * @returns {boolean} true si el reporte de calidad todavía lo puede necesitar
+ */
+export function shouldKeepProbes(entry) {
+  // Un sondeo con error se conserva siempre: es la única marca de que hubo un
+  // problema con la fuente, incluso cuando la portada terminó estando bien.
+  if (probesRecordAnError(entry?.source_probes)) return true;
+
+  const current = entry?.current;
+  // Sin copia todavía: la entrada está en pleno trabajo y el historial es lo
+  // único que explica por qué no se pudo. Se conserva.
+  if (!current?.object_key) return true;
+  // Con copia: sólo importa mientras no llegue al tamaño que Google va a pedir.
+  return !googleFutureReadyImage(current);
+}
+
+function probesRecordAnError(probes) {
+  return Array.isArray(probes) && probes.some(probe => {
+    if (!probe || typeof probe !== 'object') return false;
+    // `error` es como lo escribe fetchCover; el estado HTTP se mira igual por
+    // si alguna vez se registra sin campo `error`.
+    if (probe.error) return true;
+    const estado = Number(probe.status);
+    return Number.isFinite(estado) && estado >= 400;
+  });
+}
+
+/**
+ * La entrada sin el historial que ya no se lee. Devuelve LA MISMA referencia
+ * cuando no hay nada que sacar: así el barrido sobre 80.000 entradas no crea
+ * ochenta mil objetos nuevos sólo para dejarlos iguales.
+ *
+ * @param {object|null} entry
+ * @returns {object|null}
+ */
+export function pruneEntryProbes(entry) {
+  if (!entry || typeof entry !== 'object') return entry;
+  if (!('source_probes' in entry)) return entry;
+  if (shouldKeepProbes(entry)) return entry;
+  const { source_probes: descartado, ...resto } = entry;
+  // `descartado` no se usa: existe sólo para sacarlo del resto.
+  void descartado;
+  return resto;
+}

--- a/worker-sync/cover-mirror.js
+++ b/worker-sync/cover-mirror.js
@@ -1,6 +1,7 @@
 import { IMAGE_SOURCE_POLICY_VERSION, GOOGLE_IMAGE_MIN_EDGE, IMAGE_SOURCE_RECHECK_MS, IMAGE_FETCH_RETRY_MS, nativeImageAlternatives, mlImageIdentity, googleFutureReadyImage, resolutionDowngrade } from '../functions/_shared/image-source-policy.js';
 import { dedupeByGtinAndCondition, isEligibleForFeed } from '../functions/feed.xml.js';
 import { COVER_INDEX_METADATA, prepareCoverIndex } from '../functions/_shared/cover-public-index.js';
+import { pruneEntryProbes } from '../functions/_shared/cover-probe-retention.js';
 import { putJsonToR2 } from './json-r2-stream.js';
 import { readFullCoverManifest } from './cover-manifest-read.js';
 
@@ -129,9 +130,27 @@ async function writeManifestAttempt(bucket, state, processedEntries, nowIso) {
         : state.manifest.updated_at,
       entries: { ...state.manifest.entries },
     };
+    // El historial de sondeos de una portada que ya llegó a 500px no lo lee
+    // nadie: el reporte de calidad sólo mira el de las que todavía no llegan.
+    // Guardarlo igual es peso muerto que hay que cargar en memoria en cada
+    // escritura, y el manifest ya está cerca del límite del isolate.
+    //
+    // Se poda SOLO lo que esta corrida escribe, no todo el manifest. Un
+    // barrido global cambiaría entradas que nadie tocó, y eso rompe una
+    // garantía que vale más que el ahorro: que reescribir con un lote vacío
+    // deje el manifest idéntico. Hay tres tests y un chequeo de aceptación
+    // que la verifican, y son los que agarraron el intento anterior.
+    //
+    // El costo es que converge de a poco, al ritmo con el que el cron
+    // revalida cada portada, en vez de liberar todo de una.
+    let pruned = 0;
     for (const [key, processed] of processedEntries) {
-      nextManifest.entries[key] = mergeProcessedEntry(nextManifest.entries[key], processed);
+      const merged = mergeProcessedEntry(nextManifest.entries[key], processed);
+      const podado = pruneEntryProbes(merged);
+      if (podado !== merged) pruned += 1;
+      nextManifest.entries[key] = podado;
     }
+    const probes = { scanned: processedEntries.length, pruned };
 
     // A daily bounded rewrite repairs deleted/damaged derived objects even if
     // no image changes. Normal batches upload only changed shards.
@@ -167,7 +186,7 @@ async function writeManifestAttempt(bucket, state, processedEntries, nowIso) {
     }
     // R2 devuelve null cuando la precondición falla. `undefined` sigue siendo
     // un éxito válido para mocks/implementaciones compatibles con put().
-    return result !== null ? { manifest: nextManifest, publicIndex } : null;
+    return result !== null ? { manifest: nextManifest, publicIndex, probes } : null;
 }
 
 async function writeManifestAtomically(bucket, state, processedEntries, nowIso) {


### PR DESCRIPTION
> **NO MERGEAR sin el ok de Seba.** Toca el manifest del que dependen todas las portadas del sitio y de Google.

## Qué se está guardando de más

El manifest privado pesa **104 MB** y hay que abrirlo entero en memoria cada vez que el cron escribe. La proyección pública —lo mínimo para servir una portada— pesa **32 MB**. El ~70% restante son datos privados, y la parte más gorda es `source_probes`: qué URLs se probaron para cada imagen, con tamaño y resultado.

## Quién lo lee de verdad

Rastreé **cada lectura** de `source_probes` en el repositorio:

| Dónde | Para qué |
|---|---|
| `covers/v1/quality-report.json` | la lista `needs_better_source` |
| `worker-sync/image-system-preview.js` | pantalla interna de QA |

**Y nada más.** En particular `candidatePriority` —la función que decide qué portada trabajar— **no lo mira**: le alcanza con `last_error.at`, el `source_url` actual, `source_policy_version`, `native_checked_at`, `last_validated_at` y el tamaño de la imagen.

Y el reporte lo arma así:

```js
entry.current.object_key && !googleFutureReadyImage(entry.current)
```

Portadas que **ya tienen copia pero todavía no llegan a los 500px** que Google va a exigir. Para una que ya llegó, ese historial no lo lee nadie. Nunca.

**Y el reporte de calidad ya lo escribe aparte en cada corrida** — o sea que hoy se guarda dos veces. Esto no saca información: deja de duplicarla.

## Dos veces me corrigieron los tests

**1. Una variante caída.** El test `una variante caída no bloquea otra fuente real válida` se puso en rojo con mi primera regla. Tenía razón: si una variante de la fuente se cae (un 503) pero otra anda, la portada termina grande y el historial es **lo único** que registra que hubo un problema — quizás había una imagen mejor detrás de la caída.

→ Ahora **un historial con cualquier error se conserva siempre**, mida lo que mida la imagen final.

**2. El barrido global.** Mi primera versión barría el manifest entero en cada escritura. Tres tests más la voltearon, también con razón: **reescribir con un lote vacío tiene que dejar el manifest idéntico.** Esa garantía es la que prueba que una reescritura completa no pierde datos — la misma que verifica `full_manifest_preserved` en el chequeo de aceptación.

→ Ahora **se poda sólo la entrada que la corrida está escribiendo igual.** Se achica de a poco, al ritmo con el que el cron revalida cada portada. Es más lento y es lo correcto.

## Cuánto achica

**No prometo un número.** El ahorro depende de qué proporción del catálogo ya llegó a 500px, que es justo lo que no puedo medir desde acá — y hoy ya me equivoqué tres veces estimando cosas que no podía medir.

Lo que sí: el guardián de #349 informa el tamaño del manifest en cada corrida del chequeo de portadas, **así que el efecto se va a ver medido y no estimado.**

## Validación

**10 tests nuevos.** `bash scripts/validate-ci.sh` completo: **0 fallos**, ambos builds OK.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM)_