### PR TITLE
Mostrar disponibles y por encargo en todas las categorías

### DIFF
--- a/functions/__tests__/all-categories-orders.test.js
+++ b/functions/__tests__/all-categories-orders.test.js
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { onRequest } from '../libros/[[path]].js';
+import { SEO_CATEGORIES } from '../_shared/seo-categories.js';
+import { R2_BASE, PRODUCTION_MANIFEST_URL, PAUSED_MANIFEST_URL } from '../_shared/catalog.js';
+
+const cardIds = html => [...html.matchAll(/class="book-image" href="[^"]*\/libro\/(MLU\d+)\//g)].map(m => m[1]);
+
+// Las colecciones de tarot tienen su propia suite de formatos. Estas pruebas
+// cubren todas las demás landings con los índices compactos de cada entorno.
+for (const category of SEO_CATEGORIES.filter(c => !c.tarotFilter)) {
+    for (const appEnv of ['production', 'preview']) {
+        test(`${category.id} (${appEnv}): conserva ambos estados, ediciones y paginación`, async () => {
+            const active = Array.from({ length: 26 }, (_, i) => [
+                `MLU${10000 + i}`, `Disponible ${String(i).padStart(2, '0')}`, 'Autor', String(9780000000000 + i), '', 1000 + i, 1,
+            ]);
+            const paused = Array.from({ length: 26 }, (_, i) => [
+                `MLU${20000 + i}`, `Encargo ${String(i).padStart(2, '0')}`, 'Autor', String(9781000000000 + i), '',
+            ]);
+            // La publicación con stock gana ante ID repetido o misma edición.
+            const duplicates = [active[0].slice(0, 5), ['MLU30000', 'Edición repetida', 'Autor', active[1][3], '']];
+            const classification = (category.classificationIds || [category.classificationId || category.id])[0];
+            const paths = Object.fromEntries([...active, ...paused, ...duplicates].map(row => [row[0], [classification]]));
+            paths.MLU99999 = ['categoria-ajena'];
+            const manifest = appEnv === 'production' ? PRODUCTION_MANIFEST_URL : PAUSED_MANIFEST_URL;
+            globalThis.caches = { default: {
+                async match(request) {
+                    if (request.url.endsWith('/data/active-categories.json')) return Response.json({ categories: [], items: paths });
+                    if (request.url === manifest) return Response.json({ schema_version: 1, current: {
+                        version: 'all-categories', index_key: 'all-categories/index.json', active_index_key: 'all-categories/active-index.json', block_prefix: 'all-categories', block_count: 128,
+                    } });
+                    if (request.url === `${R2_BASE}/all-categories/active-index.json`) return Response.json({ schema_version: 1,
+                        fields: ['id', 'title', 'author', 'isbn', 'image', 'price', 'available_quantity'],
+                        derived_fields: { slug: 'slugify-v1', status: 'active' }, items: active,
+                    });
+                    if (request.url === `${R2_BASE}/all-categories/index.json`) return Response.json({ schema_version: 1,
+                        fields: ['id', 'title', 'author', 'isbn', 'image'], block_count: 128,
+                        derived_fields: { slug: 'slugify-v1', status: 'paused', block: 'numeric-id-mod-block-count' },
+                        items: [...paused, ...duplicates, ['MLU99999', 'No pertenece', 'Autor', '', '']],
+                    });
+                    assert.fail(`No debe leer el catálogo completo ni otro entorno: ${request.url}`);
+                }, async put() {},
+            } };
+            const pageSize = category.id.startsWith('biblias') ? 24 : 48;
+            const displayed = [];
+            for (let page = 1; page <= Math.ceil(52 / pageSize); page++) {
+                const host = appEnv === 'production' ? 'www.amadolibros.com' : 'preview.example';
+                const response = await onRequest({
+                    request: new Request(`https://${host}/libros/${category.id}${page > 1 ? `?page=${page}` : ''}`),
+                    params: { path: category.id.split('/') }, env: { APP_ENV: appEnv }, data: {}, waitUntil() {},
+                });
+                assert.equal(response.status, 200);
+                const html = await response.text();
+                const ids = cardIds(html);
+                displayed.push(...ids);
+                assert.equal(ids.length, Math.min(pageSize, 52 - (page - 1) * pageSize));
+                assert.equal((html.match(/class="stock-badge by-request"/g) || []).length, ids.length / 2);
+                assert.equal((html.match(/aria-label="Te llega hoy en Montevideo"/g) || []).length, ids.length / 2);
+                assert.match(html, /26 disponibles · 26 por encargo/);
+                assert.match(html, /<form class="category-order"/);
+                assert.match(html, /Consultá precio y plazo de entrega/);
+                assert.doesNotMatch(html, /Libros disponibles<\/h2>|No pertenece|Edición repetida/);
+                assert.ok(html.includes(`content="${appEnv === 'production' ? 'index, follow' : 'noindex, follow'}"`));
+            }
+            assert.equal(new Set(displayed).size, 52);
+            assert.deepEqual(displayed, active.flatMap((row, i) => [row[0], paused[i][0]]));
+        });
+    }
+}

--- a/functions/__tests__/seo-category-pages.test.js
+++ b/functions/__tests__/seo-category-pages.test.js
@@ -129,7 +129,7 @@ test('la landing filtra productos por la categoría solicitada', async () => {
     assert.ok(html.includes(`href="https://www.amadolibros.com/libro/${psychologyItem.id}/`));
     assert.ok(html.includes(`/book-cover/${psychologyItem.id}/cover.jpg`));
     assert.match(html, /srcset="[^"]+240w,[^"]+360w,[^"]+480w"/);
-    assert.match(html, /<strong>1 título disponible ahora\.<\/strong> Los 791 títulos informados en la portada incluyen disponibles y libros que podemos buscar por encargo\./);
+    assert.match(html, /<strong>1 libro<\/strong> · 1 disponible · 0 por encargo/);
 });
 
 test('Biblias une Biblia y Reina-Valera, mientras Reina-Valera conserva su intención propia', async () => {

--- a/functions/__tests__/seo-category-pagination.test.js
+++ b/functions/__tests__/seo-category-pagination.test.js
@@ -71,7 +71,7 @@ test('1. primera página sirve 48 fichas y enlaces HTML a página 2', async () =
   const { response, html } = await render();
   assert.equal(response.status, 200);
   assert.equal(ids(html).length, PAGE_SIZE);
-  assert.match(html, /Mostrando 1–48 de 100 libros disponibles/);
+  assert.match(html, /Mostrando 1–48 de 100 libros/);
   assert.match(html, /<a class="pg-ctl" rel="next" href="\/libros\/psicologia\?page=2">Siguiente/);
   assert.match(html, /<meta name="robots" content="index, follow">/);
 });
@@ -80,7 +80,7 @@ test('2. página 2 es indexable y self-canonical', async () => {
   const { response, html } = await render('?page=2');
   assert.equal(response.status, 200);
   assert.equal(ids(html).length, PAGE_SIZE);
-  assert.match(html, /Mostrando 49–96 de 100 libros disponibles/);
+  assert.match(html, /Mostrando 49–96 de 100 libros/);
   assert.match(html, /<link rel="canonical" href="https:\/\/www\.amadolibros\.com\/libros\/psicologia\?page=2">/);
   assert.match(html, /<meta name="robots" content="index, follow">/);
   assert.match(html, /<a class="pg-ctl" rel="prev" href="\/libros\/psicologia">‹ Anterior<\/a>/);
@@ -89,7 +89,7 @@ test('2. página 2 es indexable y self-canonical', async () => {
 test('3. última página sirve el resto y no enlaza a una página inexistente', async () => {
   const { html } = await render('?page=3');
   assert.equal(ids(html).length, 4);
-  assert.match(html, /Mostrando 97–100 de 100 libros disponibles/);
+  assert.match(html, /Mostrando 97–100 de 100 libros/);
   assert.match(html, /<span class="pg-ctl is-off" aria-disabled="true">Siguiente/);
 });
 
@@ -136,6 +136,6 @@ test('9. parámetros ajenos a page no crean otra landing indexable', async () =>
 test('10. preview conserva navegación relativa y permanece noindex', async () => {
   const { html } = await render('?page=2', 'preview');
   assert.match(html, /<meta name="robots" content="noindex, follow">/);
-  assert.match(html, /href="https:\/\/preview\.example\/libro\/MLU0049\//);
+  assert.match(html, /href="https:\/\/preview\.example\/libro\/MLU\d+\//);
   assert.match(html, /href="\/libros\/psicologia\?page=3"/);
 });

--- a/functions/libros/[[path]].js
+++ b/functions/libros/[[path]].js
@@ -400,7 +400,7 @@ export function editorialGuideHtml(category) {
   </section>`;
 }
 
-function renderPage({ category, categoryData, categoryUniverseCount, items, isPreview, hasUnexpectedParameters, navigationBase, page, pageSize, totalPages, order }) {
+function renderPage({ category, categoryData, items, isPreview, hasUnexpectedParameters, navigationBase, page, pageSize, totalPages, order }) {
     const simple = isSimpleCategory(category);
     const canonical = `${BASE}${categoryPath(category.id, page)}`;
     const offset = (page - 1) * pageSize;
@@ -463,8 +463,8 @@ function renderPage({ category, categoryData, categoryUniverseCount, items, isPr
     const resultText = items.length === 0
         ? 'Sin productos en esta selección'
         : totalPages > 1
-            ? `Mostrando ${rangeFrom}–${rangeTo} de ${items.length} ${productNoun}s${simple ? '' : ' disponibles'}`
-            : `${items.length} ${productNoun}${items.length === 1 ? '' : 's'}${simple ? '' : ` disponible${items.length === 1 ? '' : 's'}`}`;
+            ? `Mostrando ${rangeFrom}–${rangeTo} de ${items.length} ${productNoun}s`
+            : `${items.length} ${productNoun}${items.length === 1 ? '' : 's'}`;
     const cards = visibleItems.map((item, index) => cardHtml(item, index, navigationBase)).join('\n');
     const robots = isPreview || hasUnexpectedParameters || Boolean(order) || items.length === 0
         ? 'noindex, follow'
@@ -472,19 +472,10 @@ function renderPage({ category, categoryData, categoryUniverseCount, items, isPr
     const pageTitle = page > 1 ? `${category.title} — Página ${page}` : category.title;
     const pageDescription = page > 1 ? `${category.description} Página ${page} de ${totalPages}.` : category.description;
     const pagination = paginationHtml({ categoryId: category.id, page, totalPages, order });
-    // TAROT-HUB-MERCH-1: copy inequívoco para esoterismo-tarot — "314 título(s)
-    // informados en la portada" se podía leer como stock inmediato, que no es
-    // lo que dice. El número visible es siempre el de items.length (dinámico,
-    // nunca hardcodeado); el universo por-encargo mayor se nombra sin cifra
-    // propia, sólo cuando existe realmente. El resto de las categorías
-    // conserva el texto original, sin cambios.
+    // Contar la colección visible después de deduplicar, con ambos estados.
     const availableCount = items.filter(item => item.status === 'active' && Number(item.available_quantity) > 0).length;
     const byRequestCount = items.filter(item => item.status === 'paused').length;
-    const scopeText = simple
-        ? `<strong>${items.length} productos</strong> · ${availableCount} disponible${availableCount === 1 ? '' : 's'} · ${byRequestCount} por encargo`
-        : (Number.isFinite(categoryUniverseCount) && categoryUniverseCount > items.length
-            ? `<strong>${items.length} título${items.length === 1 ? '' : 's'} disponible${items.length === 1 ? '' : 's'} ahora.</strong> Los ${categoryUniverseCount} títulos informados en la portada incluyen disponibles y libros que podemos buscar por encargo.`
-            : `<strong>${items.length} título${items.length === 1 ? '' : 's'} disponible${items.length === 1 ? '' : 's'} ahora.</strong> También buscamos ediciones agotadas o difíciles de conseguir por encargo.`);
+    const scopeText = `<strong>${items.length} ${productNoun}${items.length === 1 ? '' : 's'}</strong> · ${availableCount} disponible${availableCount === 1 ? '' : 's'} · ${byRequestCount} por encargo`;
     const waMessage = buildWhatsAppMessage({
         greeting: 'Hola, estoy buscando un libro en Amado Libros y quisiera que me ayudaran 😊',
         motive: 'Consultar por un libro de esta categoría',
@@ -530,9 +521,10 @@ ${categoryBreadcrumbHtml(category)}
   ${biblePathwaysHtml(category)}
   ${psychologyPathwaysHtml(category)}
   ${simple ? '' : subcategoryLinksHtml(category, categoryData)}
-  ${simple ? categoryProductTabsHtml(category) + categoryOrderHtml(category.id, order || 'mezclados') : editorialGuideHtml(category)}
-  <div class="results-head"><h2>${simple ? 'Todos los productos' : 'Libros disponibles'}</h2><p>${resultText}</p></div>
-  ${items.length > 0 ? `<section class="books-grid" aria-label="${escapeHtml(category.h1)}">${cards}</section>${pagination}` : '<p class="empty">No hay títulos disponibles en esta categoría en este momento. Consultanos por WhatsApp y lo buscamos por encargo.</p>'}
+  ${simple ? categoryProductTabsHtml(category) : editorialGuideHtml(category)}
+  ${categoryOrderHtml(category.id, order || 'mezclados')}
+  <div class="results-head"><h2>${simple ? 'Todos los productos' : 'Todos los libros'}</h2><p>${resultText}</p></div>
+  ${items.length > 0 ? `<section class="books-grid" aria-label="${escapeHtml(category.h1)}">${cards}</section>${pagination}` : '<p class="empty">No hay títulos publicados en esta categoría en este momento. Consultanos por WhatsApp y lo buscamos por encargo.</p>'}
   ${categoryNavHtml(category.id)}
 </main>
 ${footerHtml(undefined, canonical)}
@@ -571,8 +563,8 @@ export async function onRequest(ctx) {
             headers: { Location: `${clean.pathname}${clean.search}` },
         });
     }
-    const order = isSimpleCategory(category) && requestUrl.searchParams.has('orden') ? parseCategoryOrder(requestUrl.searchParams.get('orden')) : '';
-    const hasUnexpectedParameters = [...requestUrl.searchParams.keys()].some(key => key !== 'page' && !(isSimpleCategory(category) && key === 'orden'))
+    const order = requestUrl.searchParams.has('orden') ? parseCategoryOrder(requestUrl.searchParams.get('orden')) : '';
+    const hasUnexpectedParameters = [...requestUrl.searchParams.keys()].some(key => key !== 'page' && key !== 'orden')
         || requestUrl.searchParams.getAll('page').length > 1 || requestUrl.searchParams.getAll('orden').length > 1;
 
     const [categoryData, activeIndex, pausedIndex] = await Promise.all([
@@ -580,7 +572,7 @@ export async function onRequest(ctx) {
         ['preview', 'production'].includes(ctx.env?.APP_ENV)
             ? fetchActiveIndex(ctx)
             : Promise.resolve(null),
-        isSimpleCategory(category) && ['preview', 'production'].includes(ctx.env?.APP_ENV)
+        ['preview', 'production'].includes(ctx.env?.APP_ENV)
             ? fetchPausedIndex(ctx) : Promise.resolve(null),
     ]);
     if (!categoryData) {
@@ -594,7 +586,7 @@ export async function onRequest(ctx) {
         if (!catalog || !Array.isArray(catalog.items)) {
             return errorPage(503, 'Catálogo temporalmente no disponible', 'Intentá nuevamente en unos minutos.');
         }
-        if (isSimpleCategory(category)) fallbackPaused = catalog.items.filter(item => item.status === 'paused');
+        fallbackPaused = catalog.items.filter(item => item.status === 'paused');
         activeItems = catalog.items.filter(item =>
             item.status === 'active' && Number(item.available_quantity) > 0
         );
@@ -631,18 +623,14 @@ export async function onRequest(ctx) {
             return price || String(a.id).localeCompare(String(b.id));
         });
     let items = dedupeCategoryResults(categoryItems);
-    if (isSimpleCategory(category)) {
-        const selectedOrder = order || 'mezclados';
-        if (['recientes', 'antiguos'].includes(selectedOrder) && items.some(item => !item.start_time)) {
-            // El índice ligero conserva stock/precio actuales, pero no fechas.
-            // Sólo se toma start_time del catálogo; nunca se pisa disponibilidad.
-            const dates = await fetchCategoryDates(ctx);
-            items = items.map(item => ({ ...item, start_time: item.start_time || dates.get(item.id) || null }));
-        }
-        items = orderCategoryItems(items, selectedOrder);
+    const selectedOrder = order || 'mezclados';
+    if (['recientes', 'antiguos'].includes(selectedOrder) && items.some(item => !item.start_time)) {
+        // El índice ligero conserva stock/precio actuales, pero no fechas.
+        // Sólo se toma start_time del catálogo; nunca se pisa disponibilidad.
+        const dates = await fetchCategoryDates(ctx);
+        items = items.map(item => ({ ...item, start_time: item.start_time || dates.get(item.id) || null }));
     }
-    const categoryUniverseCount = classificationIds.reduce((total, id) => total + classificationCount(categoryData, id), 0)
-        - excludedClassificationIds.reduce((total, id) => total + classificationCount(categoryData, id), 0);
+    items = orderCategoryItems(items, selectedOrder);
     const pageSize = BIBLE_CATEGORY_IDS.has(category.id) ? 24 : MAX_RESULTS;
     const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
     if (pageParam.page > totalPages) {
@@ -653,7 +641,6 @@ export async function onRequest(ctx) {
     const html = renderPage({
         category,
         categoryData,
-        categoryUniverseCount,
         items,
         isPreview,
         hasUnexpectedParameters,


### PR DESCRIPTION
Las categorías fuera de Tarot mostraban sólo disponibles y dejaban fuera los títulos por encargo, aunque estaban en el catálogo general. Seba pidió que el cliente vea todo.

Esta PR incluye los índices de disponibles y por encargo en todas las categorías y subcategorías. Intercala ambos estados antes de paginar, conserva las reglas temáticas y la separación de mazos/libros, y deduplica publicaciones y ediciones priorizando las disponibles. Actualiza los contadores y el encabezado de la grilla para reflejar ambos estados y extiende el orden por fecha/precio a todas las landings.

Los encargos muestran su estado, consulta de precio/plazo y acceso a la ficha. Las fichas con stock conservan «Te llega hoy · Montevideo». No cambia precios, stock, títulos, slugs, el catálogo general ni la política de indexación de las fichas.

Validación: 1.948 pruebas, sintaxis y ambos builds de checkout aprobados con scripts/validate-ci.sh (Node 22.12). Se agregan pruebas para las 14 categorías restantes en producción y preview: intercalado, paginación, aislamiento del entorno, ediciones repetidas, exclusión de otras categorías y navegación HTML. Se mantienen las pruebas de separación de mazos/libros y de los siete ejemplos aportados.

Autorización: continúa la publicación aprobada en esta conversación y aplica la instrucción explícita «QUIERO QUE EL CLIENTE VEA TODO». Publicar tras superar CI y la comprobación de preview.

CI y auditoría completa del Preview aprobados sobre a6b3f1d. Comprobadas en navegador Psicología, Cábala y Biblias, incluido el intercalado al avanzar a página 2.

PUBLICADO: integrado en main como a0128745c1a5a5c967c82b355e6227c108a4d53d. Validate before deploy y Deploy terminados correctamente, con las comprobaciones de producción. https://github.com/trexxeseba/amadolibros-web/actions/runs/34726410102

Comprobación en el dominio principal, con recarga de los enlaces sin parámetros: Psicología 476 títulos (217 disponibles + 259 por encargo), Cábala 40 (26 + 14). Las primeras filas intercalan ambos estados. La política de noindex de las fichas permanece sin cambios.