### PR TITLE
Panel: tablero con menú lateral, gráfico de facturación e indicadores

### DIFF
--- a/functions/__tests__/panel-chart.test.js
+++ b/functions/__tests__/panel-chart.test.js
@@ -1,0 +1,128 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { revenueChart, revenueTable, techoDelEje } from '../_shared/panel-chart.js';
+import { loadRevenueByMonth } from '../_shared/panel-data.js';
+
+function serie(valores) {
+  const months = valores.map((total_uyu, i) => ({
+    month: `2026-${String(i + 1).padStart(2, '0')}`,
+    orders: total_uyu > 0 ? 1 : 0,
+    total_uyu,
+  }));
+  return { months, max: Math.max(0, ...valores) };
+}
+
+test('el techo del eje deja aire arriba de la barra más alta', () => {
+  // Si la barra más alta toca el borde, no se ve que es la más alta.
+  for (const maximo of [1, 37, 5100, 84350, 999999]) {
+    const techo = techoDelEje(maximo);
+    assert.ok(techo >= maximo, `${maximo} no entra en un techo de ${techo}`);
+    assert.ok(techo <= maximo * 2.5, `${maximo} contra ${techo} deja demasiado aire`);
+  }
+});
+
+test('un catálogo sin ventas todavía no rompe el techo', () => {
+  for (const vacio of [0, -1, null, undefined, NaN, 'nada']) {
+    assert.ok(techoDelEje(vacio) > 0, `${String(vacio)} tiene que dar un techo usable`);
+  }
+});
+
+test('los meses sin ventas se dibujan como ausencia, no como hueco', () => {
+  // Un mes en cero NO es "no hay dato": es "no se vendió". Por eso no hay
+  // barra, pero sí etiqueta de mes en el eje.
+  const svg = revenueChart(serie([0, 5100, 0, 2350]));
+  assert.equal((svg.match(/class="barra"/g) || []).length, 2, 'sólo los meses con venta tienen barra');
+  assert.equal((svg.match(/class="eje"/g) || []).length, 4, 'los cuatro meses se rotulan igual');
+});
+
+test('sólo se etiqueta el mes más alto, no todos', () => {
+  // Un número sobre cada barra es ruido; el resto están en el tooltip.
+  const svg = revenueChart(serie([1000, 5100, 2350, 800]));
+  assert.equal((svg.match(/class="valor"/g) || []).length, 1);
+  assert.match(svg, /class="valor"[^>]*>\$ 5[.,]100</);
+});
+
+test('cada mes tiene un blanco de mouse de altura completa', () => {
+  // Una barra de dos pixeles en un mes flojo sería imposible de apuntar.
+  const svg = revenueChart(serie([50, 5100, 0]));
+  assert.equal((svg.match(/class="blanco"/g) || []).length, 3,
+    'incluso el mes en cero se puede apuntar');
+  assert.match(svg, /<title>.*5[.,]100.*1 pedido<\/title>/);
+});
+
+test('el gráfico dice qué es para quien no lo puede ver', () => {
+  const svg = revenueChart(serie([1000, 2000]));
+  assert.match(svg, /role="img"/);
+  assert.match(svg, /aria-label="Facturación cobrada por mes, últimos 2 meses"/);
+});
+
+test('sin datos no se dibuja un gráfico vacío: se dice que no hay', () => {
+  for (const nada of [{ months: [] }, {}, null, undefined]) {
+    const salida = revenueChart(nada);
+    assert.doesNotMatch(salida, /<svg/);
+    assert.match(salida, /Todavía no hay ventas/);
+    assert.equal(revenueTable(nada), '', 'tampoco una tabla vacía');
+  }
+});
+
+test('la tabla trae los mismos números que el gráfico', () => {
+  // No es un extra: es la vía de lectura para quien no ve el gráfico.
+  const tabla = revenueTable(serie([0, 5100, 2350]));
+  assert.match(tabla, /\$ 5[.,]100/);
+  assert.match(tabla, /\$ 2[.,]350/);
+  assert.match(tabla, /\$ 0/);
+  assert.equal((tabla.match(/<tr>/g) || []).length, 4, 'tres meses más el encabezado');
+});
+
+test('un título hostil no puede escaparse del SVG', () => {
+  // Los meses los arma el propio código, pero el escape es del molde: si
+  // mañana entra algo de afuera, tiene que salir escapado igual.
+  const svg = revenueChart({
+    months: [{ month: '<script>x</script>', orders: 1, total_uyu: 100 }], max: 100,
+  });
+  assert.doesNotMatch(svg, /<script>x<\/script>/);
+});
+
+test('la consulta rellena los meses sin ventas y no los saltea', async () => {
+  // Ésta es la parte que hace que el gráfico no mienta: la base sólo
+  // devuelve los meses que tuvieron ventas.
+  const db = {
+    prepare() {
+      const st = {
+        bind: () => st,
+        all: async () => ({ results: [{ month: '2026-09', orders: 2, total_uyu: 5100 }] }),
+      };
+      return st;
+    },
+  };
+  const revenue = await loadRevenueByMonth(db, { now: Date.parse('2026-09-10T23:00:00Z') });
+
+  assert.equal(revenue.months.length, 12, 'siempre doce meses, con ventas o sin ellas');
+  assert.equal(revenue.months.at(-1).month, '2026-09', 'el último es el mes en curso');
+  assert.equal(revenue.months.at(-1).total_uyu, 5100);
+  assert.equal(revenue.months[0].total_uyu, 0, 'los meses sin ventas vienen en cero, no faltan');
+  assert.equal(revenue.max, 5100);
+  assert.equal(revenue.total_uyu, 5100);
+  assert.equal(revenue.orders, 2);
+
+  const claves = revenue.months.map(fila => fila.month);
+  assert.deepEqual([...new Set(claves)], claves, 'sin meses repetidos');
+  assert.deepEqual([...claves].sort(), claves, 'en orden');
+});
+
+test('la consulta de facturación no escribe nada', async () => {
+  const vistas = [];
+  const db = {
+    prepare(sql) {
+      vistas.push(sql);
+      const st = { bind: () => st, all: async () => ({ results: [] }) };
+      return st;
+    },
+  };
+  await loadRevenueByMonth(db, { now: Date.parse('2026-09-10T23:00:00Z') });
+  assert.ok(vistas.length > 0);
+  for (const sql of vistas) {
+    assert.doesNotMatch(sql, /\b(INSERT|UPDATE|DELETE|DROP|ALTER)\b/i, `escribe: ${sql}`);
+  }
+});

--- a/functions/_shared/panel-chart.js
+++ b/functions/_shared/panel-chart.js
@@ -1,0 +1,157 @@
+/**
+ * functions/_shared/panel-chart.js
+ *
+ * El gráfico de facturación del tablero, dibujado en SVG a mano.
+ *
+ * POR QUE BARRAS Y NO UNA LINEA
+ *
+ * Son totales de períodos discretos —lo facturado en cada mes—, no una medición
+ * continua. Con barras, un mes sin ventas se lee como lo que es: no hay barra.
+ * Con una línea, ese mismo mes sería una caída hasta cero y después una subida,
+ * que sugiere un movimiento que nunca pasó. Con el volumen real de la librería,
+ * eso importa: hay meses en cero de verdad.
+ *
+ * POR QUE SIN LIBRERIA
+ *
+ * El panel corre en un Worker y todo lo que sirve viaja en cada carga. Doce
+ * barras y un eje no justifican traer una librería de gráficos, y además el
+ * sitio no carga scripts de terceros.
+ *
+ * UNA SOLA SERIE, A PROPOSITO
+ *
+ * Plata y cantidad de pedidos son dos magnitudes distintas y meterlas en el
+ * mismo gráfico obligaría a dos ejes verticales, que es la forma más común de
+ * hacer mentir a un gráfico. La cantidad de pedidos va en el tooltip de cada
+ * mes, no como segunda serie.
+ */
+
+const ALTO = 180;
+const ANCHO = 720;
+const MARGEN = { arriba: 24, derecha: 8, abajo: 26, izquierda: 8 };
+const RADIO = 4;
+const SEPARACION = 2;
+
+const MES_CORTO = ['ene', 'feb', 'mar', 'abr', 'may', 'jun',
+  'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function pesos(value) {
+  return `$ ${new Intl.NumberFormat('es-UY', { maximumFractionDigits: 0 }).format(Number(value) || 0)}`;
+}
+
+/** "2026-09" → "sep 26". El año sólo en enero y en el primer mes de la serie. */
+function etiquetaMes(clave, primero) {
+  const [anio, mes] = String(clave).split('-');
+  const indice = Number(mes) - 1;
+  const nombre = MES_CORTO[indice] || '?';
+  return (indice === 0 || primero) ? `${nombre} ${String(anio).slice(2)}` : nombre;
+}
+
+/**
+ * Un techo redondo para el eje: 5.100 no se dibuja contra 5.100 sino contra
+ * 6.000. Si la barra más alta toca el borde, no se ve que es la más alta.
+ */
+export function techoDelEje(maximo) {
+  const valor = Number(maximo) || 0;
+  if (valor <= 0) return 1000;
+  const magnitud = 10 ** Math.floor(Math.log10(valor));
+  for (const paso of [1, 1.2, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 10]) {
+    const candidato = paso * magnitud;
+    if (candidato >= valor) return candidato;
+  }
+  return 10 * magnitud;
+}
+
+/**
+ * @param {object} revenue  lo que devuelve loadRevenueByMonth
+ * @returns {string} el SVG listo para incrustar
+ */
+export function revenueChart(revenue) {
+  const meses = Array.isArray(revenue?.months) ? revenue.months : [];
+  if (meses.length === 0) {
+    return '<p class="empty">Todavía no hay ventas cobradas para graficar.</p>';
+  }
+
+  const techo = techoDelEje(revenue.max);
+  const util = { ancho: ANCHO - MARGEN.izquierda - MARGEN.derecha,
+    alto: ALTO - MARGEN.arriba - MARGEN.abajo };
+  const paso = util.ancho / meses.length;
+  const anchoBarra = Math.max(6, paso - SEPARACION * 2);
+  const base = MARGEN.arriba + util.alto;
+
+  // Se etiqueta sólo el mes más alto. Un número sobre cada barra es ruido: el
+  // resto de los valores están en el tooltip, que es donde se los busca.
+  const masAlto = meses.reduce((mayor, fila, indice) =>
+    (fila.total_uyu > meses[mayor].total_uyu ? indice : mayor), 0);
+
+  const grilla = [0, 0.5, 1].map(fraccion => {
+    const y = MARGEN.arriba + util.alto * (1 - fraccion);
+    return `<line class="grilla" x1="${MARGEN.izquierda}" y1="${y.toFixed(1)}"
+      x2="${ANCHO - MARGEN.derecha}" y2="${y.toFixed(1)}"></line>`;
+  }).join('');
+
+  const barras = meses.map((fila, indice) => {
+    const alto = techo > 0 ? (fila.total_uyu / techo) * util.alto : 0;
+    const x = MARGEN.izquierda + paso * indice + (paso - anchoBarra) / 2;
+    const y = base - alto;
+    const etiqueta = etiquetaMes(fila.month, indice === 0);
+    const detalle = `${etiqueta}: ${pesos(fila.total_uyu)}`
+      + ` · ${fila.orders} pedido${fila.orders === 1 ? '' : 's'}`;
+
+    // El rectángulo transparente de toda la altura es el blanco del mouse: una
+    // barra de dos pixeles en un mes flojo sería imposible de apuntar.
+    return `<g class="mes">
+      <rect class="blanco" x="${(MARGEN.izquierda + paso * indice).toFixed(1)}"
+            y="${MARGEN.arriba}" width="${paso.toFixed(1)}" height="${util.alto}">
+        <title>${escapeHtml(detalle)}</title>
+      </rect>
+      ${alto > 0 ? `<rect class="barra" x="${x.toFixed(1)}" y="${y.toFixed(1)}"
+            width="${anchoBarra.toFixed(1)}" height="${alto.toFixed(1)}"
+            rx="${Math.min(RADIO, anchoBarra / 2)}"></rect>` : ''}
+      ${indice === masAlto && fila.total_uyu > 0
+        ? `<text class="valor" x="${(x + anchoBarra / 2).toFixed(1)}"
+                 y="${(y - 7).toFixed(1)}">${escapeHtml(pesos(fila.total_uyu))}</text>`
+        : ''}
+      <text class="eje" x="${(MARGEN.izquierda + paso * indice + paso / 2).toFixed(1)}"
+            y="${(base + 16).toFixed(1)}">${escapeHtml(etiqueta)}</text>
+    </g>`;
+  }).join('');
+
+  return `<figure class="grafico">
+  <svg viewBox="0 0 ${ANCHO} ${ALTO}" role="img"
+       aria-label="Facturación cobrada por mes, últimos ${meses.length} meses">
+    ${grilla}
+    <line class="base" x1="${MARGEN.izquierda}" y1="${base}"
+          x2="${ANCHO - MARGEN.derecha}" y2="${base}"></line>
+    ${barras}
+  </svg>
+</figure>`;
+}
+
+/**
+ * La misma serie como tabla. No es un extra: es la vía de lectura para quien
+ * no puede ver el gráfico, y la que permite copiar los números.
+ */
+export function revenueTable(revenue) {
+  const meses = Array.isArray(revenue?.months) ? revenue.months : [];
+  if (meses.length === 0) return '';
+  return `<details class="tabla-datos">
+  <summary>Ver los números</summary>
+  <div class="scroll"><table>
+    <thead><tr><th>Mes</th><th>Pedidos</th><th>Facturado</th></tr></thead>
+    <tbody>${meses.map(fila => `<tr>
+      <td>${escapeHtml(etiquetaMes(fila.month, true))}</td>
+      <td>${escapeHtml(fila.orders)}</td>
+      <td>${escapeHtml(pesos(fila.total_uyu))}</td>
+    </tr>`).join('')}</tbody>
+  </table></div>
+</details>`;
+}

--- a/functions/_shared/panel-data.js
+++ b/functions/_shared/panel-data.js
@@ -23,6 +23,7 @@ const RECENT_ORDERS_LIMIT = 20;
 const STUCK_LIMIT = 25;
 const CRAWL_DAYS = 7;
 const MISSING_IMAGE_LIMIT = 25;
+const REVENUE_MONTHS = 12;
 const ORDER_EVENTS_LIMIT = 30;
 // El código va en la URL y de ahí a una consulta: sólo se acepta su forma real.
 const ORDER_CODE_RE = /^AL-[0-9]{6}-[A-Z0-9]{6}$/;
@@ -160,6 +161,56 @@ export async function loadStuck(db, { now = Date.now() } = {}) {
       paymentHanging.length +
       waitlistRestocked.length +
       notificationFailed.length,
+  };
+}
+
+/**
+ * Facturado por mes, para el gráfico del tablero.
+ *
+ * Se agrupa por MES y no por día a propósito: con el volumen real de la
+ * librería, un gráfico diario serían doce barras y trescientos ceros. El mes
+ * es la unidad en la que se mira si el negocio sube o baja.
+ *
+ * Los meses sin ventas vienen con cero y no se saltean: un hueco en la serie
+ * se leería como "no hay dato" cuando en realidad significa "no se vendió".
+ */
+export async function loadRevenueByMonth(db, { now = Date.now() } = {}) {
+  const desde = new Date(now);
+  desde.setUTCDate(1);
+  desde.setUTCHours(0, 0, 0, 0);
+  desde.setUTCMonth(desde.getUTCMonth() - (REVENUE_MONTHS - 1));
+
+  const rows = await queryAll(
+    db,
+    `SELECT substr(paid_at, 1, 7) AS month,
+            COUNT(*) AS orders,
+            COALESCE(SUM(payable_total_uyu), 0) AS total_uyu
+       FROM orders
+      WHERE payment_status = 'approved' AND paid_at >= ?
+      GROUP BY month
+      ORDER BY month ASC`,
+    [desde.toISOString()],
+  );
+
+  const porMes = new Map(rows.map(row => [String(row.month), row]));
+  const months = [];
+  for (let i = 0; i < REVENUE_MONTHS; i++) {
+    const fecha = new Date(desde);
+    fecha.setUTCMonth(desde.getUTCMonth() + i);
+    const clave = fecha.toISOString().slice(0, 7);
+    const fila = porMes.get(clave);
+    months.push({
+      month: clave,
+      orders: Number(fila?.orders) || 0,
+      total_uyu: Number(fila?.total_uyu) || 0,
+    });
+  }
+
+  return {
+    months,
+    max: months.reduce((mayor, fila) => Math.max(mayor, fila.total_uyu), 0),
+    total_uyu: months.reduce((suma, fila) => suma + fila.total_uyu, 0),
+    orders: months.reduce((suma, fila) => suma + fila.orders, 0),
   };
 }
 
@@ -340,8 +391,9 @@ export async function loadPanelData(context, { now = Date.now() } = {}) {
     ? section(() => loader(db))
     : Promise.resolve({ ok: false, error: 'ORDERS_DB no está disponible en este entorno.' }));
 
-  const [orders, stuck, waitlist, crawl, catalog] = await Promise.all([
+  const [orders, revenue, stuck, waitlist, crawl, catalog] = await Promise.all([
     withDb(database => loadOrdersOverview(database, { now })),
+    withDb(database => loadRevenueByMonth(database, { now })),
     withDb(database => loadStuck(database, { now })),
     withDb(database => loadWaitlist(database)),
     withDb(database => loadCrawl(database, { now })),
@@ -352,6 +404,7 @@ export async function loadPanelData(context, { now = Date.now() } = {}) {
     generatedAt: new Date(now).toISOString(),
     environment: environmentSummary(context?.env),
     orders,
+    revenue,
     stuck,
     waitlist,
     crawl,

--- a/functions/panel/[[path]].js
+++ b/functions/panel/[[path]].js
@@ -41,6 +41,7 @@ import {
   timingSafeEqual,
 } from '../_shared/panel-auth.js';
 import { loadOrder, loadPanelData } from '../_shared/panel-data.js';
+import { revenueChart, revenueTable } from '../_shared/panel-chart.js';
 import { loadPickup, pickupComplete, savePickup } from '../_shared/panel-settings.js';
 import {
   NOTICE_EVENT_TYPE,
@@ -117,13 +118,51 @@ function money(value) {
   return `$ ${number.toLocaleString('es-UY')}`;
 }
 
+/**
+ * Sólo el día. En la tabla del tablero la hora no aporta nada a la mirada
+ * rápida y empuja la última columna fuera de la tarjeta: la fecha terminaba
+ * cortada a la mitad. La hora exacta está en la ficha del pedido.
+ */
+function shortDay(value) {
+  const raw = cleanString(value);
+  if (!raw) return '—';
+  return escapeHtml(raw.slice(0, 10));
+}
+
 function shortDate(value) {
   const raw = cleanString(value);
   if (!raw) return '—';
   return escapeHtml(raw.slice(0, 16).replace('T', ' '));
 }
 
-function layout(title, body) {
+/**
+ * El menú lateral. Sólo lleva a lugares que existen: el tablero, la pantalla
+ * de ajustes y las secciones de esta misma página. Un menú con "Clientes" o
+ * "Marketing" que no abre nada se ve bien en una captura y estorba al usarlo.
+ */
+function sidebar(activo = 'tablero') {
+  const items = [
+    { id: 'tablero', href: '/panel', texto: 'Tablero', icono: '▦' },
+    { id: 'pendientes', href: '/panel#pendientes', texto: 'Para hacer', icono: '◉' },
+    { id: 'pedidos', href: '/panel#pedidos', texto: 'Pedidos', icono: '❑' },
+    { id: 'catalogo', href: '/panel#catalogo', texto: 'Catálogo', icono: '❏' },
+    { id: 'ajustes', href: '/panel/ajustes', texto: 'Ajustes', icono: '✧' },
+  ];
+  return `<nav class="lateral" aria-label="Secciones del panel">
+  <a class="marca" href="/panel"><b>Amado</b><span>Libros</span></a>
+  <ul>
+    ${items.map(item => `<li><a href="${item.href}"
+      class="${item.id === activo ? 'aqui' : ''}"
+      ${item.id === activo ? 'aria-current="page"' : ''}
+      ><i aria-hidden="true">${item.icono}</i>${escapeHtml(item.texto)}</a></li>`).join('')}
+  </ul>
+  <form class="salir" method="POST" action="/panel/logout">
+    <button class="logout" type="submit">Salir</button>
+  </form>
+</nav>`;
+}
+
+function layout(title, body, { nav = '' } = {}) {
   return `<!DOCTYPE html>
 <html lang="es">
 <head>
@@ -201,6 +240,75 @@ function layout(title, body) {
   details.card > .cuerpo { padding:0 1.5rem 1.35rem; }
   details.card > summary .resumen { color:var(--tinta-suave); font-weight:400;
                                     font-size:.85rem; margin-left:auto; }
+
+  /* ── Menú lateral ───────────────────────────────────────────────── */
+  body.con-lateral { display:flex; align-items:flex-start; }
+  body.con-lateral main { flex:1; min-width:0; max-width:1080px; padding-top:.5rem; }
+  .lateral { position:sticky; top:0; width:200px; flex:none; height:100vh;
+             background:var(--tarjeta); border-right:1px solid var(--borde);
+             display:flex; flex-direction:column; padding:1.35rem 0 1rem; }
+  .marca { display:block; padding:0 1.25rem 1.35rem; text-decoration:none;
+           color:var(--tinta); letter-spacing:-.02em; line-height:1.15; }
+  .marca b { display:block; font-size:1.15rem; font-weight:700; }
+  .marca span { color:var(--tinta-suave); font-size:.85rem; }
+  .lateral ul { list-style:none; margin:0; padding:0 .6rem; flex:1;
+                display:flex; flex-direction:column; gap:.15rem; }
+  .lateral a:not(.marca) { display:flex; align-items:center; gap:.65rem;
+    padding:.55rem .65rem; border-radius:9px; text-decoration:none;
+    color:var(--tinta-media); font-size:.9rem; font-weight:500; }
+  .lateral a:not(.marca):hover { background:var(--papel); color:var(--tinta); }
+  .lateral a.aqui { background:var(--acento-suave); color:var(--acento); font-weight:650; }
+  .lateral i { font-style:normal; font-size:.9rem; width:1.1rem; text-align:center; }
+  .salir { padding:0 1.25rem; margin:0; }
+  .salir button { width:100%; margin:0; }
+
+  /* ── Tarjetas de indicadores ────────────────────────────────────── */
+  .tarjetas { display:grid; grid-template-columns:repeat(auto-fit,minmax(170px,1fr));
+              gap:.8rem; margin-bottom:1.1rem; }
+  .tarjetas > .err { grid-column:1/-1; margin:0; padding:1rem 1.15rem; font-size:.9rem;
+                     border:1px solid var(--error); border-radius:var(--radio);
+                     background:var(--error-suave); }
+  .kpi { background:var(--tarjeta); border:1px solid var(--borde);
+         border-radius:var(--radio); padding:1rem 1.15rem; box-shadow:var(--sombra);
+         display:flex; flex-direction:column; gap:.15rem; }
+  .kpi span { color:var(--tinta-media); font-size:.78rem; font-weight:600;
+              text-transform:uppercase; letter-spacing:.05em; }
+  .kpi b { font-size:1.75rem; font-weight:650; letter-spacing:-.03em; line-height:1.15; }
+  .kpi small { color:var(--tinta-suave); font-size:.8rem; }
+  .kpi-alerta { border-color:var(--alerta-borde); }
+  .kpi-alerta b { color:var(--alerta); }
+
+  /* ── Gráfico ────────────────────────────────────────────────────── */
+  .card-cabeza { display:flex; justify-content:space-between; align-items:baseline;
+                 gap:1rem; margin-bottom:1rem; }
+  .card-cabeza h2 { margin:0; }
+  figure.grafico { margin:0; }
+  figure.grafico svg { width:100%; height:auto; display:block; overflow:visible; }
+  /* La grilla y el eje son recesivos: la barra es el dato, no la regla. */
+  .grilla { stroke:var(--borde-suave); stroke-width:1; }
+  .base { stroke:var(--borde); stroke-width:1; }
+  .barra { fill:var(--acento); }
+  .blanco { fill:transparent; }
+  .mes:hover .barra { filter:brightness(1.15); }
+  .mes:hover .blanco { fill:var(--acento-suave); }
+  .eje { fill:var(--tinta-suave); font-size:10px; text-anchor:middle;
+         font-variant-numeric:tabular-nums; }
+  .valor { fill:var(--tinta); font-size:11px; font-weight:650; text-anchor:middle; }
+  .tabla-datos { margin-top:1rem; }
+  .tabla-datos > summary { cursor:pointer; color:var(--tinta-media);
+                           font-size:.85rem; padding:.3rem 0; }
+  .tabla-datos > summary:hover { color:var(--acento); }
+
+  /* ── Pastillas de estado ────────────────────────────────────────── */
+  /* Color Y palabra: el color solo nunca alcanza. */
+  .pastilla { display:inline-block; padding:.15rem .55rem; border-radius:999px;
+              font-size:.78rem; font-weight:600; white-space:nowrap;
+              border:1px solid transparent; }
+  .p-bien   { background:var(--ok-suave);     color:var(--ok);     border-color:var(--ok); }
+  .p-aviso  { background:var(--alerta-suave); color:var(--alerta); border-color:var(--alerta-borde); }
+  .p-serio  { background:#fdf0e9;             color:#a1500f;       border-color:#e8b48f; }
+  .p-grave  { background:var(--error-suave);  color:var(--error);  border-color:var(--error); }
+  .p-neutro { background:var(--papel);        color:var(--tinta-media); border-color:var(--borde); }
 
   /* ── Números ────────────────────────────────────────────────────── */
   .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
@@ -328,6 +436,42 @@ function layout(title, body) {
               font-variant-numeric:tabular-nums; }
   .cifras span { color:var(--tinta-media); font-size:.8rem; }
 
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) .p-serio {
+      background:#2b1d15; color:#e8a06f; border-color:#5c3a24; }
+  }
+
+  /* En pantalla chica el lateral se acuesta arriba y se desplaza solo: un
+     menú fijo de 200px sobre 390 se come media pantalla. */
+  @media (max-width:820px) {
+    body.con-lateral { display:block; }
+    .lateral { position:static; width:auto; height:auto; flex-direction:row;
+               align-items:center; gap:.5rem; padding:.7rem .9rem;
+               border-right:0; border-bottom:1px solid var(--borde); }
+    .marca { padding:0 .5rem 0 0; flex:none; }
+    .marca b { font-size:1rem; }
+    .marca span { display:none; }
+    /* Sólo corre el menú, no la barra entera: si corriera la barra, «Salir»
+       quedaba fuera de la pantalla y había que arrastrar para encontrarlo. */
+    .lateral ul { flex-direction:row; padding:0; flex:1; gap:.3rem; min-width:0;
+                  overflow-x:auto; scrollbar-width:none; }
+    .lateral ul::-webkit-scrollbar { display:none; }
+    .lateral li { flex:none; }
+    .lateral a:not(.marca) { white-space:nowrap; padding:.4rem .6rem; }
+    .lateral i { display:none; }
+    .salir { padding:0; flex:none; }
+    .salir button { padding:.4rem .8rem; }
+
+    /* El gráfico no se achica hasta ser ilegible: se corre. A 340px de ancho,
+       doce meses en 720 de viewBox dejan las etiquetas en 5px. */
+    /* direction:rtl arranca el corrimiento del lado derecho: en el celular
+       lo primero que se ve son los meses recientes, que son los que importan,
+       y se arrastra hacia atrás para ver el historial. El SVG vuelve a ltr
+       para que las barras no se den vuelta. */
+    figure.grafico { overflow-x:auto; direction:rtl; }
+    figure.grafico svg { min-width:600px; direction:ltr; }
+  }
+
   @media (max-width:640px) {
     main { padding:0 .9rem 3rem; }
     .card { padding:1.1rem 1.15rem; }
@@ -345,7 +489,7 @@ function layout(title, body) {
   }
 </style>
 </head>
-<body><main>${body}</main></body>
+<body class="${nav ? 'con-lateral' : ''}">${nav}<main>${body}</main></body>
 </html>`;
 }
 
@@ -693,6 +837,26 @@ function tareasPendientes(data) {
   return { filas, missing };
 }
 
+/** La píldora de estado. Color Y palabra: el color solo nunca alcanza. */
+function pastilla(diccionario, valor, tono) {
+  return `<span class="pastilla p-${tono}">${label(diccionario, valor)}</span>`;
+}
+
+function tonoPedido(status) {
+  if (status === 'fulfilled') return 'bien';
+  if (status === 'paid') return 'aviso';
+  if (status === 'cancelled' || status === 'expired') return 'grave';
+  return 'neutro';
+}
+
+function tonoPago(status) {
+  if (status === 'approved') return 'bien';
+  if (status === 'pending' || status === 'not_started') return 'aviso';
+  if (status === 'rejected' || status === 'cancelled') return 'grave';
+  if (status === 'refunded') return 'serio';
+  return 'neutro';
+}
+
 function dashboardPage(data) {
   const env = data.environment;
   const { filas, missing } = tareasPendientes(data);
@@ -701,11 +865,12 @@ function dashboardPage(data) {
     !data.stuck?.ok ? data.stuck?.error : null,
     !data.catalog?.ok ? data.catalog?.error : null,
   ].filter(Boolean);
+  const pagadosSinDespachar = data.stuck?.ok ? data.stuck.data.paidNotFulfilled.length : null;
 
   return layout('Panel — Amado Libros', `
 <header class="top">
   <div>
-    <h1>Amado Libros</h1>
+    <h1>Tablero</h1>
     <p class="muted">
       ${escapeHtml(env.appEnv)} ·
       checkout ${env.checkoutEnabled ? '<span class="ok">encendido</span>' : '<span class="err">apagado</span>'} ·
@@ -713,10 +878,46 @@ function dashboardPage(data) {
       ${shortDate(data.generatedAt)} UTC
     </p>
   </div>
-  <div class="acciones"><a class="linkbtn" href="/panel/ajustes">Ajustes</a><form method="POST" action="/panel/logout"><button class="logout" type="submit">Salir</button></form></div>
+  <a class="linkbtn" href="/panel/ajustes">Ajustes</a>
 </header>
 
-<section class="hoy">
+${sectionOrError(data.orders, orders => `
+<section class="tarjetas">
+  <article class="kpi">
+    <span>Facturado · 30 días</span>
+    <b>${money(orders.paidLast30.total_uyu)}</b>
+    <small>${escapeHtml(orders.paidLast30.total ?? 0)} pedido${Number(orders.paidLast30.total) === 1 ? '' : 's'} cobrado${Number(orders.paidLast30.total) === 1 ? '' : 's'}</small>
+  </article>
+  <article class="kpi${pagadosSinDespachar ? ' kpi-alerta' : ''}">
+    <span>Pagados sin despachar</span>
+    <b>${escapeHtml(pagadosSinDespachar ?? '—')}</b>
+    <small>${pagadosSinDespachar ? 'esperando que salgan' : 'nada esperando'}</small>
+  </article>
+  ${sectionOrError(data.catalog, catalog => `
+  <article class="kpi">
+    <span>Libros publicados</span>
+    <b>${escapeHtml(catalog.feed.activeTotal)}</b>
+    <small>${escapeHtml(catalog.withStock)} con stock</small>
+  </article>
+  <article class="kpi${catalog.missingImage?.count ? ' kpi-alerta' : ''}">
+    <span>Fichas sin foto</span>
+    <b>${escapeHtml(catalog.missingImage?.count ?? 0)}</b>
+    <small>no salen en Google</small>
+  </article>`)}
+</section>`)}
+
+<section class="card grafico" id="facturacion">
+  <div class="card-cabeza">
+    <h2>Facturación cobrada</h2>
+    <span class="muted">últimos 12 meses</span>
+  </div>
+  ${sectionOrError(data.revenue, revenue => `
+    ${revenueChart(revenue)}
+    ${revenueTable(revenue)}
+  `)}
+</section>
+
+<section class="hoy" id="pendientes">
   <div class="hoy-cabeza">
     <h2>Para hacer ahora</h2>
     ${totalTareas
@@ -734,55 +935,32 @@ function dashboardPage(data) {
 </section>
 
 ${sectionOrError(data.orders, orders => `
-<section class="cifras">
-  <div><b>${escapeHtml(orders.paidLast30.total ?? 0)}</b><span>cobrados en 30 días</span></div>
-  <div><b>${money(orders.paidLast30.total_uyu)}</b><span>facturado en 30 días</span></div>
-  ${orders.byStatus.map(row => `
-    <div><b>${escapeHtml(row.total ?? 0)}</b><span>${label(ORDER_STATUS_LABEL, row.status)}</span></div>`).join('')}
-</section>
-
-<section class="card">
-  <h2>Últimos pedidos</h2>
+<section class="card" id="pedidos">
+  <div class="card-cabeza">
+    <h2>Últimos pedidos</h2>
+    <span class="muted">${escapeHtml(orders.recent.length)} más recientes</span>
+  </div>
   ${table(['Pedido', 'Comprador', 'Entrega', 'Estado', 'Pago', 'Total', 'Creado'], orders.recent, row => `
     <tr><td><a href="/panel/pedido/${encodeURIComponent(row.public_code)}">${escapeHtml(row.public_code)}</a></td>
         <td>${escapeHtml(row.buyer_name)}</td>
         <td>${label(DELIVERY_LABEL, row.delivery_type)}</td>
-        <td>${label(ORDER_STATUS_LABEL, row.status)}</td>
-        <td>${label(PAYMENT_STATUS_LABEL, row.payment_status)}</td>
+        <td>${pastilla(ORDER_STATUS_LABEL, row.status, tonoPedido(row.status))}</td>
+        <td>${pastilla(PAYMENT_STATUS_LABEL, row.payment_status, tonoPago(row.payment_status))}</td>
         <td>${money(row.payable_total_uyu)}</td>
-        <td>${shortDate(row.created_at)}</td></tr>`)}
+        <td>${shortDay(row.created_at)}</td></tr>`)}
 </section>`)}
 
-<details class="card">
-  <summary>Avisos de stock<span class="resumen">gente esperando reposición</span></summary>
-  <div class="cuerpo">
-  ${sectionOrError(data.waitlist, waitlist => `
-    ${statusList(waitlist.byStatus, WAITLIST_STATUS_LABEL)}
-    <h3>Libros más esperados</h3>
-    ${table(['Libro', 'ID', 'Personas'], waitlist.topProducts, row => `
-      <tr><td>${escapeHtml(row.product_title)}</td><td>${escapeHtml(row.product_id)}</td>
-          <td>${escapeHtml(row.total)}</td></tr>`)}
-  `)}
-  </div>
-</details>
-
-<details class="card">
-  <summary>Productos y Google Shopping<span class="resumen">catálogo y qué llega al feed</span></summary>
+<details class="card" id="catalogo">
+  <summary>Catálogo y Google Shopping<span class="resumen">qué llega al feed</span></summary>
   <div class="cuerpo">
   ${sectionOrError(data.catalog, catalog => `
-    <div class="grid">
-      <div class="stat"><b>${escapeHtml(catalog.total)}</b><span>publicaciones activas</span></div>
-      <div class="stat"><b>${escapeHtml(catalog.withStock)}</b><span>con stock</span></div>
-      <div class="stat"><b>${escapeHtml(catalog.withoutImage)}</b><span>sin imagen</span></div>
-      <div class="stat"><b>${escapeHtml(catalog.withoutIsbn)}</b><span>sin ISBN</span></div>
-    </div>
     <p class="muted">Catálogo generado: ${shortDate(catalog.generatedAt)}</p>
-
     <h3>Cuántos llegan a Google Shopping</h3>
     <div class="grid">
       <div class="stat"><b>${escapeHtml(catalog.feed.activeTotal)}</b><span>libros activos</span></div>
       <div class="stat"><b>${escapeHtml(catalog.feed.eligible)}</b><span>pasan la puerta comercial</span></div>
       <div class="stat ${catalog.feed.blocked ? 'alert' : ''}"><b>${escapeHtml(catalog.feed.blocked)}</b><span>quedan afuera</span></div>
+      <div class="stat"><b>${escapeHtml(catalog.withoutIsbn)}</b><span>sin ISBN</span></div>
     </div>
     ${catalog.feed.blockers.length
       ? `<p class="muted">Por qué quedan afuera:</p>
@@ -795,6 +973,19 @@ ${sectionOrError(data.orders, orders => `
       O sea que la cantidad real de ofertas en Merchant es <b>igual o menor</b> a
       ${escapeHtml(catalog.feed.eligible)}, nunca mayor.
     </p>
+  `)}
+  </div>
+</details>
+
+<details class="card">
+  <summary>Avisos de stock<span class="resumen">gente esperando reposición</span></summary>
+  <div class="cuerpo">
+  ${sectionOrError(data.waitlist, waitlist => `
+    ${statusList(waitlist.byStatus, WAITLIST_STATUS_LABEL)}
+    <h3>Libros más esperados</h3>
+    ${table(['Libro', 'ID', 'Personas'], waitlist.topProducts, row => `
+      <tr><td>${escapeHtml(row.product_title)}</td><td>${escapeHtml(row.product_id)}</td>
+          <td>${escapeHtml(row.total)}</td></tr>`)}
   `)}
   </div>
 </details>
@@ -814,7 +1005,7 @@ ${sectionOrError(data.orders, orders => `
                 <td>${escapeHtml(row.verified_googlebot ?? 0)}</td></tr>`,
   ))}
   </div>
-</details>`);
+</details>`, { nav: sidebar('tablero') });
 }
 
 function clientIp(request) {


### PR DESCRIPTION
El panel tenía forma de informe largo: había que leerlo entero para saber si el negocio iba bien y dónde estaba cada cosa. Esto le da forma de tablero.

## Qué cambia

**Menú lateral fijo** — Tablero, Para hacer, Pedidos, Catálogo, Ajustes. Sólo lleva a lugares que existen: un menú con "Clientes" o "Marketing" que no abre nada se ve bien en una captura y estorba al usarlo.

**Tarjetas de indicadores** arriba de todo: facturado de 30 días, pagados sin despachar, libros publicados, fichas sin foto.

**Gráfico de facturación por mes**, últimos doce meses, en SVG escrito a mano.

- Barras y no línea: son totales de meses, no una medición continua. Un mes sin ventas se lee como ausencia de barra; con una línea sería una caída hasta cero y una subida, un movimiento que nunca pasó. Con el volumen real de la librería hay meses en cero de verdad.
- Sin librería: el panel corre en un Worker y todo lo que sirve viaja en cada carga. Doce barras y un eje no justifican traerla, y el sitio no carga scripts de terceros.
- Una sola serie a propósito: plata y cantidad de pedidos son magnitudes distintas y juntarlas obligaría a dos ejes verticales. La cantidad de pedidos va en el globito de cada mes.
- Se etiqueta sólo el mes más alto. Un número sobre cada barra es ruido.
- Debajo, **"Ver los números"**: la misma serie como tabla. No es un extra, es la vía de lectura para quien no ve el gráfico.

**Pastillas de color** en estado y pago. El color acompaña a la palabra, nunca la reemplaza.

La lista **"Para hacer ahora"** queda igual que en #352.

## La consulta

`loadRevenueByMonth` rellena los doce meses aunque la base sólo devuelva los que tuvieron ventas: un hueco en la serie se leería como "no hay dato" cuando significa "no se vendió". Y no escribe nada, como el resto de `panel-data.js` — hay un test que lo verifica.

## Lo que encontró mirarlo en pantalla

Los tests pasaban y aun así había tres cosas mal, que aparecieron al renderizarlo a 1100px, a 390px y en modo oscuro:

- la fecha de la tabla de pedidos salía cortada a la mitad (la tabla pedía 870px dentro de una tarjeta de 821px);
- un error de carga aparecía como texto rojo suelto al lado de las tarjetas, sin caja;
- en el celular el gráfico quedaba de 85px de alto con las etiquetas ilegibles, y el botón "Salir" quedaba fuera de la pantalla porque corría la barra entera en vez del menú.

Los tres están arreglados. En el celular el gráfico arranca mostrando los meses recientes y se arrastra hacia atrás para ver el historial.

## Verificación

- `node --test "functions/__tests__/*.test.js"` → 1380/1380, sin tocar ningún test existente
- `bash scripts/validate-ci.sh` → completa OK
- Mirado a 1100px, 390px y en modo oscuro

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4WTtdTfP6xgnNYuau42DM)_